### PR TITLE
fix(kraken): wallet-truth portfolio mirror + DB busy_timeout + quiet HF chatter

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -20,6 +20,10 @@ class Database:
         self._db.row_factory = aiosqlite.Row
         await self._db.execute("PRAGMA journal_mode=WAL")
         await self._db.execute("PRAGMA foreign_keys=OFF")
+        # CLI commands share the file with the running bot; without a busy
+        # timeout a writer collision fails instantly ("database is locked" —
+        # bit the ledger backfill 2026-06-10). 5s covers any sane write txn.
+        await self._db.execute("PRAGMA busy_timeout=5000")
         await self._init_schema()
         log.info("database.connected", path=self.db_path)
 

--- a/auramaur/nlp/relevance.py
+++ b/auramaur/nlp/relevance.py
@@ -107,6 +107,14 @@ def _tfidf_scores(query: str, texts: list[str]) -> list[float] | None:
 @lru_cache(maxsize=2)
 def _get_embedder(model_name: str):
     """Lazily load and cache a SentenceTransformer; return None if unavailable."""
+    # Quiet the HF Hub chatter that was spamming the trading terminal
+    # ("unauthenticated requests" warnings + "Loading weights" progress
+    # bars). Loading still works without a token; these are cosmetic.
+    import logging as _logging
+    import os as _os
+    _os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    _os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+    _logging.getLogger("huggingface_hub").setLevel(_logging.ERROR)
     try:
         from sentence_transformers import SentenceTransformer
     except Exception:

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -553,11 +553,25 @@ class KrakenPillar:
                            updated_at = excluded.updated_at""",
                     (pair, qty, entry, current, (current - entry) * qty, pair, is_paper),
                 )
-            for pair in closed:
+            # Reconcile the mirror against WALLET truth, not in-memory state:
+            # `closed` only sees pairs tracked by THIS process, so positions
+            # closed in a previous session (manual flatten, prior bot run, the
+            # 2026-06-10 duplicate-process incident) left immortal rows — 12
+            # phantom positions / ~$280 of fake exposure. Any kraken row whose
+            # pair isn't currently held gets deleted.
+            rows = await db.fetchall(
+                "SELECT market_id FROM portfolio WHERE exchange = 'kraken' AND is_paper = ?",
+                (is_paper,),
+            )
+            stale = [r["market_id"] for r in (rows or [])
+                     if r["market_id"] not in held_prices]
+            for pair in stale:
                 await db.execute(
                     "DELETE FROM portfolio WHERE market_id = ? AND exchange = 'kraken' AND is_paper = ?",
                     (pair, is_paper),
                 )
+                if pair not in closed:
+                    log.info("kraken.portfolio_mirror.stale_removed", pair=pair)
             await db.commit()
         except Exception as e:  # noqa: BLE001 — visibility only; never break the pillar
             log.debug("kraken.portfolio_mirror_error", error=str(e)[:100])

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -150,10 +150,15 @@ async def test_holds_through_moderate_drop():
 @pytest.mark.asyncio
 async def test_mirror_to_portfolio_upserts_held_and_deletes_closed():
     """The spec book is reflected into the portfolio table for dashboard
-    visibility: held pairs upsert with unrealized P&L, closed pairs are deleted."""
+    visibility: held pairs upsert with unrealized P&L; rows for pairs no
+    longer held (wallet truth, not in-memory `closed`) are deleted."""
     s = MagicMock()
     s.is_live = True
     db = AsyncMock()
+    # The wallet-truth reconcile reads existing kraken rows: ETHUSDC is
+    # mirrored from a prior cycle but no longer held -> must be deleted.
+    db.fetchall = AsyncMock(return_value=[{"market_id": "ETHUSDC"},
+                                          {"market_id": "XBTUSDC"}])
     bot = MagicMock()
     bot._components = {"db": db}
     p = KrakenPillar(settings=s, kraken_client=MagicMock(), bot=bot)
@@ -188,3 +193,38 @@ async def test_exits_on_large_drop():
     client.place_spot_order.assert_awaited_once()
     assert client.place_spot_order.await_args.args[1] == OrderSide.SELL
     assert "XBTUSDC" not in p._dir_long
+
+
+@pytest.mark.asyncio
+async def test_mirror_removes_stale_rows_from_prior_sessions():
+    """Regression (2026-06-10): `closed` only sees pairs tracked by THIS
+    process, so positions closed in a previous session left immortal
+    portfolio rows — 12 phantom positions / ~$280 of fake exposure. The
+    mirror now reconciles against wallet truth: any kraken row whose pair
+    isn't currently held is deleted, even with empty in-memory state."""
+    from auramaur.db.database import Database
+
+    s = MagicMock()
+    s.is_live = True
+    db = Database(":memory:")
+    await db.connect()
+    # Stale row from a "previous session" (pair no longer held).
+    await db.execute(
+        "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+        "current_price, is_paper) VALUES ('ADAUSDC', 'kraken', 'BUY', 182, 0.16, 0.16, 0)")
+    # A non-kraken row that must survive.
+    await db.execute(
+        "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+        "current_price, is_paper) VALUES ('poly-1', 'polymarket', 'BUY', 10, 0.5, 0.5, 0)")
+    await db.commit()
+
+    bot = MagicMock()
+    bot._components = {"db": db}
+    p = KrakenPillar(settings=s, kraken_client=MagicMock(), bot=bot)
+    # Fresh process: _dir_long empty, closed empty — only XBT actually held.
+    await p._mirror_to_portfolio({"XBTUSDC": (90.0, 100.0, 0.5)}, [])
+
+    rows = {r["market_id"] for r in await db.fetchall(
+        "SELECT market_id FROM portfolio")}
+    assert rows == {"XBTUSDC", "poly-1"}  # ADAUSDC gone, polymarket untouched
+    await db.close()


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.