### PR TITLE
fix(feedback): measure category accuracy per market (not per snapshot)

### DIFF
--- a/auramaur/broker/feedback.py
+++ b/auramaur/broker/feedback.py
@@ -22,8 +22,19 @@ _BRIER_BAD = 0.30        # Above this = poorly calibrated
 _MULT_GOOD = 1.2         # Kelly multiplier for accurate categories
 _MULT_NEUTRAL = 1.0      # Kelly multiplier for average categories
 _MULT_BAD = 0.3           # Kelly multiplier for poor categories
-_AVOID_MIN_TRADES = 10    # Minimum trades before we consider avoiding
+_AVOID_MIN_TRADES = 10    # Minimum distinct markets before we consider avoiding
 _AVOID_ACCURACY = 0.40    # Directional accuracy below this = avoid
+
+# The calibration table holds one row per *analysis snapshot*, so a single
+# market re-analyzed across many cycles can appear dozens of times. Counting
+# each snapshot as an independent prediction inflates trade counts ~3-4x and
+# lets heavily-re-analyzed markets dominate a category's accuracy/Brier. Every
+# aggregate below restricts to the most recent resolved snapshot per market so
+# the unit of measure is the market (= the resolution event), not the snapshot.
+_LATEST_PER_MARKET = (
+    "id IN (SELECT MAX(id) FROM calibration "
+    "WHERE actual_outcome IS NOT NULL AND category != '' GROUP BY market_id)"
+)
 
 
 class PerformanceFeedback:
@@ -55,7 +66,7 @@ class PerformanceFeedback:
         multipliers on its next evaluation.
         """
         rows = await self._db.fetchall(
-            """
+            f"""
             SELECT category,
                    COUNT(*) AS n,
                    AVG((predicted_prob - actual_outcome) * (predicted_prob - actual_outcome)) AS brier,
@@ -69,6 +80,7 @@ class PerformanceFeedback:
             FROM calibration
             WHERE actual_outcome IS NOT NULL
               AND category != ''
+              AND {_LATEST_PER_MARKET}
             GROUP BY category
             """
         )
@@ -132,7 +144,7 @@ class PerformanceFeedback:
             ``{category: {brier, accuracy, trade_count, kelly_mult}}``
         """
         rows = await self._db.fetchall(
-            """
+            f"""
             SELECT category,
                    COUNT(*) AS n,
                    AVG((predicted_prob - actual_outcome) * (predicted_prob - actual_outcome)) AS brier,
@@ -146,6 +158,7 @@ class PerformanceFeedback:
             FROM calibration
             WHERE actual_outcome IS NOT NULL
               AND category != ''
+              AND {_LATEST_PER_MARKET}
             GROUP BY category
             """
         )
@@ -223,7 +236,8 @@ class PerformanceFeedback:
         """Categories to skip based on poor historical performance.
 
         A category is added to the avoid list when:
-        - At least ``_AVOID_MIN_TRADES`` resolved predictions exist
+        - At least ``_AVOID_MIN_TRADES`` distinct resolved markets exist
+          (snapshots of the same market are collapsed — see _LATEST_PER_MARKET)
         - Directional accuracy is below ``_AVOID_ACCURACY`` (40%)
         """
         rows = await self._db.fetchall(
@@ -240,9 +254,10 @@ class PerformanceFeedback:
             FROM calibration
             WHERE actual_outcome IS NOT NULL
               AND category != ''
+              AND {dedup}
             GROUP BY category
             HAVING n >= ?
-            """,
+            """.format(dedup=_LATEST_PER_MARKET),
             (_AVOID_MIN_TRADES,),
         )
 
@@ -290,8 +305,9 @@ class PerformanceFeedback:
             FROM calibration
             WHERE actual_outcome IS NOT NULL
               AND category != ''
+              AND {dedup}
             GROUP BY category
-            """,
+            """.format(dedup=_LATEST_PER_MARKET),
         )
 
         whitelisted: set[str] = set()

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,7 +49,11 @@ class RiskConfig(BaseModel):
     time_to_resolution_max_days: int = 0  # 0 = no ceiling
     max_correlated_positions: int = 5
     second_opinion_divergence_max: float = 0.15
