### PR TITLE
fix(config): ignore undeclared env vars so stray tokens don't crash startup

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -531,6 +531,11 @@ class Settings(BaseSettings):
     model_config = {
         "env_file": str(Path(__file__).resolve().parent.parent / ".env"),
         "env_file_encoding": "utf-8",
+        # Ignore env vars we don't declare. The process shares its environment
+        # with libraries that read their own tokens directly (e.g. HF_TOKEN /
+        # hf_token for huggingface_hub via sentence-transformers), and an
+        # unrelated stray var shouldn't crash Settings on startup.
+        "extra": "ignore",
     }
 
     @property


### PR DESCRIPTION
## Problem
`auramaur run --hybrid` crashed at startup with a pydantic `ValidationError`:
```
hf_token  Extra inputs are not permitted [type=extra_forbidden, ...]
```
`Settings` (pydantic-settings) defaults to `extra='forbid'`. An `hf_token` in the environment — read directly by `huggingface_hub`/`sentence-transformers`, not by `Settings` — tripped it and prevented the bot from launching.

## Fix
Add `"extra": "ignore"` to `Settings.model_config` so it binds only the keys it declares and tolerates other libraries' tokens in the shared environment.

## Test
`hf_token=hf_dummy .venv/bin/python -c 'from config.settings import Settings; Settings()'` now loads cleanly.

Assisted-by: Claude (Anthropic)