### PR TITLE
feat: route strategic analyzer through Gemini (shared llm_router)

### DIFF
--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -150,53 +150,10 @@ class ClaudeAnalyzer:
 
         raise last_error  # type: ignore[misc]
 
-    # ------------------------------------------------------------------
-    # LLM routing — Gemini for off-hours / Claude-budget relief
-    # ------------------------------------------------------------------
-
-    def _should_use_gemini(self) -> bool:
-        from datetime import datetime, timezone
-        g = self._settings.gemini
-        if not (g.enabled and self._settings.gemini_api_key):
-            return False
-        budget = self._settings.nlp.daily_claude_call_budget
-        if budget > 0 and self._daily_calls >= int(budget * g.claude_budget_threshold):
-            return True  # Claude budget near-exhausted
-        return datetime.now(timezone.utc).hour in g.off_hours_utc  # off-hours
-
-    async def _call_gemini(self, prompt: str) -> str:
-        """Call Gemini via REST (JSON mode). No SDK dependency."""
-        import aiohttp
-        g = self._settings.gemini
-        url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
-               f"{g.model}:generateContent?key={self._settings.gemini_api_key}")
-        body = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {
-                "maxOutputTokens": self._settings.nlp.max_tokens,
-                "temperature": 0.3,
-                "responseMimeType": "application/json",
-            },
-        }
-        async with aiohttp.ClientSession() as s:
-            async with s.post(url, json=body,
-                              timeout=aiohttp.ClientTimeout(total=120)) as r:
-                data = await r.json()
-        return data["candidates"][0]["content"]["parts"][0]["text"].strip()
-
     async def _call_llm(self, prompt: str) -> str:
-        """Route to Gemini when off-hours / Claude budget low; else Claude.
-
-        Falls back to Claude if Gemini errors.
-        """
-        if self._should_use_gemini():
-            try:
-                out = await self._call_gemini(prompt)
-                log.info("llm.routed", provider="gemini", model=self._settings.gemini.model)
-                return out
-            except Exception as e:  # noqa: BLE001 — fall back to Claude
-                log.warning("gemini.failed_fallback_claude", error=str(e)[:120])
-        return await self._call_claude_cli(prompt)
+        """Route to Gemini (off-hours / Claude budget low) else Claude."""
+        from auramaur.nlp.llm_router import route
+        return await route(self._settings, self._daily_calls, prompt, self._call_claude_cli)
 
     # ------------------------------------------------------------------
     # Core estimation methods

--- a/auramaur/nlp/llm_router.py
+++ b/auramaur/nlp/llm_router.py
@@ -1,0 +1,62 @@
+"""Shared LLM routing — send analysis to Gemini during off-hours or when Claude's
+daily budget is near-exhausted, with automatic fallback to Claude.
+
+Used by both ClaudeAnalyzer and StrategicAnalyzer so routing behaves identically
+regardless of analysis mode.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def should_use_gemini(settings, daily_calls: int) -> bool:
+    """True when we should prefer Gemini: off-hours OR Claude budget near-exhausted."""
+    from datetime import datetime, timezone
+
+    g = settings.gemini
+    if not (g.enabled and settings.gemini_api_key):
+        return False
+    budget = settings.nlp.daily_claude_call_budget
+    if budget > 0 and daily_calls >= int(budget * g.claude_budget_threshold):
+        return True  # Claude budget near-exhausted
+    return datetime.now(timezone.utc).hour in g.off_hours_utc  # off-hours
+
+
+async def call_gemini(settings, prompt: str) -> str:
+    """Call Gemini via REST (JSON mode). No SDK dependency."""
+    import aiohttp
+
+    g = settings.gemini
+    url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
+           f"{g.model}:generateContent?key={settings.gemini_api_key}")
+    body = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "maxOutputTokens": settings.nlp.max_tokens,
+            "temperature": 0.3,
+            "responseMimeType": "application/json",
+        },
+    }
+    async with aiohttp.ClientSession() as s:
+        async with s.post(url, json=body, timeout=aiohttp.ClientTimeout(total=120)) as r:
+            data = await r.json()
+    return data["candidates"][0]["content"]["parts"][0]["text"].strip()
+
+
+async def route(settings, daily_calls: int, prompt: str,
+                claude_fn: Callable[[str], Awaitable[str]]) -> str:
+    """Route to Gemini when appropriate; else call `claude_fn`. Falls back to
+    Claude if Gemini errors."""
+    if should_use_gemini(settings, daily_calls):
+        try:
+            out = await call_gemini(settings, prompt)
+            log.info("llm.routed", provider="gemini", model=settings.gemini.model)
+            return out
+        except Exception as e:  # noqa: BLE001 — fall back to Claude
+            log.warning("gemini.failed_fallback_claude", error=str(e)[:120])
+    return await claude_fn(prompt)

--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -432,7 +432,7 @@ class StrategicAnalyzer:
             if self._ensemble and self._settings.llm_ensemble.enabled:
                 result = await self._analyze_batch_ensemble(prompt, markets)
             else:
-                raw = await self._call_claude_cli(prompt)
+                raw = await self._call_llm(prompt)
                 result = self._parse_strategic_response(raw)
         except Exception as e:
             log.error("strategic.batch_failed", error=str(e))
@@ -480,7 +480,7 @@ class StrategicAnalyzer:
         )
 
         try:
-            raw = await self._call_claude_cli(prompt)
+            raw = await self._call_llm(prompt)
             adversarial = self._parse_strategic_response(raw)
 
             # Merge adversarial into primary results
@@ -755,6 +755,11 @@ class StrategicAnalyzer:
                     await asyncio.sleep(backoff[attempt - 1])
 
         raise last_error  # type: ignore[misc]
+
+    async def _call_llm(self, prompt: str) -> str:
+        """Single-model call, routed to Gemini off-hours / when Claude budget low."""
+        from auramaur.nlp.llm_router import route
+        return await route(self._settings, self._daily_calls, prompt, self._call_claude_cli)
 
     async def _call_ensemble(self, prompt: str) -> list[tuple[str, str]]:
         """Call all ensemble models in parallel, returning [(model, raw_response), ...].


### PR DESCRIPTION
Completes the Gemini routing so it works in the **default strategic mode** (the prior PR only covered the ClaudeAnalyzer pipeline path). Shared `llm_router` module; both analyzers route single-model calls through it. Multi-Claude ensemble path untouched. Verified routing fires live to Gemini; 365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)