### PR TITLE
fix: capital efficiency — net-cash sizing, order TTL, free winners, auto-redeem, dust sweep

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -145,7 +145,15 @@ class PositionSyncer:
         return positions
 
     async def _get_live_balance(self) -> float:
-        """Return spendable pUSD without mutating live order state."""
+        """Return *spendable* pUSD: gross collateral minus collateral already
+        reserved by resting BUY orders.
+
+        ``get_balance_allowance`` reports gross collateral (open orders are not
+        netted out), so without this subtraction the engine sizes Kelly bets and
+        approves trades against cash that is actually locked in open orders —
+        only for the submit-time guard to then reject them. Netting here makes
+        sizing/allocation deploy only what is genuinely available.
+        """
         self._exchange._init_clob_client()
         client = self._exchange._clob_client
         try:
@@ -153,12 +161,19 @@ class PositionSyncer:
             resp = client.get_balance_allowance(
                 BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=2)
             )
-            total = int(resp.get("balance", 0)) / 1e6 if isinstance(resp, dict) else 0.0
-            log.info("sync.balance.computed", available=round(total, 2))
-            return total
+            gross = int(resp.get("balance", 0)) / 1e6 if isinstance(resp, dict) else 0.0
         except Exception as e:
             log.error("sync.balance.error", error=str(e))
             return 0.0
+
+        reserved = 0.0
+        reserve_fn = getattr(self._exchange, "_reserved_buy_collateral_from_open_orders", None)
+        if reserve_fn is not None:
+            reserved = reserve_fn() or 0.0
+        available = max(0.0, gross - reserved)
+        log.info("sync.balance.computed", available=round(available, 2),
+                 gross=round(gross, 2), reserved=round(reserved, 2))
+        return available
 
     # ------------------------------------------------------------------
     # Paper sync

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -154,6 +154,7 @@ class ExitReason(str, Enum):
     EDGE_EROSION = "EDGE_EROSION"
     TIME_DECAY = "TIME_DECAY"
     DUST_CLEANUP = "DUST_CLEANUP"
+    CAPITAL_EFFICIENCY = "CAPITAL_EFFICIENCY"
 
 
 class Fill(BaseModel):

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -383,6 +383,28 @@ class PortfolioTracker:
                 exits.append((pos, ExitReason.EDGE_EROSION))
                 continue
 
+            # 4b. Capital efficiency — near-certain winner (small upside left)
+            #     that is still far from resolution. Holding it locks capital for
+            #     little residual gain; free it to redeploy into fresh edges.
+            #     Small remaining_upside == the held side is near its payout
+            #     boundary, so this only ever sells winners (never dumps losers).
+            if (
+                settings.execution.free_winners_enabled
+                and remaining_upside < settings.execution.free_winners_max_upside_pct
+                and market.end_date is not None
+            ):
+                end = market.end_date if market.end_date.tzinfo else market.end_date.replace(tzinfo=timezone.utc)
+                hours_left = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+                if hours_left > settings.execution.free_winners_min_hours:
+                    log.info(
+                        "exit.capital_efficiency",
+                        market_id=pos.market_id,
+                        remaining_upside_pct=round(remaining_upside, 2),
+                        hours_left=round(hours_left, 1),
+                    )
+                    exits.append((pos, ExitReason.CAPITAL_EFFICIENCY))
+                    continue
+
             # 5. Time decay — market expiring soon with thin edge
             if market.end_date is not None:
                 end = market.end_date if market.end_date.tzinfo else market.end_date.replace(tzinfo=timezone.utc)

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -413,10 +413,52 @@ class PortfolioTracker:
                     exits.append((pos, ExitReason.TIME_DECAY))
                     continue
 
