### PR TITLE
fix: 3 defects (risk bypass, loss-limit scaling, IBKR tracking) + proper edge audit

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1085,8 +1085,10 @@ class AuramaurBot:
         from auramaur.monitoring.display import console
         poly_engine = self._components.get("engines", {}).get("polymarket")
         poly_client = poly_engine.exchange if poly_engine else None
+        risk_mgr = poly_engine.risk_manager if poly_engine else None
         pillar = MomentumCouplingPillar(self.settings, console=console,
-                                        polymarket_client=poly_client)
+                                        polymarket_client=poly_client,
+                                        risk_manager=risk_mgr, bot=self)
         interval = self.settings.momentum_coupling.poll_seconds
         while self._running:
             if await self._check_kill_switch():

--- a/auramaur/exchange/ibkr_equity.py
+++ b/auramaur/exchange/ibkr_equity.py
@@ -142,6 +142,16 @@ class IBKREquityClient:
             log.warning("ibkr_equity.momentum_error", symbol=symbol, error=str(e)[:100])
             return None
 
+    async def get_positions(self) -> dict[str, float]:
+        """Held equity positions {symbol: qty} from the account (for reconcile)."""
+        try:
+            await self._ensure_connected()
+            return {p.contract.symbol: p.position
+                    for p in self._ib.positions() if p.position != 0}
+        except Exception as e:  # noqa: BLE001
+            log.debug("ibkr_equity.positions_error", error=str(e)[:80])
+            return {}
+
     async def close(self) -> None:
         if self._ib is not None and self._connected:
             self._ib.disconnect()

--- a/auramaur/risk/tolerance.py
+++ b/auramaur/risk/tolerance.py
@@ -71,9 +71,11 @@ def scale_risk(risk, kelly_fraction: float, tolerance: float):
     a, c = _aggr(t), _cons(t)
     scaled = risk.model_copy(update={
         # --- risk appetite (grow with aggression) ---
+        # NOTE: the HARD ruin limits (max_drawdown_pct, daily_loss_limit) are
+        # deliberately NOT scaled — those are circuit-breakers, not appetite.
+        # Loosening them with aggression would remove the brake exactly when
+        # sizing is biggest.
         "max_stake_per_market": risk.max_stake_per_market * a,
-        "max_drawdown_pct": min(risk.max_drawdown_pct * a, 90.0),
-        "daily_loss_limit": risk.daily_loss_limit * a,
         "max_open_positions": max(1, round(risk.max_open_positions * a)),
         "category_exposure_cap_pct": min(risk.category_exposure_cap_pct * a, 100.0),
         "max_correlated_positions": max(1, round(risk.max_correlated_positions * a)),

--- a/auramaur/strategy/momentum_coupling.py
+++ b/auramaur/strategy/momentum_coupling.py
@@ -26,10 +26,13 @@ _NAME = {"BTC": "Bitcoin", "ETH": "Ethereum"}
 
 
 class MomentumCouplingPillar:
-    def __init__(self, settings, console=None, polymarket_client=None):
+    def __init__(self, settings, console=None, polymarket_client=None,
+                 risk_manager=None, bot=None):
         self._s = settings
         self._console = console
         self._poly = polymarket_client   # PolymarketClient (client.py) for execution
+        self._risk = risk_manager        # RiskManager gateway — no trade bypasses it
+        self._bot = bot                  # for available cash
         self._spot_hist: dict[str, list[tuple[float, float]]] = defaultdict(list)
         self._kraken = None
         self._gamma = None
@@ -91,33 +94,44 @@ class MomentumCouplingPillar:
                     f"'{m.question[:38]}' (prob {m.outcome_yes_price:.2f})"
                     + ("" if cfg.execute else " [dim](detect-only)[/]"))
             if cfg.execute:
-                await self._execute(m, direction)
+                await self._execute(m, direction, move)
             break  # one signal per asset per cycle
 
-    async def _execute(self, market, direction: str) -> None:
-        """Place the coupling trade — only when execute=True. Bounded by
-        max_position_usd; the Polymarket client enforces the three live gates +
-        kill switch, so this is paper unless AURAMAUR_LIVE + execution.live."""
-        if self._poly is None:
-            log.warning("coupling.no_client", reason="no Polymarket client; detect-only")
+    async def _execute(self, market, direction: str, move: float) -> None:
+        """Place the coupling trade through the RiskManager gateway (execute=True).
+
+        The momentum signal is framed as a spot-implied prob nudge vs the market,
+        so it flows through risk_manager.evaluate() — every check, the divergence
+        filter, Kelly sizing, AND the risk_tolerance lever apply. NOTHING bypasses
+        the gateway. Detection-only if the risk manager / client isn't wired.
+        """
+        if self._poly is None or self._risk is None:
+            log.warning("coupling.no_route", reason="no risk_manager/client; detect-only")
             return
-        from auramaur.exchange.models import Order, OrderSide, TokenType
-        token = TokenType.YES if direction == "BUY_YES" else TokenType.NO
-        token_id = market.clob_token_yes if token == TokenType.YES else market.clob_token_no
-        price = market.outcome_yes_price if token == TokenType.YES else market.outcome_no_price
-        if not token_id or price <= 0:
-            log.warning("coupling.no_token", market=market.id)
-            return
-        from auramaur.risk.tolerance import scale_budget, current_tolerance
-        pos_usd = scale_budget(self._s.momentum_coupling.max_position_usd,
-                               current_tolerance(self._s))
-        size = round(pos_usd / price, 2)
-        order = Order(market_id=market.id, exchange="polymarket", token_id=token_id,
-                      side=OrderSide.BUY, token=token, size=size, price=price,
-                      dry_run=not self._s.is_live)
+        from auramaur.exchange.models import Signal, OrderSide, Confidence
+        mp = market.outcome_yes_price
+        shift = (1 if direction == "BUY_YES" else -1) * min(abs(move) / 100.0 * 5, 0.15)
+        claude_prob = max(0.02, min(0.98, mp + shift))
+        signal = Signal(
+            market_id=market.id, market_question=market.question,
+            claude_prob=claude_prob, market_prob=mp,
+            claude_confidence=Confidence.HIGH if abs(move) >= 1.0 else Confidence.MEDIUM,
+            edge=abs(claude_prob - mp) * 100,
+            recommended_side=OrderSide.BUY if direction == "BUY_YES" else OrderSide.SELL,
+            strategy_source="momentum_coupling")
+        cash = getattr(self._bot, "_last_known_cash", None) if self._bot else None
         try:
+            decision = await self._risk.evaluate(signal, market, available_cash=cash)
+            if not decision.approved or decision.position_size <= 0:
+                log.info("coupling.risk_rejected", market=market.id,
+                         reason=decision.reason[:80])
+                return
+            order = self._poly.prepare_order(signal, market, decision.position_size,
+                                             self._s.is_live)
+            if not order:
+                return
             res = await self._poly.place_order(order)
             log.warning("coupling.executed", market=market.id, direction=direction,
-                        size=size, price=price, status=res.status, is_paper=res.is_paper)
+                        size=decision.position_size, status=res.status, is_paper=res.is_paper)
         except Exception as e:  # noqa: BLE001
             log.error("coupling.execute_error", market=market.id, error=str(e)[:120])

