### PR TITLE
fix(attribution): treat cost_basis.avg_cost=0 as missing (Kraken unrealized)

### DIFF
--- a/auramaur/monitoring/attribution.py
+++ b/auramaur/monitoring/attribution.py
@@ -145,7 +145,7 @@ class PerformanceAttributor:
                       SUM(p.size * p.avg_price) AS exposure,
                       SUM(
                           (COALESCE(p.current_price, p.avg_price)
-                           - COALESCE(cb.avg_cost, p.avg_price)) * p.size
+                           - COALESCE(NULLIF(cb.avg_cost, 0), p.avg_price)) * p.size
                       ) AS unrealized_pnl
                FROM portfolio p
                LEFT JOIN markets m ON p.market_id = m.id
@@ -262,8 +262,13 @@ class PerformanceAttributor:
                       COUNT(*) AS positions,
                       SUM(p.size * p.avg_price) AS exposure,
                       SUM(
+                          -- NULLIF(...,0): the Kraken spec book writes cost_basis
+                          -- rows with avg_cost=0, so a plain COALESCE (NULL-only)
+                          -- treated cost as $0 and booked the whole position value
+                          -- as "unrealized" (+$246 vs the true -$3.85). Fall back
+                          -- to the position's own avg_price when cost basis is 0.
                           (COALESCE(p.current_price, p.avg_price)
-                           - COALESCE(cb.avg_cost, p.avg_price)) * p.size
+                           - COALESCE(NULLIF(cb.avg_cost, 0), p.avg_price)) * p.size
                       ) AS unrealized_pnl
                FROM portfolio p
                LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
@@ -438,7 +443,7 @@ class PerformanceAttributor:
                        COALESCE(SUM(unrealized), 0) AS unrealized_pnl
                 FROM (
                     SELECT (COALESCE(p.current_price, p.avg_price)
-                            - COALESCE(cb.avg_cost, p.avg_price)) * p.size AS unrealized,
+                            - COALESCE(NULLIF(cb.avg_cost, 0), p.avg_price)) * p.size AS unrealized,
                            p.market_id, {open_strat} AS strat
                     FROM portfolio p
                     LEFT JOIN cost_basis cb ON p.market_id = cb.market_id

--- a/tests/test_kalshi_pnl_tracking.py
+++ b/tests/test_kalshi_pnl_tracking.py
@@ -148,6 +148,34 @@ def test_venue_summary_breaks_down_by_exchange():
     asyncio.run(run())
 
 
+def test_venue_summary_ignores_zero_cost_basis():
+    """cost_basis.avg_cost=0 (Kraken spec book) must fall back to avg_price.
+
+    Otherwise unrealized = (current - 0) * size books the whole position value
+    as a gain (the +$246-vs-actual-(-$3.85) Kraken bug).
+    """
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('XBTUSDC', 'kraken', 'BUY', 10, 0.50, 0.60, 0)"
+        )
+        # Kraken writes a cost_basis row with avg_cost = 0.
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, "
+            "realized_pnl, is_paper) VALUES ('XBTUSDC', 'YES', 10, 0, 0, 0, 0)"
+        )
+        await db.commit()
+        attr = PerformanceAttributor(db=db)
+        rows = {r["venue"]: r for r in await attr.get_venue_summary(is_live=True)}
+        # (0.60 - 0.50) * 10 = +1.0, NOT (0.60 - 0) * 10 = +6.0
+        assert abs(rows["kraken"]["unrealized_pnl"] - 1.0) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
 def test_venue_summary_paper_scopes_out_live():
     """Paper mode excludes live Polymarket rows but keeps non-Polymarket venues."""
     async def run():


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.