### PR TITLE
feat: bull-bias Kraken directional (up to 20 longs); IBKR straight-to-live

### DIFF
--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -166,7 +166,13 @@ class KrakenPillar:
                 continue
             holding = pair in self._dir_long
 
-            if not holding and mom >= kcfg.directional_momentum_pct:
+            # Asymmetric long bias: enter on a smaller up-move, hold through a
+            # larger down-move (ride winners). Fall back to the legacy symmetric
+            # threshold if the split ones aren't configured.
+            entry_thr = getattr(kcfg, "directional_entry_momentum_pct", None) or kcfg.directional_momentum_pct
+            exit_thr = getattr(kcfg, "directional_exit_momentum_pct", None) or kcfg.directional_momentum_pct
+
+            if not holding and mom >= entry_thr:
                 # Budget ceiling: each open position ~= max_order_usd. Scaled by
                 # the global risk-tolerance lever so it moves with all exposure.
                 from auramaur.risk.tolerance import scale_budget, current_tolerance
@@ -185,7 +191,7 @@ class KrakenPillar:
                 log.info("kraken.directional.entry", pair=pair, momentum=round(mom, 2),
                          status=res.status, err=res.error_message[:80])
 
-            elif holding and mom <= -kcfg.directional_momentum_pct:
+            elif holding and mom <= -exit_thr:
                 entry = self._dir_long.get(pair) or price
                 vol = round(kcfg.max_order_usd * 0.98 / entry, 6)
                 res = await self._k.place_spot_order(

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -125,10 +125,11 @@ ibkr:
   max_contracts_per_symbol: 10
   market_data_type: 3
   readonly: false  # non-read-only socket so the options client can place orders
-  # Paper-trade until the held CAD deposit clears (~2026-06-08). IBKR runs the
-  # full pipeline against paper_budget_usd and routes orders to the paper ledger;
-  # flip paper_trade:false to go live once funded.
-  paper_trade: true
+  # Going straight to live once funded — paper-prep is bypassed. With paper_trade
+  # false, flipping enabled:true (after OPRA data + funds land ~2026-06-08) places
+  # real option orders directly. Set paper_trade:true if you want a brief paper
+  # shakeout first. paper_budget_usd is only used when paper_trade is true.
+  paper_trade: false
   paper_budget_usd: 5000.0
   # Directional equity speculation — gated; NO validated edge. Own socket
   # (equity_client_id). Needs readonly:false + a funded/permissioned account.
@@ -146,7 +147,7 @@ kraken:
   # stays OFF until a validated edge exists.
   enabled: true
   quote_currency: "USD"
-  max_order_usd: 25.0
+  max_order_usd: 30.0
   # Treasury pillar (always-on when enabled)
   treasury_interval_seconds: 300
   auto_convert: true
@@ -166,11 +167,17 @@ kraken:
     "DOTUSDC", "LINKUSDC", "LTCUSDC", "BCHUSDC", "ATOMUSDC", "ALGOUSDC", "BNBUSDC",
     "TONUSDC", "XMRUSDC", "XTZUSDC", "MANAUSDC", "APEUSDC", "VETUSDC", "XDGUSDC",
     "CROUSDC", "SHIBUSDC"]
+  # Asymmetric long bias (more bullish): enter on a +2% up-move, exit only on a
+  # -4% down-move so winners ride longer. (directional_momentum_pct kept as the
+  # legacy symmetric fallback.)
   directional_momentum_pct: 3.0
+  directional_entry_momentum_pct: 2.0
+  directional_exit_momentum_pct: 4.0
   directional_lookback: 12
-  # max total open speculative exposure (raised $50->$100 with the wider
-  # universe; ~4 concurrent $25 positions). Of ~$218 Kraken funds.
-  directional_budget_usd: 100.0
+  # Max total open speculative exposure. $600 ceiling = up to 20 concurrent $30
+  # positions. Actual fills are still gated by available USDC (~$234 incl.
+  # auto-converted CAD), so it scales toward 20 as capital grows.
+  directional_budget_usd: 600.0
 
 transfers:
   # Cross-venue fund movement (Kraken -> Polymarket, Polygon USDC only).

--- a/config/settings.py
+++ b/config/settings.py
@@ -261,7 +261,11 @@ class KrakenConfig(BaseModel):
     # --- Directional spot (gated; no validated edge — flip on deliberately) ---
     directional_enabled: bool = False
     directional_pairs: list[str] = []     # e.g. ["XBTUSDC", "ETHUSDC"] (USDC-funded)
