### PR TITLE
Isolate cost_basis paper/live rows by composite primary key

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -687,8 +687,10 @@ class AuramaurBot:
 
         if not token_id:
             try:
+                # _execute_poly_exit only fires for live positions; scope to
+                # is_paper=0 so we can't pick up a stale paper-mode token_id.
                 row = await self._components["db"].fetchone(
-                    "SELECT token_id FROM cost_basis WHERE market_id = ? AND size > 0",
+                    "SELECT token_id FROM cost_basis WHERE market_id = ? AND size > 0 AND is_paper = 0",
                     (pos.market_id,),
                 )
                 if row and row["token_id"]:
@@ -1783,12 +1785,15 @@ class AuramaurBot:
                     reconciled = await reconciler.reconcile()
                     positions = reconciler.to_live_positions(reconciled)
 
-                    # Update cost_basis from real fill prices (ground truth)
+                    # Update cost_basis from real fill prices (ground truth).
+                    # This loop only runs in live mode, so we explicitly
+                    # write is_paper=0 and conflict on (market_id, is_paper).
                     for rp in reconciled:
                         await self._components["db"].execute(
-                            """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost, total_cost, updated_at)
-                               VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
-                               ON CONFLICT(market_id) DO UPDATE SET
+                            """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost, total_cost, is_paper, updated_at)
+                               VALUES (?, ?, ?, ?, ?, ?, 0, datetime('now'))
+                               ON CONFLICT(market_id, is_paper) DO UPDATE SET
+                                   token = excluded.token,
                                    token_id = excluded.token_id,
                                    size = excluded.size,
                                    avg_cost = excluded.avg_cost,
@@ -1807,12 +1812,14 @@ class AuramaurBot:
                     if reconciled:
                         live_ids = [rp.market_id for rp in reconciled]
                         placeholders = ",".join("?" * len(live_ids))
+                        # Live-mode reconciliation must only delete live rows;
+                        # paper rows (is_paper=1) live in their own namespace.
                         cb_cur = await self._components["db"].execute(
-                            f"DELETE FROM cost_basis WHERE size > 0 AND market_id NOT IN ({placeholders})",
+                            f"DELETE FROM cost_basis WHERE size > 0 AND is_paper = 0 AND market_id NOT IN ({placeholders})",
                             live_ids,
                         )
                         pf_cur = await self._components["db"].execute(
-                            f"DELETE FROM portfolio WHERE market_id NOT IN ({placeholders})",
+                            f"DELETE FROM portfolio WHERE is_paper = 0 AND market_id NOT IN ({placeholders})",
                             live_ids,
                         )
                         log.info(

--- a/auramaur/broker/pnl.py
+++ b/auramaur/broker/pnl.py
@@ -62,10 +62,14 @@ class PnLTracker:
             ),
         )
 
-        # 2. Fetch current cost basis (if any)
+        # 2. Fetch current cost basis for the same paper/live mode (if any).
+        # cost_basis is keyed by (market_id, is_paper); reading without the
+        # is_paper filter would let paper fills consume a live row's basis
+        # and vice versa.
+        is_paper_flag = 1 if fill.is_paper else 0
         row = await self._db.fetchone(
-            "SELECT size, avg_cost, total_cost, realized_pnl FROM cost_basis WHERE market_id = ?",
-            (fill.market_id,),
+            "SELECT size, avg_cost, total_cost, realized_pnl FROM cost_basis WHERE market_id = ? AND is_paper = ?",
+            (fill.market_id, is_paper_flag),
         )
 
         old_size: float = float(row["size"]) if row else 0.0
@@ -133,18 +137,20 @@ class PnLTracker:
             new_total_cost = 0.0
             new_avg_cost = 0.0
 
-        # 5. Upsert cost_basis
+        # 5. Upsert cost_basis — composite PK (market_id, is_paper) keeps
+        # paper and live rows independent.
         now = datetime.now(timezone.utc).isoformat()
         await self._db.execute(
             """INSERT INTO cost_basis
                (market_id, token, token_id, size, avg_cost, total_cost, realized_pnl, is_paper, updated_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(market_id) DO UPDATE SET
+               ON CONFLICT(market_id, is_paper) DO UPDATE SET
+                   token = excluded.token,
+                   token_id = excluded.token_id,
                    size = excluded.size,
                    avg_cost = excluded.avg_cost,
                    total_cost = excluded.total_cost,
                    realized_pnl = excluded.realized_pnl,
-                   is_paper = excluded.is_paper,
                    updated_at = excluded.updated_at""",
             (
                 fill.market_id,
@@ -154,7 +160,7 @@ class PnLTracker:
                 new_avg_cost,
                 new_total_cost,
                 realized_pnl,
-                1 if fill.is_paper else 0,
+                is_paper_flag,
                 now,
             ),
         )

--- a/auramaur/broker/reconciler.py
+++ b/auramaur/broker/reconciler.py
@@ -280,22 +280,26 @@ class PositionReconciler:
                 continue  # Still unresolved
 
             orphan_id = pos.condition_id[:16]
