### PR TITLE
Start portfolio monitor for any exchange, not just Polymarket

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2005,9 +2005,12 @@ class AuramaurBot:
             asyncio.create_task(self._task_recalibrate(), name="recalibrate"),
         ]
 
-        # Portfolio monitor and position sync need syncer (Polymarket-specific)
-        if self._components.get("syncer"):
+        # Portfolio monitor runs whenever any exchange syncer is present so
+        # Kalshi-only runs still populate `_last_known_cash` and exits fire.
+        # Position sync (CLOB reconciler) remains Polymarket-specific.
+        if self._components.get("syncers"):
             tasks.append(asyncio.create_task(self._task_portfolio_monitor(), name="portfolio"))
+        if self._components.get("syncer"):
             tasks.append(asyncio.create_task(self._task_position_sync(), name="position_sync"))
 
         # Resolution checker and order monitor work with any exchange


### PR DESCRIPTION
## Summary
- Gate `_task_portfolio_monitor` on `self._components["syncers"]` (multi-exchange registry) instead of `self._components["syncer"]` (Polymarket CLOB only). A `--exchange kalshi` run was skipping portfolio monitoring entirely, so `_last_known_cash` never populated and exits never fired.
- Position sync (CLOB-specific reconciler) stays gated on `"syncer"`.

## Context
PR 3 of 3 from the `fix/roborev-2026-05-02` split.
**Depends on:** none. Independent of the other two PRs.

## Test plan
- [ ] Start with `--exchange kalshi` only — verify portfolio monitor task is running
- [ ] Start with `--exchange polymarket` only — verify both portfolio monitor and position sync run
- [ ] Start with both exchanges — verify both tasks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)