### PR TITLE
fix(kalshi): book settlements + record predictions + per-venue attribution

### DIFF
--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -145,10 +145,11 @@ def attribution():
         await db.connect()
         try:
             attr = PerformanceAttributor(db=db)
+            venues = await attr.get_venue_summary(is_live=settings.is_live)
             cats = await attr.get_category_summary(is_live=settings.is_live)
             strats = await attr.get_strategy_summary(is_live=settings.is_live)
             mode = "live" if settings.is_live else "paper"
-            console.print(render_attribution(cats, strats, mode=mode))
+            console.print(render_attribution(cats, strats, mode=mode, venue_rows=venues))
         finally:
             await db.close()
 

--- a/auramaur/monitoring/attribution.py
+++ b/auramaur/monitoring/attribution.py
@@ -242,6 +242,109 @@ class PerformanceAttributor:
             return 1.0
         return float(row["kelly_multiplier"])
 
+    async def get_venue_summary(self, *, is_live: bool = False) -> list[dict]:
+        """Per-venue (exchange) summary: exposure, unrealized and realized P&L.
+
+        Mirrors ``get_category_summary`` but groups by exchange so each trading
+        venue (polymarket, kalshi, cryptodotcom, …) is visible on its own.
+        Without this, a venue whose settlements lag or whose realized P&L is
+        small is indistinguishable from one that is genuinely flat — the exact
+        blind spot that hid Kalshi's unbooked settlements. Realized P&L is
+        attributed to a venue via ``markets.exchange`` (falling back to the
+        portfolio row, then "polymarket"), combining the same two authoritative
+        sources the category/strategy views use: ``resolution_pnl`` for
+        oracle-resolved markets (live) and ``cost_basis.realized_pnl`` for
+        positions closed by selling.
+        """
+        paper_flag = 0 if is_live else 1
+        portfolio_rows = await self._db.fetchall(
+            """SELECT COALESCE(NULLIF(p.exchange, ''), 'polymarket') AS venue,
+                      COUNT(*) AS positions,
+                      SUM(p.size * p.avg_price) AS exposure,
+                      SUM(
+                          (COALESCE(p.current_price, p.avg_price)
+                           - COALESCE(cb.avg_cost, p.avg_price)) * p.size
+                      ) AS unrealized_pnl
+               FROM portfolio p
+               LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
+                                       AND cb.is_paper = p.is_paper
+               WHERE (p.is_paper = ? OR p.exchange != 'polymarket') AND p.size > 0
+               GROUP BY venue""",
+            (paper_flag,),
+        )
+
+        # resolution_pnl is live-only; for the rest use cost_basis, excluding
+        # already-resolved markets so they aren't double-counted (mirrors
+        # get_strategy_summary).
+        resolved_union = (
+            "SELECT market_id, pnl AS realized FROM resolution_pnl UNION ALL "
+            if is_live else ""
+        )
+        resolved_exclusion = (
+            "AND market_id NOT IN (SELECT market_id FROM resolution_pnl)"
+            if is_live else ""
+        )
+        realized_rows = await self._db.fetchall(
+            f"""SELECT venue,
+                       COALESCE(SUM(realized), 0) AS realized_pnl,
+                       SUM(CASE WHEN realized > 0 THEN 1 ELSE 0 END) AS wins,
+                       SUM(CASE WHEN realized < 0 THEN 1 ELSE 0 END) AS losses,
+                       COUNT(*) AS resolved_count
+                FROM (
+                    SELECT mp.realized,
+                           COALESCE(
+                               (SELECT m.exchange FROM markets m WHERE m.id = mp.market_id),
+                               (SELECT p.exchange FROM portfolio p
+                                WHERE p.market_id = mp.market_id LIMIT 1),
+                               'polymarket'
+                           ) AS venue
+                    FROM (
+                        {resolved_union}
+                        SELECT market_id, realized_pnl AS realized FROM cost_basis
+                        WHERE is_paper = ? {resolved_exclusion}
+                    ) mp
+                )
+                GROUP BY venue""",
+            (paper_flag,),
+        )
+        realized_map = {r["venue"]: dict(r) for r in realized_rows}
+
+        result: list[dict] = []
+        seen: set[str] = set()
+        for row in portfolio_rows:
+            venue = row["venue"]
+            seen.add(venue)
+            rz = realized_map.get(venue, {})
+            result.append({
+                "venue": venue,
+                "positions": row["positions"],
+                "exposure": row["exposure"] or 0,
+                "unrealized_pnl": row["unrealized_pnl"] or 0,
+                "realized_pnl": rz.get("realized_pnl", 0) or 0,
+                "wins": rz.get("wins", 0) or 0,
+                "losses": rz.get("losses", 0) or 0,
+                "resolved_count": rz.get("resolved_count", 0) or 0,
+            })
+
+        # Venues with only resolved/sold history (no open positions) would
+        # otherwise vanish along with their realized P&L.
+        for venue, rz in realized_map.items():
+            if venue in seen:
+                continue
+            result.append({
+                "venue": venue,
+                "positions": 0,
+                "exposure": 0,
+                "unrealized_pnl": 0,
+                "realized_pnl": rz.get("realized_pnl", 0) or 0,
+                "wins": rz.get("wins", 0) or 0,
+                "losses": rz.get("losses", 0) or 0,
+                "resolved_count": rz.get("resolved_count", 0) or 0,
+            })
+
+        result.sort(key=lambda r: r["exposure"], reverse=True)
+        return result
+
     async def get_strategy_summary(self, *, is_live: bool = False) -> list[dict]:
         """Per-strategy realized P&L, attributed from authoritative sources.
 

--- a/auramaur/monitoring/diagnostics.py
+++ b/auramaur/monitoring/diagnostics.py
@@ -264,8 +264,14 @@ def render_doctor(s: dict) -> Panel:
     return Panel(Group(head, Text(""), t), title="doctor", border_style=border)
 
 
-def render_attribution(category_rows: list[dict], strategy_rows: list[dict], *, mode: str) -> Panel:
-    """Per-category and per-strategy P&L / accuracy / Kelly."""
+def render_attribution(
+    category_rows: list[dict],
+    strategy_rows: list[dict],
+    *,
+    mode: str,
+    venue_rows: list[dict] | None = None,
+) -> Panel:
+    """Per-venue, per-category and per-strategy P&L / accuracy / Kelly."""
     cat = Table(title="by category", expand=True)
     cat.add_column("category", style="cyan")
     cat.add_column("pos", justify="right")
@@ -301,5 +307,25 @@ def render_attribution(category_rows: list[dict], strategy_rows: list[dict], *, 
         )
 
     head = Text.from_markup(f"[bold]Performance attribution[/]  ([dim]{mode}[/])")
-    return Panel(Group(head, Text(""), cat, Text(""), strat),
-                 title="attribution", border_style="blue")
+
+    sections = [head, Text("")]
+    if venue_rows is not None:
+        venue = Table(title="by venue", expand=True)
+        venue.add_column("venue", style="green")
+        venue.add_column("pos", justify="right")
+        venue.add_column("exposure", justify="right")
+        venue.add_column("realized", justify="right")
+        venue.add_column("unrealized", justify="right")
+        venue.add_column("resolved", justify="right")
+        for r in venue_rows:
+            venue.add_row(
+                r.get("venue", "?") or "?", str(r.get("positions", 0)),
+                f"${r.get('exposure', 0):.0f}",
+                _money(r.get("realized_pnl", 0) or 0),
+                _money(r.get("unrealized_pnl", 0) or 0),
+                str(r.get("resolved_count", 0) or 0),
+            )
+        sections.extend([venue, Text("")])
+
+    sections.extend([cat, Text(""), strat])
+    return Panel(Group(*sections), title="attribution", border_style="blue")

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -1266,10 +1266,22 @@ class TradingEngine:
                 log.debug("strategic.market_id_mismatch", result_id=batch_result.market_id)
                 continue
 
-            claude_prob = batch_result.probability
+            raw_prob = batch_result.probability
+            claude_prob = raw_prob
             # Apply Platt scaling calibration to raw probability
             if self.calibration:
-                claude_prob = await self.calibration.adjust(claude_prob, market.category or "")
+                claude_prob = await self.calibration.adjust(raw_prob, market.category or "")
+                # Record the raw prediction so (a) the resolution tracker can
+                # later settle this market and (b) Platt scaling can learn from
+                # the outcome. The legacy analyze_market path records this too,
+                # but it only runs for Polymarket (the price-monitor WebSocket
+                # path). The strategic path is the ONLY path Kalshi and
+                # Crypto.com take, so without this their markets never enter the
+                # calibration table and consequently never get settled — their
+                # realized P&L was silently never booked.
+                await self.calibration.record_prediction(
+                    market.id, raw_prob, market.category or ""
+                )
             market_prob = market.outcome_yes_price
 
             # Edge calculation (same as detect_edge)

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -38,14 +38,32 @@ class ResolutionTracker:
 
         Returns the count of newly resolved markets.
         """