-            # Check if cost_basis has the orphan ID
+            # Check if cost_basis has the orphan ID — reconciler is live-only,
+            # so confine the rename to is_paper=0 rows.  cost_basis is keyed
+            # by (market_id, is_paper); without the filter we could rename a
+            # paper row into a key that already exists for live and violate
+            # the composite PK.
             row = await self._db.fetchone(
-                "SELECT market_id FROM cost_basis WHERE market_id = ?",
+                "SELECT market_id FROM cost_basis WHERE market_id = ? AND is_paper = 0",
                 (orphan_id,),
             )
             if row:
                 await self._db.execute(
-                    "UPDATE cost_basis SET market_id = ? WHERE market_id = ?",
+                    "UPDATE cost_basis SET market_id = ? WHERE market_id = ? AND is_paper = 0",
                     (pos.market_id, orphan_id),
                 )
                 await self._db.execute(
-                    "UPDATE portfolio SET market_id = ? WHERE market_id = ?",
+                    "UPDATE portfolio SET market_id = ? WHERE market_id = ? AND is_paper = 0",
                     (pos.market_id, orphan_id),
                 )
                 await self._db.execute(
-                    "UPDATE fills SET market_id = ? WHERE market_id = ?",
+                    "UPDATE fills SET market_id = ? WHERE market_id = ? AND is_paper = 0",
                     (pos.market_id, orphan_id),
                 )
                 repaired += 1

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -62,6 +62,8 @@ class Database:
             await self._migrate_v7_to_v8()
         if from_version < 9:
             await self._migrate_v8_to_v9()
+        if from_version < 10:
+            await self._migrate_v9_to_v10()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -231,6 +233,41 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 9")
         await self._db.commit()
         log.info("database.migrated", from_version=8, to_version=9)
+
+    async def _migrate_v9_to_v10(self) -> None:
+        """Make cost_basis primary key composite (market_id, is_paper).
+
+        Previously the PK was ``market_id`` alone, so paper and live fills
+        for the same market collided: ``record_fill()`` upserts with
+        ``ON CONFLICT(market_id)`` would overwrite each other's cost basis
+        and realized PnL.  Recreate the table with the composite PK and
+        copy existing rows across.
+        """
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS cost_basis_new (
+                market_id TEXT NOT NULL,
+                token TEXT NOT NULL DEFAULT 'YES',
+                token_id TEXT DEFAULT '',
+                size REAL NOT NULL,
+                avg_cost REAL NOT NULL,
+                total_cost REAL NOT NULL,
+                realized_pnl REAL DEFAULT 0,
+                is_paper INTEGER NOT NULL DEFAULT 1,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (market_id, is_paper)
+            );
+            INSERT OR IGNORE INTO cost_basis_new
+                (market_id, token, token_id, size, avg_cost, total_cost,
+                 realized_pnl, is_paper, updated_at)
+            SELECT market_id, token, token_id, size, avg_cost, total_cost,
+                   realized_pnl, is_paper, updated_at
+            FROM cost_basis;
+            DROP TABLE cost_basis;
+            ALTER TABLE cost_basis_new RENAME TO cost_basis;
+        """)
+        await self._db.execute("UPDATE schema_version SET version = 10")
+        await self._db.commit()
+        log.info("database.migrated", from_version=9, to_version=10)
 
     @property
     def db(self) -> aiosqlite.Connection:

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -183,7 +183,7 @@ CREATE TABLE IF NOT EXISTS fills (
 );
 
 CREATE TABLE IF NOT EXISTS cost_basis (
-    market_id TEXT PRIMARY KEY,
+    market_id TEXT NOT NULL,
     token TEXT NOT NULL DEFAULT 'YES',
     token_id TEXT DEFAULT '',
     size REAL NOT NULL,
@@ -191,7 +191,8 @@ CREATE TABLE IF NOT EXISTS cost_basis (
     total_cost REAL NOT NULL,
     realized_pnl REAL DEFAULT 0,
     is_paper INTEGER NOT NULL DEFAULT 1,
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (market_id, is_paper)
 );
 
 CREATE INDEX IF NOT EXISTS idx_price_history_market ON price_history(market_id);

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -171,10 +171,15 @@ class ResolutionTracker:
             # No position — we only had a calibration prediction, not a trade.
             return
 
-        entry_price = pos_row["avg_price"]
-        size = pos_row["size"]
-        side = pos_row["side"]
-        token = pos_row.get("token", "YES")
+        # aiosqlite.Row supports __getitem__ but not .get(); normalise to a
+        # plain dict so we can safely use defaults for columns added in
+        # later migrations (token, is_paper).
+        pos = dict(pos_row)
+        entry_price = pos["avg_price"]
+        size = pos["size"]
+        side = pos["side"]
+        token = pos.get("token") or "YES"
+        is_paper_flag = int(pos.get("is_paper", 1))
 
         # Settlement price: YES resolves to $1, NO resolves to $0
         if token == "NO":
@@ -205,13 +210,15 @@ class ResolutionTracker:
         except Exception as e:
             log.debug("resolution.daily_stats_error", error=str(e))
 
-        # Update cost_basis realized PnL
+        # Update cost_basis realized PnL — scoped to the same paper/live mode
+        # as the portfolio row so a paper resolution can't zero a live row's
+        # cost basis (and vice versa).
         try:
             await self._db.execute(
                 """UPDATE cost_basis
                    SET realized_pnl = realized_pnl + ?, size = 0, updated_at = datetime('now')
-                   WHERE market_id = ?""",
-                (pnl, market_id),
+                   WHERE market_id = ? AND is_paper = ?""",
+                (pnl, market_id, is_paper_flag),
             )
         except Exception as e:
             log.debug("resolution.cost_basis_error", error=str(e))


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.