### PR TITLE
feat(dust-exit): add --category filter with live re-classification

### DIFF
--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -384,12 +384,22 @@ def redeem_check():
               help="Skip the confirmation prompt (for non-interactive use).")
 @click.option("--limit", default=0, type=int,
               help="Cap how many positions to close this run (0 = no cap).")
-def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: bool, limit: int):
+@click.option("--category", default=None,
+              help="Only positions in this category (comma-separated for several, "
+                   "e.g. 'sports,esports'). The category is recomputed live with the "
+                   "current classifier, not the stored label, so stale mislabels "
+                   "don't leak in.")
+def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: bool,
+              limit: int, category: str | None):
     """List small 'dust' positions and optionally close them.
 
     Dust is open positions whose current value is below ``--max-notional``.
     Closing them frees capital and trims position count — which un-starves
     Kelly sizing and lowers the regime-driven minimum-edge bar.
+
+    Use ``--category`` to target a specific category (e.g. a blocked one like
+    sports) — the category is recomputed live so freshly-fixed classifications
+    apply even before the next scan rewrites the stored label.
 
     Safety: this attaches to the primary database with an exclusive lock, so
     it refuses to run while the live bot is running (which would risk
@@ -398,6 +408,12 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
 
     async def _run():
         from auramaur.exchange.models import ExitReason, OrderSide, Position, TokenType
+        from auramaur.strategy.classifier import classify_market
+
+        cat_filter = (
+            {c.strip().lower() for c in category.split(",") if c.strip()}
+            if category else None
+        )
 
         settings = Settings()
         bot = AuramaurBot(settings=settings, db_path="auramaur.db", exchange_filter=exchange)
@@ -440,20 +456,32 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
                 if exchanges.get(name) is None:
                     continue
                 rows = await db.fetchall(
-                    "SELECT market_id, side, size, avg_price, current_price, category, "
-                    "token, token_id FROM portfolio "
-                    "WHERE exchange = ? AND is_paper = ? AND size > 0",
+                    "SELECT p.market_id, p.side, p.size, p.avg_price, p.current_price, "
+                    "p.category, p.token, p.token_id, "
+                    "COALESCE(m.question, '') AS question, "
+                    "COALESCE(m.description, '') AS description "
+                    "FROM portfolio p LEFT JOIN markets m ON p.market_id = m.id "
+                    "WHERE p.exchange = ? AND p.is_paper = ? AND p.size > 0",
                     (name, is_paper),
                 )
                 found: list[Position] = []
                 for row in rows:
                     tok = TokenType(row["token"]) if row["token"] in ("YES", "NO") else TokenType.YES
+                    # Recompute the category with the current classifier so the
+                    # filter targets the true category, not a stale stored label
+                    # (the whole reason mislabeled markets got stuck blocked).
+                    live_cat = (
+                        classify_market(row["question"], row["description"])
+                        if row["question"] else (row["category"] or "")
+                    )
+                    if cat_filter and live_cat.lower() not in cat_filter:
+                        continue
                     p = Position(
                         market_id=row["market_id"], exchange=name,
                         side=OrderSide(row["side"]) if row["side"] else OrderSide.BUY,
                         size=float(row["size"]), avg_price=float(row["avg_price"] or 0.0),
                         current_price=float(row["current_price"] or 0.0),
-                        category=row["category"] or "",
+                        category=live_cat,
                         token=tok, token_id=row["token_id"] or "",
                     )
                     # Pre-filter on the stored value so we only hit the API for
@@ -474,17 +502,18 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
                 if found:
                     dust[name] = found
 
+            scope = f" in [{category}]" if category else ""
             total = sum(len(v) for v in dust.values())
             if total == 0:
-                console.print(f"[green]No dust positions under ${max_notional:.2f}.[/]")
+                console.print(f"[green]No dust positions under ${max_notional:.2f}{scope}.[/]")
                 return
 
             # ---- Show what we found ----
             sellables: list[tuple[str, object, object, Position]] = []
             grand_value = grand_pnl = 0.0
             for name, positions in dust.items():
-                table = Table(title=f"{name} — dust under ${max_notional:.2f}")
-                for col in ("Market", "Tok", "Size", "Price", "Value", "PnL", ""):
+                table = Table(title=f"{name} — dust under ${max_notional:.2f}{scope}")
+                for col in ("Market", "Cat", "Tok", "Size", "Price", "Value", "PnL", ""):
                     table.add_column(col)
                 for p in positions:
                     value = p.size * (p.current_price or 0.0)
@@ -494,7 +523,7 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
                     if ok:
                         sellables.append((name, discoveries[name], exchanges[name], p))
                     table.add_row(
-                        p.market_id[:34], p.token.value, f"{p.size:.1f}",
+                        p.market_id[:30], (p.category or "?")[:12], p.token.value, f"{p.size:.1f}",
                         f"${p.current_price:.3f}", f"${value:.2f}",
                         f"${p.unrealized_pnl:+.2f}",
                         "[green]sell[/]" if ok else "[dim]redeem-only[/]",

--- a/tests/test_cli_dust_exit.py
+++ b/tests/test_cli_dust_exit.py
@@ -7,7 +7,64 @@ import pytest
 from click.testing import CliRunner
 
 from auramaur.cli import main
+from auramaur.db.database import Database
 from auramaur.exchange.models import ExitReason
+
+
+class _FakeMarket:
+    outcome_yes_price = 0.2
+    outcome_no_price = 0.8
+
+
+class _FakeDiscovery:
+    async def get_market(self, market_id):
+        return _FakeMarket()
+
+
+# Two dust positions, BOTH stored with the stale label "sports". One is a real
+# sports market; the other is a politics market that only *looks* sports in the
+# stored column. --category sports must use the live classifier and keep only
+# the real one.
+_SEED = [
+    ("spt1", "Arkansas Razorbacks vs. Arizona Wildcats", ""),
+    ("pol1", "Will the Republicans win the Mississippi Senate race in 2026?",
+     "This market will resolve according to the winner of the election."),
+]
+
+
+class _FakeBot:
+    """Stands in for AuramaurBot: seeds an in-memory DB inside the command's
+    own event loop (so the aiosqlite connection is bound to the right loop)."""
+
+    def __init__(self, *args, **kwargs):
+        self._components = {}
+
+    async def _init_components(self):
+        db = Database(":memory:")
+        await db.connect()
+        for mid, q, desc in _SEED:
+            await db.execute(
+                "INSERT INTO markets (id, question, description, category, last_updated, "
+                "outcome_yes_price, outcome_no_price) VALUES (?,?,?,?,datetime('now'),?,?)",
+                (mid, q, desc, "sports", 0.2, 0.8),
+            )
+            for is_paper in (0, 1):  # seed both modes so the test is mode-agnostic
+                await db.execute(
+                    "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+                    "current_price, category, token, token_id, is_paper) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (mid, "polymarket", "BUY", 10.0, 0.3, 0.2, "sports", "YES", f"tok-{mid}", is_paper),
+                )
+        await db.commit()
+        self._components = {
+            "db": db,
+            "discoveries": {"polymarket": _FakeDiscovery()},
+            "exchanges": {"polymarket": object()},
+            "alerts": object(),
+        }
+
+    async def shutdown(self):
+        await self._components["db"].close()
 
 
 @pytest.fixture(autouse=True)
@@ -28,8 +85,25 @@ def test_dust_exit_registered_with_help():
     result = CliRunner().invoke(main, ["dust-exit", "--help"])
     assert result.exit_code == 0
     assert "dust" in result.output.lower()
-    assert "--execute" in result.output
-    assert "--max-notional" in result.output
+    assert "--category" in result.output
+
+
+def test_category_filter_uses_live_classification():
+    """--category sports keeps the real sports market and drops the politics
+    market that merely has a stale 'sports' label stored."""
+    with patch("auramaur.cli.AuramaurBot", _FakeBot):
+        result = CliRunner().invoke(main, ["dust-exit", "--category", "sports", "--max-notional", "100"])
+    assert result.exit_code == 0, result.output
+    assert "spt1" in result.output       # real sports market kept
+    assert "pol1" not in result.output   # stale-labelled politics market excluded
+
+
+def test_no_category_filter_includes_both():
+    with patch("auramaur.cli.AuramaurBot", _FakeBot):
+        result = CliRunner().invoke(main, ["dust-exit", "--max-notional", "100"])
+    assert result.exit_code == 0, result.output
+    assert "spt1" in result.output
+    assert "pol1" in result.output
 
 
 def test_dust_exit_refuses_when_bot_is_running():


### PR DESCRIPTION
## Why

`dust-exit` was all-or-nothing under a notional threshold. To clear just the genuine-sports leftovers (without also closing unrelated small positions), it needs a category filter.

## What

`auramaur dust-exit --category sports` — close only positions in the given category (comma-separated for several, e.g. `--category sports,esports`).

Key detail: the category is **recomputed live** with the current classifier, not read from the stored portfolio label. So:
- freshly-fixed classifications (PRs #15/#16) apply immediately, even before the next scan rewrites the stored `category` column;
- a politics market still carrying a **stale "sports" label** is correctly *excluded* from `--category sports`.

Also adds a `Cat` column to the preview table.

```
auramaur dust-exit --category sports                 # preview genuine-sports dust
auramaur dust-exit --category sports --max-notional 6 --execute
```

## Testing

New CliRunner tests (in-memory seeded DB): `--category sports` keeps a real sports market (`Arkansas … vs. …`) and drops a politics market (`… win the Mississippi Senate … winner of the election`) that is stored with a stale "sports" label; no-filter includes both. Full suite green: **350 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)