### PR TITLE
feat: measure + persist realized $ P&L (edge in dollars)

### DIFF
--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -198,6 +198,15 @@ CREATE TABLE IF NOT EXISTS cost_basis (
     PRIMARY KEY (market_id, is_paper)
 );
 
+-- Realized dollar P&L per market, written when a market resolves. Lets us
+-- measure edge in $ (not just calibration) and allocate by actual profit.
+CREATE TABLE IF NOT EXISTS resolution_pnl (
+    market_id TEXT PRIMARY KEY,
+    category TEXT DEFAULT '',
+    pnl REAL NOT NULL,
+    resolved_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_price_history_market ON price_history(market_id);
 CREATE INDEX IF NOT EXISTS idx_price_history_time ON price_history(recorded_at);
 

--- a/auramaur/nlp/calibration.py
+++ b/auramaur/nlp/calibration.py
@@ -145,6 +145,35 @@ class CalibrationTracker:
             category=category,
         )
 
+    async def _persist_realized_pnl(self, market_id: str, outcome_int: int,
+                                    category: str) -> None:
+        """Store realized $ P&L for a resolved market from its live fills.
+
+        P&L = sell_proceeds - buy_cost - fees + resolution_payout (held token
+        pays $1 if it won). No-op if the market had no live fills.
+        """
+        fills = await self._db.fetchall(
+            "SELECT side, token, size, price, fee FROM fills WHERE market_id=? AND is_paper=0",
+            (market_id,))
+        if not fills:
+            return
+        buy_cost = sum(f["size"] * f["price"] for f in fills if f["side"] == "BUY")
+        sell_proc = sum(f["size"] * f["price"] for f in fills if f["side"] == "SELL")
+        fees = sum(f["fee"] or 0 for f in fills)
+        net: dict[str, float] = {}
+        for f in fills:
+            net[f["token"]] = net.get(f["token"], 0.0) + (
+                f["size"] if f["side"] == "BUY" else -f["size"])
+        payout = sum(
+            sz for tok, sz in net.items() if sz > 0.01
+            and ((tok == "YES" and outcome_int == 1) or (tok == "NO" and outcome_int == 0)))
+        pnl = sell_proc - buy_cost - fees + payout
+        await self._db.execute(
+            "INSERT OR REPLACE INTO resolution_pnl (market_id, category, pnl, resolved_at) "
+            "VALUES (?, ?, ?, datetime('now'))", (market_id, category, pnl))
+        await self._db.commit()
+        log.info("pnl.realized", market_id=market_id, pnl=round(pnl, 2), category=category)
+
     async def record_resolution(self, market_id: str, actual_outcome: bool) -> None:
         """Record the actual resolution for a market.
 
@@ -181,6 +210,11 @@ class CalibrationTracker:
         )
         await self._db.commit()
         log.info("calibration.resolved", market_id=market_id, outcome=actual_outcome)
+
+        # Persist realized $ P&L from this market's fills + the outcome, so edge
+        # is measurable in dollars (trades.pnl is never populated otherwise).
+        await self._persist_realized_pnl(
+            market_id, outcome_int, pred_row["category"] if pred_row else "")
 
         # Trigger online calibration update if we have the prediction data
         if pred_row is not None:

--- a/scripts/research/dollar_edge.py
+++ b/scripts/research/dollar_edge.py
@@ -1,0 +1,91 @@
+"""Reconstruct realized $ P&L from fills + resolved outcomes — measure edge in $.
+
+trades.pnl is never persisted, so this reconstructs realized dollar P&L from the
+`fills` (actual executions w/ price+fee) and `calibration` (resolved outcomes):
+
+  realized_pnl(market) = sell_proceeds - buy_cost - fees + resolution_payout
+
+A position counts as realized when it's fully closed via sells OR the market
+resolved (held token pays $1 if it won, else $0). Still-open positions are
+skipped. Aggregated by category to show where the $ edge actually is.
+
+    python scripts/research/dollar_edge.py
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+
+DB = "auramaur.db"
+
+
+def main() -> None:
+    c = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
+    c.row_factory = sqlite3.Row
+
+    # outcome per market (1 = YES resolved true)
+    outcome = {r["market_id"]: r["actual_outcome"] for r in c.execute(
+        "SELECT market_id, actual_outcome FROM calibration WHERE actual_outcome IS NOT NULL")}
+    category = {r["id"]: (r["category"] or "none") for r in c.execute(
+        "SELECT id, category FROM markets")}
+
+    # gather fills per market
+    fills = defaultdict(list)
+    for r in c.execute("SELECT market_id, side, token, size, price, fee FROM fills WHERE is_paper=0"):
+        fills[r["market_id"]].append(r)
+    c.close()
+
+    by_cat = defaultdict(lambda: {"pnl": 0.0, "n": 0, "wins": 0})
+    total = {"pnl": 0.0, "n": 0, "wins": 0, "open": 0}
+
+    for mid, fs in fills.items():
+        buy_cost = sum(f["size"] * f["price"] for f in fs if f["side"] == "BUY")
+        sell_proc = sum(f["size"] * f["price"] for f in fs if f["side"] == "SELL")
+        fees = sum(f["fee"] or 0 for f in fs)
+        # net token held = buys - sells per token
+        net = defaultdict(float)
+        for f in fs:
+            net[f["token"]] += f["size"] if f["side"] == "BUY" else -f["size"]
+        residual = sum(v for v in net.values() if v > 0.01)
+
+        resolved = mid in outcome
+        if residual > 0.01 and not resolved:
+            total["open"] += 1
+            continue  # still open — unrealized, skip
+
+        payout = 0.0
+        if resolved:
+            o = outcome[mid]
+            for tok, sz in net.items():
+                if sz <= 0.01:
+                    continue
+                won = (tok == "YES" and o == 1) or (tok == "NO" and o == 0)
+                payout += sz * (1.0 if won else 0.0)
+
+        pnl = sell_proc - buy_cost - fees + payout
+        cat = category.get(mid, "none")
+        by_cat[cat]["pnl"] += pnl
+        by_cat[cat]["n"] += 1
+        by_cat[cat]["wins"] += 1 if pnl > 0 else 0
+        total["pnl"] += pnl
+        total["n"] += 1
+        total["wins"] += 1 if pnl > 0 else 0
+
+    print("=" * 64)
+    print("REALIZED $ EDGE (reconstructed from fills + resolved outcomes)")
+    print("=" * 64)
+    print(f"  {'category':14} {'$P&L':>9} {'closed':>7} {'win%':>6} {'$/trade':>8}")
+    print("  " + "-" * 48)
+    for cat, d in sorted(by_cat.items(), key=lambda kv: -kv[1]["pnl"]):
+        wr = f"{d['wins']/d['n']*100:.0f}%" if d["n"] else "—"
+        print(f"  {cat:14} {d['pnl']:>9.2f} {d['n']:>7} {wr:>6} {d['pnl']/d['n']:>8.2f}")
+    print("  " + "-" * 48)
+    wr = f"{total['wins']/total['n']*100:.0f}%" if total["n"] else "—"
+    print(f"  {'TOTAL':14} {total['pnl']:>9.2f} {total['n']:>7} {wr:>6}")
+    print(f"\n  ({total['open']} positions still open — unrealized, excluded)")
+    print("  NOTE: small resolved sample; treat as directional, not precise.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.