+            # 6. Dust cleanup (lowest priority — real exit reasons win first).
+            #    Tiny stale positions clog the position count and lock small
+            #    amounts of capital. Sweep only those below the notional floor,
+            #    above the per-exchange sellable size, AND old enough not to be a
+            #    freshly-opened entry (the bot itself opens $1-7 positions, so a
+            #    value-only rule would instantly sell new entries). Config-gated.
+            if settings.execution.dust_sweep_enabled:
+                current_value = pos.size * (pos.current_price or 0.0)
+                min_size = 1 if exchange == "kalshi" else 5
+                if (
+                    0.01 <= (pos.current_price or 0.0)
+                    and pos.size >= min_size
+                    and current_value < settings.execution.dust_max_notional
+                    and await self._position_age_hours(pos.market_id, mode_flag)
+                        >= settings.execution.dust_min_age_hours
+                ):
+                    log.info(
+                        "exit.dust_cleanup",
+                        market_id=pos.market_id,
+                        value=round(current_value, 2),
+                        size=pos.size,
+                    )
+                    exits.append((pos, ExitReason.DUST_CLEANUP))
+                    continue
+
         if prices_updated:
             await self.db.commit()
 
         return exits
+
+    async def _position_age_hours(self, market_id: str, mode_flag: int | None) -> float:
+        """Hours since the position's first recorded fill. Returns 0.0 when the
+        entry time is unknown, so dust-sweep treats it as 'too new to touch'."""
+        sql = "SELECT MIN(timestamp) AS first_entry FROM trades WHERE market_id = ?"
+        params: list[object] = [market_id]
+        if mode_flag is not None:
+            sql += " AND is_paper = ?"
+            params.append(mode_flag)
+        try:
+            row = await self.db.fetchone(sql, tuple(params))
+            if not row or not row["first_entry"]:
+                return 0.0
+            entry_dt = datetime.fromisoformat(row["first_entry"]).replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError, KeyError):
+            return 0.0
+        return (datetime.now(timezone.utc) - entry_dt).total_seconds() / 3600.0
 
     async def _get_peak_prices(self) -> dict[str, float]:
         """Load tracked peak PnL percentages for trailing stop."""

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -8,7 +8,7 @@ risk_tolerance: 50
 execution:
   live: true
   paper_initial_balance: 111.0
-  limit_order_ttl_seconds: 300
+  limit_order_ttl_seconds: 120
   spread_capture_min_bps: 50
   stop_loss_pct: 30.0
   profit_target_pct: 50.0

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -17,8 +17,12 @@ execution:
   # Free capital from near-certain winners far from resolution (sell early to
   # redeploy). Only fires on the winning side; see ExecutionConfig.
   free_winners_enabled: true
-  free_winners_max_upside_pct: 5.0
+  free_winners_max_upside_pct: 3.0
   free_winners_min_hours: 48.0
+  # Periodic dust sweep (age-guarded so fresh entries are never swept).
+  dust_sweep_enabled: true
+  dust_max_notional: 1.0
+  dust_min_age_hours: 24.0
 
 risk:
   max_drawdown_pct: 15.0

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -14,6 +14,11 @@ execution:
   profit_target_pct: 50.0
   edge_erosion_min_pct: 2.0
   time_decay_hours: 12.0
+  # Free capital from near-certain winners far from resolution (sell early to
+  # redeploy). Only fires on the winning side; see ExecutionConfig.
+  free_winners_enabled: true
+  free_winners_max_upside_pct: 5.0
+  free_winners_min_hours: 48.0
 
 risk:
   max_drawdown_pct: 15.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -31,6 +31,14 @@ class ExecutionConfig(BaseModel):
     profit_target_pct: float = 50.0
     edge_erosion_min_pct: float = 2.0
     time_decay_hours: float = 12.0
+    # Free capital from near-certain winners that are still far from resolution:
+    # a position with <max_upside_pct left to gain but >min_hours until it
+    # resolves ties up capital for little residual return. Sell it early to
+    # redeploy into fresh edges. Only targets the winning side (tiny remaining
+    # upside == price near the payout boundary).
+    free_winners_enabled: bool = True
+    free_winners_max_upside_pct: float = 5.0
+    free_winners_min_hours: float = 48.0
 
 
 class RiskConfig(BaseModel):
