### PR TITLE
fix(kraken): liquidate orphaned directional positions

### DIFF
--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -41,8 +41,23 @@ class KrakenPillar:
         self._pair_min: dict[str, float] = {}          # pair -> ordermin (base units)
         self._pair_lot_dec: dict[str, int] = {}        # pair -> lot_decimals (volume precision)
         self._valid_pairs: list[str] = []              # configured pairs Kraken recognizes
+        # Reverse index over the FULL Kraken catalog (base asset -> a preferred
+        # sellable pair), so a held position whose pair was pruned or de-configured
+        # can still be mapped to a pair and liquidated. Built in _resolve_pairs.
+        self._base_to_pair: dict[str, str] = {}        # base asset -> liquidation pair (altname)
+        self._base_pair_meta: dict[str, tuple] = {}    # pair -> (base, ordermin, lot_decimals)
         self._pnl = None                               # lazy PnLTracker (needs db)
         self._cooldown_until: dict[str, float] = {}    # pair -> monotonic re-entry gate
+
+    # Cash-like assets that are NOT directional crypto exposure: stablecoins,
+    # Kraken fiat (Z-prefixed), and staked/earn variants ("DOT.S", "ETH2.S").
+    _STABLES = frozenset({
+        "USDC", "USDT", "DAI", "USDG", "PYUSD", "RLUSD", "TUSD", "USDP", "USD", "ZUSD",
+    })
+
+    def _is_cash_asset(self, asset: str) -> bool:
+        a = (asset or "").upper()
+        return a in self._STABLES or a.startswith("Z") or "." in a
 
     def _db(self):
         return self._bot._components.get("db") if self._bot else None
@@ -273,13 +288,35 @@ class KrakenPillar:
         """
         self._pair_base = {}
         self._valid_pairs = []
+        self._base_to_pair = {}
+        self._base_pair_meta = {}
         try:
             info = await self._k._public("AssetPairs")
             by_altname = {}
+            # Quote preference for the orphan-liquidation reverse index (lower = better).
+            _quote_rank = {"ZUSD": 0, "USD": 0, "USDC": 1, "USDT": 2, "ZEUR": 3, "EUR": 3}
+            best_rank: dict[str, int] = {}
             for meta in info.values():
                 alt = meta.get("altname")
+                base = meta.get("base")
+                quote = meta.get("quote")
                 if alt:
                     by_altname[alt] = meta
+                # Build base -> preferred sellable pair across the WHOLE catalog.
+                if alt and base:
+                    rank = _quote_rank.get(quote, 9)
+                    if base not in best_rank or rank < best_rank[base]:
+                        try:
+                            omin = float(meta.get("ordermin", 0) or 0)
+                        except (TypeError, ValueError):
+                            omin = 0.0
+                        try:
+                            ldec = int(meta.get("lot_decimals", 8))
+                        except (TypeError, ValueError):
+                            ldec = 8
+                        best_rank[base] = rank
+                        self._base_to_pair[base] = alt
+                        self._base_pair_meta[alt] = (base, omin, ldec)
             for pair in pairs:
                 meta = by_altname.get(pair)
                 if meta is None:
@@ -302,21 +339,73 @@ class KrakenPillar:
             log.warning("kraken.reconcile_pairs_error", error=str(e))
             self._valid_pairs = list(pairs)  # fall back to all; per-call errors absorb
 
-    async def _reconcile_positions(self, bal: dict) -> dict[str, tuple[float, float, float]]:
+    def _register_orphan_pair(self, pair: str) -> None:
+        """Populate pair metadata for an orphan liquidation pair from the reverse
+        index, so exit sizing (base lookup, ordermin, lot precision) works."""
+        meta = self._base_pair_meta.get(pair)
+        if not meta:
+            return
+        base, omin, ldec = meta
+        if self._pair_base is None:
+            self._pair_base = {}
+        self._pair_base.setdefault(pair, base)
+        self._pair_min.setdefault(pair, omin)
+        self._pair_lot_dec.setdefault(pair, ldec)
+
+    def _managed_pairs(self, bal: dict) -> list[str]:
+        """Pairs to evaluate this cycle: the configured/valid set UNION every
+        pair we currently hold the base asset for.
+
+        The exit loop previously iterated only configured pairs, so a held
+        position whose pair was pruned (or removed from config) was never checked
+        and sat unsold. Here we add any non-cash crypto balance as an "orphan"
+        pair mapped through the catalog reverse index, so it gets liquidated.
+        """
+        kcfg = self._s.kraken
+        pairs = list(self._valid_pairs or kcfg.directional_pairs)
+        seen = set(pairs)
+        covered_bases = {
+            (self._pair_base or {}).get(p) for p in pairs
+        }
+        for asset, amt in bal.items():
+            if amt <= 0 or self._is_cash_asset(asset):
+                continue
+            if asset in covered_bases:
+                continue  # already handled by a managed pair
+            lp = self._base_to_pair.get(asset)
+            if not lp:
+                log.warning("kraken.directional.orphan_unmappable", asset=asset,
+                            amt=round(amt, 8),
+                            note="held crypto with no sellable pair in catalog")
+                continue
+            if lp not in seen:
+                self._register_orphan_pair(lp)
+                pairs.append(lp)
+                seen.add(lp)
+        return pairs
+
+    async def _reconcile_positions(
+        self, bal: dict, managed: list[str] | None = None,
+    ) -> dict[str, tuple[float, float, float]]:
         """Sync _dir_long to actual Kraken holdings so restarts don't lose track.
 
         A directional pair is "held" when we own a non-dust amount of its base
         asset. Adds discovered holdings, drops ones that were closed externally.
         Returns the held book as ``pair -> (entry, current, qty)`` so the exit
         path can sell the actual quantity held.
