### PR TITLE
fix: loosen Kalshi throttles — explore unknown categories + lower liquidity floor

### DIFF
--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -760,6 +760,13 @@ class TradingEngine:
 
         markets = await self.scan_and_store_markets()
 
+        # Kalshi's book is thinner than Polymarket's, so it gets a lower activity
+        # floor (kalshi_min_liquidity) to surface more genuinely-tradeable markets.
+        min_liq = (
+            self.settings.risk.kalshi_min_liquidity
+            if self.exchange_name == "kalshi"
+            else self.settings.risk.min_liquidity
+        )
         candidates = [
             m for m in markets
             if m.active
@@ -768,7 +775,7 @@ class TradingEngine:
             # liquidity but high volume on active markets. Using max() ensures
             # active Kalshi markets aren't filtered out by the Polymarket-tuned
             # min_liquidity threshold.
-            and max(m.liquidity or 0, m.volume or 0) >= self.settings.risk.min_liquidity
+            and max(m.liquidity or 0, m.volume or 0) >= min_liq
             and m.spread <= self.settings.risk.max_spread_pct / 100
             and self.settings.risk.implied_prob_min <= m.outcome_yes_price <= self.settings.risk.implied_prob_max
             # Skip near-dead markets (no volume = orders won't fill)
@@ -824,12 +831,14 @@ class TradingEngine:
                 )
                 filtered_count += 1
                 continue
-            # Hybrid mode: skip categories that are neither whitelisted nor probationary
-            # (i.e. categories with data showing poor accuracy, already in avoid_categories above)
-            # When whitelist is empty (cold start), all categories pass through
-            if hybrid_whitelist and m.category and m.category not in hybrid_whitelist and m.category not in hybrid_probationary:
-                filtered_count += 1
-                continue
+            # Hybrid mode: explore categories with no track record yet instead of
+            # filtering them. Proven-poor categories are already removed by
+            # avoid_categories above; whitelisted/probationary both pass. The old
+            # filter dropped categories absent from BOTH sets — i.e. ones with no
+            # resolved data — which created a chicken-and-egg: a newly-active venue
+            # (Kalshi) could never build a record in a category it was filtered
+            # out of. Such unknown categories now stay explorable (still gated by
+            # the edge bar + all risk checks downstream).
 
             reason = self._is_junk_market(m)
             if reason:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -31,6 +31,7 @@ risk:
   max_open_positions: 500
   min_edge_pct: 2.5
   min_liquidity: 1000.0
+  kalshi_min_liquidity: 300.0   # Kalshi book is thinner; lower its candidate floor
   max_spread_pct: 5.0
   confidence_floor: "LOW"
   implied_prob_min: 0.05
@@ -267,7 +268,7 @@ hybrid:
   news_cycle_seconds: 30
   llm_domain_filter: true
   llm_whitelist_min_accuracy: 0.50
-  llm_whitelist_min_trades: 10
+  llm_whitelist_min_trades: 5
   market_maker_auto_enable: true
 
 logging:

--- a/config/settings.py
+++ b/config/settings.py
@@ -54,6 +54,10 @@ class RiskConfig(BaseModel):
     max_open_positions: int = 200
     min_edge_pct: float = 5.0
     min_liquidity: float = 1000.0
+    # Kalshi reports thin top-of-book liquidity even on active markets, so its
+    # candidate floor is lower than the Polymarket-tuned default (the engine
+    # uses this when exchange_name == 'kalshi').
+    kalshi_min_liquidity: float = 300.0
     max_spread_pct: float = 5.0
     confidence_floor: Literal["LOW", "MEDIUM", "HIGH"] = "MEDIUM"
     implied_prob_min: float = 0.03
@@ -365,7 +369,7 @@ class HybridConfig(BaseModel):
     news_cycle_seconds: int = 30
     llm_domain_filter: bool = True
     llm_whitelist_min_accuracy: float = 0.50
-    llm_whitelist_min_trades: int = 10
+    llm_whitelist_min_trades: int = 5
     market_maker_auto_enable: bool = True
 
 

--- a/tests/test_hybrid_config.py
+++ b/tests/test_hybrid_config.py
@@ -11,7 +11,7 @@ class TestHybridConfig:
         assert cfg.news_cycle_seconds == 30
         assert cfg.llm_domain_filter is True
         assert cfg.llm_whitelist_min_accuracy == 0.50
-        assert cfg.llm_whitelist_min_trades == 10
+        assert cfg.llm_whitelist_min_trades == 5
         assert cfg.market_maker_auto_enable is True
 
     def test_settings_has_hybrid(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -54,6 +54,9 @@ def test_default_risk_params():
     assert s.risk.max_stake_per_market == 0.02
     assert s.risk.daily_loss_limit == 200.0
     assert s.risk.max_open_positions == 500
+    # Kalshi gets a lower candidate liquidity floor than Polymarket (thinner book)
+    assert s.risk.min_liquidity == 1000.0
+    assert s.risk.kalshi_min_liquidity == 300.0
     assert s.kelly.fraction == 0.30
 
 


### PR DESCRIPTION
Kalshi felt timid because its liquid universe is dominated by sports/weather game-outcomes (correctly blocked + junk-filtered — no edge vs sharps), plus two over-tight gates. This pulls levers #1 and #2 from the review. **Full suite: 412 passed.**

## #1 Whitelist exploration — fixes a real chicken-and-egg
`get_whitelist_categories` only returns categories that *have* resolved data, so a no-track-record category landed in **neither** the whitelist nor probationary set — and the engine's hybrid domain filter dropped exactly those. Result: a newly-active venue (Kalshi) could never build a record in a category it was filtered out of. The docstring says cold-start categories should be *explored*, so:
- **Unknown categories now stay explorable** (still gated by the edge bar + all 15 risk checks; proven-poor categories are still removed by `avoid_categories`).
- `llm_whitelist_min_trades` 10 → 5 (qualify for the whitelist with less history).

## #2 Per-exchange liquidity floor
Kalshi's top-of-book is thinner than Polymarket's. New `risk.kalshi_min_liquidity` (300, vs the 1000 default); the engine uses it when `exchange_name == 'kalshi'`, so more genuinely-tradeable Kalshi markets survive the pre-filter.

## Deliberately unchanged
Sports stays **blocked** and the junk filter (game-outcomes, exact-weather, unresearchable) is untouched — per the edge map, that's no-edge territory and most of Kalshi's volume. The point is to surface Kalshi's *edge-relevant* markets (econ/politics-intl/tech), not to chase sports.

Tests: config defaults for `kalshi_min_liquidity` + `llm_whitelist_min_trades`.

Assisted-by: Claude (Anthropic)