@@ -392,10 +400,12 @@ class Settings(BaseSettings):
 
     # Safety
     auramaur_live: bool = False
-    # Separate opt-in for on-chain redemption — real Polygon transactions.
-    # Gated independently of auramaur_live so you can run live-trading without
-    # inadvertently enabling automated redemption submission.
-    auramaur_enable_redemption: bool = False
+    # On-chain redemption — real Polygon transactions. Defaulted ON so resolved
+    # winners auto-claim back to USDC (recycling capital). Still requires the
+    # full live triple-gate (auramaur_live + execution.live + no KILL_SWITCH) in
+    # _is_live_submission_allowed(), so this never fires outside live trading;
+    # override with env AURAMAUR_ENABLE_REDEMPTION=false to disable.
+    auramaur_enable_redemption: bool = True
 
     # Separate opt-in for cross-venue fund transfers (Kraken -> Polymarket
     # withdrawals). Gated independently of auramaur_live AND of redemption so

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,7 +25,7 @@ _DEFAULTS = _load_defaults()
 class ExecutionConfig(BaseModel):
     live: bool = False
     paper_initial_balance: float = 1000.0
-    limit_order_ttl_seconds: int = 300
+    limit_order_ttl_seconds: int = 120
     spread_capture_min_bps: int = 50
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -37,8 +37,14 @@ class ExecutionConfig(BaseModel):
     # redeploy into fresh edges. Only targets the winning side (tiny remaining
     # upside == price near the payout boundary).
     free_winners_enabled: bool = True
-    free_winners_max_upside_pct: float = 5.0
+    free_winners_max_upside_pct: float = 3.0
     free_winners_min_hours: float = 48.0
+    # Periodic dust sweep: close tiny stale positions to trim position count and
+    # free locked slots. Age-guarded so freshly-opened small entries are never
+    # swept (the bot opens $1-7 positions). Runs via the portfolio exit monitor.
+    dust_sweep_enabled: bool = True
+    dust_max_notional: float = 1.0
+    dust_min_age_hours: float = 24.0
 
 
 class RiskConfig(BaseModel):

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -29,6 +29,9 @@ def settings():
     s.execution.free_winners_enabled = False
     s.execution.free_winners_max_upside_pct = 5.0
     s.execution.free_winners_min_hours = 48.0
+    s.execution.dust_sweep_enabled = False
+    s.execution.dust_max_notional = 1.0
+    s.execution.dust_min_age_hours = 24.0
     return s
 
 
@@ -154,6 +157,59 @@ async def test_free_winners_holds_when_resolution_near(mock_db, settings):
     # so neither fires -> held.
     end_date = datetime.now(timezone.utc) + timedelta(hours=24)
     gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.96, end_date=end_date))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert exits == []
+
+
+@pytest.mark.asyncio
+async def test_dust_sweep_old_small_position(mock_db, settings):
+    """A small (<$1), sellable, old (>24h) position → DUST_CLEANUP."""
+    settings.execution.dust_sweep_enabled = True
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.10, size=8.0),  # value $0.80, 8 tokens
+    ])
+    # First fill 100h ago → older than the 24h guard.
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    mock_db.fetchone = AsyncMock(return_value={"first_entry": old_ts})
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.10))  # flat → no PnL exit
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert len(exits) == 1
+    assert exits[0][1] == ExitReason.DUST_CLEANUP
+
+
+@pytest.mark.asyncio
+async def test_dust_sweep_skips_fresh_position(mock_db, settings):
+    """A small position that was just opened (<24h) is NOT swept (age guard)."""
+    settings.execution.dust_sweep_enabled = True
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.10, size=8.0),
+    ])
+    fresh_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    mock_db.fetchone = AsyncMock(return_value={"first_entry": fresh_ts})
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.10))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert exits == []
+
+
+@pytest.mark.asyncio
+async def test_dust_sweep_skips_sub_minimum_size(mock_db, settings):
+    """A <$1 position too small to sell (poly needs >=5 tokens) is left alone."""
+    settings.execution.dust_sweep_enabled = True
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.20, size=2.0),  # value $0.40, only 2 tokens
+    ])
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    mock_db.fetchone = AsyncMock(return_value={"first_entry": old_ts})
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.20))
 
     tracker = PortfolioTracker(db=mock_db)
     exits = await tracker.check_exits(settings, gamma)

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -25,6 +25,10 @@ def settings():
     s.execution.profit_target_pct = 50.0
     s.execution.edge_erosion_min_pct = 2.0
     s.execution.time_decay_hours = 12.0
