### PR TITLE
feat: momentum-coupling pillar (fast path, gated/detection-only)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1076,6 +1076,24 @@ class AuramaurBot:
         finally:
             await client.close()
 
+    async def _task_momentum_coupling(self) -> None:
+        """Fast path: spot->prediction momentum-coupling pillar (gated, detect-only).
+
+        Separate fast cadence + momentum signal, distinct from the LLM loop.
+        """
+        from auramaur.strategy.momentum_coupling import MomentumCouplingPillar
+        from auramaur.monitoring.display import console
+        pillar = MomentumCouplingPillar(self.settings, console=console)
+        interval = self.settings.momentum_coupling.poll_seconds
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:  # noqa: BLE001
+                log.error("coupling.error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_recalibrate(self) -> None:
         """Periodically refit Platt scaling calibration parameters."""
         calibration: CalibrationTracker = self._components["calibration"]
@@ -2682,6 +2700,10 @@ class AuramaurBot:
         # IBKR directional equity speculation (gated by directional_equity_enabled)
         if self.settings.ibkr.enabled and self.settings.ibkr.directional_equity_enabled:
             tasks.append(asyncio.create_task(self._task_ibkr_directional(), name="ibkr_directional"))
+
+        # Fast path: momentum-coupling pillar (gated by momentum_coupling.enabled)
+        if self.settings.momentum_coupling.enabled:
+            tasks.append(asyncio.create_task(self._task_momentum_coupling(), name="momentum_coupling"))
 
         # Market maker (if enabled)
         if self._components.get("market_maker"):

--- a/auramaur/strategy/momentum_coupling.py
+++ b/auramaur/strategy/momentum_coupling.py
@@ -1,0 +1,93 @@
+"""Momentum-coupling pillar — the FAST PATH (spot -> prediction lead-lag).
+
+Distinct from the slow LLM loop: a fast-cadence momentum signal. When crypto
+spot moves over a short window, the coupled near-the-money prediction market
+("Will BTC be above $X") is expected to reprice minutes later (coupling_discovery
+found spot leads). We'd take the matching side early.
+
+OFF by default and DETECTION-ONLY (logs the signal, places nothing) until
+coupling_tradeability.py confirms after-cost edge. Its signals carry
+strategy_source="momentum_coupling" so they never run through the LLM-divergence
+filter (that's scoped to LLM disagreement, which this isn't).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections import defaultdict
+
+import structlog
+
+log = structlog.get_logger()
+
+_PAIR = {"BTC": "XBTUSD", "ETH": "ETHUSD"}
+_NAME = {"BTC": "Bitcoin", "ETH": "Ethereum"}
+
+
+class MomentumCouplingPillar:
+    def __init__(self, settings, console=None):
+        self._s = settings
+        self._console = console
+        self._spot_hist: dict[str, list[tuple[float, float]]] = defaultdict(list)
+        self._kraken = None
+        self._gamma = None
+
+    async def run_once(self) -> None:
+        cfg = self._s.momentum_coupling
+        if not cfg.enabled:
+            return
+        if self._kraken is None:
+            from auramaur.exchange.kraken import KrakenSpotClient
+            from auramaur.exchange.gamma import GammaClient
+            self._kraken = KrakenSpotClient(self._s)
+            self._gamma = GammaClient()
+
+        now = time.time()
+        for asset in cfg.assets:
+            pair = _PAIR.get(asset)
+            if not pair:
+                continue
+            try:
+                price = await self._kraken.get_price(pair)
+            except Exception as e:  # noqa: BLE001
+                log.debug("coupling.spot_error", asset=asset, error=str(e)[:80])
+                continue
+            if not price:
+                continue
+            hist = self._spot_hist[asset]
+            hist.append((now, price))
+            hist[:] = [(t, p) for t, p in hist if now - t <= cfg.lookback_seconds]
+            if len(hist) < 2:
+                continue
+            move = (price - hist[0][1]) / hist[0][1] * 100
+            if abs(move) >= cfg.move_threshold_pct:
+                await self._emit(asset, price, move)
+
+    async def _emit(self, asset: str, spot: float, move: float) -> None:
+        cfg = self._s.momentum_coupling
+        try:
+            markets = await self._gamma.search_markets(f"{_NAME[asset]} above", limit=20)
+        except Exception:
+            return
+        for m in markets:
+            mt = re.search(r"\$?([\d,]{4,})", m.question)
+            if not mt:
+                continue
+            strike = float(mt.group(1).replace(",", ""))
+            if strike <= 0 or abs(strike - spot) / spot > cfg.near_money_pct:
+                continue  # only near-the-money markets are spot-sensitive
+            direction = "BUY_YES" if move > 0 else "BUY_NO"
+            log.info("coupling.signal", asset=asset, move_pct=round(move, 2), spot=round(spot),
+                     market=m.question[:50], strike=strike,
+                     market_prob=round(m.outcome_yes_price, 3), direction=direction,
+                     size_usd=cfg.max_position_usd, execute=cfg.execute)
+            if self._console:
+                self._console.print(
+                    f"[cyan]coupling[/] {asset} spot {move:+.1f}% -> {direction} "
+                    f"'{m.question[:38]}' (prob {m.outcome_yes_price:.2f})"
+                    + ("" if cfg.execute else " [dim](detect-only)[/]"))
+            # Execution intentionally not wired until the coupling validates.
+            # When cfg.execute: route a strategy_source='momentum_coupling' order
+            # through the Polymarket engine here, bounded by max_position_usd.
+            break  # one signal per asset per cycle

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -176,6 +176,19 @@ llm_ensemble:
   min_samples_for_weights: 10
   default_weight: 0.5
 
+momentum_coupling:
+  # FAST PATH — spot->prediction lead-lag pillar. OFF + detection-only until
+  # coupling_tradeability.py confirms after-cost edge. Separate fast cadence +
+  # momentum signal, NOT the LLM loop.
+  enabled: false
+  poll_seconds: 60
+  lookback_seconds: 600
+  move_threshold_pct: 0.5
+  assets: ["BTC", "ETH"]
+  near_money_pct: 0.05
+  max_position_usd: 25.0
+  execute: false
+
 gemini:
   # Route analysis to Gemini during off-hours OR when Claude's daily budget is
   # near-exhausted; falls back to Claude on Gemini error. Needs GEMINI_API_KEY.

--- a/config/settings.py
+++ b/config/settings.py
@@ -281,6 +281,25 @@ class LLMEnsembleConfig(BaseModel):
     default_weight: float = 0.5  # Starting weight per model (50/50)
 
 
+class MomentumCouplingConfig(BaseModel):
+    """Fast path — the short-turnaround spot->prediction lead-lag pillar.
+
+    Runs on a fast cadence with a momentum signal (NOT the LLM loop): when crypto
+    spot moves, the coupled prediction market is expected to reprice ~minutes
+    later, so we'd take the matching side early. OFF by default — detection-only
+    scaffold until coupling_tradeability.py confirms it's profitable after cost.
+    """
+
+    enabled: bool = False
+    poll_seconds: int = 60
+    lookback_seconds: int = 600        # window over which a spot move is measured
+    move_threshold_pct: float = 0.5    # |spot move| over lookback to fire
+    assets: list[str] = ["BTC", "ETH"]
+    near_money_pct: float = 0.05       # only trade markets whose strike is within this of spot
+    max_position_usd: float = 25.0
+    execute: bool = False              # detection-only until True (post-validation)
+
+
 class GeminiConfig(BaseModel):
     """Gemini as an off-hours / budget-relief LLM. Routes analysis to Gemini when
     it's off-hours OR Claude's daily budget is near-exhausted; falls back to
@@ -398,6 +417,7 @@ class Settings(BaseSettings):
     ensemble: EnsembleConfig = Field(default_factory=lambda: EnsembleConfig(**_DEFAULTS.get("ensemble", {})))
     llm_ensemble: LLMEnsembleConfig = Field(default_factory=lambda: LLMEnsembleConfig(**_DEFAULTS.get("llm_ensemble", {})))
     gemini: GeminiConfig = Field(default_factory=lambda: GeminiConfig(**_DEFAULTS.get("gemini", {})))
+    momentum_coupling: MomentumCouplingConfig = Field(default_factory=lambda: MomentumCouplingConfig(**_DEFAULTS.get("momentum_coupling", {})))
     market_maker: MarketMakerConfig = Field(default_factory=lambda: MarketMakerConfig(**_DEFAULTS.get("market_maker", {})))
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))


### PR DESCRIPTION
Scopes the **fast path** for the spot->prediction lead-lag, in parallel with the slow-loop divergence filter. Separate fast cadence + momentum signal (distinct from the LLM loop). Detects crypto spot moves -> near-the-money prediction markets -> emits a coupling signal that bypasses the LLM-divergence filter. **OFF + detection-only** until `coupling_tradeability.py` confirms after-cost edge; execution is a clearly-marked stub. Verified detect+emit. 365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)