### PR TITLE
feat: divergence-aware trade filter (gated, A/B-ready)

### DIFF
--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -134,6 +134,39 @@ async def check_min_edge(edge: float, min_edge_pct: float = 5.0) -> CheckResult:
     )
 
 
+async def check_divergence_band(
+    claude_prob: float,
+    market_prob: float,
+    confidence,
+    enabled: bool = False,
+    low: float = 0.05,
+    high: float = 0.20,
+    require_confidence: str = "HIGH",
+) -> CheckResult:
+    """Be skeptical in the adverse mid-divergence band (LLM-signal only).
+
+    Edge-gap analysis: trades where the LLM *moderately* disagrees with the
+    market (|claude-market| in ~[5%, 20%]) are adversely selected — the market
+    is usually right. When enabled, such trades are rejected unless confidence
+    meets `require_confidence`. Naturally inert for momentum/fast signals where
+    claude_prob ~= market_prob (divergence ~0 -> not in the band).
+    """
+    div = abs((claude_prob or 0.0) - (market_prob or 0.0))
+    if not enabled or not (low <= div < high):
+        return CheckResult(name="divergence_band", passed=True, reason="", value=div)
+    rank = {"LOW": 0, "MEDIUM": 1, "HIGH": 2}
+    conf = (confidence.value if hasattr(confidence, "value") else str(confidence)).upper()
+    ok = rank.get(conf, 0) >= rank.get(require_confidence.upper(), 2)
+    return CheckResult(
+        name="divergence_band",
+        passed=ok,
+        reason=("" if ok else
+                f"divergence {div:.0%} in adverse band [{low:.0%},{high:.0%}) "
+                f"with confidence {conf} < {require_confidence}"),
+        value=div,
+    )
+
+
 # ---------------------------------------------------------------------------
 # 8. Min liquidity
 # ---------------------------------------------------------------------------

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -16,6 +16,7 @@ from auramaur.risk.checks import (
     check_confidence_floor,
     check_correlation,
     check_daily_loss,
+    check_divergence_band,
     check_drawdown_heat,
     check_implied_prob_bounds,
     check_kill_switch,
@@ -117,7 +118,7 @@ class RiskManager:
         cat_exp = category_exposure.get(market.category, 0.0)
 
         # ----------------------------------------------------------------
-        # Run 14 pre-sizing checks (max_stake validated after sizing)
+        # Run pre-sizing checks (max_stake validated after sizing)
         # ----------------------------------------------------------------
         pre_checks: list[CheckResult] = [
             await check_kill_switch(),
@@ -126,6 +127,10 @@ class RiskManager:
             await check_daily_loss(abs(daily_pnl), rc.daily_loss_limit),
             await check_max_positions(len(positions), rc.max_open_positions),
             await check_min_edge(signal.edge, regime.min_edge_pct),
+            await check_divergence_band(
+                signal.claude_prob, signal.market_prob, signal.claude_confidence,
+                rc.divergence_filter_enabled, rc.divergence_adverse_low,
+                rc.divergence_adverse_high, rc.divergence_require_confidence),
             await check_min_liquidity(max(market.liquidity, market.volume), rc.min_liquidity),
             await check_max_spread(market.spread, rc.max_spread_pct),
             await check_confidence_floor(signal.claude_confidence, rc.confidence_floor),

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -27,6 +27,12 @@ risk:
   time_to_resolution_max_days: 0   # 0 = no ceiling; set to 90 to reject 3+ month markets
   max_correlated_positions: 10
   second_opinion_divergence_max: 0.25
+  # Divergence-aware filter (LLM signal). OFF — A/B once resolution_pnl confirms
+  # the mid-divergence adverse-selection pattern at scale.
+  divergence_filter_enabled: false
+  divergence_adverse_low: 0.05
+  divergence_adverse_high: 0.20
+  divergence_require_confidence: "HIGH"
 
 kelly:
   fraction: 0.30

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,6 +49,14 @@ class RiskConfig(BaseModel):
     time_to_resolution_max_days: int = 0  # 0 = no ceiling
     max_correlated_positions: int = 5
     second_opinion_divergence_max: float = 0.15
+    # Divergence-aware filter (LLM signal). Edge-gap analysis found trades where
+    # the LLM moderately disagrees with the market (|claude-market| in the band)
+    # are adversely selected. When enabled, those need >= require_confidence.
+    # OFF by default — A/B when resolution_pnl confirms the pattern at scale.
+    divergence_filter_enabled: bool = False
+    divergence_adverse_low: float = 0.05
+    divergence_adverse_high: float = 0.20
+    divergence_require_confidence: str = "HIGH"
     # sports: the LLM has no structural edge on game outcomes / spreads / O-U
     # (driven by live injury & lineup info we don't ingest), and resolved-market
     # performance bears that out. Blocked outright rather than left to the

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -51,6 +51,10 @@ def _make_settings(
     rc.second_opinion_divergence_max = second_opinion_divergence_max
     rc.max_stake_per_market = max_stake_per_market
     rc.blocked_categories = blocked_categories or []
+    rc.divergence_filter_enabled = False
+    rc.divergence_adverse_low = 0.05
+    rc.divergence_adverse_high = 0.20
+    rc.divergence_require_confidence = "HIGH"
     s.risk = rc
     s.kelly = MagicMock()
     s.kelly.fraction = kelly_fraction
@@ -133,7 +137,7 @@ async def test_evaluate_passing_case(mock_kill):
 
     assert decision.approved is True
     assert decision.position_size > 0
-    assert len(decision.checks) == 15
+    assert len(decision.checks) == 16
     assert all(c.passed for c in decision.checks)
 
 


### PR DESCRIPTION
Acts on the adverse-selection finding (edge_gap.py): the LLM's *moderate* disagreements with the market (5-20% divergence) lose money. New `check_divergence_band` requires HIGH confidence for trades in that band. **OFF by default** — A/B once `resolution_pnl` confirms at scale. Scoped to the LLM signal (inert when claude~=market), leaving room for a separate fast-momentum pillar. 365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)