-        """
-        kcfg = self._s.kraken
-        if self._pair_base is None:
-            await self._resolve_pairs(kcfg.directional_pairs)
 
+        ``managed`` is the union of configured pairs and currently-held (incl.
+        orphan) pairs — iterating it means a held position whose pair was pruned
+        is reconciled and exited instead of being silently dropped as "closed".
+        Defaults to the computed union when not supplied.
+        """
+        if self._pair_base is None:
+            await self._resolve_pairs(self._s.kraken.directional_pairs)
+        if managed is None:
+            managed = self._managed_pairs(bal)
         held: dict[str, float] = {}
         held_prices: dict[str, tuple[float, float, float]] = {}  # pair -> (entry, current, qty)
-        for pair in (self._valid_pairs or kcfg.directional_pairs):
+        for pair in managed:
             base = self._pair_base.get(pair)
             amt = bal.get(base, 0.0) if base else 0.0
             if amt <= 0:
@@ -391,30 +480,52 @@ class KrakenPillar:
         # Sizing exits/entries off the free amount avoids requesting more than is
         # actually sellable/spendable (which Kraken rejects as insufficient funds).
         bal = await self._k.get_free_balance()
-        held_prices = await self._reconcile_positions(bal)
-        for pair in (self._valid_pairs or kcfg.directional_pairs):
-            mom = await self._momentum(pair)
-            if mom is None:
-                continue
+        if self._pair_base is None:
+            await self._resolve_pairs(kcfg.directional_pairs)
+        # Evaluate the UNION of configured pairs and everything we actually hold,
+        # so a position whose pair was pruned/de-configured still gets exited.
+        managed = self._managed_pairs(bal)
+        held_prices = await self._reconcile_positions(bal, managed)
+        valid_set = set(self._valid_pairs or kcfg.directional_pairs)
+        liquidate_orphans = getattr(kcfg, "directional_liquidate_orphans", True)
+
+        # Asymmetric long bias: enter on a smaller up-move, hold through a larger
+        # down-move (ride winners). Fall back to the legacy symmetric threshold.
+        entry_thr = getattr(kcfg, "directional_entry_momentum_pct", None) or kcfg.directional_momentum_pct
+        exit_thr = getattr(kcfg, "directional_exit_momentum_pct", None) or kcfg.directional_momentum_pct
+
+        for pair in managed:
+            orphaned = pair not in valid_set
             price = await self._k.get_price(pair)
             if not price or price <= 0:
