### PR TITLE
feat(ibkr): runnable directional-equity book on a CAD cash account

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -324,8 +324,10 @@ class AuramaurBot:
             except ImportError:
                 log.warning("optional.missing", component="CryptoComClient")
 
-        # Interactive Brokers (optional, guarded import)
-        if s.ibkr.enabled and (self._exchange_filter is None or self._exchange_filter == "ibkr"):
+        # Interactive Brokers options scanner (optional, guarded import). Gated
+        # by options_enabled so the equity book can run without waking the
+        # OPRA-less option scanner (which otherwise spams Error 200/10091).
+        if s.ibkr.enabled and s.ibkr.options_enabled and (self._exchange_filter is None or self._exchange_filter == "ibkr"):
             try:
                 from auramaur.exchange.ibkr import IBKRClient
                 ibkr = IBKRClient(settings=s, paper_trader=paper)
@@ -2798,11 +2800,13 @@ class AuramaurBot:
             except Exception as e:
                 log.debug("startup.kraken_balance_error", error=str(e))
 
-        # IBKR status (options client + gated equity speculation)
+        # IBKR status (independently-gated options scanner + equity speculation)
         if self.settings.ibkr.enabled and self._exchange_filter in (None, "ibkr"):
+            opt = ("[red]options ON[/]" if self.settings.ibkr.options_enabled
+                   else "options off")
             eq = ("[red]equity SPEC ON[/]" if self.settings.ibkr.directional_equity_enabled
                   else "equity spec off")
-            console.print(f"  IBKR: enabled ({self.settings.ibkr.environment}) | {eq}")
+            console.print(f"  IBKR: enabled ({self.settings.ibkr.environment}) | {opt} | {eq}")
 
         show_startup(
             self._components["source_names"],

--- a/auramaur/exchange/ibkr_equity.py
+++ b/auramaur/exchange/ibkr_equity.py
@@ -18,6 +18,11 @@ from auramaur.exchange.models import OrderResult, OrderSide
 
 log = structlog.get_logger()
 
+# Hold-off between FX top-up conversions. The fill posts to the cash balance
+# within seconds, so this only needs to outlast that latency; kept generous
+# since funds settle T+1 and there's never a reason to re-convert quickly.
+_FX_COOLDOWN_S = 1800
+
 
 class IBKREquityClient:
     def __init__(self, settings):
@@ -25,6 +30,10 @@ class IBKREquityClient:
         self._ib = None
         self._connected = False
         self._cooldown_until = 0.0
+        # After a conversion fires, hold off re-converting until the fill posts
+        # to the cash balance, so a fast loop can't double-convert while T+1
+        # settlement is pending.
+        self._fx_cooldown_until = 0.0
 
     async def _ensure_connected(self) -> None:
         if self._connected and self._ib is not None:
@@ -60,7 +69,19 @@ class IBKREquityClient:
             if px and px > 0:
                 return float(px)
             # delayed feeds often only populate close
-            return float(tk.close) if tk.close and tk.close > 0 else None
+            if tk.close and tk.close > 0:
+                return float(tk.close)
+            # No live/delayed entitlement (e.g. Error 10089 without a US-equity
+            # market-data subscription) leaves every quote NaN. Fall back to the
+            # most recent historical daily close, which uses the free HMDS feed
+            # and works without a subscription — same source momentum() reads.
+            bars = await self._ib.reqHistoricalDataAsync(
+                stock, endDateTime="", durationStr="3 D",
+                barSizeSetting="1 day", whatToShow="TRADES", useRTH=True,
+            )
+            if bars and bars[-1].close and bars[-1].close > 0:
+                return float(bars[-1].close)
+            return None
         except Exception as e:  # noqa: BLE001
             log.warning("ibkr_equity.price_error", symbol=symbol, error=str(e)[:100])
             return None
@@ -69,7 +90,11 @@ class IBKREquityClient:
         self, symbol: str, side: OrderSide | str, usd_amount: float,
         dry_run: bool | None = None,
     ) -> OrderResult:
