### PR TITLE
feat: surface Kraken + IBKR in live output

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2587,6 +2587,34 @@ class AuramaurBot:
             except Exception as e:
                 log.debug("startup.balance_error", error=str(e))
 
+        # Kraken treasury/speculation pool (separate from prediction-market bankroll)
+        if self.settings.kraken.enabled and self._exchange_filter in (None, "kraken"):
+            try:
+                from auramaur.exchange.kraken import KrakenSpotClient
+                kclient = KrakenSpotClient(self.settings)
+                kb = await kclient.get_balance()
+                usdc = kb.get("USDC", 0.0)
+                cad = kb.get("ZCAD", 0.0)
+                cadpx = await kclient.get_price("USDCCAD") or 1.38
+                cad_usd = cad / cadpx if cadpx else 0.0
+                crypto = [a for a, v in kb.items() if v > 0 and a not in ("USDC", "ZCAD")]
+                spec = (f"[red]SPEC ON[/] ({len(self.settings.kraken.directional_pairs)} pairs, "
+                        f"${self.settings.kraken.directional_budget_usd:.0f} budget)"
+                        if self.settings.kraken.directional_enabled else "spec off")
+                console.print(
+                    f"  Kraken: [green]${usdc:.2f}[/] USDC + [green]${cad_usd:.0f}[/] CAD"
+                    f"{' + ' + ','.join(crypto) if crypto else ''} | {spec}"
+                )
+                await kclient.close()
+            except Exception as e:
+                log.debug("startup.kraken_balance_error", error=str(e))
+
+        # IBKR status (options client + gated equity speculation)
+        if self.settings.ibkr.enabled and self._exchange_filter in (None, "ibkr"):
+            eq = ("[red]equity SPEC ON[/]" if self.settings.ibkr.directional_equity_enabled
+                  else "equity spec off")
+            console.print(f"  IBKR: enabled ({self.settings.ibkr.environment}) | {eq}")
+
         show_startup(
             self._components["source_names"],
             startup_balance,

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -57,6 +57,21 @@ class KrakenPillar:
         log.info("kraken.treasury.balances", **{a: round(v, 4) for a, v in bal.items() if v > 0})
         usdc = bal.get("USDC", 0.0)
 
+        # Surface Kraken in the live console (not just the JSON log). Show actual
+        # crypto holdings (= open speculative exposure), not the in-memory count.
+        if self._console:
+            cad = bal.get("ZCAD", 0.0)
+            crypto = [a for a, v in bal.items()
+                      if v > 0 and a != "USDC" and not a.startswith("Z")]
+            if kcfg.directional_enabled:
+                spec = f"[red]spec: {','.join(crypto)}[/]" if crypto else "spec: flat"
+            else:
+                spec = "spec off"
+            self._console.print(
+                f"[magenta]kraken[/] [green]${usdc:.2f}[/] USDC"
+                f"{f' + {cad:.0f} CAD' if cad else ''} | {spec}"
+            )
+
         # Idle fiat -> USDC toward the target reserve (one conversion per cycle).
         if kcfg.auto_convert and usdc < kcfg.target_usdc:
             for fiat in kcfg.fiat_assets:


### PR DESCRIPTION
Kraken was running but invisible in the console (only in the JSON log). Now:
- Startup shows the Kraken pool (USDC/CAD + crypto, spec state) and IBKR status.
- Kraken pillar prints a per-cycle console line with actual holdings.

Surfaced a real issue while testing (separate fix needed): the directional pillar tracks open positions **in-memory**, so a restart forgets them — the console line now derives spec exposure from actual balances to stay honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)