-        # Get market_ids with predictions but no resolution yet.
-        # Join against markets table to get the exchange, falling back to
-        # "polymarket" when the row is missing (e.g. paper-only runs).
+        # Resolve two groups of markets:
+        #   1. Markets we have an open prediction for (calibration), and
+        #   2. Markets we currently hold a position in (portfolio).
+        # The portfolio arm is essential: a held position must settle when it
+        # resolves even if no calibration prediction was ever recorded for it.
+        # Kalshi/Crypto.com positions historically fell into exactly this gap —
+        # their strategic-path predictions weren't logged, so they never entered
+        # calibration, were never checked here, and their realized P&L was never
+        # booked. Driving settlement off open positions makes it robust for any
+        # venue regardless of how the prediction was (or wasn't) recorded.
+        # The exchange is taken from the markets join for the calibration arm
+        # and from the portfolio row directly for the position arm; MAX() picks
+        # a non-NULL value when a market appears in both, falling back to
+        # "polymarket" below when neither knows the venue.
         rows = await self._db.fetchall(
-            """SELECT DISTINCT c.market_id, m.exchange
-               FROM calibration c
-               LEFT JOIN markets m ON c.market_id = m.id
-               WHERE c.actual_outcome IS NULL"""
+            """SELECT market_id, MAX(exchange) AS exchange FROM (
+                   SELECT c.market_id AS market_id, m.exchange AS exchange
+                   FROM calibration c
+                   LEFT JOIN markets m ON c.market_id = m.id
+                   WHERE c.actual_outcome IS NULL
+                   UNION ALL
+                   SELECT p.market_id AS market_id, p.exchange AS exchange
+                   FROM portfolio p
+                   WHERE p.size > 0
+               )
+               GROUP BY market_id"""
         )
 
         resolved_count = 0

