### PR TITLE
feat(strategy): entailment arbitrage — trade logical-implication violations, paper-forced

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2548,6 +2548,29 @@ class AuramaurBot:
                 log.error("bias_harvest.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_entailment_arb(self) -> None:
+        """Periodic entailment-arbitrage scan (paper-forced by config)."""
+        from auramaur.strategy.entailment_arb import EntailmentArbPillar
+
+        pillar = EntailmentArbPillar(
+            db=self._components["db"],
+            settings=self.settings,
+            discovery=self._components["discovery"],
+            exchange=self._components["exchange"],
+            risk_manager=self._components["risk_manager"],
+            pnl_tracker=self._components["pnl_tracker"],
+            analyzer=self._components.get("analyzer"),
+        )
+        interval = max(60, self.settings.entailment_arb.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("entailment.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_order_monitor(self) -> None:
         """Monitor pending limit orders for fills and expiry."""
         from datetime import datetime, timezone
@@ -2894,6 +2917,10 @@ class AuramaurBot:
         # Favorite-longshot bias harvest (paper-forced until proven)
         if self.settings.bias_harvest.enabled:
             tasks.append(asyncio.create_task(self._task_bias_harvest(), name="bias_harvest"))
+
+        # Entailment arbitrage (paper-forced until proven)
+        if self.settings.entailment_arb.enabled:
+            tasks.append(asyncio.create_task(self._task_entailment_arb(), name="entailment_arb"))
 
         # Kraken treasury/capital pillar (+ gated directional spot)
         if self.settings.kraken.enabled:

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -643,6 +643,60 @@ def graduation():
     asyncio.run(_run())
 
 
+@main.command("entailment")
+def entailment():
+    """Entailment-arb status: cached LLM verdicts + ladder families visible
+    in the markets table (detection view; the live scan runs in the bot)."""
+
+    async def _run():
+        from auramaur.exchange.models import Market
+        from auramaur.strategy.entailment_arb import ladder_pairs
+
+        db = Database()
+        await db.connect()
+        try:
+            rows = await db.fetchall(
+                "SELECT * FROM entailment_verdicts ORDER BY checked_at DESC LIMIT 25")
+            if rows:
+                t = Table(title="LLM entailment verdicts (cached)")
+                t.add_column("pair")
+                t.add_column("direction")
+                t.add_column("conf", justify="right")
+                t.add_column("traded")
+                for r in rows:
+                    t.add_row(f"{r['market_id_a'][:18]} / {r['market_id_b'][:18]}",
+                              r["direction"], f"{r['confidence']:.2f}",
+                              "yes" if r["traded_at"] else "")
+                console.print(t)
+            else:
+                console.print("[dim]No LLM verdicts cached yet.[/]")
+
+            mrows = await db.fetchall(
+                """SELECT id, question, outcome_yes_price, liquidity
+                   FROM markets WHERE active = 1 AND question IS NOT NULL""")
+            markets = [Market(id=r["id"], exchange="polymarket",
+                              question=r["question"] or "",
+                              outcome_yes_price=r["outcome_yes_price"] or 0.5,
+                              liquidity=r["liquidity"] or 0.0)
+                       for r in (mrows or [])]
+            pairs = ladder_pairs(markets)
+            viol = [(im, ip, why, im.outcome_yes_price - ip.outcome_yes_price)
+                    for im, ip, why in pairs
+                    if im.outcome_yes_price - ip.outcome_yes_price >= 0.04]
+            console.print(f"\nladder families: [cyan]{len(pairs)}[/] pairs from "
+                          f"{len(markets)} active markets; "
+                          f"[cyan]{len(viol)}[/] showing >=4c violations "
+                          "(before dead-book/liquidity guards)")
+            for im, ip, why, gap in sorted(viol, key=lambda v: -v[3])[:10]:
+                console.print(f"  [red]{gap:+.2f}[/] {why}")
+                console.print(f"        implier: {im.question[:64]} @ {im.outcome_yes_price:.2f}")
+                console.print(f"        implied: {ip.question[:64]} @ {ip.outcome_yes_price:.2f}")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
 @main.command("repair-pnl")
 @click.option("--write", is_flag=True,
               help="Persist resolution_pnl rows and rebuild category_stats dollar fields.")

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -74,6 +74,8 @@ class Database:
             await self._migrate_v13_to_v14()
         if from_version < 15:
             await self._migrate_v14_to_v15()
+        if from_version < 16:
+            await self._migrate_v15_to_v16()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -398,6 +400,12 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 15")
         await self._db.commit()
         log.info("database.migrated", from_version=14, to_version=15)
+
+    async def _migrate_v15_to_v16(self) -> None:
+        """Add the entailment_verdicts table (created by TABLES executescript)."""
+        await self._db.execute("UPDATE schema_version SET version = 16")
+        await self._db.commit()
+        log.info("database.migrated", from_version=15, to_version=16)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -238,6 +238,18 @@ CREATE TABLE IF NOT EXISTS pnl_ledger (
 
 CREATE INDEX IF NOT EXISTS idx_pnl_ledger_market ON pnl_ledger(market_id, is_paper);
 CREATE INDEX IF NOT EXISTS idx_pnl_ledger_realized ON pnl_ledger(realized_at);
+
+CREATE TABLE IF NOT EXISTS entailment_verdicts (
+    market_id_a TEXT NOT NULL,
+    market_id_b TEXT NOT NULL,
+    direction TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 0,
+    source TEXT NOT NULL DEFAULT 'llm',
+    reasoning TEXT NOT NULL DEFAULT '',
+    traded_at TEXT,
+    checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (market_id_a, market_id_b)
+);
 
 CREATE INDEX IF NOT EXISTS idx_price_history_market ON price_history(market_id);
 CREATE INDEX IF NOT EXISTS idx_price_history_time ON price_history(recorded_at);

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -1,0 +1,422 @@
+"""Entailment arbitrage — trade logical-implication violations between markets.
+
+If market A logically implies market B at the RESOLUTION-CRITERIA level
+(A resolving YES guarantees B resolves YES), then P(A) <= P(B) must hold.
+A violation P(A) > P(B) + gap is model-free profit: buy NO on A at
+(1 - P(A)) and YES on B at P(B) in equal token counts n. Cost is
+n*(1 - gap); payout is n if A=YES (then B=YES: 0 + 1), 2n if A=NO,B=YES,
+n if both NO — i.e. >= n in every world where the entailment holds.
+The only real risks are (1) the entailment being wrong in the fine print
+and (2) leg risk (one side fills, the other doesn't).
+
+Pair sources, by trust:
+  * LADDERS (deterministic, no LLM): families of markets differing only in
+    a numeric threshold — "BTC above 70,200 / 71,000 on <same date>",
+    "<same player> Top 5 / Top 10 / Top 20 at <same event>". Direction is
+    mathematical: above(hi) => above(lo); Top(small) => Top(big).
+  * market_relationships 'conditional' pairs, LLM-verified ADVERSARIALLY
+    ("can A resolve YES while B resolves NO?") and cached in
+    entailment_verdicts. Stored direction is never trusted — the
+    correlator's rows are direction-ambiguous and often junk.
+
+Dead-book guard: the 2026-06 relationship scan was full of phantom
+"violations" — illiquid books showing placeholder mids near 0.5 (the same
+pattern PR #80 fixed for the market maker). Legs require real liquidity
+AND a sane spread before any price is believed.
+
+Safety: PAPER-FORCED by default; both legs risk-checked and placed only
+together (no single-leg); one shot per pair; rides the standard rails
+(signals/trades/fills/portfolio) under strategy_source='entailment_arb',
+which the graduation ladder scores like any other cell.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.exchange.models import (
+    Confidence,
+    Fill,
+    Market,
+    OrderSide,
+    Signal,
+)
+
+log = structlog.get_logger()
+
+
+# ----------------------------------------------------------------------
+# Deterministic ladder detection
+# ----------------------------------------------------------------------
+
+_THRESHOLD_RE = re.compile(
+    r"^(?P<pre>.*?)\b(?P<dir>above|below)\b\s*\$?(?P<num>\d[\d,]*(?:\.\d+)?)(?P<post>.*)$",
+    re.IGNORECASE,
+)
+_TOPN_RE = re.compile(r"\btop\s+(?P<n>\d+)\b", re.IGNORECASE)
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip().lower())
+
+
+def parse_threshold(question: str):
+    """Return (family_key, direction, value) for 'X above/below N' questions."""
+    m = _THRESHOLD_RE.match(question or "")
+    if not m:
+        return None
+    value = float(m.group("num").replace(",", ""))
+    direction = m.group("dir").lower()
+    key = ("thr", _norm(m.group("pre")), direction, _norm(m.group("post")))
+    return key, direction, value
+
+
+def parse_topn(question: str):
+    """Return (family_key, n) for '<player> Top N at <event>' questions."""
+    m = _TOPN_RE.search(question or "")
+    if not m:
+        return None
+    n = int(m.group("n"))
+    key = ("topn", _norm(_TOPN_RE.sub("top {n}", question, count=1)))
+    return key, n
+
+
+def ladder_pairs(markets: list[Market]) -> list[tuple[Market, Market, str]]:
+    """All (implier, implied, why) pairs from threshold/Top-N families.
+
+    implier => implied, so P(implier) <= P(implied) must hold.
+    """
+    thr_families: dict[tuple, list[tuple[float, Market]]] = {}
+    top_families: dict[tuple, list[tuple[int, Market]]] = {}
+    for m in markets:
+        t = parse_threshold(m.question)
+        if t:
+            key, _direction, value = t
+            thr_families.setdefault(key, []).append((value, m))
+            continue
+        t2 = parse_topn(m.question)
+        if t2:
+            key2, n = t2
+            top_families.setdefault(key2, []).append((n, m))
+
+    pairs: list[tuple[Market, Market, str]] = []
+    for key, members in thr_families.items():
+        if len(members) < 2:
+            continue
+        direction = key[2]
+        members.sort()
+        for i, (v_lo, m_lo) in enumerate(members):
+            for v_hi, m_hi in members[i + 1:]:
+                if v_hi == v_lo:
+                    continue
+                if direction == "above":
+                    # above(hi) => above(lo)
+                    pairs.append((m_hi, m_lo, f"above {v_hi:g} => above {v_lo:g}"))
+                else:
+                    # below(lo) => below(hi)
+                    pairs.append((m_lo, m_hi, f"below {v_lo:g} => below {v_hi:g}"))
+    for _key, members2 in top_families.items():
+        if len(members2) < 2:
+            continue
+        members2.sort()
+        for i, (n_small, m_small) in enumerate(members2):
+            for n_big, m_big in members2[i + 1:]:
+                if n_big == n_small:
+                    continue
+                # Top 5 => Top 10
+                pairs.append((m_small, m_big, f"top {n_small} => top {n_big}"))
+    return pairs
+
+
+# ----------------------------------------------------------------------
+# LLM verification prompt (fuzzy pairs only)
+# ----------------------------------------------------------------------
+
+ENTAILMENT_PROMPT = """You are auditing two prediction markets for STRICT logical entailment at the resolution-criteria level. Be adversarial: the default answer is "none".
+
+Market A: "{question_a}"
+Resolution details A: {description_a}
+
+Market B: "{question_b}"
+Resolution details B: {description_b}
+
+Strict entailment means: in EVERY possible world, if the implier resolves YES then the implied market MUST resolve YES under its own written criteria. Consider timing windows, qualifying language, different resolution sources, and edge cases. If you can construct ANY plausible scenario where the implier resolves YES and the implied resolves NO, the entailment fails.
+
+Respond with ONLY this JSON:
+{{"direction": "a_implies_b" | "b_implies_a" | "none", "confidence": 0.0-1.0, "counterexample": "<the best scenario that breaks the strongest candidate direction, or 'none found'>"}}"""
+
+
+# ----------------------------------------------------------------------
+# Pillar
+# ----------------------------------------------------------------------
+
+class EntailmentArbPillar:
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, analyzer=None) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._analyzer = analyzer
+
+    # -- market quality -------------------------------------------------
+
+    def _real_book(self, m: Market) -> bool:
+        """Reject dead/placeholder books before believing any price."""
+        cfg = self._settings.entailment_arb
+        if not m.active or not (0.0 < m.outcome_yes_price < 1.0):
+            return False
+        if (m.exchange or "polymarket") != "polymarket":
+            return False
+        if m.liquidity < cfg.min_liquidity:
+            return False
+        if m.spread and m.spread * 100.0 > cfg.max_spread_pct:
+            return False
+        if m.end_date is None:
+            return False
+        end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+        hours = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+        return hours >= cfg.min_hours_to_resolution
+
+    # -- pair sources ---------------------------------------------------
+
+    async def _conditional_pairs(self, by_id: dict[str, Market]):
+        rows = await self._db.fetchall(
+            "SELECT market_id_a, market_id_b FROM market_relationships "
+            "WHERE relationship_type = 'conditional'",
+        )
+        out = []
+        for r in rows or []:
+            a, b = by_id.get(r["market_id_a"]), by_id.get(r["market_id_b"])
+            if a is not None and b is not None:
+                out.append((a, b))
+        return out
+
+    async def _verify_llm(self, a: Market, b: Market):
+        """Cached adversarial entailment verdict for a fuzzy pair."""
+        key = tuple(sorted((a.id, b.id)))
+        row = await self._db.fetchone(
+            "SELECT direction, confidence FROM entailment_verdicts "
+            "WHERE market_id_a = ? AND market_id_b = ?", key,
+        )
+        if row is not None:
+            return row["direction"], float(row["confidence"])
+        if self._analyzer is None:
+            return "none", 0.0
+        first, second = (a, b) if key[0] == a.id else (b, a)
+        prompt = ENTAILMENT_PROMPT.format(
+            question_a=first.question, description_a=(first.description or "")[:600],
+            question_b=second.question, description_b=(second.description or "")[:600],
+        )
+        direction, confidence, reasoning = "none", 0.0, ""
+        try:
+            raw = await self._analyzer._call_llm(prompt)
+            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            direction = str(parsed.get("direction", "none"))
+            confidence = float(parsed.get("confidence", 0.0))
+            reasoning = str(parsed.get("counterexample", ""))[:400]
+            if direction not in ("a_implies_b", "b_implies_a"):
+                direction = "none"
+        except Exception as e:
+            log.warning("entailment.llm_parse_error", a=a.id, b=b.id, error=str(e))
+        await self._db.execute(
+            """INSERT OR REPLACE INTO entailment_verdicts
+               (market_id_a, market_id_b, direction, confidence, source, reasoning)
+               VALUES (?, ?, ?, ?, 'llm', ?)""",
+            (key[0], key[1], direction, confidence, reasoning),
+        )
+        await self._db.commit()
+        return direction, confidence
+
+    async def _already_traded(self, a_id: str, b_id: str) -> bool:
+        row = await self._db.fetchone(
+            """SELECT 1 FROM trades WHERE strategy_source = 'entailment_arb'
+               AND market_id IN (?, ?) LIMIT 1""", (a_id, b_id),
+        )
+        return row is not None
+
+    # -- main cycle -------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.entailment_arb
+        if not cfg.enabled:
+            return 0
+        markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        good = [m for m in markets if self._real_book(m)]
+        by_id = {m.id: m for m in good}
+
+        # 1. Deterministic ladders — direction known mathematically.
+        candidates: list[tuple[Market, Market, str, float]] = [
+            (impl, imp, why, 1.0) for impl, imp, why in ladder_pairs(good)
+        ]
+
+        # 2. Fuzzy conditional pairs — verify with the LLM ONLY when a
+        # violation is on the table (saves calls), direction never trusted
+        # from the correlator.
+        if cfg.llm_enabled and self._analyzer is not None:
+            for a, b in await self._conditional_pairs(by_id):
+                gap_ab = a.outcome_yes_price - b.outcome_yes_price
+                if abs(gap_ab) < cfg.min_gap:
+                    continue
+                direction, conf = await self._verify_llm(a, b)
+                if conf < cfg.llm_min_confidence:
+                    continue
+                if direction == "a_implies_b":
+                    candidates.append((a, b, "llm-verified", conf))
+                elif direction == "b_implies_a":
+                    candidates.append((b, a, "llm-verified", conf))
+
+        placed = 0
+        for implier, implied, why, conf in candidates:
+            if placed >= cfg.max_pairs_per_cycle:
+                break
+            gap = implier.outcome_yes_price - implied.outcome_yes_price
+            if gap < cfg.min_gap:
+                continue
+            if await self._already_traded(implier.id, implied.id):
+                continue
+            try:
+                if await self._enter_pair(implier, implied, gap, why, conf):
+                    placed += 1
+            except Exception as e:
+                log.error("entailment.entry_error", a=implier.id, b=implied.id,
+                          error=str(e))
+        if placed:
+            log.info("entailment.cycle_done", pairs=placed)
+        return placed
+
+    # -- execution --------------------------------------------------------
+
+    def _leg_signal(self, market: Market, side: OrderSide, fair: float,
+                    gap: float, why: str) -> Signal:
+        return Signal(
+            market_id=market.id,
+            market_question=market.question,
+            # fair value is the OTHER leg's price — the entailment bound.
+            claude_prob=max(0.01, min(0.99, fair)),
+            # Verified structural implication, not a forecast — HIGH is honest
+            # and keeps the divergence filter meaningful for true forecasts.
+            claude_confidence=Confidence.HIGH,
+            market_prob=market.outcome_yes_price,
+            edge=gap * 100.0,
+            evidence_summary=f"Entailment arb ({why}): P(implier) must be <= P(implied).",
+            recommended_side=side,
+            strategy_source="entailment_arb",
+        )
+
+    async def _enter_pair(self, implier: Market, implied: Market,
+                          gap: float, why: str, conf: float) -> bool:
+        cfg = self._settings.entailment_arb
+        # Leg 1: NO on the implier (its YES is overpriced vs the bound).
+        sig_a = self._leg_signal(implier, OrderSide.SELL,
+                                 fair=implied.outcome_yes_price, gap=gap, why=why)
+        # Leg 2: YES on the implied (its YES is underpriced vs the bound).
+        sig_b = self._leg_signal(implied, OrderSide.BUY,
+                                 fair=implier.outcome_yes_price, gap=gap, why=why)
+
+        dec_a = await self._risk.evaluate(sig_a, implier)
+        dec_b = await self._risk.evaluate(sig_b, implied)
+        if not (dec_a.approved and dec_b.approved):
+            log.info("entailment.risk_rejected", a=implier.id, b=implied.id,
+                     reason_a=dec_a.reason, reason_b=dec_b.reason)
+            return False
+
+        # Equal-notional legs, capped by config; both-or-nothing.
+        size = min(dec_a.position_size, dec_b.position_size, cfg.stake_usd)
+        if size <= 0:
+            return False
+        force_paper = (getattr(dec_a, "force_paper", False)
+                       or getattr(dec_b, "force_paper", False))
+        is_live = self._settings.is_live and not cfg.paper and not force_paper
+
+        order_a = self._exchange.prepare_order(sig_a, implier, size, is_live)
+        order_b = self._exchange.prepare_order(sig_b, implied, size, is_live)
+        if order_a is None or order_b is None:
+            return False
+
+        result_a = await self._exchange.place_order(order_a)
+        if result_a.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("entailment.leg_a_rejected", a=implier.id,
+                        status=result_a.status)
+            return False
+        result_b = await self._exchange.place_order(order_b)
+        if result_b.status not in ("filled", "paper", "partial", "pending"):
+            # Leg risk: A is in, B failed. Flag loudly — the position is
+            # directional until B fills or A is exited.
+            log.error("entailment.leg_b_failed_single_leg", a=implier.id,
+                      b=implied.id, status=result_b.status,
+                      error=result_b.error_message)
+
+        for market, order, result in ((implier, order_a, result_a),
+                                      (implied, order_b, result_b)):
+            if result.status in ("filled", "paper", "partial", "pending"):
+                await self._record_leg(market, order, result, why, gap)
+
+        await self._db.execute(
+            "UPDATE entailment_verdicts SET traded_at = datetime('now') "
+            "WHERE market_id_a = ? AND market_id_b = ?",
+            tuple(sorted((implier.id, implied.id))),
+        )
+        await self._db.commit()
+        log.info("entailment.entered", a=implier.id, b=implied.id,
+                 gap=round(gap, 3), why=why, confidence=conf,
+                 paper=result_a.is_paper)
+        return True
+
+    async def _record_leg(self, market: Market, order, result, why: str,
+                          gap: float) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        if result.status in ("filled", "paper", "partial") and fill_size > 0:
+            await self._pnl.record_fill(Fill(
+                order_id=result.order_id, market_id=order.market_id,
+                token_id=order.token_id, side=order.side, token=order.token,
+                size=fill_size, price=fill_price, is_paper=is_paper,
+            ))
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, question, category,
+               active, outcome_yes_price, outcome_no_price, volume, liquidity,
+               last_updated)
+               VALUES (?, 'polymarket', ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.question, market.category or "",
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, 'HIGH', ?, ?, ?, ?, 'entailment_arb')""",
+            (market.id, market.outcome_yes_price, market.outcome_yes_price,
+             gap * 100.0, f"entailment ({why})",
+             order.side.value),
+        )
+        await self._db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, strategy_source, exchange)
+               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'entailment_arb',
+                       'polymarket')""",
+            (order.market_id, order.side.value, fill_size, fill_price,
+             1 if is_paper else 0, result.order_id,
+             "filled" if result.status in ("filled", "paper") else result.status),
+        )
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size, avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0),
+        )
+        await self._db.commit()

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -335,6 +335,28 @@ technical:
   mean_rev_threshold: 0.10
   min_history_points: 5
 
+entailment_arb:
+  # Entailment arbitrage: if A=>B at resolution level, P(A) <= P(B) must
+  # hold; violations are model-free profit (buy NO-A + YES-B, both-or-
+  # nothing legs). Ladder pairs (threshold/Top-N families) are detected
+  # deterministically; fuzzy 'conditional' pairs are LLM-verified
+  # ADVERSARIALLY (default verdict: none) and cached in entailment_verdicts.
+  # Dead-book guard rejects placeholder mids (the #80 lesson) before any
+  # price is believed. PAPER-FORCED until the paper ledger proves it —
+  # the real unknowns are fine-print entailment failures and leg risk.
+  enabled: true
+  paper: true
+  min_gap: 0.04          # violation must exceed this after both legs
+  stake_usd: 10.0        # per leg, also capped by risk sizing
+  max_pairs_per_cycle: 3
+  scan_limit: 300
+  min_liquidity: 1000.0
+  max_spread_pct: 5.0
+  min_hours_to_resolution: 2.0
+  llm_enabled: true
+  llm_min_confidence: 0.9
+  interval_seconds: 900
+
 bias_harvest:
   # Favorite-longshot bias harvest — forecast-free base-load strategy.
   # Backtest (scripts/research/favorite_longshot_backtest.py, 414 resolved

--- a/config/settings.py
+++ b/config/settings.py
@@ -243,6 +243,29 @@ class BiasHarvestConfig(BaseModel):
     interval_seconds: int = 600
 
 
+class EntailmentArbConfig(BaseModel):
+    """Entailment arbitrage (strategy/entailment_arb.py).
+
+    Trades P(implier) > P(implied) violations between logically linked
+    markets. Ladder pairs (numeric threshold / Top-N families) are
+    deterministic; fuzzy 'conditional' pairs are LLM-verified
+    adversarially and cached. PAPER-FORCED by default.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    min_gap: float = 0.04
+    stake_usd: float = 10.0
+    max_pairs_per_cycle: int = 3
+    scan_limit: int = 300
+    min_liquidity: float = 1000.0
+    max_spread_pct: float = 5.0
+    min_hours_to_resolution: float = 2.0
+    llm_enabled: bool = True
+    llm_min_confidence: float = 0.9
+    interval_seconds: int = 900
+
+
 class GraduationConfig(BaseModel):
     """Graduation ladder (risk/graduation.py) — capital earned per
     (strategy × category) cell from the pnl_ledger record.
@@ -615,6 +638,7 @@ class Settings(BaseSettings):
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))
     bias_harvest: BiasHarvestConfig = Field(default_factory=lambda: BiasHarvestConfig(**_DEFAULTS.get("bias_harvest", {})))
     graduation: GraduationConfig = Field(default_factory=lambda: GraduationConfig(**_DEFAULTS.get("graduation", {})))
+    entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))
     analysis: AnalysisConfig = Field(default_factory=lambda: AnalysisConfig(**_DEFAULTS.get("analysis", {})))
     hybrid: HybridConfig = Field(default_factory=lambda: HybridConfig(**_DEFAULTS.get("hybrid", {})))

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -1,0 +1,316 @@
+"""Tests for entailment arbitrage (strategy/entailment_arb.py).
+
+Locks in:
+  1. Ladder detection: threshold families (above/below) and Top-N families
+     produce mathematically-directed (implier => implied) pairs; unrelated
+     questions never pair.
+  2. Dead-book guard: illiquid / wide-spread / non-Polymarket markets are
+     never believed.
+  3. Violations below min_gap are ignored; one shot per pair.
+  4. Both-or-nothing legs: a risk rejection on either leg places nothing.
+  5. Paper-forcing (config and graduation force_paper).
+  6. LLM verification: stored direction is never trusted; verdicts are
+     cached; low confidence blocks the trade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderResult,
+    OrderSide,
+    OrderType,
+    TokenType,
+)
+from auramaur.strategy.entailment_arb import (
+    EntailmentArbPillar,
+    ladder_pairs,
+    parse_threshold,
+    parse_topn,
+)
+from config.settings import Settings
+
+
+def _market(mid, question, yes, liquidity=5000.0, spread=0.01,
+            exchange="polymarket", days_out=5.0, active=True) -> Market:
+    return Market(
+        id=mid, exchange=exchange, question=question, active=active,
+        outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=liquidity, volume=liquidity, spread=spread,
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_out),
+        clob_token_yes="ty", clob_token_no="tn", category="crypto",
+    )
+
+
+def _settings(**overrides) -> Settings:
+    s = Settings()
+    s.entailment_arb.enabled = True
+    s.entailment_arb.paper = True
+    s.entailment_arb.min_gap = 0.04
+    s.entailment_arb.llm_enabled = False
+    for k, v in overrides.items():
+        setattr(s.entailment_arb, k, v)
+    return s
+
+
+def _exchange():
+    ex = MagicMock()
+
+    def prepare_order(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(
+            market_id=market.id, token_id="tok", side=OrderSide.BUY,
+            token=token, size=round(size / max(price, 0.01), 2),
+            price=round(price, 2), order_type=OrderType.LIMIT,
+            dry_run=not is_live,
+        )
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(side_effect=lambda order: OrderResult(
+        order_id=f"ord-{order.market_id}", market_id=order.market_id,
+        status="paper" if order.dry_run else "filled",
+        filled_size=order.size, filled_price=order.price,
+        is_paper=order.dry_run,
+    ))
+    return ex
+
+
+def _risk(approved=True, size=8.0, force_paper=False):
+    rm = MagicMock()
+    decision = MagicMock()
+    decision.approved = approved
+    decision.position_size = size if approved else 0.0
+    decision.reason = "" if approved else "blocked"
+    decision.force_paper = force_paper
+    rm.evaluate = AsyncMock(return_value=decision)
+    return rm
+
+
+def _pillar(db, settings, markets, exchange=None, risk=None, analyzer=None):
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    return EntailmentArbPillar(
+        db=db, settings=settings, discovery=discovery,
+        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        pnl_tracker=PnLTracker(db, settings), analyzer=analyzer,
+    )
+
+
+# ----------------------------------------------------------------------
+# Ladder parsing
+# ----------------------------------------------------------------------
+
+def test_threshold_and_topn_parsing():
+    key1, d1, v1 = parse_threshold("Bitcoin above 70,200 on March 20, 10PM ET?")
+    key2, d2, v2 = parse_threshold("Bitcoin above 71,000 on March 20, 10PM ET?")
+    assert key1 == key2 and d1 == "above" and (v1, v2) == (70200.0, 71000.0)
+    # different date -> different family
+    key3, _, _ = parse_threshold("Bitcoin above 70,200 on March 21, 10PM ET?")
+    assert key3 != key1
+
+    k1, n1 = parse_topn("Will Mac Meissner finish in the Top 10 at the Valero?")
+    k2, n2 = parse_topn("Will Mac Meissner finish in the Top 20 at the Valero?")
+    assert k1 == k2 and (n1, n2) == (10, 20)
+    k3, _ = parse_topn("Will Aaron Rai finish in the Top 20 at the Valero?")
+    assert k3 != k1
+
+
+def test_ladder_pairs_direction():
+    above_lo = _market("lo", "Bitcoin above 70,200 on March 20, 10PM ET?", 0.50)
+    above_hi = _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60)
+    pairs = ladder_pairs([above_lo, above_hi])
+    assert len(pairs) == 1
+    implier, implied, why = pairs[0]
+    assert implier.id == "hi" and implied.id == "lo"  # above(hi) => above(lo)
+
+    below_lo = _market("blo", "Will CPI be below 2.5 in May?", 0.30)
+    below_hi = _market("bhi", "Will CPI be below 3.5 in May?", 0.20)
+    pairs = ladder_pairs([below_lo, below_hi])
+    implier, implied, _ = pairs[0]
+    assert implier.id == "blo" and implied.id == "bhi"  # below(lo) => below(hi)
+
+    top5 = _market("t5", "Will X finish in the Top 5 at the Open?", 0.30)
+    top20 = _market("t20", "Will X finish in the Top 20 at the Open?", 0.20)
+    pairs = ladder_pairs([top5, top20])
+    implier, implied, _ = pairs[0]
+    assert implier.id == "t5" and implied.id == "t20"  # Top 5 => Top 20
+
+    # Unrelated questions never pair.
+    assert ladder_pairs([above_lo, top5]) == []
+
+
+# ----------------------------------------------------------------------
+# Pillar behavior
+# ----------------------------------------------------------------------
+
+def _violating_ladder():
+    # above(hi) => above(lo), but P(hi)=0.60 > P(lo)=0.50: 10c violation.
+    return [
+        _market("lo", "Bitcoin above 70,200 on March 20, 10PM ET?", 0.50),
+        _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60),
+    ]
+
+
+def test_enters_violating_pair_both_legs_paper():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange()
+        pillar = _pillar(db, _settings(), _violating_ladder(), exchange=ex)
+        assert await pillar.run_once() == 1
+
+        # Both legs placed, both dry-run (paper-forced).
+        assert ex.place_order.await_count == 2
+        orders = [c.args[0] for c in ex.place_order.await_args_list]
+        assert all(o.dry_run for o in orders)
+        # NO on the implier (hi), YES on the implied (lo).
+        by_mid = {o.market_id: o for o in orders}
+        assert by_mid["hi"].token == TokenType.NO
+        assert by_mid["lo"].token == TokenType.YES
+
+        trades = await db.fetchall(
+            "SELECT market_id FROM trades WHERE strategy_source='entailment_arb'")
+        assert {t["market_id"] for t in trades} == {"hi", "lo"}
+
+        # One shot per pair: second scan does nothing.
+        assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_below_min_gap_ignored():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        markets = [
+            _market("lo", "Bitcoin above 70,200 on March 20, 10PM ET?", 0.50),
+            _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.52),
+        ]
+        pillar = _pillar(db, _settings(min_gap=0.04), markets)
+        assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_dead_book_guard():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # Violation exists but the implier book is junk in various ways.
+        for bad in (
+            _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60,
+                    liquidity=10.0),                       # illiquid
+            _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60,
+                    spread=0.40),                          # dead-book spread
+            _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60,
+                    exchange="kalshi"),                    # wrong venue
+            _market("hi", "Bitcoin above 71,400 on March 20, 10PM ET?", 0.60,
+                    days_out=0.01),                        # resolving too soon
+        ):
+            markets = [_market("lo", "Bitcoin above 70,200 on March 20, 10PM ET?", 0.50), bad]
+            pillar = _pillar(db, _settings(), markets)
+            assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_risk_rejection_on_either_leg_places_nothing():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange()
+        pillar = _pillar(db, _settings(), _violating_ladder(), exchange=ex,
+                         risk=_risk(approved=False))
+        assert await pillar.run_once() == 0
+        ex.place_order.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_graduation_force_paper_honored():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange()
+        settings = _settings(paper=False)  # only graduation forces paper here
+        pillar = _pillar(db, settings, _violating_ladder(), exchange=ex,
+                         risk=_risk(force_paper=True))
+        await pillar.run_once()
+        # is_live arg to prepare_order must be False on both legs.
+        assert all(c.args[3] is False for c in ex.prepare_order.call_args_list)
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_llm_verification_gates_fuzzy_pairs():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        a = _market("ma", "Will Pezeshkian be out by December 31?", 0.60)
+        b = _market("mb", "Will Khorasani be head of state at year end?", 0.40)
+        await db.execute(
+            "INSERT INTO market_relationships (market_id_a, market_id_b, "
+            "relationship_type, strength) VALUES ('ma', 'mb', 'conditional', 0.9)")
+        await db.commit()
+
+        # Analyzer says: entailment confirmed a=>b with high confidence.
+        analyzer = MagicMock()
+        analyzer._call_llm = AsyncMock(return_value=(
+            '{"direction": "a_implies_b", "confidence": 0.95, '
+            '"counterexample": "none found"}'))
+        ex = _exchange()
+        pillar = _pillar(db, _settings(llm_enabled=True), [a, b],
+                         exchange=ex, analyzer=analyzer)
+        assert await pillar.run_once() == 1
+        analyzer._call_llm.assert_awaited_once()
+
+        # Verdict is cached: a new pillar over the same pair does not re-call
+        # (and does not re-trade — pair already traded).
+        analyzer2 = MagicMock()
+        analyzer2._call_llm = AsyncMock()
+        pillar2 = _pillar(db, _settings(llm_enabled=True), [a, b],
+                          analyzer=analyzer2)
+        assert await pillar2.run_once() == 0
+        analyzer2._call_llm.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_llm_low_confidence_blocks():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        a = _market("ma", "Will Pezeshkian be out by December 31?", 0.60)
+        b = _market("mb", "Will Khorasani be head of state at year end?", 0.40)
+        await db.execute(
+            "INSERT INTO market_relationships (market_id_a, market_id_b, "
+            "relationship_type, strength) VALUES ('ma', 'mb', 'conditional', 0.9)")
+        await db.commit()
+
+        analyzer = MagicMock()
+        analyzer._call_llm = AsyncMock(return_value=(
+            '{"direction": "a_implies_b", "confidence": 0.55, '
+            '"counterexample": "Pezeshkian could be out via a successor other '
+            'than Khorasani"}'))
+        ex = _exchange()
+        pillar = _pillar(db, _settings(llm_enabled=True), [a, b],
+                         exchange=ex, analyzer=analyzer)
+        assert await pillar.run_once() == 0
+        ex.place_order.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## What

