### PR TITLE
fix(kalshi): None-safe get_order_status + don't guess 'expired' on errors

### DIFF
--- a/auramaur/broker/order_reconcile.py
+++ b/auramaur/broker/order_reconcile.py
@@ -30,7 +30,18 @@ class ReconcileResult:
     scanned: int = 0
     updated: int = 0
     still_pending: int = 0
+    errors: int = 0
     by_status: dict[str, int] = field(default_factory=dict)
+
+
+def _is_not_found(err: Exception) -> bool:
+    """True if the error means the venue has no such order (so it's expired).
+
+    Anything else (a parse bug, a transient network/API error) must NOT be
+    treated as a terminal state — guessing would corrupt the ledger.
+    """
+    msg = str(err).lower()
+    return "404" in msg or "not found" in msg or "not_found" in msg
 
 
 async def reconcile_pending_kalshi_orders(
@@ -66,10 +77,15 @@ async def reconcile_pending_kalshi_orders(
                     size = status_result.filled_size
                 if status_result.filled_price > 0:
                     price = status_result.filled_price
-        except Exception:
-            # The venue no longer knows this order (too old / pruned). It is by
-            # definition no longer resting and can never fill — treat as expired.
-            status = "expired"
+        except Exception as e:
+            if _is_not_found(e):
+                # The venue has no such order (too old / pruned). It is by
+                # definition no longer resting and can never fill — expired.
+                status = "expired"
+            else:
+                # Transient / unexpected error — don't guess a terminal state.
+                result.errors += 1
+                continue
 
         if status not in _TERMINAL:
             result.still_pending += 1
@@ -96,6 +112,7 @@ async def reconcile_pending_kalshi_orders(
         scanned=result.scanned,
         updated=result.updated,
         still_pending=result.still_pending,
+        errors=result.errors,
         by_status=result.by_status,
         dry_run=dry_run,
     )

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -540,7 +540,8 @@ def reconcile_kalshi_orders(write: bool):
             console.print(
                 f"Pending rows scanned: [cyan]{res.scanned}[/]  "
                 f"{'updated' if write else 'would update'}: [cyan]{res.updated}[/]  "
-                f"still pending: [cyan]{res.still_pending}[/]"
+                f"still pending: [cyan]{res.still_pending}[/]  "
+                f"errors (left untouched): [yellow]{res.errors}[/]"
             )
             if res.by_status:
                 table = Table(title="Reconciled by status")

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -473,14 +473,20 @@ class KalshiClient:
             raw_status = str(getattr(order_data, "status", "pending")).lower()
             status = status_map.get(raw_status, "pending")
 
+            # Terminal/historical orders come back with count, remaining_count
+            # and yes_price all None — coerce to 0 so the arithmetic below
+            # doesn't raise (which previously made every status query on an old
+            # order fail).
+            count = getattr(order_data, "count", 0) or 0
+            remaining = getattr(order_data, "remaining_count", 0) or 0
+            yes_price = getattr(order_data, "yes_price", 0) or 0
+
             return OrderResult(
                 order_id=order_id,
-                market_id=getattr(order_data, "ticker", ""),
+                market_id=getattr(order_data, "ticker", "") or "",
                 status=status,  # type: ignore[arg-type]
-                filled_size=float(
-                    getattr(order_data, "count", 0) - getattr(order_data, "remaining_count", 0)
-                ),
-                filled_price=float(getattr(order_data, "yes_price", 0)) / 100,
+                filled_size=float(count - remaining),
+                filled_price=float(yes_price) / 100,
                 is_paper=False,
             )
         except Exception as e:

--- a/tests/test_kalshi_order_tracking.py
+++ b/tests/test_kalshi_order_tracking.py
@@ -82,22 +82,83 @@ async def test_reconcile_open_orders_noop_when_not_live():
 def _make_exchange(status_by_oid: dict[str, str]):
     """Mock exchange whose get_order_status returns mapped statuses.
 
-    A missing oid raises (simulating an order the venue no longer knows).
+    A missing oid raises a 'not found' error (order the venue no longer knows).
+    The sentinel value '__transient__' raises a non-not-found error.
     """
     exch = MagicMock()
 
     async def _status(oid):
         if oid not in status_by_oid:
             raise RuntimeError("order not found")
+        val = status_by_oid[oid]
+        if val == "__transient__":
+            raise RuntimeError("connection reset by peer")
         return OrderResult(
-            order_id=oid, market_id="m", status=status_by_oid[oid],
-            filled_size=10 if status_by_oid[oid] == "filled" else 0,
-            filled_price=0.5 if status_by_oid[oid] == "filled" else 0,
+            order_id=oid, market_id="m", status=val,
+            filled_size=10 if val == "filled" else 0,
+            filled_price=0.5 if val == "filled" else 0,
             is_paper=False,
         )
 
     exch.get_order_status = AsyncMock(side_effect=_status)
     return exch
+
+
+def test_reconcile_leaves_transient_errors_pending():
+    """A non-'not found' error must NOT be guessed as a terminal status."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        for oid in ("o-flaky", "o-filled"):
+            await db.execute(
+                "INSERT INTO trades (market_id, side, size, price, is_paper, "
+                "order_id, status, exchange, strategy_source) "
+                "VALUES ('m', 'BUY', 1, 0.4, 0, ?, 'pending', 'kalshi', 'llm')",
+                (oid,),
+            )
+        await db.commit()
+        exch = _make_exchange({"o-flaky": "__transient__", "o-filled": "filled"})
+
+        res = await reconcile_pending_kalshi_orders(db, exch, dry_run=False)
+        assert res.errors == 1
+        assert res.updated == 1
+        statuses = {
+            r["order_id"]: r["status"]
+            for r in await db.fetchall("SELECT order_id, status FROM trades")
+        }
+        # The flaky one is untouched; only the cleanly-filled one moved.
+        assert statuses["o-flaky"] == "pending"
+        assert statuses["o-filled"] == "filled"
+        await db.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_handles_none_fields():
+    """Terminal/historical orders return None count/price — must not crash.
+
+    This was the bug that made every reconcile query on an old order fail with
+    'unsupported operand type(s) for -: NoneType and NoneType'.
+    """
+    client = _client(is_live=True)
+    client._init_api = MagicMock()
+    client._portfolio_api = MagicMock()  # normally set by _init_api
+
+    order_data = MagicMock()
+    order_data.status = "executed"
+    order_data.ticker = "KXFOO-1"
+    order_data.count = None
+    order_data.remaining_count = None
+    order_data.yes_price = None
+    response = MagicMock()
+    response.order = order_data
+    client._call = AsyncMock(return_value=response)
+
+    result = await client.get_order_status("o1")
+    assert result.status == "filled"
+    assert result.filled_size == 0
+    assert result.filled_price == 0
 
 
 def test_reconcile_pending_orders_updates_terminal_only():
@@ -158,5 +219,7 @@ if __name__ == "__main__":
     test_client_exposes_live_pending()
     asyncio.run(test_reconcile_open_orders_rehydrates_resting())
     asyncio.run(test_reconcile_open_orders_noop_when_not_live())
+    asyncio.run(test_get_order_status_handles_none_fields())
+    test_reconcile_leaves_transient_errors_pending()
     test_reconcile_pending_orders_updates_terminal_only()
     print("ok")


### PR DESCRIPTION
## Why

Running `auramaur reconcile-kalshi-orders` (from #71) against the live venue exposed two bugs — caught safely by the dry-run.

### 1. `get_order_status` crashed on every old order
Kalshi returns `count`, `remaining_count`, and `yes_price` as `None` for terminal/historical orders, so `count - remaining_count` threw `unsupported operand type(s) for -: 'NoneType' and 'NoneType'` on all 48. This bug also affects the **live order monitor**, which calls `get_order_status` every cycle. Fix: coerce the numeric fields to `0`.

### 2. The reconcile guessed `expired` on *any* error
The fallback treated every `get_order_status` exception as proof the order had expired. Combined with bug #1, the dry-run reported **all 48 as `expired`** — wrong, since 15 had filled and 37 markets are still held. Fix: only a genuine "not found" (404) maps to `expired`; transient/unexpected errors are counted (`errors`) and the row is **left untouched**, never guessed.

```
DRY RUN Kalshi order reconcile     <-- before this fix
Pending rows scanned: 48  would update: 48  ... expired: 48   # all wrong
```

## What changed
- `kalshi.get_order_status` — None-safe parsing of `count`/`remaining_count`/`yes_price`/`ticker`.
- `order_reconcile` — `_is_not_found()` gate; non-404 errors increment `errors` and skip the row.
- CLI summary now shows `errors (left untouched)`.

## Tests
Added to `tests/test_kalshi_order_tracking.py`:
- `get_order_status` returns `filled` (not a crash) when count/price are `None`.
- transient (non-not-found) errors leave the row `pending` and are counted.

All passing (run directly).

## Next step
After merge, re-run `auramaur reconcile-kalshi-orders` (dry-run first) — it should now report the real mix of filled/cancelled/expired instead of all-expired.

Assisted-by: Claude (Anthropic)