### PR TITLE
feat: Kraken directional speculation (budget-capped)

### DIFF
--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -114,7 +114,15 @@ class KrakenPillar:
             holding = pair in self._dir_long
 
             if not holding and mom >= kcfg.directional_momentum_pct:
-                vol = round(kcfg.max_order_usd / price, 6)
+                # Budget ceiling: each open position ~= max_order_usd. Don't open
+                # a new one if it would push total speculation over budget.
+                allocated = len(self._dir_long) * kcfg.max_order_usd
+                if allocated + kcfg.max_order_usd > kcfg.directional_budget_usd:
+                    log.info("kraken.directional.budget_full", pair=pair,
+                             allocated=allocated, budget=kcfg.directional_budget_usd)
+                    continue
+                # 2% buffer so float rounding never trips the per-order cap.
+                vol = round(kcfg.max_order_usd * 0.98 / price, 6)
                 res = await self._k.place_spot_order(
                     pair, OrderSide.BUY, volume=vol, ordertype="market", purpose="directional")
                 if res.order_id not in ("ERROR", "BLOCKED"):
@@ -124,7 +132,7 @@ class KrakenPillar:
 
             elif holding and mom <= -kcfg.directional_momentum_pct:
                 entry = self._dir_long.get(pair) or price
-                vol = round(kcfg.max_order_usd / entry, 6)
+                vol = round(kcfg.max_order_usd * 0.98 / entry, 6)
                 res = await self._k.place_spot_order(
                     pair, OrderSide.SELL, volume=vol, ordertype="market", purpose="directional")
                 if res.order_id not in ("ERROR", "BLOCKED"):

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -114,11 +114,16 @@ kraken:
   target_usdc: 50.0
   fiat_assets: ["ZCAD", "ZUSD", "ZEUR"]
   refill_cash_floor: 20.0
-  # Directional spot — gated; NO validated edge (Path B). Flip on deliberately.
-  directional_enabled: false
-  directional_pairs: []          # e.g. ["XBTUSD", "ETHUSD"]
+  # Directional spot — speculation. NO validated edge (Path B momentum); bounded
+  # by directional_budget_usd + max_order_usd. USDC-funded pairs (you hold USDC).
+  directional_enabled: true
+  # Major crypto, USDC-funded (you hold USDC). True fiat/FX spot isn't fundable
+  # with current holdings — spot can't short a currency. Budget caps concurrent
+  # positions regardless of list length.
+  directional_pairs: ["XBTUSDC", "ETHUSDC", "SOLUSDC", "ADAUSDC", "AVAXUSDC", "DOTUSDC", "LINKUSDC", "LTCUSDC"]
   directional_momentum_pct: 3.0
   directional_lookback: 12
+  directional_budget_usd: 50.0   # max total open speculative exposure
 
 transfers:
   # Cross-venue fund movement (Kraken -> Polymarket, Polygon USDC only).

--- a/config/settings.py
+++ b/config/settings.py
@@ -216,9 +216,12 @@ class KrakenConfig(BaseModel):
 
     # --- Directional spot (gated; no validated edge — flip on deliberately) ---
     directional_enabled: bool = False
-    directional_pairs: list[str] = []     # e.g. ["XBTUSD", "ETHUSD"]
+    directional_pairs: list[str] = []     # e.g. ["XBTUSDC", "ETHUSDC"] (USDC-funded)
     directional_momentum_pct: float = 3.0  # |momentum| over the lookback to act
     directional_lookback: int = 12        # OHLC candles (hourly) for the momentum read
+    # Total $ the speculation engine may hold in open directional positions at
+    # once — a hard ceiling so it can't consume the treasury reserve / CAD.
+    directional_budget_usd: float = 50.0
 
 
 class TransfersConfig(BaseModel):


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.