### PR TITLE
config(kraken): enable LLM directional book LIVE (user-authorized)

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -197,8 +197,8 @@ kraken:
   # (P(up) over a multi-day horizon) instead. OFF by default; PAPER-forced when on
   # (validate-only orders) until the paper record proves edge — then set
   # directional_llm_paper: false to go live. Inspect with `auramaur kraken signal`.
-  directional_llm_enabled: false
-  directional_llm_paper: true
+  directional_llm_enabled: true
+  directional_llm_paper: false   # LIVE — user-authorized 2026-06-06 (guardrails: $150 budget, $30/order, 12% stop)
   directional_llm_min_prob: 0.60
   directional_llm_exit_prob: 0.45
   directional_llm_min_confidence: "MEDIUM"


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.