### PR TITLE
feat: Kraken directional — arbitrary pairs / any quote currency, ordermin-aware

### DIFF
--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -40,10 +40,17 @@ _RATE_LIMIT = 8  # conservative; Kraken counts private calls against a tier budg
 
 
 class KrakenSpotClient:
+    # Quote assets that trade ~1:1 with USD, so no FX conversion is needed for
+    # USD-denominated sizing / caps. Everything else (ZEUR, ZGBP, …) is converted
+    # via a live <fiat>USD rate so any quote currency can be sized correctly.
+    _USD_PEGGED = {"ZUSD", "USD", "USDC", "USDT", "DAI", "PYUSD", "USDG", "RLUSD"}
+
     def __init__(self, settings):
         self._settings = settings
         self._session: aiohttp.ClientSession | None = None
         self._sem = asyncio.Semaphore(_RATE_LIMIT)
+        self._quote_rate_cache: dict[str, float] = {}  # quote asset -> USD rate
+        self._pair_quote_cache: dict[str, str] = {}     # pair -> quote asset code
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -119,11 +126,55 @@ class KrakenSpotClient:
 
     async def get_pair_quote(self, pair: str) -> str | None:
         """Quote-currency asset code for a pair (e.g. PAXGUSD -> 'ZUSD')."""
+        if pair in self._pair_quote_cache:
+            return self._pair_quote_cache[pair]
         info = await self._public("AssetPairs", {"pair": pair})
         if not info:
             return None
         meta = next(iter(info.values()))
-        return meta.get("quote")
+        quote = meta.get("quote")
+        if quote:
+            self._pair_quote_cache[pair] = quote
+        return quote
+
+    async def quote_usd_rate(self, quote: str) -> float:
+        """USD value of one unit of a quote currency. 1.0 for USD-pegged quotes
+        (USD/USDC/USDT/…); otherwise the live <fiat>USD rate (ZEUR -> EURUSD).
+        Cached. Falls back to 1.0 if the rate can't be fetched."""
+        q = (quote or "").upper()
+        if q in self._USD_PEGGED:
+            return 1.0
+        if q in self._quote_rate_cache:
+            return self._quote_rate_cache[q]
+        # Kraken fiat codes are Z-prefixed (ZEUR, ZGBP); the FX pair drops it.
+        fiat = q[1:] if (q.startswith("Z") and len(q) == 4) else q
+        rate = 1.0
+        px = await self.get_price(f"{fiat}USD")
+        if px and px > 0:
+            rate = px
+        self._quote_rate_cache[q] = rate
+        return rate
+
+    async def usd_notional(self, pair: str, volume: float, price: float | None = None) -> float | None:
+        """USD value of `volume` base units of `pair`, accounting for the quote
+        currency. Returns None if price is unavailable."""
+        price = price if price is not None else await self.get_price(pair)
+        if not price or price <= 0:
+            return None
+        quote = await self.get_pair_quote(pair) or "ZUSD"
+        return volume * price * await self.quote_usd_rate(quote)
+
+    async def size_for_usd(self, pair: str, usd: float, price: float | None = None) -> float | None:
+        """Base-unit volume whose value is ~`usd`, for any quote currency.
+        Returns None if price/quote can't be resolved."""
+        price = price if price is not None else await self.get_price(pair)
+        if not price or price <= 0:
+            return None
+        quote = await self.get_pair_quote(pair) or "ZUSD"
+        usd_per_base = price * await self.quote_usd_rate(quote)
+        if usd_per_base <= 0:
+            return None
+        return usd / usd_per_base
 
     # ------------------------------------------------------------------
     # Spot order placement
@@ -164,10 +215,12 @@ class KrakenSpotClient:
                                error_message="directional trading disabled (no validated edge)")
 
         # 3. Per-order USD cap (manual CLI may pass a higher confirmed ceiling).
+        #    Convert to USD via the pair's quote currency so the cap holds for
+        #    any quote (USDC/USDT/EUR/…), not just USD-quoted pairs.
         cap = max_usd if max_usd is not None else self._settings.kraken.max_order_usd
         est_price = price or await self.get_price(pair)
         if est_price:
