### PR TITLE
fix: IBKR delayed market data + stale risk-params test

### DIFF
--- a/auramaur/exchange/ibkr.py
+++ b/auramaur/exchange/ibkr.py
@@ -92,6 +92,12 @@ class IBKRClient:
             self._ib = None
             self._connect_cooldown_until = _time.monotonic() + 300  # back off 5 min
             raise
+        # Use the configured market-data type (default delayed) so option
+        # scanning works without a paid OPRA/equity subscription.
+        try:
+            self._ib.reqMarketDataType(cfg.market_data_type)
+        except Exception as e:  # noqa: BLE001 — non-fatal; live data may still flow
+            log.warning("ibkr.market_data_type_failed", error=str(e)[:100])
         self._connected = True
         self._connect_warned = False
         log.info(

--- a/config/settings.py
+++ b/config/settings.py
@@ -181,6 +181,10 @@ class IBKRConfig(BaseModel):
     environment: str = "paper"  # "paper" | "live"
     watchlist: list[str] = ["SPY", "QQQ", "AAPL", "MSFT", "TSLA", "NVDA", "AMZN", "META", "GOOGL"]
     max_contracts_per_symbol: int = 10
+    # IB market-data type: 1=live (needs paid subscription), 2=frozen,
+    # 3=delayed, 4=delayed-frozen. Default 3 so the scanner works WITHOUT an
+    # OPRA/equity subscription (delayed quotes + greeks). Set 1 once subscribed.
+    market_data_type: int = 3
 
 
 class CryptoComConfig(BaseModel):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,9 +49,11 @@ def test_kill_switch_overrides():
 def test_default_risk_params():
     s = Settings()
     assert s.risk.max_drawdown_pct == 15.0
-    assert s.risk.max_stake_per_market == 25.0
+    # max_stake_per_market <= 1.0 is interpreted as a fraction of equity
+    # (0.02 = 2%); see RiskManager. defaults.yaml tunes it to 2%.
+    assert s.risk.max_stake_per_market == 0.02
     assert s.risk.daily_loss_limit == 200.0
-    assert s.risk.max_open_positions == 500
+    assert s.risk.max_open_positions == 50
     assert s.kelly.fraction == 0.30
 
 


### PR DESCRIPTION
Two small fixes:
- **IBKR delayed data** — request market-data type 3 (delayed) by default so the option scanner works without a paid OPRA subscription (`market_data_type` configurable; set 1 once subscribed). Gets discovery past the equity-pricing block; full option discovery still needs options permissions on the account.
- **Stale test** — `test_default_risk_params` now matches the tuned `defaults.yaml` (2%-of-equity stake, 50 positions). Full suite green (365 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)