+    # Off by default so existing exit tests are unaffected; opted in per-test.
+    s.execution.free_winners_enabled = False
+    s.execution.free_winners_max_upside_pct = 5.0
+    s.execution.free_winners_min_hours = 48.0
     return s
 
 
@@ -117,6 +121,43 @@ async def test_time_decay_triggered(mock_db, settings):
     exits = await tracker.check_exits(settings, gamma)
     assert len(exits) == 1
     assert exits[0][1] == ExitReason.TIME_DECAY
+
+
+@pytest.mark.asyncio
+async def test_free_winners_far_dated(mock_db, settings):
+    """Near-certain winner (4% upside) far from resolution → CAPITAL_EFFICIENCY."""
+    settings.execution.free_winners_enabled = True
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.90),
+    ])
+    gamma = AsyncMock()
+    # 0.96 → remaining upside 4% (>2% edge-erosion floor, <5% free-winners cap);
+    # PnL +6.7% (below profit target). Resolves in ~8 days (>48h).
+    end_date = datetime.now(timezone.utc) + timedelta(hours=200)
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.96, end_date=end_date))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert len(exits) == 1
+    assert exits[0][1] == ExitReason.CAPITAL_EFFICIENCY
+
+
+@pytest.mark.asyncio
+async def test_free_winners_holds_when_resolution_near(mock_db, settings):
+    """Same near-winner but resolving soon (<48h) is held, not freed early."""
+    settings.execution.free_winners_enabled = True
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.90),
+    ])
+    gamma = AsyncMock()
+    # 0.96, resolves in 24h: free-winners needs >48h, and time-decay needs <=12h,
+    # so neither fires -> held.
+    end_date = datetime.now(timezone.utc) + timedelta(hours=24)
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.96, end_date=end_date))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert exits == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -319,3 +319,29 @@ async def test_live_balance_does_not_cancel_resting_orders(client, mock_paper):
 
     assert balance == 123.0
     mock_clob.cancel_all.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_balance_nets_out_open_buy_orders(client, mock_paper):
+    """Spendable balance subtracts collateral reserved by resting BUYs (not
+    SELLs) so the engine sizes against genuinely-available cash, not gross."""
+    mock_clob = MagicMock()
+    mock_clob.get_balance_allowance.return_value = {"balance": 26_275_397}  # $26.28 gross
+    mock_clob.get_open_orders.return_value = [
+        {"side": "BUY", "price": "0.5", "original_size": "51.78", "size_matched": "0"},  # $25.89 locked
+        {"side": "SELL", "price": "0.9", "original_size": "100", "size_matched": "0"},   # excluded
+    ]
+    client._clob_client = mock_clob
+    client._init_clob_client = MagicMock()
+
+    syncer = PositionSyncer(
+        settings=client._settings,
+        db=AsyncMock(),
+        exchange=client,
+        paper=mock_paper,
+        pnl=AsyncMock(),
+    )
+
+    balance = await syncer._get_live_balance()
+
+    assert balance == pytest.approx(0.39, abs=0.01)  # 26.28 - 25.89


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.