-        """Place a market equity order sized to ~usd_amount. Gated + capped."""
+        """Open/add to a position with ~usd_amount of `symbol`, dollar-sized via a
+        monetary-value (cashQty) order. IBKR REJECTS a fractional share quantity
+        over the API (Error 10243 "use desktop version") but accepts a cash amount
+        and sizes the fraction server-side — so we never send a fractional qty.
+        Gated + capped. To exit a position use close_position()."""
         side_str = (side.value if isinstance(side, OrderSide) else str(side)).upper()
 
         if Path("KILL_SWITCH").exists():
@@ -83,37 +108,79 @@ class IBKREquityClient:
                                is_paper=True,
                                error_message=f"${usd_amount:.2f} exceeds cap ${cap:.2f}")
 
-        price = await self.get_price(symbol)
-        if not price:
-            return OrderResult(order_id="ERROR", market_id=symbol, status="rejected",
-                               is_paper=True, error_message="no price")
-        qty = int(usd_amount / price)
-        if qty < 1:
-            return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
-                               is_paper=True, error_message=f"size <1 share at ${price:.2f}")
-
         if dry_run is None:
             dry_run = not self._settings.is_live
-        # Paper: route through the simulated path (no IBKR order).
+        # Price is only for paper sizing + the recorded fill estimate; the live
+        # order sizes itself from cashQty, so a missing quote never blocks it.
+        price = await self.get_price(symbol)
         if dry_run:
-            log.info("ibkr_equity.order.paper", symbol=symbol, side=side_str, qty=qty,
-                     price=price)
+            qty = round(usd_amount / price, 4) if price else 0.0
+            log.info("ibkr_equity.order.paper", symbol=symbol, side=side_str,
+                     usd=round(usd_amount, 2), qty=qty, price=price)
             return OrderResult(order_id="PAPER", market_id=symbol, status="paper",
-                               filled_size=qty, filled_price=price, is_paper=True)
+                               filled_size=qty, filled_price=price or 0.0, is_paper=True)
 
-        # === LIVE ===
         if self._settings.ibkr.readonly:
             return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
                                is_paper=False,
                                error_message="ibkr.readonly=true — cannot place orders")
+        return await self._place_cash_order(symbol, side_str, usd_amount, price or 0.0)
+
+    async def close_position(
+        self, symbol: str, dry_run: bool | None = None,
+    ) -> OrderResult | None:
+        """Fully exit a held position. Selling a fractional *quantity* is also
+        rejected over the API (Error 10243), so we close by cash VALUE: a SELL
+        cashQty sized to the position's current market value. Returns None when
+        nothing is held (caller should still drop it from its book).
+
+        CAVEAT: a cashQty close is only as exact as the quote, so it may leave
+        sub-cent dust — verify live that positions flatten cleanly before trusting
+        this for hands-off exits."""
+        if Path("KILL_SWITCH").exists():
+            log.critical("kill_switch.active", action="ibkr_equity_close_blocked")
+            return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
+                               is_paper=True, error_message="kill switch")
+
+        held = (await self.get_positions()).get(symbol, 0.0)
+        if abs(held) < 1e-6:
+            return None  # nothing to close
+
+        if dry_run is None:
+            dry_run = not self._settings.is_live
+        price = await self.get_price(symbol)
+        value = round(held * price, 2) if price else 0.0
+        if dry_run:
+            log.info("ibkr_equity.close.paper", symbol=symbol, qty=held,
+                     value=value, price=price)
+            return OrderResult(order_id="PAPER", market_id=symbol, status="paper",
+                               filled_size=held, filled_price=price or 0.0, is_paper=True)
+
+        if self._settings.ibkr.readonly:
+            return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
+                               is_paper=False,
+                               error_message="ibkr.readonly=true — cannot place orders")
+        if not value:
+            return OrderResult(order_id="ERROR", market_id=symbol, status="rejected",
+                               is_paper=False, error_message="no price to size close")
+        return await self._place_cash_order(symbol, "SELL", value, price or 0.0)
+
+    async def _place_cash_order(
+        self, symbol: str, side_str: str, usd_amount: float, price: float,
+    ) -> OrderResult:
+        """Place a live market order denominated in cash (cashQty=usd_amount,
+        totalQuantity=0) — the API path IBKR accepts for fractional equity sizing
+        (a fractional totalQuantity is rejected with Error 10243)."""
         await self._ensure_connected()
         try:
             from ib_async import Stock, MarketOrder
             stock = Stock(symbol, "SMART", "USD")
             await self._ib.qualifyContractsAsync(stock)
