### PR TITLE
Fix portfolio PK collision, unify fee tables, add risk manager tests

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -228,7 +228,7 @@ class PositionSyncer:
                 """INSERT INTO portfolio
                    (market_id, exchange, side, size, avg_price, current_price, category, token, token_id, is_paper, updated_at)
                    VALUES (?, 'polymarket', ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(market_id) DO UPDATE SET
+                   ON CONFLICT(market_id, is_paper) DO UPDATE SET
                        exchange = excluded.exchange,
                        size = excluded.size,
                        avg_price = excluded.avg_price,
@@ -295,7 +295,7 @@ class PositionSyncer:
                 """INSERT INTO portfolio
                    (market_id, exchange, side, size, avg_price, current_price, category, token, token_id, is_paper, updated_at)
                    VALUES (?, 'polymarket', ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(market_id) DO UPDATE SET
+                   ON CONFLICT(market_id, is_paper) DO UPDATE SET
                        exchange = excluded.exchange,
                        side = excluded.side,
                        size = excluded.size,
@@ -396,7 +396,7 @@ class KalshiPositionSyncer:
                    (market_id, exchange, side, size, avg_price, current_price,
                     category, token, token_id, is_paper, updated_at)
                    VALUES (?, 'kalshi', ?, ?, ?, ?, ?, ?, ?, 1, ?)
-                   ON CONFLICT(market_id) DO UPDATE SET
+                   ON CONFLICT(market_id, is_paper) DO UPDATE SET
                        exchange = excluded.exchange,
                        side = excluded.side,
                        size = excluded.size,

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -64,6 +64,8 @@ class Database:
             await self._migrate_v8_to_v9()
         if from_version < 10:
             await self._migrate_v9_to_v10()
+        if from_version < 11:
+            await self._migrate_v10_to_v11()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -268,6 +270,42 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 10")
         await self._db.commit()
         log.info("database.migrated", from_version=9, to_version=10)
+
+    async def _migrate_v10_to_v11(self) -> None:
+        """Make portfolio primary key composite (market_id, is_paper).
+
+        Same treatment as cost_basis got in v9→v10: paper and live rows
+        for the same market can now coexist.
+        """
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS portfolio_new (
+                market_id TEXT NOT NULL,
+                exchange TEXT DEFAULT 'polymarket',
+                side TEXT NOT NULL,
+                size REAL NOT NULL,
+                avg_price REAL NOT NULL,
+                current_price REAL,
+                unrealized_pnl REAL DEFAULT 0,
+                category TEXT,
+                token TEXT NOT NULL DEFAULT 'YES',
+                token_id TEXT DEFAULT '',
+                is_paper INTEGER NOT NULL DEFAULT 1,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (market_id, is_paper),
+                FOREIGN KEY (market_id) REFERENCES markets(id)
+            );
+            INSERT OR IGNORE INTO portfolio_new
+                (market_id, exchange, side, size, avg_price, current_price,
+                 unrealized_pnl, category, token, token_id, is_paper, updated_at)
+            SELECT market_id, exchange, side, size, avg_price, current_price,
+                   unrealized_pnl, category, token, token_id, is_paper, updated_at
+            FROM portfolio;
+            DROP TABLE portfolio;
+            ALTER TABLE portfolio_new RENAME TO portfolio;
+        """)
+        await self._db.execute("UPDATE schema_version SET version = 11")
+        await self._db.commit()
+        log.info("database.migrated", from_version=10, to_version=11)
 
     @property
     def db(self) -> aiosqlite.Connection:

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS trades (
 );
 
 CREATE TABLE IF NOT EXISTS portfolio (
-    market_id TEXT PRIMARY KEY,
+    market_id TEXT NOT NULL,
     exchange TEXT DEFAULT 'polymarket',
     side TEXT NOT NULL,
     size REAL NOT NULL,
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS portfolio (
     token_id TEXT DEFAULT '',
     is_paper INTEGER NOT NULL DEFAULT 1,
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (market_id, is_paper),
     FOREIGN KEY (market_id) REFERENCES markets(id)
 );
 

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -498,9 +498,9 @@ class KalshiClient:
 
                 await db.execute(
                     """INSERT INTO portfolio
-                       (market_id, exchange, side, size, avg_price, current_price, token, updated_at)
-                       VALUES (?, 'kalshi', 'BUY', ?, ?, ?, ?, datetime('now'))
-                       ON CONFLICT(market_id) DO UPDATE SET
+                       (market_id, exchange, side, size, avg_price, current_price, token, is_paper, updated_at)
+                       VALUES (?, 'kalshi', 'BUY', ?, ?, ?, ?, 0, datetime('now'))
+                       ON CONFLICT(market_id, is_paper) DO UPDATE SET
                            exchange = excluded.exchange,
                            size = excluded.size,
                            avg_price = excluded.avg_price,

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -367,13 +367,13 @@ class PortfolioTracker:
     # Updates
     # ------------------------------------------------------------------
 
-    async def update_position(self, position: Position) -> None:
+    async def update_position(self, position: Position, is_paper: bool = True) -> None:
         """Insert or replace a position row in the portfolio table."""
         await self.db.execute(
             """
-            INSERT INTO portfolio (market_id, exchange, side, size, avg_price, current_price, category, token, token_id, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(market_id) DO UPDATE SET
+            INSERT INTO portfolio (market_id, exchange, side, size, avg_price, current_price, category, token, token_id, is_paper, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(market_id, is_paper) DO UPDATE SET
                 exchange = excluded.exchange,
                 side = excluded.side,
                 size = excluded.size,
@@ -394,6 +394,7 @@ class PortfolioTracker:
                 position.category,
                 position.token.value,
                 position.token_id,
+                int(is_paper),
                 datetime.now(timezone.utc).isoformat(),
             ),
         )

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -494,7 +494,7 @@ class TradingEngine:
                 analysis.probability = max(0.01, min(0.99, analysis.probability + nudge))
 
         # 3. Signal detection
-        signal = detect_edge(market, analysis)
+        signal = detect_edge(market, analysis, exchange_fees=self.settings.arbitrage.exchange_fees)
         if signal is None:
             return None
 
@@ -1037,7 +1037,7 @@ class TradingEngine:
         from pathlib import Path
         from auramaur.nlp.strategic import StrategicAnalyzer
         from auramaur.exchange.models import Confidence, Signal, OrderSide
-        from auramaur.strategy.signals import EXCHANGE_FEES
+        exchange_fees = self.settings.arbitrage.exchange_fees
 
         # Kill switch check — halt immediately if active
         if Path("KILL_SWITCH").exists():
@@ -1151,7 +1151,7 @@ class TradingEngine:
             if abs(raw_edge) < 0.001:
                 continue
             side = OrderSide.BUY if raw_edge > 0 else OrderSide.SELL
-            fee_rate = EXCHANGE_FEES.get(market.exchange or self.exchange_name, 0.0)
+            fee_rate = exchange_fees.get(market.exchange or self.exchange_name, 0.0)
             edge = abs(raw_edge) - fee_rate
 
             signal = Signal(

--- a/auramaur/strategy/pipeline_analyzer.py
+++ b/auramaur/strategy/pipeline_analyzer.py
@@ -229,7 +229,7 @@ class PipelineAnalyzer:
                 analysis.probability = max(0.01, min(0.99, analysis.probability + nudge))
 
         # 3. Signal detection
-        signal = detect_edge(market, analysis)
+        signal = detect_edge(market, analysis, exchange_fees=self.settings.arbitrage.exchange_fees)
         if signal is None:
             return None
 

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -226,10 +226,11 @@ class ResolutionTracker:
         except Exception as e:
             log.debug("resolution.cost_basis_error", error=str(e))
 
-        # Remove from portfolio
+        # Remove from portfolio — scoped by is_paper so a paper resolution
+        # doesn't delete a live position for the same market (and vice versa).
         await self._db.execute(
-            "DELETE FROM portfolio WHERE market_id = ?",
-            (market_id,),
+            "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ?",
+            (market_id, is_paper_flag),
         )
 
         # Remove peak tracking

--- a/auramaur/strategy/signals.py
+++ b/auramaur/strategy/signals.py
@@ -12,15 +12,14 @@ from auramaur.nlp.analyzer import AnalysisResult
 
 log = structlog.get_logger()
 
-# Per-exchange fee rates (as fractions, not percentages).
-# Applied to edge calculation so only genuinely profitable trades pass.
+# Fallback fee rates — callers should prefer passing exchange_fees from config.
+# Kept as a default so standalone calls (tests, REPL) still work.
 EXCHANGE_FEES: dict[str, float] = {
-    "polymarket": 0.0,    # 0% for reward tier accounts
-    "kalshi": 0.07,       # 7% fee on winnings
-    "cryptodotcom": 0.01, # ~1% fee
+    "polymarket": 0.0,
+    "kalshi": 0.07,
+    "cryptodotcom": 0.075,
 }
 
-# Legacy alias for backward compatibility
 POLYMARKET_FEE_PCT = 0.0
 
 
@@ -130,10 +129,16 @@ def _has_inverted_semantics(question: str) -> bool:
     return any(re.search(pat, q) for pat in _NEGATION_REGEXES)
 
 
-def detect_edge(market: Market, analysis: AnalysisResult) -> Signal | None:
+def detect_edge(
+    market: Market,
+    analysis: AnalysisResult,
+    exchange_fees: dict[str, float] | None = None,
+) -> Signal | None:
     """Compare Claude's probability estimate against the market price.
 
     Returns a Signal if there's a tradeable edge, None otherwise.
+    *exchange_fees* overrides the module-level EXCHANGE_FEES when provided
+    (callers should pass settings.arbitrage.exchange_fees).
     """
     if analysis.skipped_reason:
         log.info("signal.skipped", market_id=market.id, reason=analysis.skipped_reason)
@@ -179,7 +184,8 @@ def detect_edge(market: Market, analysis: AnalysisResult) -> Signal | None:
         return None
 
     # Adjust for exchange-specific fees
-    fee_rate = EXCHANGE_FEES.get(market.exchange, 0.0)
+    fees = exchange_fees if exchange_fees is not None else EXCHANGE_FEES
+    fee_rate = fees.get(market.exchange, 0.0)
     net_edge = edge - fee_rate
 
     if net_edge <= 0:

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -209,7 +209,7 @@ class TestCheckResolutions:
     def test_multi_exchange_resolution(self, resolved_yes_market, resolved_no_market):
         """Markets from different exchanges are resolved correctly."""
         resolved_no_market_kalshi = _make_market(
-            market_id="kalshi-mkt", active=False, yes_price=0.02, exchange="kalshi",
+            market_id="kalshi-mkt", active=False, yes_price=0.01, exchange="kalshi",
         )
         rows = [
             {"market_id": "mkt-1", "exchange": "polymarket"},

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,242 @@
+"""Integration tests for RiskManager.evaluate() — exercises the full flow
+including pre/post sizing checks, Kelly bankroll=cash, and edge capping."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.risk.manager import RiskManager
+
+
+def _make_settings(
+    *,
+    max_drawdown_pct=15.0,
+    daily_loss_limit=200.0,
+    max_open_positions=500,
+    min_edge_pct=5.0,
+    min_liquidity=1000.0,
+    max_spread_pct=5.0,
+    confidence_floor="LOW",
+    implied_prob_min=0.05,
+    implied_prob_max=0.95,
+    category_exposure_cap_pct=60.0,
+    max_correlated_positions=10,
+    time_to_resolution_min_hours=24,
+    time_to_resolution_max_days=0,
+    second_opinion_divergence_max=0.25,
+    max_stake_per_market=25.0,
+    kelly_fraction=0.40,
+    paper_initial_balance=500.0,
+    blocked_categories=None,
+):
+    s = MagicMock()
+    rc = MagicMock()
+    rc.max_drawdown_pct = max_drawdown_pct
+    rc.daily_loss_limit = daily_loss_limit
+    rc.max_open_positions = max_open_positions
+    rc.min_edge_pct = min_edge_pct
+    rc.min_liquidity = min_liquidity
+    rc.max_spread_pct = max_spread_pct
+    rc.confidence_floor = confidence_floor
+    rc.implied_prob_min = implied_prob_min
+    rc.implied_prob_max = implied_prob_max
+    rc.category_exposure_cap_pct = category_exposure_cap_pct
+    rc.max_correlated_positions = max_correlated_positions
+    rc.time_to_resolution_min_hours = time_to_resolution_min_hours
+    rc.time_to_resolution_max_days = time_to_resolution_max_days
+    rc.second_opinion_divergence_max = second_opinion_divergence_max
+    rc.max_stake_per_market = max_stake_per_market
+    rc.blocked_categories = blocked_categories or []
+    s.risk = rc
+    s.kelly = MagicMock()
+    s.kelly.fraction = kelly_fraction
+    s.execution = MagicMock()
+    s.execution.paper_initial_balance = paper_initial_balance
+    return s
+
+
+def _make_signal(
+    *,
+    edge=10.0,
+    claude_prob=0.60,
+    market_prob=0.50,
+    confidence=Confidence.HIGH,
+    divergence=0.05,
+):
+    return Signal(
+        market_id="test-market-1",
+        claude_prob=claude_prob,
+        claude_confidence=confidence,
+        market_prob=market_prob,
+        edge=edge,
+        divergence=divergence,
+        recommended_side=OrderSide.BUY,
+    )
+
+
+def _make_market(
+    *,
+    yes_price=0.50,
+    liquidity=10000.0,
+    spread=1.0,
+    category="politics",
+    days_until_resolution=7,
+):
+    end = datetime.now(timezone.utc) + timedelta(days=days_until_resolution)
+    return Market(
+        id="test-market-1",
+        exchange="polymarket",
+        ticker="test-market-1",
+        question="Will test event happen?",
+        outcome_yes_price=yes_price,
+        outcome_no_price=1.0 - yes_price,
+        liquidity=liquidity,
+        volume=liquidity,
+        spread=spread,
+        category=category,
+        end_date=end,
+        active=True,
+    )
+
+
+def _mock_portfolio(*, drawdown=3.0, daily_pnl=0.0, positions=None, category_exposure=None, correlated=0):
+    tracker = MagicMock()
+    tracker.get_drawdown = AsyncMock(return_value=drawdown)
+    tracker.get_daily_pnl = AsyncMock(return_value=daily_pnl)
+    tracker.get_positions = AsyncMock(return_value=positions or [])
+    tracker.get_category_exposure = AsyncMock(return_value=category_exposure or {})
+    tracker.get_correlated_markets = AsyncMock(return_value=correlated)
+    return tracker
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_evaluate_passing_case(mock_kill):
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings()
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    signal = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    market = _make_market()
+
+    decision = await manager.evaluate(signal, market, available_cash=500.0)
+
+    assert decision.approved is True
+    assert decision.position_size > 0
+    assert len(decision.checks) == 15
+    assert all(c.passed for c in decision.checks)
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_evaluate_fails_on_low_edge(mock_kill):
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(min_edge_pct=5.0)
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    signal = _make_signal(edge=2.0, claude_prob=0.52, market_prob=0.50)
+    market = _make_market()
+
+    decision = await manager.evaluate(signal, market, available_cash=500.0)
+
+    assert decision.approved is False
+    assert decision.position_size == 0.0
+    failed_names = [c.name for c in decision.checks if not c.passed]
+    assert "min_edge" in failed_names
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_bankroll_uses_cash_not_equity(mock_kill):
+    """Kelly bankroll should be based on cash, not equity (cash + position notional)."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(max_stake_per_market=25.0)
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    signal = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    market = _make_market()
+
+    small_cash = await manager.evaluate(signal, market, available_cash=100.0)
+    big_cash = await manager.evaluate(signal, market, available_cash=500.0)
+
+    assert small_cash.approved is True
+    assert big_cash.approved is True
+    assert small_cash.position_size < big_cash.position_size
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_edge_cap_limits_outsized_bets(mock_kill):
+    """A 45% claimed edge should be capped at 20% inside Kelly, preventing
+    outsized bets relative to a more moderate 15% edge signal."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings()
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+    market = _make_market()
+
+    huge_edge = _make_signal(edge=45.0, claude_prob=0.95, market_prob=0.50)
+    moderate_edge = _make_signal(edge=15.0, claude_prob=0.65, market_prob=0.50)
+
+    huge_decision = await manager.evaluate(huge_edge, market, available_cash=500.0)
+    moderate_decision = await manager.evaluate(moderate_edge, market, available_cash=500.0)
+
+    assert huge_decision.approved is True
+    assert moderate_decision.approved is True
+    # With the 20% edge cap, the "huge" edge signal should NOT produce
+    # a dramatically larger position than the moderate one
+    ratio = huge_decision.position_size / moderate_decision.position_size if moderate_decision.position_size > 0 else float("inf")
+    assert ratio < 3.0, f"Edge cap not working: huge/moderate ratio = {ratio:.1f}"
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_max_stake_check_runs_after_sizing(mock_kill):
+    """The 15th check (max_stake) should validate the actual computed size,
+    not the signal's recommended_size."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings()
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    signal = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    market = _make_market()
+
+    decision = await manager.evaluate(signal, market, available_cash=500.0)
+
+    stake_check = next(c for c in decision.checks if c.name == "max_stake")
+    assert stake_check.passed is True
+    # The stake check's value should be the actual position_size, not 0 or the signal's recommended_size
+    assert stake_check.value == decision.position_size


### PR DESCRIPTION
## Summary

Three targeted fixes identified during today's fork review and code audit:

- **Portfolio composite PK migration (v10→v11)** — Same bug that was fixed for `cost_basis` in PR #2: `portfolio` table had `market_id TEXT PRIMARY KEY` which causes paper/live positions for the same market to silently overwrite each other. Now `PRIMARY KEY (market_id, is_paper)`. All `ON CONFLICT(market_id)` clauses updated across 6 files. Resolution tracker `DELETE` now scoped by `is_paper`.
- **Unify duplicate fee tables** — `signals.py` hardcoded `cryptodotcom: 0.01` while `defaults.yaml` had `0.075`. `detect_edge()` now accepts `exchange_fees` param; all callers pass `settings.arbitrage.exchange_fees`. Hardcoded fallback also corrected to 0.075.
- **Risk manager integration tests** — 5 tests covering the full `evaluate()` flow: passing case, min_edge rejection, bankroll=cash (not equity), edge cap at ±20%, and max_stake check running after sizing.
- **Bonus**: fix pre-existing `test_multi_exchange_resolution` failure from PR #1's tightened thresholds (Kalshi fixture 0.02 → 0.01).

## Test plan
- [x] 307 tests pass (full suite minus test_onchain_redeemer which needs web3 installed)
- [x] New test_risk_manager.py: 5 integration tests all pass
- [ ] Verify v10→v11 migration on existing DB with portfolio rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)