+                if (pair in self._dir_long) and orphaned:
+                    log.warning("kraken.directional.orphan_no_price", pair=pair,
+                                note="held position Kraken won't price; manual close may be needed")
                 continue
             holding = pair in self._dir_long
-
-            # Asymmetric long bias: enter on a smaller up-move, hold through a
-            # larger down-move (ride winners). Fall back to the legacy symmetric
-            # threshold if the split ones aren't configured.
-            entry_thr = getattr(kcfg, "directional_entry_momentum_pct", None) or kcfg.directional_momentum_pct
-            exit_thr = getattr(kcfg, "directional_exit_momentum_pct", None) or kcfg.directional_momentum_pct
+            mom: float | None = None
 
             if holding:
-                # Exit side: stop-loss / take-profit / trailing-stop / momentum,
-                # all measured against the real entry basis and the persisted
-                # peak. _exit_reason owns the priority + fee-netting.
+                # Exit side. For orphans (pair pruned/de-configured while still
+                # held) force-close regardless of momentum — we no longer manage
+                # it. Otherwise stop-loss / take-profit / trailing-stop / momentum
+                # via _exit_reason (priority + fee-netting), against real basis.
                 entry_px = self._dir_long.get(pair) or price
                 gain_pct = (price - entry_px) / entry_px * 100.0 if entry_px > 0 else 0.0
-                peak_pct = await self._update_and_get_peak(pair, gain_pct)
-                reason = self._exit_reason(mom, gain_pct, peak_pct, exit_thr, kcfg)
+                if orphaned:
+                    if not liquidate_orphans:
+                        log.warning("kraken.directional.orphan_detected", pair=pair,
+                                    gain_pct=round(gain_pct, 2),
+                                    note="liquidation disabled; position left open")
+                        continue
+                    reason = "orphaned"
+                    peak_pct = gain_pct
+                else:
+                    peak_pct = await self._update_and_get_peak(pair, gain_pct)
+                    mom = await self._momentum(pair)
+                    if mom is None:
+                        continue
+                    reason = self._exit_reason(mom, gain_pct, peak_pct, exit_thr, kcfg)
                 if not reason:
                     continue
                 # Sell the ACTUAL held quantity (from balance reconciliation), not
@@ -449,11 +560,17 @@ class KrakenPillar:
                     await self._clear_peak(pair)
                     self._set_cooldown(pair)   # damp whipsaw re-entry
                 log.info("kraken.directional.exit", pair=pair, reason=reason,
-                         momentum=round(mom, 2), gain_pct=round(gain_pct, 2),
+                         orphaned=orphaned,
+                         momentum=(round(mom, 2) if mom is not None else None),
+                         gain_pct=round(gain_pct, 2),
                          peak_pct=round(peak_pct, 2),
                          status=res.status, err=res.error_message[:80])
 
-            elif mom >= entry_thr and not self._in_cooldown(pair):
+            elif not orphaned:
+                # Entry side — configured pairs only; never re-enter an orphan.
+                mom = await self._momentum(pair)
+                if mom is None or mom < entry_thr or self._in_cooldown(pair):
+                    continue
                 # Budget ceiling: cap TOTAL open directional exposure at the
                 # tolerance-scaled budget, measured by ACTUAL notional (count×cap
                 # understates appreciated winners).

--- a/config/settings.py
+++ b/config/settings.py
@@ -295,6 +295,13 @@ class KrakenConfig(BaseModel):
     # --- Directional spot (gated; no validated edge — flip on deliberately) ---
     directional_enabled: bool = False
     directional_pairs: list[str] = []     # e.g. ["XBTUSDC", "ETHUSDC"] (USDC-funded)
