### PR TITLE
fix: dedupe calibration per market; classify individual sports

### DIFF
--- a/auramaur/nlp/calibration.py
+++ b/auramaur/nlp/calibration.py
@@ -22,6 +22,17 @@ _ONLINE_LR = 0.01
 # Window size for moving Brier score
 _BRIER_WINDOW = 20
 
+# One row per market — its most recent resolved forecast. The calibration table
+# holds a row per analysis snapshot, so a market re-analysed N times across
+# cycles appears N times. Without this, the batch Platt fit, Brier score, and
+# calibration curve over-weight heavily-re-analysed markets (the same bias
+# fixed in broker/feedback.py), and refit_all periodically clobbers the clean
+# per-resolution online-SGD params with that biased fit.
+_LATEST_RESOLVED_PER_MARKET = (
+    "id IN (SELECT MAX(id) FROM calibration "
+    "WHERE actual_outcome IS NOT NULL GROUP BY market_id)"
+)
+
 
 def _clamp(p: float) -> float:
     """Clamp probability to avoid log(0)."""
@@ -85,9 +96,10 @@ class CalibrationTracker:
         self._initialized = True
         try:
             rows = await self._db.fetchall(
-                """SELECT predicted_prob, actual_outcome
+                f"""SELECT predicted_prob, actual_outcome
                    FROM calibration
                    WHERE actual_outcome IS NOT NULL
+                     AND {_LATEST_RESOLVED_PER_MARKET}
                    ORDER BY resolved_at DESC
                    LIMIT ?""",
                 (_BRIER_WINDOW,),
@@ -303,12 +315,13 @@ class CalibrationTracker:
             The Brier score, or None if no resolved predictions exist.
         """
         row = await self._db.fetchone(
-            """
+            f"""
             SELECT AVG((predicted_prob - actual_outcome) * (predicted_prob - actual_outcome))
                    AS brier_score,
                    COUNT(*) AS n
             FROM calibration
             WHERE actual_outcome IS NOT NULL
+              AND {_LATEST_RESOLVED_PER_MARKET}
             """,
         )
         if row is None or row["n"] == 0:
@@ -334,10 +347,11 @@ class CalibrationTracker:
             A list of (mean_predicted, mean_actual) tuples, one per non-empty bin.
         """
         rows = await self._db.fetchall(
-            """
+            f"""
             SELECT predicted_prob, actual_outcome
             FROM calibration
             WHERE actual_outcome IS NOT NULL
+              AND {_LATEST_RESOLVED_PER_MARKET}
             ORDER BY predicted_prob
             """,
         )
@@ -384,19 +398,21 @@ class CalibrationTracker:
         cat = category or ""
         if cat:
             rows = await self._db.fetchall(
-                """
+                f"""
                 SELECT predicted_prob, actual_outcome
                 FROM calibration
                 WHERE actual_outcome IS NOT NULL AND category = ?
+                  AND {_LATEST_RESOLVED_PER_MARKET}
                 """,
                 (cat,),
             )
         else:
             rows = await self._db.fetchall(
-                """
+                f"""
                 SELECT predicted_prob, actual_outcome
                 FROM calibration
                 WHERE actual_outcome IS NOT NULL
+                  AND {_LATEST_RESOLVED_PER_MARKET}
                 """,
             )
 
@@ -534,10 +550,11 @@ class CalibrationTracker:
 
         # Per-category fits
         rows = await self._db.fetchall(
-            """
+            f"""
             SELECT category, COUNT(*) AS n
             FROM calibration
             WHERE actual_outcome IS NOT NULL AND category != ''
+              AND {_LATEST_RESOLVED_PER_MARKET}
             GROUP BY category
             HAVING n >= ?
             """,

--- a/auramaur/strategy/classifier.py
+++ b/auramaur/strategy/classifier.py
@@ -13,6 +13,12 @@ SPORTS_KEYWORDS: list[str] = [
     "world cup", "vs.", "o/u", "spread", "game", "match", "fc",
     "league", "premier", "serie a", "bundesliga", "ligue 1",
     "eredivisie", "champions league", "europa league", "nhl", "mls",
+    # Individual-sport / event markets — these often lack a team-vs marker and
+    # used to rely on the removed "winner" keyword, so without explicit markers
+    # they fall to "other" (which is NOT blocked) and the bot would trade them.
+    "golf", "pga", "masters", "ryder cup", "tennis", "wimbledon", "grand slam",
+    "us open", "australian open", "french open", "atp", "wta",
+    "grand prix", "nascar", "tour de france", "ufc", "boxing",
 ]
 # Note: "winner" is intentionally NOT a sports marker — it appears in the
 # resolution boilerplate of nearly every election/award market ("resolve
@@ -20,7 +26,7 @@ SPORTS_KEYWORDS: list[str] = [
 # matching below runs against the question, not the description.
 # Sports markets phrased "<team> win on <date>", e.g. "Will Poland win on
 # 2026-03-26?". A plain keyword can't express the year, so it's a pattern.
-SPORTS_PATTERNS: list[str] = [r"win on 20\d\d"]
+SPORTS_PATTERNS: list[str] = [r"win on 20\d\d", r"\bolympics?\b", r"\bf1\b"]
 
 # Checked BEFORE sports so award-show markets ("Eurovision ... Jury Winner",
 # "win the Oscar") aren't stolen by the sports "winner"/"win" markers.

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -363,3 +363,32 @@ class TestOnlineCalibration:
         # Record resolution for a market with no prediction
         run(tracker.record_resolution("nonexistent", True), event_loop)
         # Should not crash — just no online update triggered
+
+
+class TestSnapshotDedup:
+    """Calibration must measure per resolved market, not per analysis snapshot —
+    otherwise a heavily re-analysed market dominates the Platt fit / Brier."""
+
+    async def _seed(self, db, market_id, prob, outcome, n=1, category=""):
+        for _ in range(n):
+            await db.execute(
+                "INSERT INTO calibration (market_id, predicted_prob, actual_outcome, category) "
+                "VALUES (?, ?, ?, ?)",
+                (market_id, prob, outcome, category),
+            )
+        await db.commit()
+
+    def test_brier_dedups_snapshots(self, db, tracker, event_loop):
+        # m1 snapshotted 5x (0.2, YES); m2 once (0.8, YES).
+        run(self._seed(db, "m1", 0.2, 1, n=5), event_loop)
+        run(self._seed(db, "m2", 0.8, 1, n=1), event_loop)
+        score = run(tracker.get_brier_score(), event_loop)
+        # Deduped: mean((0.2-1)^2, (0.8-1)^2) = (0.64 + 0.04) / 2 = 0.34.
+        # Per-snapshot it would be (5*0.64 + 0.04) / 6 = 0.54.
+        assert abs(score - 0.34) < 1e-9
+
+    def test_fit_counts_distinct_markets(self, db, event_loop):
+        tracker = CalibrationTracker(db=db, min_samples=10)
+        # 15 snapshots but ONE market — below the 10 distinct-market threshold.
+        run(self._seed(db, "m1", 0.6, 1, n=15), event_loop)
+        assert run(tracker.fit_params(category=None), event_loop) is None

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -83,3 +83,17 @@ def test_primary_winner_boilerplate_not_sports():
 
 def test_ncaa_is_sports():
     assert classify_market("NCAA Tournament: No. 15 seed to pull off an upset?") == "sports"
+
+
+def test_individual_sports_stay_blocked():
+    """Individual-event sports (no team-vs marker) must classify as sports so
+    the block keeps them out, not leak into the tradeable 'other' bucket."""
+    for q in [
+        "Will Scottie Scheffler win the 2026 Masters?",
+        "Who will win Wimbledon 2026 men's singles?",
+        "Will Max Verstappen win the 2026 Monaco Grand Prix?",
+        "Will Novak Djokovic win the US Open?",
+        "Will Team USA win gold in the 2026 Olympics?",
+        "Will the winner of the 2026 Tour de France be from Slovenia?",
+    ]:
+        assert classify_market(q) == "sports", q


### PR DESCRIPTION
Two issues surfaced while reviewing the sports work — bundled per request.

## 1. Platt-scaling calibration had the same per-snapshot bug as PR #14 — but higher-stakes

The `calibration` table holds one row per analysis *snapshot* (`record_prediction` inserts each cycle; `record_resolution` stamps the outcome onto *all* of a market's rows). The **batch** Platt refit read every resolved row:

```sql
SELECT predicted_prob, actual_outcome FROM calibration WHERE actual_outcome IS NOT NULL
```

So a market re-analysed N times contributed N points — the Atlanta Hawks market alone was 16 of 24 "sports" points. And `refit_all` (every 10 resolutions) **clobbers** the clean per-resolution online-SGD params with this biased fit, so it skews `adjust()` — i.e. **every probability the bot emits**, which feeds every edge calc and trade.

Fix: apply the same `_LATEST_RESOLVED_PER_MARKET` dedup (one row per market = the resolution event) to the batch reads — `fit_params`, `get_brier_score`, `get_calibration_curve`, `refit_all`, and the Brier-window init. The per-resolution online-SGD path was already one-per-resolution and is untouched.

## 2. Individual-sport markets were leaking to "other" (tradeable)

Removing `"winner"` in #16 left individual-event sports with no marker:

```
other -> Will Scottie Scheffler win the 2026 Masters?
other -> Who will win Wimbledon 2026 men's singles?
other -> Will Max Verstappen win the 2026 Monaco Grand Prix?
other -> Will Team USA win gold in the 2026 Olympics?
```

`"other"` isn't blocked, so the bot would trade these — reintroducing the exact sports exposure we just blocked. Added markers: golf/pga/masters/tennis/wimbledon/grand-slam/us-open/grand-prix/nascar/tour-de-france/ufc/boxing + `\bolympics?\b`, `\bf1\b` patterns. Now all classify `sports`; politics/entertainment/crypto/economics spot-checks unaffected.

## Testing

- Calibration: Brier dedups snapshots (5 snapshots of one market + 1 other → uses 2 points, not 6); `fit_params` counts distinct markets vs `min_samples`.
- Classifier: individual-event sports stay `sports`.
- Full suite green: **353 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)