### PR TITLE
Tighten resolution detection: require not-active + 0.99/0.01 thresholds

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -125,32 +125,35 @@ class ResolutionTracker:
             True  — resolved YES
             False — resolved NO
             None  — not yet resolved / ambiguous
+
+        Resolution is only declared when the exchange itself has signalled
+        closure.  The earlier implementation checked price convergence
+        before ``market.active`` and could mark a still-trading market at
+        95%/5% as resolved — which then settled the portfolio position
+        prematurely and fed a fake outcome into calibration.
         """
-        yes_price = market.outcome_yes_price
-
-        # Price convergence is the strongest signal.  Resolved markets go
-        # to ~0 or ~1.  Check this FIRST because some APIs (Gamma/Polymarket)
-        # keep the ``active`` flag True even after a market has fully resolved
-        # and prices have converged.
-        if yes_price >= 0.95:
-            return True  # Resolved YES
-        if yes_price <= 0.05:
-            return False  # Resolved NO
-
-        # Market still trading at a non-extreme price and flagged active
-        # by the exchange — genuinely unresolved.
-        if market.active:
-            return None
-
-        # Kalshi-specific: markets have an explicit status field.  If the
-        # market is settled/finalized but the price didn't clearly converge
-        # (rare edge case for multi-outcome events), use price as tiebreak.
+        # Kalshi exposes an explicit settlement status — trust it first.
         if exchange == "kalshi":
             status = getattr(market, "status", None)
             if status in ("settled", "finalized"):
-                return yes_price > 0.5
+                return market.outcome_yes_price > 0.5
 
-        # Market inactive but price ambiguous — can't determine cleanly.
+        # For everything else, the exchange must have flagged the market
+        # inactive (closed/resolved on Polymarket's side).  A still-active
+        # market is by definition not resolved, regardless of price.
+        if market.active:
+            return None
+
+        # Inactive + tightly converged price → resolution.  The threshold
+        # is intentionally tight (0.99/0.01) to avoid declaring a winner
+        # on markets that closed early or paused with non-trivial spread.
+        yes_price = market.outcome_yes_price
+        if yes_price >= 0.99:
+            return True
+        if yes_price <= 0.01:
+            return False
+
+        # Inactive but price ambiguous — wait for clearer signal.
         return None
 
     # ------------------------------------------------------------------

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -72,7 +72,7 @@ class TestDetectResolution:
         assert ResolutionTracker._detect_resolution(market, "polymarket") is True
 
     def test_resolved_no(self):
-        market = _make_market(active=False, yes_price=0.02)
+        market = _make_market(active=False, yes_price=0.01)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is False
 
     def test_ambiguous_price_returns_none(self):
@@ -97,17 +97,28 @@ class TestDetectResolution:
         market.status = "finalized"
         assert ResolutionTracker._detect_resolution(market, "kalshi") is False
 
-    def test_boundary_yes_095(self):
-        market = _make_market(active=False, yes_price=0.95)
+    def test_boundary_yes_099(self):
+        market = _make_market(active=False, yes_price=0.99)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is True
 
-    def test_boundary_no_005(self):
-        market = _make_market(active=False, yes_price=0.05)
+    def test_boundary_no_001(self):
+        market = _make_market(active=False, yes_price=0.01)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is False
 
     def test_just_below_threshold_returns_none(self):
-        market = _make_market(active=False, yes_price=0.94)
+        """0.95 used to trigger resolution but is now too loose — must be inactive
+        AND tightly converged (>=0.99 / <=0.01) before we declare a winner."""
+        market = _make_market(active=False, yes_price=0.95)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is None
+
+    def test_active_high_price_returns_none(self):
+        """Even at 95%/5%, an active market is NOT resolved — the prior
+        ordering let high-confidence still-trading markets be settled
+        prematurely and have their portfolio rows deleted."""
+        yes_market = _make_market(active=True, yes_price=0.97)
+        no_market = _make_market(active=True, yes_price=0.03)
+        assert ResolutionTracker._detect_resolution(yes_market, "polymarket") is None
+        assert ResolutionTracker._detect_resolution(no_market, "polymarket") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reorder `_detect_resolution` so the exchange-flagged closure check (`market.active` / Kalshi `settled|finalized`) runs *before* any price check; previously a still-active 95%/5% market would be marked resolved, settled, and fed to calibration as a fake outcome.
- Tighten the price-convergence threshold from 0.95/0.05 to 0.99/0.01 so we don't declare a winner on markets that closed early or paused with non-trivial spread.
- Add a regression test (`test_active_high_price_returns_none`) covering the active-at-95%/5% case.

## Context
PR 1 of 3 from the `fix/roborev-2026-05-02` split.
**Depends on:** none. Independent of the other two PRs.

## Test plan
- [x] `pytest tests/test_resolution_tracker.py::TestDetectResolution` — 10/10 pass
- [ ] No active market should ever be settled regardless of price extremes
- [ ] Inactive markets at 0.95/0.05 are now treated as ambiguous (return None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)