-            notional = volume * est_price
+            notional = await self.usd_notional(pair, volume, est_price) or (volume * est_price)
             if notional > cap:
                 return OrderResult(order_id="BLOCKED", market_id=pair, status="rejected",
                                    is_paper=True,

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -35,6 +35,7 @@ class KrakenPillar:
         # survives restarts instead of silently over-allocating.
         self._dir_long: dict[str, float] = {}
         self._pair_base: dict[str, str] | None = None  # pair -> base asset code
+        self._pair_min: dict[str, float] = {}          # pair -> ordermin (base units)
 
     async def run_once(self) -> None:
         try:
@@ -135,6 +136,10 @@ class KrakenPillar:
                     alt = meta.get("altname")
                     if alt:
                         self._pair_base[alt] = meta.get("base")
+                        try:
+                            self._pair_min[alt] = float(meta.get("ordermin", 0) or 0)
+                        except (TypeError, ValueError):
+                            self._pair_min[alt] = 0.0
             except Exception as e:  # noqa: BLE001
                 log.warning("kraken.reconcile_pairs_error", error=str(e))
 
@@ -221,8 +226,24 @@ class KrakenPillar:
                     log.info("kraken.directional.budget_full", pair=pair,
                              allocated=allocated, budget=round(budget, 2))
                     continue
-                # 2% buffer so float rounding never trips the per-order cap.
-                vol = round(kcfg.max_order_usd * 0.98 / price, 6)
+                # Size in USD terms via the pair's quote currency (works for any
+                # quote: USDC/USDT/EUR/…). 2% buffer so rounding never trips the
+                # per-order cap.
+                vol = await self._k.size_for_usd(pair, kcfg.max_order_usd * 0.98, price)
+                if not vol or vol <= 0:
+                    continue
+                # Respect the pair's minimum lot. Bump up to it only if the min
+                # still fits ~1.5x the per-order cap in USD; else the pair is too
+                # expensive per lot to trade within budget.
+                ordermin = self._pair_min.get(pair, 0.0)
+                if ordermin and vol < ordermin:
+                    min_usd = await self._k.usd_notional(pair, ordermin, price)
+                    if min_usd and min_usd > kcfg.max_order_usd * 1.5:
+                        log.info("kraken.directional.min_lot_too_large", pair=pair,
+                                 ordermin=ordermin, min_usd=round(min_usd, 2))
+                        continue
+                    vol = ordermin
+                vol = round(vol, 8)
                 res = await self._k.place_spot_order(
                     pair, OrderSide.BUY, volume=vol, ordertype="market", purpose="directional")
                 if res.order_id not in ("ERROR", "BLOCKED"):
@@ -232,7 +253,10 @@ class KrakenPillar:
 
             elif holding and mom <= -exit_thr:
                 entry = self._dir_long.get(pair) or price
-                vol = round(kcfg.max_order_usd * 0.98 / entry, 6)
+                vol = await self._k.size_for_usd(pair, kcfg.max_order_usd * 0.98, entry)
+                if not vol or vol <= 0:
+                    continue
+                vol = round(vol, 8)
                 res = await self._k.place_spot_order(
                     pair, OrderSide.SELL, volume=vol, ordertype="market", purpose="directional")
                 if res.order_id not in ("ERROR", "BLOCKED"):

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -157,16 +157,20 @@ kraken:
   # Directional spot — speculation. NO validated edge (Path B momentum); bounded
   # by directional_budget_usd + max_order_usd. USDC-funded pairs (you hold USDC).
   directional_enabled: true
-  # Major crypto, USDC-funded (you hold USDC). True fiat/FX spot isn't fundable
-  # with current holdings — spot can't short a currency. Budget caps concurrent
-  # positions regardless of list length.
-  # Low + medium risk only (liquid majors/midcaps). High-risk memes/new tokens
-  # (BERA, TRUMP, PENGU, VIRTUAL, FARTCOIN, MELANIA, PEAQ) deliberately excluded.
-  # Budget caps exposure regardless of list length, so breadth is low-risk.
+  # Pairs are ARBITRARY now: any base/quote works. Sizing + the per-order cap are
+  # quote-currency-aware (USD-converted via a live <fiat>USD rate), and each
+  # pair's ordermin is respected, so USDC / USD / USDT / EUR / … quotes all size
+  # correctly. NOTE: a pair only *fills* if you hold its quote currency — you
+  # hold USDC, so USDC pairs are the fundable set; USD/USDT/EUR pairs need a
+  # balance in that quote. Kraken spot is always 2-asset (base/quote) — no
+  # multi-leg pairs. Budget caps exposure regardless of list length.
+  # Liquid majors/midcaps; high-risk memes (TRUMP, PENGU, FARTCOIN, …) excluded.
   directional_pairs: ["XBTUSDC", "ETHUSDC", "SOLUSDC", "XRPUSDC", "ADAUSDC", "AVAXUSDC",
     "DOTUSDC", "LINKUSDC", "LTCUSDC", "BCHUSDC", "ATOMUSDC", "ALGOUSDC", "BNBUSDC",
     "TONUSDC", "XMRUSDC", "XTZUSDC", "MANAUSDC", "APEUSDC", "VETUSDC", "XDGUSDC",
-    "CROUSDC", "SHIBUSDC"]
+    "CROUSDC", "SHIBUSDC", "NEARUSDC", "ARBUSDC", "OPUSDC", "INJUSDC", "SUIUSDC",
+    "SEIUSDC", "FILUSDC", "RENDERUSDC", "FETUSDC", "TIAUSDC", "ICPUSDC", "AAVEUSDC",
+    "GRTUSDC", "JUPUSDC"]
   # Asymmetric long bias (more bullish): enter on a +2% up-move, exit only on a
   # -4% down-move so winners ride longer. (directional_momentum_pct kept as the
   # legacy symmetric fallback.)

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -6,7 +6,53 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from auramaur.treasury.kraken_pillar import KrakenPillar
+from auramaur.exchange.kraken import KrakenSpotClient
 from auramaur.exchange.models import OrderResult, OrderSide
