### PR TITLE
feat: fast-path execution (execute flag) + gate dashboard

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1083,7 +1083,10 @@ class AuramaurBot:
         """
         from auramaur.strategy.momentum_coupling import MomentumCouplingPillar
         from auramaur.monitoring.display import console
-        pillar = MomentumCouplingPillar(self.settings, console=console)
+        poly_engine = self._components.get("engines", {}).get("polymarket")
+        poly_client = poly_engine.exchange if poly_engine else None
+        pillar = MomentumCouplingPillar(self.settings, console=console,
+                                        polymarket_client=poly_client)
         interval = self.settings.momentum_coupling.poll_seconds
         while self._running:
             if await self._check_kill_switch():

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -272,6 +272,13 @@ def cockpit():
     asyncio.run(_run())
 
 
+@main.command()
+def gates():
+    """Show feature gates — which experimental switches the data has earned."""
+    from auramaur.monitoring import gates as g
+    console.print(g.render(g.gather(Settings())))
+
+
 @main.group()
 def kraken():
     """Manual Kraken spot trading (gated + typed confirmation)."""

--- a/auramaur/monitoring/gates.py
+++ b/auramaur/monitoring/gates.py
@@ -1,0 +1,95 @@
+"""Gate dashboard — for each gated/experimental feature, show its flag state and
+whether the data has earned flipping it on (GO / WAIT / NO-GO).
+
+Everything risky in Auramaur is measure-gated. This is the one place to see, at a
+glance, which switches are ready and which are still waiting on evidence.
+
+    auramaur gates
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from rich.table import Table
+from rich.text import Text
+
+
+def _resolved_dollar_markets(db_path: str) -> int:
+    """Count live markets with fills AND a resolved outcome (the $-edge sample)."""
+    try:
+        c = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        n = c.execute(
+            "SELECT COUNT(DISTINCT f.market_id) FROM fills f "
+            "JOIN calibration cal ON cal.market_id=f.market_id "
+            "WHERE f.is_paper=0 AND cal.actual_outcome IS NOT NULL").fetchone()[0]
+        c.close()
+        return n
+    except Exception:
+        return 0
+
+
+def gather(settings, db_path: str = "auramaur.db") -> list[dict]:
+    n_resolved = _resolved_dollar_markets(db_path)
+    mc = settings.momentum_coupling
+    rows = [
+        {
+            "feature": "Divergence filter (slow loop)",
+            "flag": f"divergence_filter_enabled={settings.risk.divergence_filter_enabled}",
+            "criterion": "≥100 resolved-$ markets confirm mid-divergence adverse selection",
+            "status": f"{n_resolved}/100 resolved-$ markets",
+            "verdict": "GO" if n_resolved >= 100 else "WAIT (need data)",
+        },
+        {
+            "feature": "Momentum coupling — detect (fast path)",
+            "flag": f"momentum_coupling.enabled={mc.enabled}",
+            "criterion": "always safe (detection-only, places nothing)",
+            "status": "ready",
+            "verdict": "GO (safe to enable for detection)",
+        },
+        {
+            "feature": "Momentum coupling — EXECUTE",
+            "flag": f"momentum_coupling.execute={mc.execute}",
+            "criterion": "coupling_tradeability.py net > 0 after cost",
+            "status": "last measured: -0.13 / 9 trades (cost-dominated)",
+            "verdict": "NO-GO (not tradeable yet)",
+        },
+        {
+            "feature": "Kraken directional speculation",
+            "flag": f"kraken.directional_enabled={settings.kraken.directional_enabled}",
+            "criterion": "validated momentum edge vs buy-and-hold",
+            "status": "measured: -5.1% vs -1.3% B&H (value-destroying)",
+            "verdict": "NO-GO (kept ON by choice)",
+        },
+        {
+            "feature": "IBKR equity directional",
+            "flag": f"ibkr.directional_equity_enabled={settings.ibkr.directional_equity_enabled}",
+            "criterion": "validated edge + funded account + market data",
+            "status": "no edge + account unfunded/options pending",
+            "verdict": "NO-GO",
+        },
+        {
+            "feature": "Cross-venue transfers (armed)",
+            "flag": f"transfers_armed={settings.transfers_armed}",
+            "criterion": "operational gate (not edge): env + config + whitelist + approval",
+            "status": "armed" if settings.transfers_armed else "disarmed",
+            "verdict": "operational" if settings.transfers_armed else "disarmed",
+        },
+    ]
+    return rows
+
+
+def render(rows: list[dict]) -> Table:
+    t = Table(title="Auramaur — feature gates", expand=True)
+    t.add_column("feature", style="cyan", no_wrap=True)
+    t.add_column("flag")
+    t.add_column("gate criterion", style="dim")
+    t.add_column("current status")
+    t.add_column("verdict")
+    for r in rows:
+        v = r["verdict"]
+        color = ("green" if v.startswith("GO") or v == "operational"
+                 else "yellow" if v.startswith("WAIT") or v == "disarmed" else "red")
+        t.add_row(r["feature"], r["flag"], r["criterion"], r["status"],
+                  Text(v, style=color))
+    return t