**Phase 4 of the edge-first redesign**: if market A logically implies market B at the resolution-criteria level, then P(A) ≤ P(B) must hold. Violations are model-free profit: buy NO-A + YES-B in equal token counts — payout ≥ n in every world where the entailment holds, cost n·(1−gap). Ships **paper-forced**.

## Pair sources, by trust

**1. Deterministic ladders (no LLM, maximum precision).** Threshold families (`BTC above 70,200 / 71,000 on <same date>`) and Top-N families (`<same player> Top 5 / 10 / 20 at <same event>`) parsed from question text — the entailment direction is mathematical. Run against production data, the detector finds **64 raw violations** across active markets (most then stripped by the guards below, which is the point).

**2. LLM-verified fuzzy pairs.** The 55 `conditional` rows in `market_relationships` turned out to be direction-ambiguous and often junk on inspection — so the stored direction is **never trusted**. Instead, when a violation is actually on the table (saves calls), the LLM is asked *adversarially* ("construct a scenario where the implier resolves YES and the implied NO; default verdict: none") and the verdict is cached permanently in the new `entailment_verdicts` table (schema v16). Trades require confidence ≥ 0.9.

## The guard that matters

The relationship scan was full of phantom "violations" — illiquid books showing placeholder mids near 0.5 (Top-10 at "0.47" vs Top-20 at 0.01), the same dead-book pattern PR #80 fixed for the market maker. **No price is believed** unless the book has real liquidity, a sane spread, and a real resolution window.

## Safety

- Paper-forced by default; honors graduation `force_paper`; un-papering sits behind the three live gates
- **Both-or-nothing legs**: risk rejection on either leg places nothing; a single-leg fill failure (the residual leg risk) is loudly logged
- One shot per pair; rides the standard rails as `strategy_source='entailment_arb'` — the graduation ladder scores it like any other cell
- `auramaur entailment` CLI shows cached verdicts + visible ladder violations

## Testing

9 new tests: parsing + family keys, ladder direction (above/below/Top-N), both-legs-or-nothing, min-gap, all four dead-book guards, paper-forcing + graduation interplay, LLM gating + verdict caching + low-confidence block. Full suite: **570 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)