+
+
+# ---------------------------------------------------------------------------
+# Quote-currency-aware sizing — arbitrary pairs / quote currencies
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_quote_usd_rate_pegged_and_fiat():
+    c = KrakenSpotClient(MagicMock())
+    assert await c.quote_usd_rate("USDC") == 1.0
+    assert await c.quote_usd_rate("ZUSD") == 1.0
+    assert await c.quote_usd_rate("USDT") == 1.0
+    c.get_price = AsyncMock(return_value=1.16)  # EURUSD
+    assert await c.quote_usd_rate("ZEUR") == 1.16
+    # cached: a second call must not hit the API again
+    c.get_price = AsyncMock(side_effect=AssertionError("rate should be cached"))
+    assert await c.quote_usd_rate("ZEUR") == 1.16
+
+
+@pytest.mark.asyncio
+async def test_size_for_usd_usdc_no_fx():
+    c = KrakenSpotClient(MagicMock())
+    c.get_pair_quote = AsyncMock(return_value="USDC")
+    vol = await c.size_for_usd("XBTUSDC", 30.0, price=60000.0)
+    assert abs(vol - 30.0 / 60000.0) < 1e-12
+
+
+@pytest.mark.asyncio
+async def test_size_for_usd_is_quote_aware_for_eur():
+    """$30 of a EUR-quoted pair buys fewer base units than the raw price implies,
+    because EUR is worth >$1 — sizing must convert via the EURUSD rate."""
+    c = KrakenSpotClient(MagicMock())
+    c.get_pair_quote = AsyncMock(return_value="ZEUR")
+    c.get_price = AsyncMock(return_value=1.16)  # EURUSD rate lookup
+    vol = await c.size_for_usd("XBTEUR", 30.0, price=60000.0)
+    assert abs(vol - 30.0 / (60000.0 * 1.16)) < 1e-12
+
+
+@pytest.mark.asyncio
+async def test_usd_notional_converts_quote():
+    c = KrakenSpotClient(MagicMock())
+    c.get_pair_quote = AsyncMock(return_value="ZEUR")
+    c.get_price = AsyncMock(return_value=1.16)
+    # 1 unit at price 100 EUR = 116 USD
+    assert abs(await c.usd_notional("XEUR", 1.0, price=100.0) - 116.0) < 1e-9
 
 
 def _pillar(*, holding: bool):
@@ -22,6 +68,8 @@ def _pillar(*, holding: bool):
     client = MagicMock()
     client.get_balance = AsyncMock(return_value={})
     client.get_price = AsyncMock(return_value=100.0)
+    client.size_for_usd = AsyncMock(return_value=0.3)   # USD-aware volume
+    client.usd_notional = AsyncMock(return_value=30.0)
     client.place_spot_order = AsyncMock(return_value=OrderResult(
         order_id="OK", market_id="XBTUSDC", status="filled", is_paper=False))
     p = KrakenPillar(settings=s, kraken_client=client)


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.