### PR TITLE
fix(kalshi): monitor live orders so they don't get stuck 'pending'

### DIFF
--- a/auramaur/broker/order_reconcile.py
+++ b/auramaur/broker/order_reconcile.py
@@ -1,0 +1,102 @@
+"""One-time reconciliation of stale Kalshi order rows.
+
+Kalshi orders inserted at placement carry status ``pending``. The order
+monitor is meant to flip them to a terminal status once the venue fills or
+cancels them — but Kalshi historically wasn't monitored at all (its client
+didn't expose ``_live_pending``), so those rows accumulated as permanent
+``pending`` cruft even though the underlying orders long since executed,
+cancelled, or expired on-venue.
+
+This re-queries each pending Kalshi order against the venue and updates the
+``trades`` row to match. It is ledger hygiene only — it does NOT record fills
+or mutate P&L (realized P&L already flows from fills/sync/resolution), so it is
+safe to run repeatedly and cannot double-count.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import structlog
+
+log = structlog.get_logger()
+
+# Statuses we consider terminal — anything here moves a row out of 'pending'.
+_TERMINAL = {"filled", "cancelled", "expired", "rejected"}
+
+
+@dataclass
+class ReconcileResult:
+    scanned: int = 0
+    updated: int = 0
+    still_pending: int = 0
+    by_status: dict[str, int] = field(default_factory=dict)
+
+
+async def reconcile_pending_kalshi_orders(
+    db, exchange, *, dry_run: bool = True
+) -> ReconcileResult:
+    """Reconcile every ``pending`` live Kalshi trade against the venue.
+
+    Args:
+        db: Database handle.
+        exchange: A KalshiClient exposing ``get_order_status(order_id)``.
+        dry_run: When True (default) compute the changes but don't write.
+
+    Returns:
+        ReconcileResult summarising what was (or would be) updated.
+    """
+    rows = await db.fetchall(
+        """SELECT id, order_id, market_id FROM trades
+           WHERE exchange = 'kalshi' AND status = 'pending'
+             AND order_id IS NOT NULL AND order_id != ''
+             AND order_id NOT IN ('unknown', 'ERROR', 'SKIP_DUP', 'BLOCKED')"""
+    )
+
+    result = ReconcileResult(scanned=len(rows))
+    for r in rows:
+        oid = r["order_id"]
+        size: float | None = None
+        price: float | None = None
+        try:
+            status_result = await exchange.get_order_status(oid)
+            status = status_result.status
+            if status == "filled":
+                if status_result.filled_size > 0:
+                    size = status_result.filled_size
+                if status_result.filled_price > 0:
+                    price = status_result.filled_price
+        except Exception:
+            # The venue no longer knows this order (too old / pruned). It is by
+            # definition no longer resting and can never fill — treat as expired.
+            status = "expired"
+
+        if status not in _TERMINAL:
+            result.still_pending += 1
+            continue
+
+        result.updated += 1
+        result.by_status[status] = result.by_status.get(status, 0) + 1
+        if not dry_run:
+            if size is not None and price is not None:
+                await db.execute(
+                    "UPDATE trades SET status = ?, size = ?, price = ? WHERE id = ?",
+                    (status, size, price, r["id"]),
+                )
+            else:
+                await db.execute(
+                    "UPDATE trades SET status = ? WHERE id = ?", (status, r["id"]),
+                )
+
+    if not dry_run:
+        await db.commit()
+
+    log.info(
+        "kalshi.order_reconcile",
+        scanned=result.scanned,
+        updated=result.updated,
+        still_pending=result.still_pending,
+        by_status=result.by_status,
+        dry_run=dry_run,
+    )
+    return result

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -509,6 +509,54 @@ def repair_pnl(write: bool):
     asyncio.run(_run())
 
 
+@main.command("reconcile-kalshi-orders")
+@click.option("--write", is_flag=True,
+              help="Persist the reconciled trade statuses (default is a dry-run).")
+def reconcile_kalshi_orders(write: bool):
+    """Reconcile stale 'pending' Kalshi trade rows against the venue.
+
+    Kalshi orders inserted at placement stayed 'pending' because the client
+    historically wasn't monitored. This re-queries each one and flips it to its
+    real terminal status (filled/cancelled/expired). Ledger hygiene only — it
+    does not touch P&L. Default mode is a dry-run.
+    """
+
+    async def _run():
+        from auramaur.broker.order_reconcile import reconcile_pending_kalshi_orders
+        from auramaur.exchange.kalshi import KalshiClient
+        from auramaur.exchange.paper import PaperTrader
+
+        settings = Settings()
+        db = Database()
+        await db.connect()
+        try:
+            paper = PaperTrader(db=db)
+            exchange = KalshiClient(settings=settings, paper_trader=paper)
+            res = await reconcile_pending_kalshi_orders(
+                db, exchange, dry_run=not write,
+            )
+            mode = "WRITE" if write else "DRY RUN"
+            console.print(f"[bold]{mode}[/] Kalshi order reconcile")
+            console.print(
+                f"Pending rows scanned: [cyan]{res.scanned}[/]  "
+                f"{'updated' if write else 'would update'}: [cyan]{res.updated}[/]  "
+                f"still pending: [cyan]{res.still_pending}[/]"
+            )
+            if res.by_status:
+                table = Table(title="Reconciled by status")
+                table.add_column("status", style="cyan")
+                table.add_column("count", justify="right")
+                for status, n in sorted(res.by_status.items()):
+                    table.add_row(status, str(n))
+                console.print(table)
+            if not write:
+                console.print("\n[dim]Preview only. Re-run with [cyan]--write[/] to persist.[/]")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
 @main.command("dust-exit")
 @click.option("--max-notional", default=5.0, type=float,
               help="Treat open positions worth less than this (current value, $) as dust.")

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -15,6 +15,7 @@ from auramaur.exchange.models import (
     OrderBookLevel,
     OrderResult,
     OrderSide,
+    OrderType,
     Signal,
     TokenType,
 )
@@ -51,6 +52,13 @@ class KalshiClient:
         self._markets_api = None
         self._portfolio_api = None
         self._semaphore = asyncio.Semaphore(_RATE_LIMIT)
+        # order_id -> Order for live order tracking. The order monitor polls
+        # this dict to reconcile fills and TTL-cancel resting orders; its
+        # presence is also the duck-typed signal that tells the monitor this
+        # client supports live order tracking (bot._task_order_monitor skips
+        # clients without it). Kalshi previously lacked it entirely, so its
+        # orders were never monitored and their trade rows stayed 'pending'.
+        self._live_pending: dict[str, Order] = {}
 
     def _init_api(self):
         """Lazily initialize the kalshi-python client."""
@@ -386,6 +394,12 @@ class KalshiClient:
                 status=order_data.get("status"),
             )
 
+            # Track the live order so the order monitor can poll it for fills,
+            # reconcile trades.status, and TTL-cancel it if it rests unfilled.
+            # Without this the row inserted at placement stays 'pending' forever.
+            if order_id and order_id != "unknown":
+                self._live_pending[order_id] = order
+
             return OrderResult(
                 order_id=order_id,
                 market_id=order.market_id,
@@ -483,6 +497,87 @@ class KalshiClient:
         except Exception as e:
             log.error("kalshi.cancel_error", order_id=order_id, error=str(e))
             return False
+
+    async def reconcile_open_orders(self) -> int:
+        """Pull resting Kalshi orders into ``_live_pending`` at startup.
+
+        Orders left resting by a prior session ("orphans") are otherwise
+        untracked, so the order monitor can neither record their fills nor
+        TTL-cancel them (freeing locked collateral). Reconstruct lightweight
+        Order records stamped with each order's real ``created_at`` so stale
+        ones are reaped on the first monitor pass. Mirrors the Polymarket
+        client's reconcile_open_orders. Best-effort: returns the number
+        reconciled, 0 if live trading is off or the query fails.
+        """
+        if not self._settings.is_live:
+            return 0
+        import json as _json
+        from datetime import datetime, timezone
+
+        self._init_api()
+        try:
+            raw = await self._call_raw(
+                self._portfolio_api.get_orders_without_preload_content,
+            )
+            data = _json.loads(raw)
+        except Exception as e:
+            log.warning("kalshi.reconcile_failed", error=str(e))
+            return 0
+
+        count = 0
+        for o in data.get("orders", []):
+            if o.get("status") != "resting":
+                continue
+            oid = str(o.get("order_id") or "")
+            if not oid or oid in self._live_pending:
+                continue
+            try:
+                side = (
+                    OrderSide.BUY
+                    if str(o.get("action", "")).lower() == "buy"
+                    else OrderSide.SELL
+                )
+                token = (
+                    TokenType.NO
+                    if str(o.get("side", "")).lower() == "no"
+                    else TokenType.YES
+                )
+                ticker = str(o.get("ticker") or "")
+                # Kalshi quotes everything as a yes_price in cents; a NO order's
+                # own price is the complement.
+                yes_price = float(o.get("yes_price", 0) or 0) / 100
+                price = (1 - yes_price) if token == TokenType.NO else yes_price
+                created_raw = o.get("created_time") or o.get("created_ts")
+                try:
+                    created = (
+                        datetime.fromisoformat(str(created_raw).replace("Z", "+00:00"))
+                        if created_raw
+                        else datetime.now(timezone.utc)
+                    )
+                except (TypeError, ValueError):
+                    created = datetime.now(timezone.utc)
+                remaining = float(
+                    o.get("remaining_count", o.get("count", 0)) or 0
+                )
+                self._live_pending[oid] = Order(
+                    market_id=ticker,
+                    exchange="kalshi",
+                    token_id=ticker,
+                    side=side,
+                    token=token,
+                    size=remaining,
+                    price=price,
+                    order_type=OrderType.LIMIT,
+                    dry_run=False,
+                    created_at=created,
+                )
+                count += 1
+            except (TypeError, ValueError) as e:
+                log.debug("kalshi.reconcile_parse_skip", order_id=oid, error=str(e))
+                continue
+        if count:
+            log.info("kalshi.reconciled_open_orders", count=count)
+        return count
 
     async def get_balance(self) -> float:
         """Get account balance in dollars."""

--- a/tests/test_kalshi_order_tracking.py
+++ b/tests/test_kalshi_order_tracking.py
@@ -1,0 +1,162 @@
+"""Regression tests for Kalshi live-order tracking.
+
+Kalshi orders were inserted at placement with status 'pending' and never
+reconciled, because KalshiClient didn't expose the `_live_pending` interface
+the order monitor keys on — so the monitor skipped Kalshi entirely and the
+rows stayed 'pending' forever (48 such rows had accumulated).
+
+These tests lock in:
+  1. KalshiClient exposes `_live_pending` (so the monitor no longer skips it).
+  2. reconcile_open_orders rehydrates resting orders across restarts.
+  3. reconcile_pending_kalshi_orders cleans up the stale historical rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.broker.order_reconcile import reconcile_pending_kalshi_orders
+from auramaur.db.database import Database
+from auramaur.exchange.kalshi import KalshiClient
+from auramaur.exchange.models import OrderResult, OrderSide, TokenType
+
+
+def _client(is_live: bool = True) -> KalshiClient:
+    settings = MagicMock()
+    settings.is_live = is_live
+    return KalshiClient(settings=settings, paper_trader=MagicMock())
+
+
+def test_client_exposes_live_pending():
+    """The monitor's `hasattr(client, "_live_pending")` guard must pass."""
+    client = _client()
+    assert hasattr(client, "_live_pending")
+    assert client._live_pending == {}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_open_orders_rehydrates_resting():
+    client = _client(is_live=True)
+    client._init_api = MagicMock()
+    client._portfolio_api = MagicMock()  # normally set by _init_api
+    client._call_raw = AsyncMock(return_value=json.dumps({
+        "orders": [
+            {"order_id": "o1", "status": "resting", "ticker": "KXFOO-1",
+             "action": "buy", "side": "yes", "yes_price": 60,
+             "remaining_count": 5, "created_time": "2026-06-01T00:00:00Z"},
+            {"order_id": "o2", "status": "resting", "ticker": "KXBAR-1",
+             "action": "buy", "side": "no", "yes_price": 30,
+             "remaining_count": 3, "created_time": "2026-06-01T00:00:00Z"},
+            # Non-resting orders must be ignored.
+            {"order_id": "o3", "status": "executed", "ticker": "KXBAZ-1",
+             "action": "buy", "side": "yes", "yes_price": 50},
+        ]
+    }))
+
+    count = await client.reconcile_open_orders()
+    assert count == 2
+    assert set(client._live_pending) == {"o1", "o2"}
+
+    o1 = client._live_pending["o1"]
+    assert o1.token == TokenType.YES and o1.side == OrderSide.BUY
+    assert abs(o1.price - 0.60) < 1e-9 and o1.size == 5
+
+    # NO order: its own price is the complement of the yes_price.
+    o2 = client._live_pending["o2"]
+    assert o2.token == TokenType.NO
+    assert abs(o2.price - 0.70) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_reconcile_open_orders_noop_when_not_live():
+    client = _client(is_live=False)
+    client._call_raw = AsyncMock()  # should never be called
+    assert await client.reconcile_open_orders() == 0
+    client._call_raw.assert_not_called()
+
+
+def _make_exchange(status_by_oid: dict[str, str]):
+    """Mock exchange whose get_order_status returns mapped statuses.
+
+    A missing oid raises (simulating an order the venue no longer knows).
+    """
+    exch = MagicMock()
+
+    async def _status(oid):
+        if oid not in status_by_oid:
+            raise RuntimeError("order not found")
+        return OrderResult(
+            order_id=oid, market_id="m", status=status_by_oid[oid],
+            filled_size=10 if status_by_oid[oid] == "filled" else 0,
+            filled_price=0.5 if status_by_oid[oid] == "filled" else 0,
+            is_paper=False,
+        )
+
+    exch.get_order_status = AsyncMock(side_effect=_status)
+    return exch
+
+
+def test_reconcile_pending_orders_updates_terminal_only():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        rows = [
+            ("KX1", "o-filled"),
+            ("KX2", "o-cancelled"),
+            ("KX3", "o-resting"),    # still open → get_order_status maps to 'pending'
+            ("KX4", "o-gone"),       # venue 404 → expired
+        ]
+        for mid, oid in rows:
+            await db.execute(
+                "INSERT INTO trades (market_id, side, size, price, is_paper, "
+                "order_id, status, exchange, strategy_source) "
+                "VALUES (?, 'BUY', 1, 0.4, 0, ?, 'pending', 'kalshi', 'llm')",
+                (mid, oid),
+            )
+        await db.commit()
+
+        # A resting Kalshi order surfaces via get_order_status as 'pending'
+        # (the client maps resting -> pending); 'o-gone' is absent -> raises -> expired.
+        exch = _make_exchange({
+            "o-filled": "filled", "o-cancelled": "cancelled", "o-resting": "pending",
+        })
+
+        # Dry-run writes nothing.
+        res = await reconcile_pending_kalshi_orders(db, exch, dry_run=True)
+        assert res.scanned == 4
+        assert res.updated == 3  # filled, cancelled, expired
+        assert res.still_pending == 1
+        n_pending = (await db.fetchone(
+            "SELECT COUNT(*) c FROM trades WHERE status='pending'"))["c"]
+        assert n_pending == 4  # nothing written yet
+
+        # Write mode persists terminal statuses.
+        res = await reconcile_pending_kalshi_orders(db, exch, dry_run=False)
+        assert res.by_status == {"filled": 1, "cancelled": 1, "expired": 1}
+        statuses = {
+            r["order_id"]: r["status"]
+            for r in await db.fetchall("SELECT order_id, status FROM trades")
+        }
+        assert statuses["o-filled"] == "filled"
+        assert statuses["o-cancelled"] == "cancelled"
+        assert statuses["o-gone"] == "expired"
+        assert statuses["o-resting"] == "pending"
+        # Filled row took on the venue's filled size/price.
+        filled = await db.fetchone(
+            "SELECT size, price FROM trades WHERE order_id='o-filled'")
+        assert filled["size"] == 10 and abs(filled["price"] - 0.5) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    test_client_exposes_live_pending()
+    asyncio.run(test_reconcile_open_orders_rehydrates_resting())
+    asyncio.run(test_reconcile_open_orders_noop_when_not_live())
+    test_reconcile_pending_orders_updates_terminal_only()
+    print("ok")


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.