### PR TITLE
feat: Gemini adapter + off-hours/budget LLM routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ KRAKEN_API_SECRET=
 # Interactive Brokers needs no API key — it connects to a running TWS / IB
 # Gateway over a local socket (configure host/port via config: ibkr.*).
 
+# Google Gemini — LLM fallback for off-hours / when Claude's daily budget is low
+# (config: gemini.enabled + gemini.model). Get a key at aistudio.google.com.
+GEMINI_API_KEY=
+
 # Data Sources
 NEWSAPI_KEY=
 REDDIT_CLIENT_ID=

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -151,6 +151,54 @@ class ClaudeAnalyzer:
         raise last_error  # type: ignore[misc]
 
     # ------------------------------------------------------------------
+    # LLM routing — Gemini for off-hours / Claude-budget relief
+    # ------------------------------------------------------------------
+
+    def _should_use_gemini(self) -> bool:
+        from datetime import datetime, timezone
+        g = self._settings.gemini
+        if not (g.enabled and self._settings.gemini_api_key):
+            return False
+        budget = self._settings.nlp.daily_claude_call_budget
+        if budget > 0 and self._daily_calls >= int(budget * g.claude_budget_threshold):
+            return True  # Claude budget near-exhausted
+        return datetime.now(timezone.utc).hour in g.off_hours_utc  # off-hours
+
+    async def _call_gemini(self, prompt: str) -> str:
+        """Call Gemini via REST (JSON mode). No SDK dependency."""
+        import aiohttp
+        g = self._settings.gemini
+        url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
+               f"{g.model}:generateContent?key={self._settings.gemini_api_key}")
+        body = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {
+                "maxOutputTokens": self._settings.nlp.max_tokens,
+                "temperature": 0.3,
+                "responseMimeType": "application/json",
+            },
+        }
+        async with aiohttp.ClientSession() as s:
+            async with s.post(url, json=body,
+                              timeout=aiohttp.ClientTimeout(total=120)) as r:
+                data = await r.json()
+        return data["candidates"][0]["content"]["parts"][0]["text"].strip()
+
+    async def _call_llm(self, prompt: str) -> str:
+        """Route to Gemini when off-hours / Claude budget low; else Claude.
+
+        Falls back to Claude if Gemini errors.
+        """
+        if self._should_use_gemini():
+            try:
+                out = await self._call_gemini(prompt)
+                log.info("llm.routed", provider="gemini", model=self._settings.gemini.model)
+                return out
+            except Exception as e:  # noqa: BLE001 — fall back to Claude
+                log.warning("gemini.failed_fallback_claude", error=str(e)[:120])
+        return await self._call_claude_cli(prompt)
+
+    # ------------------------------------------------------------------
     # Core estimation methods
     # ------------------------------------------------------------------
 
@@ -168,7 +216,7 @@ class ClaudeAnalyzer:
             evidence=evidence_text,
         )
 
-        raw = await self._call_claude_cli(prompt)
+        raw = await self._call_llm(prompt)
         parsed = _parse_claude_json(raw)
         return AnalysisResult(**parsed)
 
@@ -188,7 +236,7 @@ class ClaudeAnalyzer:
             evidence=evidence_text,
         )
 
-        raw = await self._call_claude_cli(prompt)
+        raw = await self._call_llm(prompt)
         parsed = _parse_claude_json(raw)
         return AnalysisResult(**parsed)
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -170,6 +170,14 @@ llm_ensemble:
   min_samples_for_weights: 10
   default_weight: 0.5
 
+gemini:
+  # Route analysis to Gemini during off-hours OR when Claude's daily budget is
+  # near-exhausted; falls back to Claude on Gemini error. Needs GEMINI_API_KEY.
+  enabled: true
+  model: "gemini-2.5-flash"
+  off_hours_utc: [4, 5, 6, 7, 8, 9]   # deep-night ET — conserve Claude
+  claude_budget_threshold: 0.8        # switch at 80% of daily_claude_call_budget
+
 market_maker:
   enabled: true
   min_spread_bps: 40        # minimum 0.4% spread (BBO-join kicks in when 1-tick improvement would go below this)

--- a/config/settings.py
+++ b/config/settings.py
@@ -273,6 +273,19 @@ class LLMEnsembleConfig(BaseModel):
     default_weight: float = 0.5  # Starting weight per model (50/50)
 
 
+class GeminiConfig(BaseModel):
+    """Gemini as an off-hours / budget-relief LLM. Routes analysis to Gemini when
+    it's off-hours OR Claude's daily budget is near-exhausted; falls back to
+    Claude if Gemini errors."""
+
+    enabled: bool = False
+    model: str = "gemini-2.5-flash"
+    # UTC hours to prefer Gemini (default = deep-night quiet hours).
+    off_hours_utc: list[int] = Field(default_factory=lambda: [4, 5, 6, 7, 8, 9])
+    # Switch to Gemini once Claude calls reach this fraction of the daily budget.
+    claude_budget_threshold: float = 0.8
+
+
 class ArbitrageConfig(BaseModel):
     enabled: bool = True
     min_profit_after_fees_pct: float = 1.5
@@ -342,6 +355,9 @@ class Settings(BaseSettings):
     kraken_api_key: str = ""
     kraken_api_secret: str = ""
 
+    # Google Gemini — LLM fallback for off-hours / when Claude budget is low.
+    gemini_api_key: str = ""
+
     # Safety
     auramaur_live: bool = False
     # Separate opt-in for on-chain redemption — real Polygon transactions.
@@ -373,6 +389,7 @@ class Settings(BaseSettings):
     transfers: TransfersConfig = Field(default_factory=lambda: TransfersConfig(**_DEFAULTS.get("transfers", {})))
     ensemble: EnsembleConfig = Field(default_factory=lambda: EnsembleConfig(**_DEFAULTS.get("ensemble", {})))
     llm_ensemble: LLMEnsembleConfig = Field(default_factory=lambda: LLMEnsembleConfig(**_DEFAULTS.get("llm_ensemble", {})))
+    gemini: GeminiConfig = Field(default_factory=lambda: GeminiConfig(**_DEFAULTS.get("gemini", {})))
     market_maker: MarketMakerConfig = Field(default_factory=lambda: MarketMakerConfig(**_DEFAULTS.get("market_maker", {})))
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))


### PR DESCRIPTION
Adds a dependency-free Gemini REST adapter and routes analysis to Gemini **during off-hours OR when Claude's daily budget is near-exhausted** (`claude_budget_threshold`, default 0.8), with automatic fallback to Claude on Gemini error. Default model `gemini-2.5-flash`. Verified with a live call (returns parseable JSON). Gated by `gemini.enabled` + `GEMINI_API_KEY`. 365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)