### PR TITLE
fix(kraken): gain-based exits apply in LLM mode — the wind-down can actually exit

### DIFF
--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -156,12 +156,32 @@ class KrakenPillar:
             return "momentum"
         return None
 
-    async def _llm_exit_reason(self, pair: str, gain_pct: float, kcfg) -> str | None:
-        """Exit a held LLM-driven long: hard stop floor, else exit when the LLM
-        view turns bearish. A missing view holds (don't churn on a transient gap)."""
+    async def _llm_exit_reason(self, pair: str, gain_pct: float, kcfg,
+                               peak_pct: float | None = None) -> str | None:
+        """Exit a held LLM-driven long.
+
+        The GAIN-based exits (stop-loss, fee-netted take-profit, trailing
+        stop) apply regardless of signal source — they protect the position,
+        not the thesis. BUG fixED 2026-06-10: the LLM pivot (#76) routed
+        exits here WITHOUT them, so a winner could never bank a target (TON
+        sat at +40% over basis with no exit able to fire — the same failure
+        mode #68 fixed once before on the momentum path) and a missing LLM
+        view froze exits entirely. Priority matches _exit_reason: cut losers
+        -> bank the target -> protect the peak -> then ask the LLM.
+        A missing view still holds (don't churn on a transient gap) — but
+        only after the gain-based exits had their chance.
+        """
         stop_pct = getattr(kcfg, "directional_stop_loss_pct", 0.0) or 0.0
+        tp_pct = getattr(kcfg, "directional_take_profit_pct", 0.0) or 0.0
+        trail_pct = getattr(kcfg, "directional_trailing_stop_pct", 0.0) or 0.0
+        rt_fee = 2.0 * (getattr(kcfg, "directional_fee_pct", 0.0) or 0.0)
         if stop_pct > 0 and gain_pct <= -stop_pct:
             return "stop_loss"
+        if tp_pct > 0 and (gain_pct - rt_fee) >= tp_pct:
+            return "take_profit"
+        if (trail_pct > 0 and peak_pct is not None and peak_pct > rt_fee
+                and (peak_pct - gain_pct) >= trail_pct):
+            return "trailing_stop"
         view = await self._llm_view(pair)
         if view is None:
             return None
@@ -643,7 +663,7 @@ class KrakenPillar:
                 else:
                     peak_pct = await self._update_and_get_peak(pair, gain_pct)
                     if llm_on:
-                        reason = await self._llm_exit_reason(pair, gain_pct, kcfg)
+                        reason = await self._llm_exit_reason(pair, gain_pct, kcfg, peak_pct=peak_pct)
                     else:
                         mom = await self._momentum(pair)
                         if mom is None:

--- a/tests/test_kraken_directional_exit.py
+++ b/tests/test_kraken_directional_exit.py
@@ -462,3 +462,75 @@ if __name__ == "__main__":
     test_paper_mode_records_nothing()
     test_entry_basis_recovered_from_cost_basis_on_restart()
     print("ok")
+
+
+# ---------------------------------------------------------------------------
+# LLM-mode exits — gain-based exits apply regardless of signal source
+# (regression 2026-06-10: the LLM pivot dropped TP/trailing, so a +40%
+# winner could never bank and a missing LLM view froze exits entirely)
+# ---------------------------------------------------------------------------
+
+def _llm_pillar(view):
+    from unittest.mock import MagicMock
+    p = KrakenPillar(settings=MagicMock(), kraken_client=MagicMock())
+    p._llm_view = AsyncMock(return_value=view)
+    return p
+
+
+def _llm_kcfg(**over):
+    base = dict(
+        directional_stop_loss_pct=12.0,
+        directional_take_profit_pct=4.0,
+        directional_trailing_stop_pct=8.0,
+        directional_fee_pct=0.26,
+        directional_llm_exit_prob=0.45,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_llm_exit_takes_profit_even_when_view_is_missing():
+    """The TON case: +40% over basis, LLM view unavailable. Take-profit must
+    fire WITHOUT consulting the LLM — gain exits protect the position."""
+    async def run():
+        p = _llm_pillar(view=None)
+        reason = await p._llm_exit_reason("TONUSDC", gain_pct=40.0,
+                                          kcfg=_llm_kcfg(), peak_pct=40.0)
+        assert reason == "take_profit"
+        p._llm_view.assert_not_awaited()  # banked before any LLM call
+    asyncio.run(run())
+
+
+def test_llm_exit_trailing_protects_peak():
+    async def run():
+        p = _llm_pillar(view=(0.70, "HIGH"))  # LLM still bullish — irrelevant
+        reason = await p._llm_exit_reason(
+            "XBTUSDC", gain_pct=11.0,
+            kcfg=_llm_kcfg(directional_take_profit_pct=0.0), peak_pct=20.0)
+        assert reason == "trailing_stop"
+    asyncio.run(run())
+
+
+def test_llm_exit_stop_loss_first():
+    async def run():
+        p = _llm_pillar(view=(0.90, "HIGH"))
+        assert await p._llm_exit_reason("X", gain_pct=-15.0, kcfg=_llm_kcfg(),
+                                        peak_pct=0.0) == "stop_loss"
+    asyncio.run(run())
+
+
+def test_llm_exit_bearish_view_still_exits_flat_position():
+    async def run():
+        p = _llm_pillar(view=(0.30, "MEDIUM"))
+        assert await p._llm_exit_reason("X", gain_pct=0.5, kcfg=_llm_kcfg(),
+                                        peak_pct=0.5) == "llm_bearish"
+    asyncio.run(run())
+
+
+def test_llm_exit_holds_when_flat_and_view_missing():
+    """No gain trigger + no view -> hold (don't churn on a transient gap)."""
+    async def run():
+        p = _llm_pillar(view=None)
+        assert await p._llm_exit_reason("X", gain_pct=1.0, kcfg=_llm_kcfg(),
+                                        peak_pct=1.0) is None
+    asyncio.run(run())


### PR DESCRIPTION
## The bug

Operator report: Kraken exits appeared blocked. They were.

With `directional_llm_enabled`, exits route through `_llm_exit_reason`, which knew exactly two exits: the -12% hard stop, and "LLM turned bearish" — and **held whenever the LLM view was missing**. The take-profit and trailing stop existed only on the momentum path that the LLM pivot (#76/#77) bypassed.

In the wind-down book that meant:
- **TON at ~+40% over basis with no exit able to bank it** — TP on the wrong code path, stop far below, trailing absent
- with Claude budget conservation, `_llm_view` frequently returns `None` → every exit resolves to "hold" → the book is frozen

Same failure class #68 fixed on the momentum path ("banking a win was structurally impossible").

## The fix

Gain-based exits (stop-loss, fee-netted take-profit, trailing stop) now apply in `_llm_exit_reason` **before** consulting the LLM — they protect the *position*, not the *thesis*. Priority: cut losers → bank the target → protect the peak → then ask the LLM. A missing view still holds, but only after the gain exits had their chance — and the TP path makes **zero LLM calls**.

Effect: TON banks on the next cycle; the remaining four wind-down positions exit via TP/stop/trailing/llm-bearish as they move, with no LLM availability required.

## Testing

5 new tests: TP fires with view missing (and asserts no LLM call), trailing protects the peak despite a bullish view, stop-loss first, bearish view exits a flat position, flat+no-view still holds. Full suite: **592 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)