+    # Liquidate "orphaned" directional positions — crypto we still hold on Kraken
+    # whose pair was pruned from the valid set or removed from directional_pairs.
+    # Without this they sit unsold forever (the exit loop only iterates configured
+    # pairs). Safe because treasury holds only USDC/fiat, so non-stable crypto on
+    # the account is by definition directional exposure. Set False to only detect
+    # + log orphans without auto-selling.
+    directional_liquidate_orphans: bool = True
     directional_momentum_pct: float = 3.0  # legacy symmetric threshold (fallback)
     # Asymmetric long bias: enter on a smaller up-move, exit only on a larger
     # down-move so winners ride longer. Fall back to directional_momentum_pct.

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -58,6 +58,7 @@ async def test_usd_notional_converts_quote():
 def _pillar(*, holding: bool):
     s = MagicMock()
     s.risk_tolerance = 50.0
+    s.is_live = False                      # paper: skip live fill recording
     k = s.kraken
     k.directional_pairs = ["XBTUSDC"]
     k.directional_entry_momentum_pct = 2.0
@@ -65,15 +66,36 @@ def _pillar(*, holding: bool):
     k.directional_momentum_pct = 3.0       # legacy fallback (unused when split set)
     k.directional_budget_usd = 600.0
     k.max_order_usd = 30.0
+    # Numeric exit params so _exit_reason isn't evaluated against MagicMocks.
+    k.directional_stop_loss_pct = 12.0
+    k.directional_take_profit_pct = 0.0
+    k.directional_trailing_stop_pct = 0.0
+    k.directional_fee_pct = 0.26
+    k.directional_reentry_cooldown_min = 0.0
+    k.directional_liquidate_orphans = True
     client = MagicMock()
-    client.get_balance = AsyncMock(return_value={})
+    # _directional sizes off FREE balance; exits read the reconciled held qty.
+    bal = {"XBT": 0.5, "USDC": 1000.0} if holding else {"USDC": 1000.0}
+    client.get_balance = AsyncMock(return_value=bal)
+    client.get_free_balance = AsyncMock(return_value=bal)
     client.get_price = AsyncMock(return_value=100.0)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
     client.size_for_usd = AsyncMock(return_value=0.3)   # USD-aware volume
     client.usd_notional = AsyncMock(return_value=30.0)
     client.place_spot_order = AsyncMock(return_value=OrderResult(
         order_id="OK", market_id="XBTUSDC", status="filled", is_paper=False))
     p = KrakenPillar(settings=s, kraken_client=client)
-    p._reconcile_positions = AsyncMock()   # don't touch _dir_long from balances
+    # Pre-resolve pair metadata so _directional skips the catalog fetch and
+    # _managed_pairs treats XBT as a configured (non-orphan) base.
+    p._pair_base = {"XBTUSDC": "XBT"}
+    p._valid_pairs = ["XBTUSDC"]
+    p._pair_min = {"XBTUSDC": 0.0}
+    p._pair_lot_dec = {"XBTUSDC": 8}
+    p._base_to_pair = {"XBT": "XBTUSDC"}
+    # Reconcile is covered by its own tests; here return a fixed held book so the
+    # exit path sizes off the actual qty without re-reading balances.
+    held = {"XBTUSDC": (90.0, 100.0, 0.5)} if holding else {}
+    p._reconcile_positions = AsyncMock(return_value=held)
     if holding:
         p._dir_long = {"XBTUSDC": 90.0}
     return p, client

