### PR TITLE
fix(classifier): route foreign elections to politics_intl, not politics_us

### DIFF
--- a/auramaur/strategy/classifier.py
+++ b/auramaur/strategy/classifier.py
@@ -49,8 +49,6 @@ GAMBLING_KEYWORDS: list[str] = [
 
 # --- General keyword scoring (used when no priority category matches) ---
 CATEGORY_KEYWORDS: dict[str, list[str]] = {
-    "politics_us": ["president", "congress", "senate", "house", "democrat", "republican", "biden", "trump", "election", "vote", "primary", "gop"],
-    "politics_intl": ["ukraine", "russia", "china", "eu", "nato", "war", "un", "geopoliti"],
     "economics": ["gdp", "inflation", "fed", "interest rate", "unemployment", "recession", "cpi", "jobs report", "treasury"],
     "crypto": ["bitcoin", "ethereum", "crypto", "btc", "eth", "defi", "nft", "token"],
     "tech": ["ai", "artificial intelligence", "openai", "google", "apple", "meta", "microsoft", "tech"],
@@ -58,6 +56,33 @@ CATEGORY_KEYWORDS: dict[str, list[str]] = {
     "science": ["climate", "nasa", "space", "vaccine", "covid", "health", "fda"],
     "legal": ["supreme court", "lawsuit", "trial", "verdict", "indictment", "ruling"],
 }
+
+# Politics is split US vs. international by COUNTRY CONTEXT, not handled in the
+# generic dict above. Generic governance terms (president, election, vote, ...)
+# describe both, so they must not by themselves pull a market into politics_us —
+# that previously misfiled every foreign election (a French presidential race, a
+# Bolivian president question) as politics_us, because politics_intl carried no
+# governance or country markers to compete. We score US-specific markers,
+# foreign country/demonym markers, and shared governance terms separately, then
+# let country context decide the bucket (see classify_market).
+POLITICS_US_KEYWORDS: list[str] = [
+    "congress", "senate", "house", "democrat", "republican", "biden", "trump",
+    "gop", "white house", "american", "governor", "midterm",
+]
+POLITICS_INTL_KEYWORDS: list[str] = [
+    "ukraine", "russia", "china", "eu", "nato", "war", "un", "geopoliti",
+    "france", "french", "germany", "german", "uk", "britain", "british",
+    "canada", "canadian", "mexico", "mexican", "brazil", "brazilian",
+    "india", "indian", "japan", "japanese", "israel", "israeli",
+    "iran", "iranian", "venezuela", "argentina", "bolivia", "bolivian",
+    "poland", "polish", "italy", "italian", "spain", "spanish",
+    "turkey", "turkish", "taiwan", "pakistan", "nigeria",
+    "south korea", "north korea",
+]
+POLITICS_GOVERNANCE_KEYWORDS: list[str] = [
+    "president", "presidential", "election", "vote", "primary", "parliament",
+    "prime minister", "referendum", "chancellor", "coalition",
+]
 
 
 def _compile_one(keyword: str) -> re.Pattern:
@@ -101,6 +126,10 @@ _CATEGORY_RES: dict[str, list[re.Pattern]] = {
     cat: _compile_many(kws) for cat, kws in CATEGORY_KEYWORDS.items()
 }
 
+_POLITICS_US_RE = _compile_many(POLITICS_US_KEYWORDS)
+_POLITICS_INTL_RE = _compile_many(POLITICS_INTL_KEYWORDS)
+_POLITICS_GOV_RE = _compile_many(POLITICS_GOVERNANCE_KEYWORDS)
+
 
 def classify_market(question: str, description: str = "") -> str:
     """Classify a market question into a category.
@@ -129,6 +158,21 @@ def classify_market(question: str, description: str = "") -> str:
         score = sum(1 for p in patterns if p.search(full))
         if score > 0:
             scores[category] = score
+
+    # Politics: decide US vs. international by country context. Governance terms
+    # (president/election/...) count toward whichever bucket the country markers
+    # select, so a foreign election lands in politics_intl instead of defaulting
+    # to politics_us. With no country marker, generic governance defaults to US
+    # (the bulk of prediction-market election markets), preserving prior behavior.
+    us = sum(1 for p in _POLITICS_US_RE if p.search(full))
+    intl = sum(1 for p in _POLITICS_INTL_RE if p.search(full))
+    gov = sum(1 for p in _POLITICS_GOV_RE if p.search(full))
+    if intl and not us:
+        scores["politics_intl"] = intl + gov
+    elif us:
+        scores["politics_us"] = us + gov
+    elif gov:
+        scores["politics_us"] = gov
 
     if not scores:
         return "other"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -81,6 +81,38 @@ def test_primary_winner_boilerplate_not_sports():
     assert cat == "politics_us"
 
 
+def test_foreign_election_is_politics_intl():
+    """Generic governance terms (president/election) must not pull a foreign
+    election into politics_us — country context routes it to politics_intl."""
+    assert classify_market(
+        "Will Jordan Bardella win the 2027 French presidential election?"
+    ) == "politics_intl"
+    assert classify_market("Rodrigo Paz out as President of Bolivia?") == "politics_intl"
+    assert classify_market("Will Germany hold a snap election in 2026?") == "politics_intl"
+
+
+def test_us_election_stays_politics_us():
+    """US-marked elections must still classify as politics_us after the split."""
+    assert classify_market("Will Trump win the 2024 election?") == "politics_us"
+    assert classify_market(
+        "Will the Democratic Party win the NY-21 House seat?"
+    ) == "politics_us"
+
+
+def test_unmarked_governance_defaults_us():
+    """Governance terms with no country marker default to politics_us (the bulk
+    of prediction-market election markets), preserving prior behavior."""
+    assert classify_market("Who will win the presidential election?") == "politics_us"
+
+
+def test_commodity_not_politics():
+    """A commodities/price market must not land in any politics bucket."""
+    assert classify_market("Will WTI Crude Oil close above $88 on Friday?") not in (
+        "politics_us",
+        "politics_intl",
+    )
+
+
 def test_ncaa_is_sports():
     assert classify_market("NCAA Tournament: No. 15 seed to pull off an upset?") == "sports"
 


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.