-            order = MarketOrder(side_str, qty)
+            order = MarketOrder(side_str, 0)   # size comes from cashQty, not qty
+            order.cashQty = round(usd_amount, 2)
             trade = self._ib.placeOrder(stock, order)
-            log.warning("ibkr_equity.order.live", symbol=symbol, side=side_str, qty=qty)
+            log.warning("ibkr_equity.order.live", symbol=symbol, side=side_str,
+                        usd=round(usd_amount, 2))
             return OrderResult(order_id=str(trade.order.orderId), market_id=symbol,
                                status="pending", filled_price=price, is_paper=False)
         except Exception as e:  # noqa: BLE001
@@ -151,6 +218,103 @@ class IBKREquityClient:
         except Exception as e:  # noqa: BLE001
             log.debug("ibkr_equity.positions_error", error=str(e)[:80])
             return {}
+
+    async def usd_cash(self) -> float | None:
+        """Total USD held in the account — the funding the (USD-priced) stock book
+        draws on, and the re-conversion guard for ensure_usd_float. Returns None
+        if the gateway is unreachable so the caller skips rather than misfires.
+
+        IBKR holds non-base cash as a *virtual FX position* (symbol USD, secType
+        CASH), so a freshly converted balance shows up in positions() — NOT in
+        accountValues().CashBalance, which stays empty on this account. Reading
+        the FX position is what lets us see the convert and avoid re-converting
+        every cooldown. We deliberately count total (incl. unsettled T+1) USD:
+        the question here is 'have we already funded?', and IBKR — not this
+        method — enforces settlement at order time. Falls back to the CashBalance
+        row if a position isn't present (e.g. after settlement folds into base)."""
+        try:
+            await self._ensure_connected()
+            for p in self._ib.positions():
+                c = p.contract
+                if getattr(c, "symbol", None) == "USD" and getattr(c, "secType", None) == "CASH":
+                    return float(p.position or 0.0)
+            for v in self._ib.accountValues():
+                if v.tag == "CashBalance" and v.currency == "USD":
+                    return float(v.value or 0.0)
+            return 0.0
+        except Exception as e:  # noqa: BLE001
+            log.debug("ibkr_equity.usd_cash_error", error=str(e)[:80])
+            return None
+
+    async def ensure_usd_float(
+        self, *, target_usd: float, max_convert_usd: float,
+        min_convert_usd: float, source_ccy: str = "CAD",
+        dry_run: bool | None = None,
+    ) -> OrderResult | None:
+        """Top up settled USD toward `target_usd` by converting `source_ccy`->USD,
+        so the USD-priced stock book has buying power. Capped per conversion and
+        gated like every order. Returns None when no action is needed (already at
+        target, can't read balance, or below the dust floor).
+
+        Converting BUYs the USD.<ccy> forex pair (e.g. USDCAD): buying USD, paying
+        the source currency. On a cash account the proceeds settle T+1, so this is
+        a buffer-maintainer, not same-cycle funding."""
+        if dry_run is None:
+            dry_run = not self._settings.is_live
+
+        if Path("KILL_SWITCH").exists():
+            log.critical("kill_switch.active", action="ibkr_fx_convert_blocked")
+            return OrderResult(order_id="BLOCKED", market_id=f"USD{source_ccy}",
+                               status="rejected", is_paper=True,
+                               error_message="kill switch")
+
+        # Don't re-fire while a just-placed conversion is still posting/settling.
+        if time.monotonic() < self._fx_cooldown_until:
+            return None
+
+        usd = await self.usd_cash()
+        if usd is None:
+            return None  # unreachable — skip quietly, sizing will degrade anyway
+        if usd >= target_usd:
+            return None  # already funded
+
+        # Round to whole USD; small sizes auto-route as odd lots, so the cap can
+        # sit far below the IDEALPRO 25k minimum.
+        convert = float(round(min(target_usd - usd, max_convert_usd)))
+        if convert < min_convert_usd:
+            return None
+
+        if dry_run:
+            self._fx_cooldown_until = time.monotonic() + _FX_COOLDOWN_S
+            log.info("ibkr_equity.fx_convert.paper", source=source_ccy,
+                     usd=convert, have_usd=round(usd, 2), target=target_usd)
+            return OrderResult(order_id="PAPER", market_id=f"USD{source_ccy}",
+                               status="paper", filled_size=convert, is_paper=True)
+
+        # === LIVE ===
+        if self._settings.ibkr.readonly:
+            return OrderResult(order_id="BLOCKED", market_id=f"USD{source_ccy}",
+                               status="rejected", is_paper=False,
+                               error_message="ibkr.readonly=true — cannot convert")
+        try:
+            await self._ensure_connected()
+            from ib_async import Forex, MarketOrder
+            contract = Forex(f"USD{source_ccy}")
+            await self._ib.qualifyContractsAsync(contract)
+            order = MarketOrder("BUY", convert)  # buy USD, sell source_ccy
+            trade = self._ib.placeOrder(contract, order)
+            self._fx_cooldown_until = time.monotonic() + _FX_COOLDOWN_S
+            log.warning("ibkr_equity.fx_convert.live", source=source_ccy,
+                        usd=convert, have_usd=round(usd, 2), target=target_usd)
+            return OrderResult(order_id=str(trade.order.orderId),
+                               market_id=f"USD{source_ccy}", status="pending",
+                               filled_size=convert, is_paper=False)
+        except Exception as e:  # noqa: BLE001
+            log.error("ibkr_equity.fx_convert.error", source=source_ccy,
+                      error=str(e)[:150])
+            return OrderResult(order_id="ERROR", market_id=f"USD{source_ccy}",
+                               status="rejected", is_paper=False,
+                               error_message=str(e)[:200])
 
     async def close(self) -> None:
         if self._ib is not None and self._connected:

