### PR TITLE
fix: parse CLOB order book (was always empty) + correct flow-nudge token id

### DIFF
--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -540,9 +540,11 @@ class PolymarketClient:
         self._init_clob_client()
         try:
             raw = self._clob_client.get_order_book(token_id)
-            # OrderBookSummary is a dataclass with .bids/.asks as lists of OrderSummary
-            raw_bids = getattr(raw, "bids", []) or []
-            raw_asks = getattr(raw, "asks", []) or []
+            # py_clob_client_v2 returns a plain dict ({"bids": [...], "asks": [...]}),
+            # not a dataclass — read by key, falling back to attribute access for
+            # any client version that returns an OrderBookSummary object.
+            raw_bids = (raw.get("bids") if isinstance(raw, dict) else getattr(raw, "bids", [])) or []
+            raw_asks = (raw.get("asks") if isinstance(raw, dict) else getattr(raw, "asks", [])) or []
             bids = [
                 OrderBookLevel(
                     price=float(getattr(b, "price", b.get("price", 0)) if isinstance(b, dict) else b.price),

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -486,7 +486,7 @@ class TradingEngine:
         # 2c. Order flow nudge
         if self.flow_tracker is not None:
             try:
-                order_book = await self.exchange.get_order_book(market.id)
+                order_book = await self.exchange.get_order_book(market.clob_token_yes)
                 self.flow_tracker.record_book_snapshot(market.id, order_book)
             except Exception:
                 pass

--- a/auramaur/strategy/pipeline_analyzer.py
+++ b/auramaur/strategy/pipeline_analyzer.py
@@ -218,7 +218,7 @@ class PipelineAnalyzer:
         # 2c. Order flow nudge
         if self.flow_tracker is not None:
             try:
-                order_book = await self.exchange.get_order_book(market.id)
+                order_book = await self.exchange.get_order_book(market.clob_token_yes)
                 self.flow_tracker.record_book_snapshot(market.id, order_book)
             except Exception:
                 pass

--- a/tests/test_orderbook_parse.py
+++ b/tests/test_orderbook_parse.py
@@ -1,0 +1,86 @@
+"""Regression: PolymarketClient.get_order_book must parse the py_clob_client_v2
+response, which is a plain dict ({"bids": [...], "asks": [...]}) — NOT a dataclass.
+
+The original code read the levels via getattr(raw, "bids", []), which silently
+returned [] for a dict, so every order book came back empty. That single bug
+made the market maker skip every market on "empty_book" and silently killed the
+order-flow nudge. These tests lock the dict-parsing in place.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from auramaur.exchange.client import PolymarketClient
+
+
+def _client() -> PolymarketClient:
+    c = PolymarketClient(MagicMock(), MagicMock())
+    # Pre-set the clob client so _init_clob_client() short-circuits (no live init).
+    c._clob_client = MagicMock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_parses_v2_dict_response():
+    """A dict with string-priced levels (exactly what v2 returns) parses fully."""
+    c = _client()
+    c._clob_client.get_order_book = MagicMock(return_value={
+        "market": "0xabc",
+        "asset_id": "72094069823942324362",
+        "bids": [{"price": "0.61", "size": "1200"}, {"price": "0.60", "size": "800"}],
+        "asks": [{"price": "0.63", "size": "1610076.25"}, {"price": "0.64", "size": "500"}],
+    })
+
+    book = await c.get_order_book("72094069823942324362")
+
+    assert len(book.bids) == 2
+    assert len(book.asks) == 2
+    assert book.best_bid == 0.61
+    assert book.best_ask == 0.63
+    assert book.bids[0].size == 1200.0
+    assert book.asks[0].size == 1610076.25
+
+
+@pytest.mark.asyncio
+async def test_one_sided_dict_book():
+    """One-sided book (common near resolution) parses without error."""
+    c = _client()
+    c._clob_client.get_order_book = MagicMock(return_value={
+        "bids": [],
+        "asks": [{"price": "0.999", "size": "1610076.25"}],
+    })
+
+    book = await c.get_order_book("tok")
+
+    assert book.bids == []
+    assert len(book.asks) == 1
+    assert book.best_ask == 0.999
+
+
+@pytest.mark.asyncio
+async def test_still_parses_object_response():
+    """Falls back to attribute access if a client version returns an object."""
+    c = _client()
+    level = MagicMock(price="0.5", size="100")
+    raw = MagicMock(bids=[level], asks=[level])
+    c._clob_client.get_order_book = MagicMock(return_value=raw)
+
+    book = await c.get_order_book("tok")
+
+    assert len(book.bids) == 1
+    assert len(book.asks) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_error_returns_empty_book():
+    """A raised exception still yields an empty OrderBook, not a crash."""
+    c = _client()
+    c._clob_client.get_order_book = MagicMock(side_effect=RuntimeError("404"))
+
+    book = await c.get_order_book("tok")
+
+    assert book.bids == []
+    assert book.asks == []


### PR DESCRIPTION
## Summary
The order book never loaded anywhere in the bot — two bugs hiding behind silent fallbacks. This is the root cause of the market maker capturing **zero** spread despite running 34,634 cycles.

### Bug A — `client.py` parsed the book as empty (the MM blocker)
`PolymarketClient.get_order_book` read the `py_clob_client_v2` response via `getattr(raw, "bids", [])`. But v2 returns a **plain `dict`**, not a dataclass — so `getattr` always fell through to `[]`, and **every order book came back empty regardless of real depth.**

The market maker passed the *correct* token, fetched a *real* book, and threw it away in the parse → `empty_book` skip on 100% of cycles → never quoted, never filled.

```python
# before
raw_bids = getattr(raw, "bids", []) or []
# after
raw_bids = (raw.get("bids") if isinstance(raw, dict) else getattr(raw, "bids", [])) or []
```

### Bug B — wrong identifier in the order-flow nudge (the 404 spam)
`engine.py:489` and `pipeline_analyzer.py:221` passed `market.id` (a short numeric id) instead of `market.clob_token_yes` (the 77-digit CLOB token), producing **1,862** `No orderbook exists for the requested token id` 404s and a silently-dead nudge (`try/except: pass`).

## Verification
Against the live CLOB, markets that returned `0 bids / 0 asks` before the fix now parse full depth:

| market | before | after |
|---|---|---|
| Will no Fed rate cuts happen in 2026? | 0b/0a | **173b / 98a** |
| Will 1 Fed rate cut happen in 2026? | 0b/0a | **17b / 39a** |
| Will 3 Fed rate cuts happen in 2026? | 0b/0a | **23b / 83a** |

## Tests
Adds `tests/test_orderbook_parse.py` covering the v2 dict response, one-sided books, the object-response fallback, and the fetch-error path. `tests/test_orderbook_parse.py + test_post_only.py + test_order_flow.py` → 20 passed.

## Impact
Unblocks the market maker — the one EMH-consistent strategy that could still have an edge. It will now see real books and begin quoting; the order-flow nudge comes alive too. (Whether MM is *profitable* is the next question — but now it can actually run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)