### PR TITLE
fix(market-maker): reject dead/empty books to stop cancel/replace churn

### DIFF
--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -92,6 +92,7 @@ class MarketMaker:
         # MM configuration from settings
         mm_cfg = settings.market_maker
         self._min_spread_bps: int = mm_cfg.min_spread_bps
+        self._max_spread_bps: int = mm_cfg.max_spread_bps
         self._quote_size: float = mm_cfg.quote_size
         self._max_inventory: float = mm_cfg.max_inventory
         self._max_markets: int = mm_cfg.max_markets
@@ -203,9 +204,16 @@ class MarketMaker:
                 if hours_remaining < 48:
                     continue
 
-            # Spread must be wide enough to profit
+            # Spread must be wide enough to profit...
             spread_bps = int(market.spread * 10000) if market.spread else 0
             if spread_bps < self._min_spread_bps:
+                continue
+
+            # ...but not SO wide that it's a dead/empty book. A near-100% nominal
+            # spread (e.g. bid 0.02 / ask 0.98 = 9600 bps) is not an opportunity —
+            # it's a market with no real two-sided liquidity, where neither leg
+            # ever fills and we churn cancel/replace every cycle. Reject it.
+            if spread_bps > self._max_spread_bps:
                 continue
 
             # Don't exceed max inventory on this market
@@ -215,7 +223,9 @@ class MarketMaker:
 
             suitable.append(market)
 
-        # Sort by spread (widest first = most profitable)
+        # Sort by spread, widest first — but now bounded above by max_spread_bps,
+        # so dead books no longer dominate the top of the list. Among legitimate
+        # spreads, wider = more profit per round-trip.
         suitable.sort(key=lambda m: m.spread or 0, reverse=True)
 
         return suitable
@@ -260,6 +270,22 @@ class MarketMaker:
 
         if best_bid is None or best_ask is None:
             return None, "no_bbo"
+
+        # Dead-book guard on the LIVE book (selection used market.spread, a summary
+        # field that can be stale or differ from the CLOB BBO). If the actual best
+        # bid/ask are this far apart, there's no genuine two-sided market — quoting
+        # into it just churns and risks one-sided fills at an extreme price.
+        book_spread_bps = int((best_ask - best_bid) * 10000)
+        if book_spread_bps > self._max_spread_bps:
+            log.debug(
+                "market_maker.dead_book",
+                market_id=market.id,
+                best_bid=best_bid,
+                best_ask=best_ask,
+                book_spread_bps=book_spread_bps,
+                max_spread_bps=self._max_spread_bps,
+            )
+            return None, "dead_book"
 
         # Polymarket has 1-cent ticks. Try to price-improve by one tick on each
         # side; if the underlying spread is too tight for that (which is the

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -266,6 +266,7 @@ gemini:
 market_maker:
   enabled: true
   min_spread_bps: 40        # minimum 0.4% spread (BBO-join kicks in when 1-tick improvement would go below this)
+  max_spread_bps: 1500      # max 15% spread — wider = dead/empty book (bid 0.02/ask 0.98), never fills; reject it
   quote_size: 10.0          # tokens per side
   max_inventory: 50.0       # max directional exposure per market
   max_markets: 5            # max simultaneous MM markets

--- a/config/settings.py
+++ b/config/settings.py
@@ -199,6 +199,11 @@ class CalibrationConfig(BaseModel):
 class MarketMakerConfig(BaseModel):
     enabled: bool = True
     min_spread_bps: int = 40  # minimum spread in bps; below the 1-tick improvement, join BBO