-    blocked_categories: list[str] = []
+    # sports: the LLM has no structural edge on game outcomes / spreads / O-U
+    # (driven by live injury & lineup info we don't ingest), and resolved-market
+    # performance bears that out. Blocked outright rather than left to the
+    # feedback loop, which needs a sample sports keeps losing money to build.
+    blocked_categories: list[str] = ["sports"]
 
 
 class KellyConfig(BaseModel):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,103 @@
+"""Tests for the per-category performance feedback loop.
+
+Focus: the calibration table holds one row per analysis *snapshot*, so a single
+market re-analyzed across many cycles appears many times. Accuracy, Brier, the
+avoid-list, and the hybrid whitelist must all measure per distinct *market* (the
+resolution event), not per snapshot — otherwise one heavily-re-analyzed market
+dominates a whole category.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from auramaur.broker.feedback import PerformanceFeedback
+from auramaur.db.database import Database
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def db(event_loop):
+    async def _setup():
+        database = Database(db_path=":memory:")
+        await database.connect()
+        return database
+
+    database = event_loop.run_until_complete(_setup())
+    yield database
+    event_loop.run_until_complete(database.close())
+
+
+@pytest.fixture
+def feedback(db):
+    return PerformanceFeedback(db)
+
+
+def run(coro, loop):
+    return loop.run_until_complete(coro)
+
+
+async def _add(db, market_id, pred, outcome, category):
+    await db.execute(
+        "INSERT INTO calibration (market_id, predicted_prob, actual_outcome, category) "
+        "VALUES (?, ?, ?, ?)",
+        (market_id, pred, outcome, category),
+    )
+    await db.commit()
+
+
+class TestSnapshotDedup:
+    def test_snapshots_of_one_market_count_once(self, db, feedback, event_loop):
+        """One market snapshotted 12 times is a single resolution event."""
+        for _ in range(12):
+            run(_add(db, "m1", 0.2, 1, "sports"), event_loop)  # predicted NO, resolved YES
+
+        stats = run(feedback.get_category_accuracy(), event_loop)
+        assert stats["sports"]["trade_count"] == 1
+
+        # One distinct market is below _AVOID_MIN_TRADES (10), so a single bad
+        # market must NOT drag the whole category onto the avoid list.
+        avoid = run(feedback.get_avoid_categories(), event_loop)
+        assert "sports" not in avoid
+
+    def test_avoid_fires_on_distinct_bad_markets(self, db, feedback, event_loop):
+        """12 distinct markets all called wrong → category is avoided."""
+        for i in range(12):
+            run(_add(db, f"bad{i}", 0.2, 1, "badcat"), event_loop)
+
+        stats = run(feedback.get_category_accuracy(), event_loop)
+        assert stats["badcat"]["trade_count"] == 12
+        assert stats["badcat"]["accuracy"] == 0.0
+
+        avoid = run(feedback.get_avoid_categories(), event_loop)
+        assert "badcat" in avoid
+
+    def test_dedup_keeps_latest_prediction(self, db, feedback, event_loop):
+        """When a market is re-forecast, the most recent snapshot wins."""
+        run(_add(db, "m1", 0.1, 1, "tech"), event_loop)  # early: wrong
+        run(_add(db, "m1", 0.9, 1, "tech"), event_loop)  # latest: right
+
+        stats = run(feedback.get_category_accuracy(), event_loop)
+        assert stats["tech"]["trade_count"] == 1
+        assert stats["tech"]["accuracy"] == 1.0  # latest snapshot is correct
+
+    def test_whitelist_counts_distinct_markets(self, db, feedback, event_loop):
+        """A single good market snapshotted many times must not satisfy the
+        whitelist's min-trades gate (which means min distinct markets)."""
+        for _ in range(12):
+            run(_add(db, "g1", 0.9, 1, "crypto"), event_loop)  # one market, called right
+
+        whitelisted, probationary = run(
+            feedback.get_whitelist_categories(min_accuracy=0.5, min_trades=10),
+            event_loop,
+        )
+        assert "crypto" not in whitelisted  # only 1 distinct market
+        assert "crypto" in probationary


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.