--- a/auramaur/treasury/ibkr_pillar.py
+++ b/auramaur/treasury/ibkr_pillar.py
@@ -26,6 +26,18 @@ class IBKRDirectionalPillar:
         cfg = self._s.ibkr
         if not cfg.directional_equity_enabled:
             return
+        # Reconcile open positions from the IBKR account so a restart doesn't lose
+        # track (re-buy / miss exits). Empty when disconnected — safe.
+        try:
+            held = await self._eq.get_positions()
+            for sym in cfg.directional_equity_symbols:
+                if abs(held.get(sym, 0)) > 1e-6:
+                    self._long.setdefault(sym, 0.0)   # discovered holding
+            for sym in list(self._long):
+                if abs(held.get(sym, 0)) <= 1e-6:
+                    self._long.pop(sym, None)          # closed externally
+        except Exception as e:  # noqa: BLE001
+            log.debug("ibkr_equity.reconcile_error", error=str(e)[:80])
         for sym in cfg.directional_equity_symbols:
             try:
                 await self._eval(sym)

--- a/scripts/research/edge_vs_market.py
+++ b/scripts/research/edge_vs_market.py
@@ -1,0 +1,82 @@
+"""Proper edge audit — does the model beat the MARKET, not just look calibrated?
+
+The original edge_audit.py measured the model's Brier in isolation, which rewards
+predicting the base rate (a 90%-NO category scores well by always saying NO). That
+is NOT edge. Real edge means the model's prediction beats two baselines:
+
+  1. the MARKET PRICE (market_prob) — if Brier_model >= Brier_market, trusting the
+     market would have been at least as good: NO edge over the market.
+  2. the category BASE RATE — Brier Skill Score vs always-predict-base-rate.
+
+Per category we show both, so we can tell whether the reallocation (#36) tilted
+toward real skill or toward base-rate-predictable categories (an artifact).
+
+Read-only.
+    python scripts/research/edge_vs_market.py
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+
+DB = "auramaur.db"
+
+
+def _brier(rs, key):
+    return sum((r[key] - r["o"]) ** 2 for r in rs) / len(rs) if rs else float("nan")
+
+
+def main():
+    c = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
+    c.row_factory = sqlite3.Row
+    # latest market_prob per market from signals
+    mkt = {}
+    for r in c.execute("SELECT market_id, market_prob FROM signals "
+                       "WHERE market_prob IS NOT NULL ORDER BY timestamp"):
+        mkt[r["market_id"]] = r["market_prob"]
+    rows = []
+    for r in c.execute("SELECT market_id, predicted_prob, actual_outcome, category "
+                       "FROM calibration WHERE actual_outcome IS NOT NULL "
+                       "AND predicted_prob IS NOT NULL"):
+        if r["market_id"] in mkt:
+            rows.append({"m": r["predicted_prob"], "mkt": mkt[r["market_id"]],
+                         "o": r["actual_outcome"], "cat": r["category"] or "none"})
+    c.close()
+
+    def block(rs):
+        bm, bk = _brier(rs, "m"), _brier(rs, "mkt")
+        base = sum(r["o"] for r in rs) / len(rs)
+        bb = sum((base - r["o"]) ** 2 for r in rs) / len(rs)
+        # % of disagreements (|model-market|>5%) where the model was the better side
+        dis = [r for r in rs if abs(r["m"] - r["mkt"]) > 0.05]
+        right = sum(1 for r in dis if (r["m"] - r["mkt"]) * (r["o"] - r["mkt"]) > 0)
+        return bm, bk, bb, base, len(dis), (right / len(dis) if dis else float("nan"))
+
+    print("=" * 86)
+    print("EDGE vs MARKET — does the model beat the price? (Brier: lower=better)")
+    print("  beats_market = Brier_market - Brier_model  (>0 = model better than the price)")
+    print("=" * 86)
+    bm, bk, bb, base, ndis, dwin = block(rows)
+    print(f"  OVERALL n={len(rows)}: model {bm:.3f} | market {bk:.3f} | base-rate {bb:.3f}"
+          f"  -> beats_market {bk-bm:+.3f}")
+    print(f"           when model disagreed w/ market by >5% (n={ndis}), it was right {dwin*100:.0f}% of the time\n")
+    cats = defaultdict(list)
+    for r in rows:
+        cats[r["cat"]].append(r)
+    print(f"  {'category':14} {'n':>4} {'model':>6} {'market':>7} {'baserate':>8} "
+          f"{'beats_mkt':>9} {'disagree-win%':>13}")
+    print("  " + "-" * 70)
+    for cat, rs in sorted(cats.items(), key=lambda kv: -( _brier(kv[1],'mkt') - _brier(kv[1],'m'))):
+        if len(rs) < 3:
+            continue
+        bm, bk, bb, baserate, nd, dw = block(rs)
+        flag = "BEATS MKT" if bk - bm > 0.005 else ("≈market" if abs(bk-bm) <= 0.005 else "WORSE")
+        print(f"  {cat:14} {len(rs):>4} {bm:>6.3f} {bk:>7.3f} {bb:>8.3f} "
+              f"{bk-bm:>+9.3f} {(f'{dw*100:.0f}% (n={nd})' if nd else '—'):>13}  {flag}")
+    print("\n  READ: a category only has real edge if model < market (beats_mkt > 0) AND")
+    print("  the model wins its disagreements with the market >50% of the time.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Cleanup from the deep review.

**#1** Momentum-coupling execution now routes through `RiskManager.evaluate()` — no trade bypasses the gateway (verified a rejected decision blocks the order).
**#2** `risk_tolerance` no longer loosens the hard loss limits (`max_drawdown_pct`, `daily_loss_limit`).
**#3** IBKR equity pillar reconciles positions from the account (mirrors the Kraken fix).

**Proper edge audit** (`edge_vs_market.py`): the model's Brier (0.191) is **worse than the market price (0.119) in every category**; disagree-with-market win rate 29% (n=1078). The original audit measured base-rate predictability, not edge — so #36 reallocated toward where the market beats us most. **No edge over market.**

365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)