--- a/tests/test_kalshi_pnl_tracking.py
+++ b/tests/test_kalshi_pnl_tracking.py
@@ -1,0 +1,174 @@
+"""Regression tests for the Kalshi P&L-tracking gap.
+
+Kalshi (and Crypto.com) trade exclusively through the strategic path, which —
+unlike the Polymarket-only price-monitor path — never recorded calibration
+predictions. As a result Kalshi markets never entered the calibration table,
+the resolution tracker (which iterated only calibration) never settled them,
+their realized P&L was never booked, and the attribution scorecard had no
+per-venue view to surface any of it.
+
+These tests lock in the three fixes:
+  1. The resolution tracker settles *held positions*, not just markets with a
+     calibration prediction.
+  2. get_venue_summary breaks realized/unrealized P&L down by exchange.
+
+The third fix — the strategic path now records a calibration prediction for
+every analyzed market (engine._run_cycle_strategic) — closes the root cause
+going forward; fix #1 here is the robust safety net that also recovers the
+already-open book that predates it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.monitoring.attribution import PerformanceAttributor
+from auramaur.strategy.resolution_tracker import ResolutionTracker
+
+
+def _make_discovery(market: Market | None):
+    disc = AsyncMock()
+    disc.get_market = AsyncMock(return_value=market)
+    return disc
+
+
+def test_held_position_without_calibration_settles():
+    """A held Kalshi position with NO calibration row still settles.
+
+    This is the core regression: previously check_resolutions only looked at
+    the calibration table, so a Kalshi position the bot held would never be
+    settled and its realized P&L would never be booked.
+    """
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+
+        mid = "KXTESTMARKET-30JAN01-YES"
+        # A live BUY-YES position, entered at 0.40, no calibration prediction.
+        await db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                                      current_price, is_paper)
+               VALUES (?, 'kalshi', 'BUY', 10, 0.40, 0.99, 0)""",
+            (mid,),
+        )
+        await db.execute(
+            "INSERT INTO markets (id, exchange, question, active, last_updated) "
+            "VALUES (?, 'kalshi', 'q', 1, datetime('now'))",
+            (mid,),
+        )
+        await db.commit()
+
+        # Sanity: nothing in calibration, so the OLD query would have found this.
+        cal = await db.fetchall("SELECT * FROM calibration")
+        assert cal == []
+
+        # Market reports resolved YES (inactive + price pinned to 0.99).
+        market = Market(
+            id=mid, exchange="kalshi", question="q",
+            active=False, outcome_yes_price=0.99, outcome_no_price=0.01,
+        )
+        calibration = AsyncMock()
+        tracker = ResolutionTracker(
+            db=db, calibration=calibration,
+            discoveries={"kalshi": _make_discovery(market)},
+        )
+
+        count = await tracker.check_resolutions()
+        assert count == 1
+
+        # Position settled: removed from portfolio, P&L booked into cost_basis.
+        remaining = await db.fetchall(
+            "SELECT * FROM portfolio WHERE market_id = ?", (mid,)
+        )
+        assert remaining == []
+        # BUY YES @0.40, resolves YES (->$1): pnl = (1 - 0.40) * 10 = 6.0
+        cb = await db.fetchone(
+            "SELECT realized_pnl FROM cost_basis WHERE market_id = ?", (mid,)
+        )
+        # cost_basis row only exists if it was pre-seeded; settlement updates it
+        # when present. Verify daily_stats captured the realized P&L either way.
+        stats = await db.fetchone("SELECT total_pnl FROM daily_stats LIMIT 1")
+        assert stats is not None
+        assert abs(stats["total_pnl"] - 6.0) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_venue_summary_breaks_down_by_exchange():
+    """get_venue_summary attributes exposure + realized P&L per venue."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+
+        # Open positions: one Kalshi, one Polymarket (live).
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('KXFOO-1', 'kalshi', 'BUY', 10, 0.50, 0.60, 0)"
+        )
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('12345', 'polymarket', 'BUY', 10, 0.50, 0.40, 0)"
+        )
+        # Realized: Kalshi market resolved +4 (resolution_pnl), Poly sold -2 (cost_basis).
+        await db.execute(
+            "INSERT INTO markets (id, exchange, question, last_updated) "
+            "VALUES ('KXBAR-1', 'kalshi', 'q', datetime('now'))"
+        )
+        await db.execute(
+            "INSERT INTO resolution_pnl (market_id, category, pnl, resolved_at) "
+            "VALUES ('KXBAR-1', 'crypto', 4.0, '2026-06-01T00:00')"
+        )
+        await db.execute(
+            "INSERT INTO markets (id, exchange, question, last_updated) "
+            "VALUES ('67890', 'polymarket', 'q', datetime('now'))"
+        )
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, "
+            "realized_pnl, is_paper) VALUES ('67890', 'YES', 0, 0, 0, -2.0, 0)"
+        )
+        await db.commit()
+
+        attr = PerformanceAttributor(db=db)
+        rows = {r["venue"]: r for r in await attr.get_venue_summary(is_live=True)}
+
+        assert set(rows) == {"kalshi", "polymarket"}
+        # Kalshi: exposure 10*0.50=5, unrealized (0.60-0.50)*10=+1, realized +4.
+        assert abs(rows["kalshi"]["exposure"] - 5.0) < 1e-9
+        assert abs(rows["kalshi"]["unrealized_pnl"] - 1.0) < 1e-9
+        assert abs(rows["kalshi"]["realized_pnl"] - 4.0) < 1e-9
+        # Polymarket: unrealized (0.40-0.50)*10=-1, realized -2 (sold).
+        assert abs(rows["polymarket"]["unrealized_pnl"] - (-1.0)) < 1e-9
+        assert abs(rows["polymarket"]["realized_pnl"] - (-2.0)) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_venue_summary_paper_scopes_out_live():
+    """Paper mode excludes live Polymarket rows but keeps non-Polymarket venues."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('12345', 'polymarket', 'BUY', 10, 0.50, 0.40, 0)"
+        )
+        await db.commit()
+        attr = PerformanceAttributor(db=db)
+        rows = await attr.get_venue_summary(is_live=False)
+        # The only row is a live Polymarket position → invisible in paper mode.
+        assert all(r["venue"] != "polymarket" for r in rows)
+        await db.close()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    test_held_position_without_calibration_settles()
+    test_venue_summary_breaks_down_by_exchange()
+    test_venue_summary_paper_scopes_out_live()
+    print("ok")


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.