-    directional_momentum_pct: float = 3.0  # |momentum| over the lookback to act
+    directional_momentum_pct: float = 3.0  # legacy symmetric threshold (fallback)
+    # Asymmetric long bias: enter on a smaller up-move, exit only on a larger
+    # down-move so winners ride longer. Fall back to directional_momentum_pct.
+    directional_entry_momentum_pct: float = 2.0
+    directional_exit_momentum_pct: float = 4.0
     directional_lookback: int = 12        # OHLC candles (hourly) for the momentum read
     # Total $ the speculation engine may hold in open directional positions at
     # once — a hard ceiling so it can't consume the treasury reserve / CAD.

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -194,7 +194,7 @@ class TestIBKRConfig:
         assert s.ibkr.enabled is False
         assert s.ibkr.environment == "live"
         assert s.ibkr.readonly is False
-        assert s.ibkr.paper_trade is True
+        assert s.ibkr.paper_trade is False  # going straight to live once funded
         assert s.ibkr.paper_budget_usd == 5000.0
         assert s.ibkr.paper_port == 7497
         assert s.ibkr.live_port == 7496
@@ -210,4 +210,4 @@ class TestIBKRConfig:
 
         assert raw["ibkr"]["enabled"] is False
         assert raw["ibkr"]["environment"] == "live"
-        assert raw["ibkr"]["paper_trade"] is True
+        assert raw["ibkr"]["paper_trade"] is False

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -1,0 +1,85 @@
+"""Tests for the Kraken directional spot pillar — asymmetric long bias."""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auramaur.treasury.kraken_pillar import KrakenPillar
+from auramaur.exchange.models import OrderResult, OrderSide
+
+
+def _pillar(*, holding: bool):
+    s = MagicMock()
+    s.risk_tolerance = 50.0
+    k = s.kraken
+    k.directional_pairs = ["XBTUSDC"]
+    k.directional_entry_momentum_pct = 2.0
+    k.directional_exit_momentum_pct = 4.0
+    k.directional_momentum_pct = 3.0       # legacy fallback (unused when split set)
+    k.directional_budget_usd = 600.0
+    k.max_order_usd = 30.0
+    client = MagicMock()
+    client.get_balance = AsyncMock(return_value={})
+    client.get_price = AsyncMock(return_value=100.0)
+    client.place_spot_order = AsyncMock(return_value=OrderResult(
+        order_id="OK", market_id="XBTUSDC", status="filled", is_paper=False))
+    p = KrakenPillar(settings=s, kraken_client=client)
+    p._reconcile_positions = AsyncMock()   # don't touch _dir_long from balances
+    if holding:
+        p._dir_long = {"XBTUSDC": 90.0}
+    return p, client
+
+
+@contextlib.contextmanager
+def _stable_budget():
+    # Isolate from the risk-tolerance budget scaler (identity at neutral).
+    with patch("auramaur.risk.tolerance.scale_budget", lambda b, t: b), \
+         patch("auramaur.risk.tolerance.current_tolerance", lambda s: 50.0):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_enters_long_at_entry_threshold():
+    """+2.5% momentum (>= 2% entry) opens a long."""
+    p, client = _pillar(holding=False)
+    p._momentum = AsyncMock(return_value=2.5)
+    with _stable_budget():
+        await p._directional()
+    client.place_spot_order.assert_awaited_once()
+    assert client.place_spot_order.await_args.args[1] == OrderSide.BUY
+    assert "XBTUSDC" in p._dir_long
+
+
+@pytest.mark.asyncio
+async def test_no_entry_below_entry_threshold():
+    """+1.5% (< 2% entry) does not open a position."""
+    p, client = _pillar(holding=False)
+    p._momentum = AsyncMock(return_value=1.5)
+    with _stable_budget():
+        await p._directional()
+    client.place_spot_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_holds_through_moderate_drop():
+    """Asymmetric bias: -3.5% does NOT exit (needs <= -4%) — winner rides on.
+    The old symmetric -3% rule would have sold here."""
+    p, client = _pillar(holding=True)
+    p._momentum = AsyncMock(return_value=-3.5)
+    with _stable_budget():
+        await p._directional()
+    client.place_spot_order.assert_not_called()
+    assert "XBTUSDC" in p._dir_long
+
+
+@pytest.mark.asyncio
+async def test_exits_on_large_drop():
+    """-4.5% (<= -4% exit) closes the long."""
+    p, client = _pillar(holding=True)
+    p._momentum = AsyncMock(return_value=-4.5)
+    with _stable_budget():
+        await p._directional()
+    client.place_spot_order.assert_awaited_once()
+    assert client.place_spot_order.await_args.args[1] == OrderSide.SELL
+    assert "XBTUSDC" not in p._dir_long


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.