--- a/auramaur/strategy/momentum_coupling.py
+++ b/auramaur/strategy/momentum_coupling.py
@@ -26,9 +26,10 @@ _NAME = {"BTC": "Bitcoin", "ETH": "Ethereum"}
 
 
 class MomentumCouplingPillar:
-    def __init__(self, settings, console=None):
+    def __init__(self, settings, console=None, polymarket_client=None):
         self._s = settings
         self._console = console
+        self._poly = polymarket_client   # PolymarketClient (client.py) for execution
         self._spot_hist: dict[str, list[tuple[float, float]]] = defaultdict(list)
         self._kraken = None
         self._gamma = None
@@ -77,6 +78,8 @@ class MomentumCouplingPillar:
             strike = float(mt.group(1).replace(",", ""))
             if strike <= 0 or abs(strike - spot) / spot > cfg.near_money_pct:
                 continue  # only near-the-money markets are spot-sensitive
+            if not (0.10 < m.outcome_yes_price < 0.90):
+                continue  # skip pinned markets — prob must be live to move with spot
             direction = "BUY_YES" if move > 0 else "BUY_NO"
             log.info("coupling.signal", asset=asset, move_pct=round(move, 2), spot=round(spot),
                      market=m.question[:50], strike=strike,
@@ -87,7 +90,31 @@ class MomentumCouplingPillar:
                     f"[cyan]coupling[/] {asset} spot {move:+.1f}% -> {direction} "
                     f"'{m.question[:38]}' (prob {m.outcome_yes_price:.2f})"
                     + ("" if cfg.execute else " [dim](detect-only)[/]"))
-            # Execution intentionally not wired until the coupling validates.
-            # When cfg.execute: route a strategy_source='momentum_coupling' order
-            # through the Polymarket engine here, bounded by max_position_usd.
+            if cfg.execute:
+                await self._execute(m, direction)
             break  # one signal per asset per cycle
+
+    async def _execute(self, market, direction: str) -> None:
+        """Place the coupling trade — only when execute=True. Bounded by
+        max_position_usd; the Polymarket client enforces the three live gates +
+        kill switch, so this is paper unless AURAMAUR_LIVE + execution.live."""
+        if self._poly is None:
+            log.warning("coupling.no_client", reason="no Polymarket client; detect-only")
+            return
+        from auramaur.exchange.models import Order, OrderSide, TokenType
+        token = TokenType.YES if direction == "BUY_YES" else TokenType.NO
+        token_id = market.clob_token_yes if token == TokenType.YES else market.clob_token_no
+        price = market.outcome_yes_price if token == TokenType.YES else market.outcome_no_price
+        if not token_id or price <= 0:
+            log.warning("coupling.no_token", market=market.id)
+            return
+        size = round(self._s.momentum_coupling.max_position_usd / price, 2)
+        order = Order(market_id=market.id, exchange="polymarket", token_id=token_id,
+                      side=OrderSide.BUY, token=token, size=size, price=price,
+                      dry_run=not self._s.is_live)
+        try:
+            res = await self._poly.place_order(order)
+            log.warning("coupling.executed", market=market.id, direction=direction,
+                        size=size, price=price, status=res.status, is_paper=res.is_paper)
+        except Exception as e:  # noqa: BLE001
+            log.error("coupling.execute_error", market=market.id, error=str(e)[:120])


### PR DESCRIPTION
**(a)** Momentum-coupling pillar executes when `momentum_coupling.execute=True` — builds a bounded Polymarket order via the CLOB client (three-gate + kill switch intact). One switch flips it live once validated. Verified it builds+places (mocked). Added a prob-sensitivity guard (skip pinned markets).

**(b)** `auramaur gates` — a board of every experimental flag: state, gate criterion, current data status, GO/WAIT/NO-GO. (divergence 32/100=WAIT, coupling-execute NO-GO, kraken-directional NO-GO.)

365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)