--- a/auramaur/treasury/ibkr_pillar.py
+++ b/auramaur/treasury/ibkr_pillar.py
@@ -26,6 +26,20 @@ class IBKRDirectionalPillar:
         cfg = self._s.ibkr
         if not cfg.directional_equity_enabled:
             return
+        # Auto FX top-up: keep settled USD buying power for the USD-priced book by
+        # converting idle base-currency cash (CAD->USD). Gated by auto_fx_enabled;
+        # the conversion itself dry-runs unless the live gates are open. T+1 on a
+        # cash account, so it funds a buffer for future cycles, not this one.
+        if cfg.auto_fx_enabled:
+            try:
+                await self._eq.ensure_usd_float(
+                    target_usd=cfg.fx_target_usd,
+                    max_convert_usd=cfg.fx_max_convert_usd,
+                    min_convert_usd=cfg.fx_min_convert_usd,
+                    source_ccy=cfg.fx_source_currency,
+                )
+            except Exception as e:  # noqa: BLE001 — never kill the loop on FX
+                log.error("ibkr_equity.fx_convert.pillar_error", error=str(e)[:120])
         # Reconcile open positions from the IBKR account so a restart doesn't lose
         # track (re-buy / miss exits). Empty when disconnected — safe.
         try:
@@ -66,8 +80,12 @@ class IBKRDirectionalPillar:
                      status=res.status, err=res.error_message[:80])
 
         elif holding and mom <= -cfg.directional_equity_momentum_pct:
-            res = await self._eq.place_order(sym, OrderSide.SELL, cfg.equity_max_order_usd)
-            if res.order_id not in ("ERROR", "BLOCKED"):
+            # Close the whole position (cashQty-valued sell). res is None when
+            # nothing is actually held — drop it from the book either way unless
+            # the close errored/was blocked.
+            res = await self._eq.close_position(sym)
+            if res is None or res.order_id not in ("ERROR", "BLOCKED"):
                 self._long.pop(sym, None)
             log.info("ibkr_equity.directional.exit", symbol=sym, momentum=round(mom, 2),
-                     status=res.status, err=res.error_message[:80])
+                     status=(res.status if res else "noop"),
+                     err=(res.error_message[:80] if res else ""))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -120,6 +120,11 @@ ibkr:
   # active AND funds clear; then flip paper_trade:false to go fully live.
   # Ports: TWS 7497 paper / 7496 live; IB Gateway 4002 / 4001.
   enabled: false
+  # Master switch above just connects. The two books are gated independently
+  # (both also need enabled:true): options_enabled = the option-chain scanner
+  # (needs OPRA data; off = no Error 200/10091 scan spam); directional_equity_
+  # enabled (below) = the stocks book. Run equities with options_enabled:false.
+  options_enabled: false
   # "paper" connects to the paper TWS/Gateway on paper_port (read-only).
   # Switch to "live" only with a live Gateway running and the live gates open.
   environment: "live"