+    # Upper spread bound. A nominal spread this wide is not a fat opportunity —
+    # it's a dead/empty book (e.g. bid 0.02 / ask 0.98 = 9600 bps), where neither
+    # leg ever fills and we churn cancel/replace forever. Real MM edge lives in
+    # the ~100-1000 bps range; reject anything wider at both selection and quote time.
+    max_spread_bps: int = 1500
     quote_size: float = 10.0  # tokens per side
     max_inventory: float = 50.0  # max directional exposure per market
     max_markets: int = 5  # max simultaneous MM markets

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -13,6 +13,7 @@ def _maker(*, quote_size=10.0, max_inventory=50.0) -> MarketMaker:
         is_live=False,
         market_maker=SimpleNamespace(
             min_spread_bps=40,
+            max_spread_bps=1500,
             quote_size=quote_size,
             max_inventory=max_inventory,
             max_markets=5,
@@ -63,3 +64,70 @@ def test_market_maker_still_skips_when_capacity_cannot_meet_min_notional():
 
     assert quote is None
     assert reason == "min_notional"
+
+
+def test_compute_quotes_rejects_dead_book_at_price_bounds():
+    """A live book sitting at the 0.02/0.98 bounds is no real market — reject it
+    rather than quote into a 9600 bps 'spread' that never fills."""
+    mm = _maker()
+    market = Market(
+        id="m1",
+        question="Will this happen?",
+        clob_token_yes="yes",
+        clob_token_no="no",
+    )
+    book = OrderBook(
+        bids=[OrderBookLevel(price=0.02, size=100)],
+        asks=[OrderBookLevel(price=0.98, size=100)],
+    )
+
+    quote, reason = mm._compute_quotes(market, book)
+
+    assert quote is None
+    assert reason == "dead_book"
+
+
+def test_compute_quotes_accepts_book_just_under_max_spread():
+    """A wide-but-real book (within max_spread_bps) is still quotable."""
+    mm = _maker()
+    market = Market(
+        id="m1",
+        question="Will this happen?",
+        clob_token_yes="yes",
+        clob_token_no="no",
+    )
+    # 0.45 / 0.58 = 1300 bps < 1500 max
+    book = OrderBook(
+        bids=[OrderBookLevel(price=0.45, size=100)],
+        asks=[OrderBookLevel(price=0.58, size=100)],
+    )
+
+    quote, reason = mm._compute_quotes(market, book)
+
+    assert reason is None
+    assert quote is not None
+
+
+def test_select_skips_dead_book_but_keeps_real_spread():
+    """Selection rejects a near-100% summary spread (dead book) while keeping a
+    normal one — and no longer ranks the dead book first."""
+    mm = _maker()
+
+    def _mkt(mid, spread):
+        return Market(
+            id=mid,
+            question="Will this happen?",
+            clob_token_yes="yes",
+            clob_token_no="no",
+            liquidity=10000,
+            spread=spread,
+        )
+
+    dead = _mkt("dead", 0.96)   # 9600 bps — empty book
+    real = _mkt("real", 0.05)   # 500 bps — legitimate
+
+    suitable = mm._select_mm_markets([dead, real])
+
+    ids = [m.id for m in suitable]
+    assert "dead" not in ids
+    assert ids == ["real"]


### PR DESCRIPTION
## Problem
The live `--hybrid` market maker was placing ~**1,606 `order.live` events/day** that **never filled** (`inventory_markets: 0` every cycle) — pure cancel/replace churn. Root cause: it repeatedly quoted markets whose live CLOB book sits at the **0.02 / 0.98 price bounds** (a ~9600 bps nominal "spread"), mistaking an empty/dead book for the most profitable opportunity. **713 of today's quotes were at `spread_bps: 9600`.**

Only a `min_spread_bps` floor existed — there was **no upper bound**, and selection sorted widest-spread-first, so dead books ranked top and got quoted every cycle.

No capital was ever at risk (nothing filled), but it created order/cancel-ratio exposure on Polymarket and a one-sided-fill tail risk at an extreme price.

## Fix
- Add `market_maker.max_spread_bps` (default **1500** = 15%). Real MM edge lives in ~100–1000 bps; anything wider is a dead book.
- Reject `spread > max_spread_bps` in `_select_mm_markets` (summary spread).
- Add a **live-book `dead_book` guard** in `_compute_quotes` using the actual CLOB BBO — the summary `market.spread` can be stale or differ from the live book.
- Sort stays widest-first but is now bounded above, so dead books no longer dominate selection.

## Tests
3 new tests: dead book rejected at both selection and quote time; wide-but-real (1300 bps) and normal (500 bps) spreads still quoted. All 5 MM tests + 10 adjacent config/execution tests pass.

## Verified live
Restarted the live hybrid bot on this branch: **0** quotes at 9600 bps, **`dead_book` skips firing** every cycle, **Polymarket `order.live` churn = 0** since restart (was ~1,606/day). Both guards confirmed pulling weight — markets that pass selection on a stale summary spread are caught at quote time by the live-book BBO check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)