### PR TITLE
fix(risk): round interpolated min_edge_pct to avoid false rejections

### DIFF
--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -129,7 +129,7 @@ async def check_min_edge(edge: float, min_edge_pct: float = 5.0) -> CheckResult:
     return CheckResult(
         name="min_edge",
         passed=not too_small,
-        reason=f"Edge {edge:.2f}% below minimum {min_edge_pct:.1f}%" if too_small else "",
+        reason=f"Edge {edge:.2f}% below minimum {min_edge_pct:.2f}%" if too_small else "",
         value=edge,
     )
 

--- a/auramaur/risk/regime.py
+++ b/auramaur/risk/regime.py
@@ -80,5 +80,7 @@ def resolve_regime(
         name="transition",
         kelly_fraction=GROWTH_KELLY_FRACTION + (base_kelly - GROWTH_KELLY_FRACTION) * t,
         max_stake=growth_stake + (base_max_stake - growth_stake) * t,
-        min_edge_pct=GROWTH_MIN_EDGE_PCT + (base_min_edge_pct - GROWTH_MIN_EDGE_PCT) * t,
+        min_edge_pct=round(
+            GROWTH_MIN_EDGE_PCT + (base_min_edge_pct - GROWTH_MIN_EDGE_PCT) * t, 2
+        ),
     )

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -91,3 +91,16 @@ def test_growth_applied_uniformly_below_threshold():
         assert r.name == "growth"
         assert r.kelly_fraction == GROWTH_KELLY_FRACTION
         assert r.max_stake == pytest.approx(equity * GROWTH_MAX_STAKE_PCT / 100.0)
+
+
+def test_transition_min_edge_has_no_floating_point_residue():
+    # At equity just above the growth cap, interpolation should yield
+    # exactly GROWTH_MIN_EDGE_PCT (2.50), not 2.5003 or similar.
+    for equity in (
+        GROWTH_EQUITY_MAX + 0.01,
+        GROWTH_EQUITY_MAX + 1.0,
+        GROWTH_EQUITY_MAX + 10.0,
+    ):
+        r = resolve_regime(equity, BASE_KELLY, BASE_MAX_STAKE, BASE_MIN_EDGE)
+        assert r.name == "transition"
+        assert r.min_edge_pct == round(r.min_edge_pct, 2)

--- a/tests/test_risk_checks.py
+++ b/tests/test_risk_checks.py
@@ -133,6 +133,18 @@ async def test_min_edge_insufficient():
     assert result.passed is False
 
 
+@pytest.mark.asyncio
+async def test_min_edge_at_exact_threshold_passes():
+    result = await check_min_edge(2.5, 2.5)
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+async def test_min_edge_reason_shows_two_decimal_places():
+    result = await check_min_edge(2.0, 3.50)
+    assert "3.50%" in result.reason
+
+
 # 8. Min liquidity
 @pytest.mark.asyncio
 async def test_min_liquidity_sufficient():


### PR DESCRIPTION
Cherry-picks smartwatermelon@5e95603 (their PR #22) — the one portable fix worth pulling from the fork survey.

## Problem
In the regime-transition zone, `min_edge_pct` is linearly interpolated between the growth and base thresholds. The raw float result (e.g. `5.0000000001%`) could land just above a trade's edge and **falsely reject** trades that actually meet the edge floor.

## Change
- `risk/regime.py` — round the interpolated `min_edge_pct` to 2 decimal places, eliminating float drift at regime boundaries
- `risk/checks.py` — rejection message now reports the threshold at `.2f` precision (was `.1f`) so the logged reason matches the rounded value
- Regression tests added in `test_regime.py` and `test_risk_checks.py`

## Testing
All 48 tests in `test_regime.py` + `test_risk_checks.py` pass.

Original author (Andrew Rich / smartwatermelon) preserved via cherry-pick `-x`.

Assisted-by: Claude (Anthropic)