### PR TITLE
fix(gamma): log transient network errors at warning, not error

### DIFF
--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -29,6 +29,17 @@ _NEGATIVE_CACHE_TTL = 3600.0
 _GAMMA_TIMEOUT = aiohttp.ClientTimeout(total=20, sock_connect=10, sock_read=15)
 
 
+def _is_transient(e: BaseException) -> bool:
+    """Network blips — DNS resolution, connection refused, TLS/cert, timeouts —
+    are environmental and self-healing. They arrive in bursts during a
+    connectivity outage (hundreds in one cycle), so logging each at ERROR
+    spikes the health monitor into DEGRADED and buries genuine faults. Treat
+    them as warnings; reserve ERROR for unexpected client errors (e.g. malformed
+    responses) that actually indicate something is broken on our side.
+    """
+    return isinstance(e, (aiohttp.ClientConnectionError, asyncio.TimeoutError))
+
+
 class GammaClient:
     """Unauthenticated Gamma API for market discovery and filtering."""
 
@@ -80,7 +91,8 @@ class GammaClient:
             return markets
 
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            log.error("gamma.fetch_error", error=str(e), kind=type(e).__name__)
+            logf = log.warning if _is_transient(e) else log.error
+            logf("gamma.fetch_error", error=str(e), kind=type(e).__name__)
             return []
 
     async def get_market(self, market_id: str) -> Market | None:
@@ -116,7 +128,8 @@ class GammaClient:
                 data = await resp.json()
                 return self._parse_market(data)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            log.error(
+            logf = log.warning if _is_transient(e) else log.error
+            logf(
                 "gamma.market_fetch_error",
                 market_id=market_id,
                 error=str(e),
@@ -163,7 +176,8 @@ class GammaClient:
             return markets
 
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            log.error("gamma.search_error", query=query, error=str(e), kind=type(e).__name__)
+            logf = log.warning if _is_transient(e) else log.error
+            logf("gamma.search_error", query=query, error=str(e), kind=type(e).__name__)
             return []
 
     def _parse_market(self, data: dict) -> Market | None:


### PR DESCRIPTION
## Context
The original task was a "gamma hex-ID 422 bug." On investigation, **that bug is already fixed** — `get_market` has a `0x` guard (gamma.py:95) that skips hex condition-ids before they hit the numeric `/markets/{id}` endpoint. Recent 422s are down to a handful; the audit's ~106k count was cumulative over the 77-day log, from before that guard.

## The real remaining issue
The Gamma client logs **every** `aiohttp.ClientError`/timeout at `ERROR` across all three call sites. During a connectivity blip these arrive in bursts — the live log shows **777 errors in just 16 distinct minutes** (290 in a single minute), all `ClientConnectorDNSError`/cert/timeout from the host briefly losing DNS to `gamma-api.polymarket.com`. That bursty noise is a primary driver of the `doctor` DEGRADED state, burying genuine faults.

## Fix
Add `_is_transient()` (DNS / connection / cert / timeout) and log those at `warning`, reserving `ERROR` for unexpected client errors (e.g. malformed responses) that signal a real problem. Applied at `get_markets`, `get_market`, and `search_markets`.

## Test
Verified the classifier against the exact exception types in the log:
| error | classified |
|---|---|
| ClientConnectorDNSError | transient → warning |
| ClientConnectorCertificateError | transient → warning |
| SocketTimeoutError / asyncio.TimeoutError | transient → warning |
| ClientPayloadError (unexpected) | → error |

Assisted-by: Claude (Anthropic)