--- a/tests/test_kraken_orphan_exit.py
+++ b/tests/test_kraken_orphan_exit.py
@@ -1,0 +1,162 @@
+"""Tests for Kraken directional orphan-position exit wiring.
+
+Regression coverage for the gap where a held directional position whose pair was
+pruned from the valid set (or removed from config) was never iterated by the
+exit loop — leaving it stuck on Kraken, unsold. _directional now evaluates the
+union of configured pairs and currently-held bases, force-closing orphans.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from auramaur.exchange.models import OrderSide
+from auramaur.treasury.kraken_pillar import KrakenPillar
+from config.settings import Settings
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeKraken:
+    """Minimal async stub of KrakenSpotClient for the pillar's exit path."""
+
+    def __init__(self, balances: dict, price: float = 150.0):
+        self._bal = balances
+        self._price = price
+        self.sells: list[tuple[str, float]] = []
+        self.buys: list[tuple[str, float]] = []
+
+    async def get_free_balance(self):
+        return dict(self._bal)
+
+    async def get_price(self, pair):
+        return self._price
+
+    async def usd_notional(self, pair, volume, price=None):
+        return volume * (price or self._price)
+
+    async def size_for_usd(self, pair, usd, price=None):
+        return usd / (price or self._price)
+
+    async def get_pair_quote(self, pair):
+        return "ZUSD"
+
+    async def query_fill(self, txid):
+        return None
+
+    async def _public(self, endpoint, params=None):
+        return {}
+
+    async def place_spot_order(self, pair, side, **kw):
+        rec = (pair, kw.get("volume"))
+        (self.sells if side == OrderSide.SELL else self.buys).append(rec)
+        return SimpleNamespace(order_id="OK", status="ok", error_message="")
+
+
+def _pillar(fake, **kraken_overrides) -> KrakenPillar:
+    s = Settings()
+    s.kraken.directional_enabled = True
+    s.kraken.directional_pairs = []
+    for k, v in kraken_overrides.items():
+        setattr(s.kraken, k, v)
+    p = KrakenPillar(settings=s, kraken_client=fake, bot=None)
+    # Pre-resolve so _directional skips the catalog fetch.
+    p._pair_base = {}
+    p._valid_pairs = []
+    p._base_to_pair = {"SOL": "SOLUSD", "XXBT": "BTCUSD"}
+    p._base_pair_meta = {"SOLUSD": ("SOL", 0.0, 8), "BTCUSD": ("XXBT", 0.0, 8)}
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _is_cash_asset
+# ---------------------------------------------------------------------------
+
+class TestCashAssetFilter:
+    def test_classification(self):
+        p = KrakenPillar(settings=Settings(), kraken_client=None, bot=None)
+        assert p._is_cash_asset("USDC")
+        assert p._is_cash_asset("ZUSD")
+        assert p._is_cash_asset("ZEUR")
+        assert p._is_cash_asset("ETH2.S")   # staked variant
+        assert not p._is_cash_asset("SOL")
+        assert not p._is_cash_asset("XXBT")
+
+
+# ---------------------------------------------------------------------------
+# _managed_pairs — the union
+# ---------------------------------------------------------------------------
+
+class TestManagedPairs:
+    def test_union_adds_orphans_skips_cash(self):
+        fake = FakeKraken({})
+        p = _pillar(fake)
+        p._valid_pairs = ["BTCUSD"]
+        p._pair_base = {"BTCUSD": "XXBT"}
+        bal = {"XXBT": 0.5, "SOL": 1.0, "USDC": 50.0, "ZEUR": 10.0, "DOT.S": 3.0}
+        managed = p._managed_pairs(bal)
+        assert "BTCUSD" in managed       # configured/valid
+        assert "SOLUSD" in managed       # orphan (held, not configured)
+        assert len(managed) == 2         # cash + staked excluded; BTC not duplicated
+
+    def test_unmappable_orphan_skipped(self):
+        fake = FakeKraken({})
+        p = _pillar(fake)
+        p._base_to_pair = {}             # nothing maps
+        managed = p._managed_pairs({"WIF": 100.0})
+        assert managed == []
+
+
+# ---------------------------------------------------------------------------
+# reconcile keeps orphans (does not drop as "closed externally")
+# ---------------------------------------------------------------------------
+
+class TestReconcileKeepsOrphan:
+    def test_orphan_not_dropped(self):
+        fake = FakeKraken({"SOL": 1.0})
+        p = _pillar(fake)
+        p._dir_long = {"SOLUSD": 140.0}
+        p._register_orphan_pair("SOLUSD")
+        held = run(p._reconcile_positions({"SOL": 1.0}, ["SOLUSD"]))
+        assert "SOLUSD" in held
+        assert "SOLUSD" in p._dir_long   # NOT dropped
+
+
+# ---------------------------------------------------------------------------
+# _directional — orphan liquidation
+# ---------------------------------------------------------------------------
+
+class TestOrphanLiquidation:
+    def test_orphan_is_sold(self):
+        fake = FakeKraken({"SOL": 1.0, "USDC": 100.0})
+        p = _pillar(fake)  # no valid pairs → SOL is an orphan
+        run(p._directional())
+        assert fake.sells == [("SOLUSD", 1.0)]
+        assert "SOLUSD" not in p._dir_long  # tracking cleared after close
+
+    def test_orphan_left_when_liquidation_disabled(self):
+        fake = FakeKraken({"SOL": 1.0, "USDC": 100.0})
+        p = _pillar(fake, directional_liquidate_orphans=False)
+        run(p._directional())
+        assert fake.sells == []
+
+    def test_configured_pair_not_treated_as_orphan(self):
+        # SOL is configured+valid: it should go through the normal exit path
+        # (momentum), not the forced orphan liquidation. With flat momentum and
+        # default stops it holds, so no sell.
+        fake = FakeKraken({"SOL": 1.0, "USDC": 100.0})
+        p = _pillar(fake)
+        p._valid_pairs = ["SOLUSD"]
+        p._pair_base = {"SOLUSD": "SOL"}
+        p._pair_min = {"SOLUSD": 0.0}
+        p._pair_lot_dec = {"SOLUSD": 8}
+        p._dir_long = {"SOLUSD": 150.0}   # entry == price → flat
+        # momentum returns 0 (flat) → no momentum exit, no stop hit
+        async def _flat_mom(pair):
+            return 0.0
+        p._momentum = _flat_mom
+        run(p._directional())
+        assert fake.sells == []


