### PR TITLE
fix(attribution): credit entry strategy + stop counting open positions as trades

### DIFF
--- a/auramaur/monitoring/attribution.py
+++ b/auramaur/monitoring/attribution.py
@@ -345,17 +345,57 @@ class PerformanceAttributor:
         result.sort(key=lambda r: r["exposure"], reverse=True)
         return result
 
-    async def get_strategy_summary(self, *, is_live: bool = False) -> list[dict]:
-        """Per-strategy realized P&L, attributed from authoritative sources.
+    @staticmethod
+    def _entry_strategy_expr(alias: str) -> str:
+        """SQL that resolves a market's *entry* strategy.
 
-        The old version summed ``trades.pnl`` — the unreliable legacy mirror —
-        so every strategy showed $0 / 0 wins. Realized P&L actually lives in two
-        places (mirroring the cockpit's split): ``resolution_pnl`` for
-        oracle-resolved markets (live) and ``cost_basis.realized_pnl`` for
-        positions closed by selling. Each market is attributed to the strategy
-        that traded it (most recent ``trades.strategy_source``, falling back to
-        the signal's). ``trade_count`` is markets attributed; ``wins`` counts
-        markets that ended net-positive.
+        Attribution must credit the strategy that DECIDED to open a position,
+        not the last thing to touch it. The old version used the most-recent
+        ``trades.strategy_source``, which meant exits — recorded by the order
+        monitor as ``strategy_source = 'order_monitor'`` — stole every closed
+        position's P&L from the strategy that actually opened it. Here we take
+        the earliest non-``order_monitor`` trade, fall back to the earliest such
+        signal, and only as a last resort accept ``order_monitor`` itself (for
+        markets that genuinely have no other source).
+        """
+        return f"""COALESCE(
+            (SELECT t.strategy_source FROM trades t
+             WHERE t.market_id = {alias}.market_id
+               AND t.strategy_source IS NOT NULL
+               AND t.strategy_source != 'order_monitor'
+             ORDER BY t.timestamp ASC LIMIT 1),
+            (SELECT s.strategy_source FROM signals s
+             WHERE s.market_id = {alias}.market_id
+               AND s.strategy_source IS NOT NULL
+               AND s.strategy_source != 'order_monitor'
+             ORDER BY s.timestamp ASC LIMIT 1),
+            (SELECT t.strategy_source FROM trades t
+             WHERE t.market_id = {alias}.market_id
+               AND t.strategy_source IS NOT NULL
+             ORDER BY t.timestamp ASC LIMIT 1)
+        )"""
+
+    async def get_strategy_summary(self, *, is_live: bool = False) -> list[dict]:
+        """Per-strategy performance, attributed to the strategy that opened each
+        position.
+
+        Two earlier blind spots are fixed here:
+
+        * **Open positions were counted as completed trades.** ``cost_basis``
+          carries a row for every position, open or closed, with
+          ``realized_pnl = 0`` until it closes. Summing them blind made a
+          strategy actively building a book (e.g. news_speed, 21 open / 1
+          closed) read as "21 trades, 0 wins, $0.00". ``trade_count`` now counts
+          only *closed* markets — ``cost_basis`` rows with ``size = 0`` plus
+          oracle-resolved markets — and the open book is reported separately as
+          ``open_positions`` / ``unrealized_pnl``.
+
+        * **Exits stole the wins.** See :meth:`_entry_strategy_expr` — P&L is now
+          credited to the entry strategy, not ``order_monitor``.
+
+        Realized P&L still comes from the two authoritative sources:
+        ``resolution_pnl`` (oracle-resolved, live) and ``cost_basis.realized_pnl``
+        (closed by selling).
         """
         paper_flag = 0 if is_live else 1
         # resolution_pnl is live-only; for the rest use cost_basis, excluding
@@ -368,33 +408,66 @@ class PerformanceAttributor:
             "AND market_id NOT IN (SELECT market_id FROM resolution_pnl)"
             if is_live else ""
         )
-        rows = await self._db.fetchall(
+        realized_strat = self._entry_strategy_expr("mp")
+        # Realized arm: closed positions only (cost_basis.size = 0) + resolved.
+        realized_rows = await self._db.fetchall(
             f"""SELECT strat AS strategy_source,
                        COUNT(*) AS trade_count,
                        COALESCE(SUM(realized), 0) AS total_pnl,
                        SUM(CASE WHEN realized > 0 THEN 1 ELSE 0 END) AS wins,
                        SUM(CASE WHEN realized < 0 THEN 1 ELSE 0 END) AS losses
                 FROM (
-                    SELECT mp.realized,
-                           COALESCE(
-                               (SELECT t.strategy_source FROM trades t
-                                WHERE t.market_id = mp.market_id
-                                  AND t.strategy_source IS NOT NULL
-                                ORDER BY t.timestamp DESC LIMIT 1),
-                               (SELECT s.strategy_source FROM signals s
-                                WHERE s.market_id = mp.market_id
-                                  AND s.strategy_source IS NOT NULL
-                                ORDER BY s.timestamp DESC LIMIT 1)
-                           ) AS strat
+                    SELECT mp.realized, {realized_strat} AS strat
                     FROM (
                         {resolved_union}
                         SELECT market_id, realized_pnl AS realized FROM cost_basis
-                        WHERE is_paper = ? {resolved_exclusion}
+                        WHERE is_paper = ? AND size = 0 {resolved_exclusion}
                     ) mp
                 )
                 WHERE strat IS NOT NULL
-                GROUP BY strat
-                ORDER BY total_pnl ASC""",
+                GROUP BY strat""",
             (paper_flag,),
         )
-        return [dict(row) for row in rows]
+
+        # Open arm: live/non-polymarket open positions, with unrealized P&L,
+        # attributed to the same entry strategy.
+        open_strat = self._entry_strategy_expr("p")
+        open_rows = await self._db.fetchall(
+            f"""SELECT strat AS strategy_source,
+                       COUNT(*) AS open_positions,
+                       COALESCE(SUM(unrealized), 0) AS unrealized_pnl
+                FROM (
+                    SELECT (COALESCE(p.current_price, p.avg_price)
+                            - COALESCE(cb.avg_cost, p.avg_price)) * p.size AS unrealized,
+                           p.market_id, {open_strat} AS strat
+                    FROM portfolio p
+                    LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
+                                            AND cb.is_paper = p.is_paper
+                    WHERE (p.is_paper = ? OR p.exchange != 'polymarket') AND p.size > 0
+                ) op
+                WHERE strat IS NOT NULL
+                GROUP BY strat""",
+            (paper_flag,),
+        )
+
+        merged: dict[str, dict] = {}
+        for r in realized_rows:
+            merged[r["strategy_source"]] = {
+                "strategy_source": r["strategy_source"],
+                "trade_count": r["trade_count"],
+                "total_pnl": r["total_pnl"] or 0,
+                "wins": r["wins"] or 0,
+                "losses": r["losses"] or 0,
+                "open_positions": 0,
+                "unrealized_pnl": 0,
+            }
+        for r in open_rows:
+            entry = merged.setdefault(r["strategy_source"], {
+                "strategy_source": r["strategy_source"],
+                "trade_count": 0, "total_pnl": 0, "wins": 0, "losses": 0,
+                "open_positions": 0, "unrealized_pnl": 0,
+            })
+            entry["open_positions"] = r["open_positions"]
+            entry["unrealized_pnl"] = r["unrealized_pnl"] or 0
+
+        return sorted(merged.values(), key=lambda r: r["total_pnl"])

--- a/auramaur/monitoring/diagnostics.py
+++ b/auramaur/monitoring/diagnostics.py
@@ -293,10 +293,12 @@ def render_attribution(
 
     strat = Table(title="by strategy", expand=True)
     strat.add_column("strategy", style="magenta")
-    strat.add_column("trades", justify="right")
+    strat.add_column("closed", justify="right")
     strat.add_column("wins", justify="right")
     strat.add_column("win%", justify="right")
-    strat.add_column("pnl", justify="right")
+    strat.add_column("realized", justify="right")
+    strat.add_column("open", justify="right")
+    strat.add_column("unrealized", justify="right")
     for r in strategy_rows:
         n = r.get("trade_count", 0) or 0
         w = r.get("wins", 0) or 0
@@ -304,6 +306,8 @@ def render_attribution(
         strat.add_row(
             r.get("strategy_source", "?") or "?", str(n), str(w), wr,
             _money(r.get("total_pnl", 0) or 0),
+            str(r.get("open_positions", 0) or 0),
+            _money(r.get("unrealized_pnl", 0) or 0),
         )
 
     head = Text.from_markup(f"[bold]Performance attribution[/]  ([dim]{mode}[/])")

--- a/tests/test_attribution_strategy_entry.py
+++ b/tests/test_attribution_strategy_entry.py
@@ -1,0 +1,88 @@
+"""Strategy attribution credits the *entry* strategy and ignores open noise.
+
+Two blind spots, analogous to the Kalshi one, are locked in here:
+  1. Open positions must NOT be counted as completed trades (they have
+     realized_pnl = 0 until they close) — they're reported separately as
+     open_positions / unrealized_pnl.
+  2. Realized P&L is credited to the strategy that OPENED the position, not the
+     order monitor that recorded its exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from auramaur.db.database import Database
+from auramaur.monitoring.attribution import PerformanceAttributor
+
+
+def test_entry_attribution_and_open_vs_closed():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+
+        # Market A: opened by news_speed, EXITED by order_monitor, closed +0.9.
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, "
+            "realized_pnl, is_paper) VALUES ('A','YES',0,0,0,0.9,0)")
+        await db.execute(
+            "INSERT INTO trades (market_id, side, size, price, is_paper, strategy_source, timestamp) "
+            "VALUES ('A','BUY',1,0.5,0,'news_speed','2026-06-01T01:00')")
+        await db.execute(  # the exit — most recent, must NOT win attribution
+            "INSERT INTO trades (market_id, side, size, price, is_paper, strategy_source, timestamp) "
+            "VALUES ('A','SELL',1,0.6,0,'order_monitor','2026-06-02T01:00')")
+
+        # Market B: OPEN position opened by news_speed, unrealized +2.
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, "
+            "realized_pnl, is_paper) VALUES ('B','YES',10,0.5,5,0,0)")
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('B','polymarket','BUY',10,0.5,0.7,0)")
+        await db.execute(
+            "INSERT INTO trades (market_id, side, size, price, is_paper, strategy_source, timestamp) "
+            "VALUES ('B','BUY',10,0.5,0,'news_speed','2026-06-01T01:00')")
+        await db.commit()
+
+        attr = PerformanceAttributor(db=db)
+        rows = {r["strategy_source"]: r for r in await attr.get_strategy_summary(is_live=True)}
+
+        # The exit plumbing never claims the P&L.
+        assert "order_monitor" not in rows
+        ns = rows["news_speed"]
+        assert ns["trade_count"] == 1            # only the closed market A
+        assert ns["wins"] == 1
+        assert abs(ns["total_pnl"] - 0.9) < 1e-9
+        assert ns["open_positions"] == 1         # market B, not counted as a trade
+        assert abs(ns["unrealized_pnl"] - 2.0) < 1e-9  # (0.7 - 0.5) * 10
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_order_monitor_only_market_still_visible():
+    """A market with no entry strategy still shows under order_monitor."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, "
+            "realized_pnl, is_paper) VALUES ('C','YES',0,0,0,-5.0,0)")
+        await db.execute(
+            "INSERT INTO trades (market_id, side, size, price, is_paper, strategy_source, timestamp) "
+            "VALUES ('C','SELL',1,0.4,0,'order_monitor','2026-06-02T01:00')")
+        await db.commit()
+
+        attr = PerformanceAttributor(db=db)
+        rows = {r["strategy_source"]: r for r in await attr.get_strategy_summary(is_live=True)}
+        assert "order_monitor" in rows
+        assert abs(rows["order_monitor"]["total_pnl"] - (-5.0)) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    test_entry_attribution_and_open_vs_closed()
+    test_order_monitor_only_market_still_visible()
+    print("ok")


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.