@@ -145,6 +150,17 @@ ibkr:
   directional_equity_momentum_pct: 2.0
   directional_equity_lookback: 12
   equity_client_id: 2
+  # Auto FX top-up: convert idle CAD -> USD so the USD-priced stock book has
+  # settled buying power (the account base is CAD; US shares settle in USD).
+  # Mirrors the Kraken fiat->USDC convert. Off by default; a real conversion
+  # needs the three live gates, else it dry-runs (logs the intended convert).
+  # Cash account => converted funds settle T+1, so this keeps a buffer ahead of
+  # trading. Small orders auto-route as odd lots (under the IDEALPRO 25k min).
+  auto_fx_enabled: false
+  fx_source_currency: "CAD"
+  fx_target_usd: 120.0
+  fx_max_convert_usd: 150.0
+  fx_min_convert_usd: 20.0
 
 kraken:
   # Spot venue for treasury/conversion (sell POL -> USDC, etc). Not a binary

--- a/config/settings.py
+++ b/config/settings.py
@@ -230,6 +230,11 @@ class KalshiConfig(BaseModel):
 
 class IBKRConfig(BaseModel):
     enabled: bool = False
+    # `enabled` is the master switch (connect to IBKR at all). The two books
+    # beneath it are gated independently: options_enabled (the option-chain
+    # scanner) and directional_equity_enabled (the stocks book). Keep options
+    # off to run equities without the OPRA-less scanner spamming Error 200/10091.
+    options_enabled: bool = False
     host: str = "127.0.0.1"
     paper_port: int = 7497
     live_port: int = 7496
@@ -263,6 +268,20 @@ class IBKRConfig(BaseModel):
     directional_equity_momentum_pct: float = 2.0
     directional_equity_lookback: int = 12          # bars of recent history
     equity_client_id: int = 2                      # distinct from client_id
+
+    # --- Auto FX top-up (CAD->USD funding for the USD-priced stock book) ---
+    # Mirrors the Kraken fiat->USDC treasury convert: keep enough *settled* USD
+    # buying power for the equity book by converting idle base-currency cash.
+    # Off by default. A real conversion still needs the three live gates;
+    # otherwise it dry-runs (logs the intended convert). On a cash account
+    # converted funds settle T+1, so this maintains a buffer AHEAD of trading
+    # rather than funding a same-cycle order. Small orders auto-route as odd
+    # lots, so the per-convert cap can sit well under the IDEALPRO 25k minimum.
+    auto_fx_enabled: bool = False
+    fx_source_currency: str = "CAD"                 # idle cash to draw down
+    fx_target_usd: float = 120.0                    # keep >= this much settled USD
+    fx_max_convert_usd: float = 150.0              # hard per-conversion ceiling
+    fx_min_convert_usd: float = 20.0              # skip dust conversions
 
 
 class CryptoComConfig(BaseModel):