### PR DESCRIPTION
## Problem
The Kraken directional ("spec book") exit was wired into the run loop, but it only iterated the **configured/valid** pair set. A position held in a pair pruned from `_valid_pairs` (transient catalog miss, or removed from `directional_pairs`) was never checked by the exit loop, and was actively dropped from `_dir_long` as "closed externally" by `_reconcile_positions` — even though the asset was still held on Kraken. It sat **unsold forever**; the `unstick_kraken_spec.py` script was a manual band-aid for exactly this.

## Fix
`_directional` now evaluates the **union** of configured pairs and every pair whose base asset we currently hold:
- `_resolve_pairs` builds a full-catalog reverse index (`base → preferred sellable pair`).
- `_managed_pairs` returns `valid ∪ held-bases`; `_reconcile_positions` iterates it (held orphans reconciled, not dropped).
- Orphaned holdings are **force-closed regardless of momentum** (`"orphaned"` reason), gated by new `kraken.directional_liquidate_orphans` (default on; `False` = detect-and-log only).
- Cash/stable/fiat/staked assets excluded — only directional crypto is sold. Safe because treasury holds only USDC/fiat.
- All sells still pass the three live gates + kill switch.

## Tests
- New `tests/test_kraken_orphan_exit.py` (7): union, orphan detection, cash filter, liquidation, gate-off, reconcile-keeps-orphan regression.
- Repaired `tests/test_kraken_directional.py` (4): failing on `main` since `_directional` moved to free-balance + held-qty sizing.
- 53 relevant tests pass.

Assisted-by: Claude (Anthropic)