--- a/tests/test_ibkr_equity.py
+++ b/tests/test_ibkr_equity.py
@@ -1,0 +1,365 @@
+"""Tests for the IBKR directional-equity client — fractional-share sizing.
+
+The book caps each order at a small USD amount (default $50). With whole-share
+sizing `int($50/price)` rounded to 0 for every watchlist name (cheapest ~$200),
+so the book could never open a position. These tests pin the fractional sizing
+that fixes that, plus the surrounding guards (cap, no-price, zero-rounding).
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.exchange.ibkr_equity import IBKREquityClient
+from auramaur.exchange.models import OrderSide
+
+
+def _settings(*, is_live=False, readonly=False, cap=50.0):
+    return SimpleNamespace(
+        is_live=is_live,
+        ibkr=SimpleNamespace(
+            equity_max_order_usd=cap,
+            readonly=readonly,
+            environment="live",
+            host="127.0.0.1",
+            paper_port=7497,
+            live_port=7496,
+            equity_client_id=2,
+            market_data_type=3,
+        ),
+    )
+
+
+async def test_high_priced_stock_sizes_fractionally_not_blocked():
+    """$50 into a $737 stock used to round to 0 shares (BLOCKED). It must now
+    take a fractional position instead."""
+    client = IBKREquityClient(_settings())
+    client.get_price = AsyncMock(return_value=737.55)
+
+    res = await client.place_order("SPY", OrderSide.BUY, 50.0)
+
+    assert res.order_id == "PAPER"
+    assert res.status == "paper"
+    assert res.filled_size == pytest.approx(round(50.0 / 737.55, 4))
+    assert 0 < res.filled_size < 1  # genuinely fractional
+
+
+async def test_midpriced_stock_fractional():
+    client = IBKREquityClient(_settings())
+    client.get_price = AsyncMock(return_value=205.10)
+
+    res = await client.place_order("NVDA", OrderSide.BUY, 50.0)
+
+    assert res.order_id == "PAPER"
+    assert res.filled_size == pytest.approx(round(50.0 / 205.10, 4))
+
+
+async def test_per_order_cap_still_enforced():
+    """Fractional sizing must not weaken the hard per-order USD ceiling."""
+    client = IBKREquityClient(_settings(cap=50.0))
+    client.get_price = AsyncMock(return_value=205.10)
+
+    res = await client.place_order("NVDA", OrderSide.BUY, 75.0)
+
+    assert res.order_id == "BLOCKED"
+    assert "exceeds cap" in res.error_message
+    client.get_price.assert_not_awaited()  # capped before any price fetch
+
+
+async def test_no_price_paper_still_returns_paper():
+    """A missing quote no longer errors the order (live sizing is server-side via
+    cashQty); paper just reports a 0-qty estimate."""
+    client = IBKREquityClient(_settings())
+    client.get_price = AsyncMock(return_value=None)
+
+    res = await client.place_order("SPY", OrderSide.BUY, 50.0)
+
+    assert res.order_id == "PAPER"
+    assert res.filled_size == 0.0
+
+
+def _fake_ib_async(monkeypatch, created):
+    """Install a fake ib_async whose MarketOrder records the order object so a
+    test can assert on cashQty / totalQuantity."""
+    fake = types.ModuleType("ib_async")
+    fake.Stock = lambda *a, **k: SimpleNamespace(symbol=a[0] if a else "X")
+
+    def _market_order(action, qty):
+        o = SimpleNamespace(action=action, totalQuantity=qty, cashQty=None)
+        created["order"] = o
+        return o
+
+    fake.MarketOrder = _market_order
+    monkeypatch.setitem(sys.modules, "ib_async", fake)
+
+
+async def test_live_order_uses_cashqty_not_fractional_qty(monkeypatch):
+    """The live order must be dollar-denominated (cashQty), never a fractional
+    share quantity — IBKR rejects the latter over the API with Error 10243."""
+    created = {}
+    _fake_ib_async(monkeypatch, created)
+
+    client = IBKREquityClient(_settings(is_live=True, readonly=False))
+    client.get_price = AsyncMock(return_value=205.10)
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(
+        qualifyContractsAsync=AsyncMock(),
+        placeOrder=lambda stock, order: SimpleNamespace(order=SimpleNamespace(orderId=42)),
+    )
+
+    res = await client.place_order("NVDA", OrderSide.BUY, 50.0)
+
+    assert res.is_paper is False
+    assert res.order_id == "42"
+    o = created["order"]
+    assert o.action == "BUY"
+    assert o.totalQuantity == 0                  # never a fractional share qty
+    assert o.cashQty == pytest.approx(50.0)      # dollar-sized instead
+
+
+async def test_live_order_places_without_price_via_cashqty(monkeypatch):
+    """No market-data entitlement (price None) must NOT block a live order —
+    cashQty sizes server-side, so it still goes out."""
+    created = {}
+    _fake_ib_async(monkeypatch, created)
+
+    client = IBKREquityClient(_settings(is_live=True, readonly=False))
+    client.get_price = AsyncMock(return_value=None)
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(
+        qualifyContractsAsync=AsyncMock(),
+        placeOrder=lambda stock, order: SimpleNamespace(order=SimpleNamespace(orderId=43)),
+    )
+
+    res = await client.place_order("SPY", OrderSide.BUY, 50.0)
+
+    assert res.order_id == "43"
+    assert created["order"].cashQty == pytest.approx(50.0)
+
+
+# --- close_position (cashQty-valued exit of a fractional position) ---
+
+async def test_close_position_no_holding_returns_none():
+    client = IBKREquityClient(_settings())
+    client.get_positions = AsyncMock(return_value={})
+
+    assert await client.close_position("NVDA") is None
+
+
+async def test_close_position_paper():
+    client = IBKREquityClient(_settings())
+    client.get_positions = AsyncMock(return_value={"NVDA": 0.16})
+    client.get_price = AsyncMock(return_value=205.10)
+
+    res = await client.close_position("NVDA")
+
+    assert res.order_id == "PAPER"
+    assert res.filled_size == pytest.approx(0.16)
+
+
+async def test_close_position_live_sells_full_value_via_cashqty(monkeypatch):
+    """Exit sells the position's market VALUE via cashQty (a fractional sell qty
+    would hit Error 10243 just like a buy)."""
+    created = {}
+    _fake_ib_async(monkeypatch, created)
+
+    client = IBKREquityClient(_settings(is_live=True, readonly=False))
+    client.get_positions = AsyncMock(return_value={"NVDA": 0.16})
+    client.get_price = AsyncMock(return_value=205.10)
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(
+        qualifyContractsAsync=AsyncMock(),
+        placeOrder=lambda stock, order: SimpleNamespace(order=SimpleNamespace(orderId=44)),
+    )
+
+    res = await client.close_position("NVDA")
+
+    assert res.order_id == "44"
+    o = created["order"]
+    assert o.action == "SELL"
+    assert o.totalQuantity == 0
+    assert o.cashQty == pytest.approx(round(0.16 * 205.10, 2))
+
+
+async def test_close_position_readonly_blocked_when_live():
+    client = IBKREquityClient(_settings(is_live=True, readonly=True))
+    client.get_positions = AsyncMock(return_value={"NVDA": 0.16})
+    client.get_price = AsyncMock(return_value=205.10)
+
+    res = await client.close_position("NVDA")
+
+    assert res.order_id == "BLOCKED"
+    assert "readonly" in res.error_message
+
+
+# --- get_price historical-close fallback (no live data subscription) ---
+
+async def test_get_price_falls_back_to_historical_close(monkeypatch):
+    """With no US-equity entitlement, live/delayed quotes are NaN; get_price must
+    fall back to the most recent historical daily close rather than return None."""
+    fake = types.ModuleType("ib_async")
+    fake.Stock = lambda *a, **k: SimpleNamespace(symbol=a[0] if a else "X")
+    monkeypatch.setitem(sys.modules, "ib_async", fake)
+
+    nan = float("nan")
+    ticker = SimpleNamespace(marketPrice=lambda: nan, close=nan)
+    client = IBKREquityClient(_settings())
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(
+        qualifyContractsAsync=AsyncMock(),
+        reqTickersAsync=AsyncMock(return_value=[ticker]),
+        reqHistoricalDataAsync=AsyncMock(return_value=[SimpleNamespace(close=205.10)]),
+    )
+
+    px = await client.get_price("NVDA")
+
+    assert px == pytest.approx(205.10)
+    client._ib.reqHistoricalDataAsync.assert_awaited_once()
+
+
+# --- usd_cash reads the FX position (converted USD shows there, not CashBalance) ---
+
+async def test_usd_cash_reads_fx_position():
+    """Converted USD lands as a virtual FX position (symbol USD / secType CASH),
+    while accountValues().CashBalance is empty — usd_cash must read the position
+    so it sees the funding and doesn't re-convert every cooldown."""
+    client = IBKREquityClient(_settings())
+    client._ensure_connected = AsyncMock()
+    usd_pos = SimpleNamespace(
+        contract=SimpleNamespace(symbol="USD", secType="CASH"), position=120.0
+    )
+    client._ib = SimpleNamespace(positions=lambda: [usd_pos], accountValues=lambda: [])
+
+    assert await client.usd_cash() == pytest.approx(120.0)
+
+
+async def test_usd_cash_zero_when_no_usd():
+    client = IBKREquityClient(_settings())
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(positions=lambda: [], accountValues=lambda: [])
+
+    assert await client.usd_cash() == 0.0
+
+
+# --- auto FX top-up (CAD -> USD) ---
+
+async def test_fx_topup_below_target_converts_dry_run():
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=0.0)
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res is not None
+    assert res.order_id == "PAPER"
+    assert res.market_id == "USDCAD"
+    assert res.filled_size == pytest.approx(120.0)  # tops up the full shortfall
+
+
+async def test_fx_topup_capped_per_conversion():
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=0.0)
+
+    res = await client.ensure_usd_float(
+        target_usd=300.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res.filled_size == pytest.approx(150.0)  # clamped to the cap, not 300
+
+
+async def test_fx_topup_already_funded_noops():
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=200.0)
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res is None  # at/above target -> no conversion
+
+
+async def test_fx_topup_below_dust_floor_noops():
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=110.0)  # shortfall 10 < min 20
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res is None
+
+
+async def test_fx_topup_unreachable_balance_noops():
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=None)  # gateway unreachable
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res is None
+
+
+async def test_fx_topup_live_places_forex_buy(monkeypatch):
+    """Live path must BUY the USD.<ccy> forex pair for the (whole-USD) shortfall."""
+    captured = {}
+
+    fake = types.ModuleType("ib_async")
+    fake.Forex = lambda pair: SimpleNamespace(pair=pair)
+
+    def _market_order(action, qty):
+        captured["action"] = action
+        captured["qty"] = qty
+        return SimpleNamespace(order=SimpleNamespace(orderId=0))
+
+    fake.MarketOrder = _market_order
+    monkeypatch.setitem(sys.modules, "ib_async", fake)
+
+    client = IBKREquityClient(_settings(is_live=True, readonly=False))
+    client.usd_cash = AsyncMock(return_value=0.0)
+    client._ensure_connected = AsyncMock()
+    client._ib = SimpleNamespace(
+        qualifyContractsAsync=AsyncMock(),
+        placeOrder=lambda contract, order: SimpleNamespace(
+            order=SimpleNamespace(orderId=7)
+        ),
+    )
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res.is_paper is False
+    assert res.order_id == "7"
+    assert captured["action"] == "BUY"
+    assert captured["qty"] == pytest.approx(120.0)
+
+
+async def test_fx_topup_cooldown_prevents_double_convert():
+    """A second call right after a conversion must no-op, so a fast loop can't
+    double-convert while the first fill is still posting/settling."""
+    client = IBKREquityClient(_settings(is_live=False))
+    client.usd_cash = AsyncMock(return_value=0.0)
+    kw = dict(target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD")
+
+    first = await client.ensure_usd_float(**kw)
+    second = await client.ensure_usd_float(**kw)
+
+    assert first is not None and first.order_id == "PAPER"
+    assert second is None  # suppressed by the cooldown
+
+
+async def test_fx_topup_readonly_blocked_when_live():
+    client = IBKREquityClient(_settings(is_live=True, readonly=True))
+    client.usd_cash = AsyncMock(return_value=0.0)
+
+    res = await client.ensure_usd_float(
+        target_usd=120.0, max_convert_usd=150.0, min_convert_usd=20.0, source_ccy="CAD"
+    )
+
+    assert res.order_id == "BLOCKED"
+    assert "readonly" in res.error_message


### PR DESCRIPTION
Makes the gated IBKR stocks book actually placeable on the small CAD cash account, after a live run surfaced several hard IBKR/API realities. All gates remain OFF by default (tracked defaults false) — this only makes the code runnable when explicitly enabled.

## What it adds
- **cashQty orders**: IBKR rejects a fractional share *quantity* over the API (Error 10243); place dollar-denominated (cashQty) orders instead and let IBKR size the fraction server-side. Adds `close_position()` for exits (same restriction — sell by cash value).
- **get_price historical-close fallback**: size without a US-equity market-data subscription (HMDS daily close).
- **usd_cash() FX-position read**: converted USD lands as a virtual FX position (symbol USD / secType CASH), not `accountValues().CashBalance` (empty on this account).
- **auto FX top-up** (`ensure_usd_float`): gated + capped CAD→USD convert. Dry-runs unless live gates open.
- **options_enabled gate**: decouples the OPRA-less option scanner from `ibkr.enabled` so the equity book runs cleanly without Error 200/10091 spam.

## Tests
365 lines of new tests (`tests/test_ibkr_equity.py`).

## Validation status
Connection to the live account verified (clientId 2, no entitlement errors). **cashQty exits are not yet live-validated** — close path is approximate to the quote and needs one real round-trip before hands-off use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)