### PR TITLE
fix(risk): blocked_categories enforced at the single gateway — news_speed leak closed

### DIFF
--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -391,3 +391,30 @@ async def check_mispricing_named(
         ),
         value=mispricing_reason or "none",
     )
+
+
+# ---------------------------------------------------------------------------
+# 17. Blocked category (at the single gateway — no entry path bypasses it)
+# ---------------------------------------------------------------------------
+
+async def check_blocked_category(
+    category: str, blocked: list[str], applies: bool = True,
+) -> CheckResult:
+    """Fail when the market's category is blocked.
+
+    Originally enforced only as a market-SELECTION filter in the engine's
+    run_cycle, which news_speed (via analyze_market) and other entry paths
+    never pass through — caught live 2026-06-10 buying $42 of politics_us
+    Senate control. Entries only by construction (exits never reach
+    evaluate); structural two-sided strategies pass ``applies=False``.
+    """
+    if not applies:
+        return CheckResult(name="blocked_category", passed=True, reason="",
+                           value=category)
+    hit = bool(category) and category in set(blocked or [])
+    return CheckResult(
+        name="blocked_category",
+        passed=not hit,
+        reason=f"category '{category}' is blocked" if hit else "",
+        value=category,
+    )

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -25,6 +25,7 @@ from auramaur.risk.checks import (
     check_max_stake,
     check_min_edge,
     check_min_liquidity,
+    check_blocked_category,
     check_mispricing_named,
     check_second_opinion_divergence,
     check_time_to_resolution,
@@ -157,6 +158,21 @@ class RiskManager:
             await check_time_to_resolution(hours_remaining, rc.time_to_resolution_min_hours, rc.time_to_resolution_max_days * 24.0),
             await check_second_opinion_divergence(divergence, rc.second_opinion_divergence_max),
         ]
+
+        # Blocked categories at the single gateway: the engine-level filter
+        # only covers run_cycle's candidate selection — news_speed (via
+        # analyze_market) and other entry paths sailed past it (caught live
+        # 2026-06-10 buying politics_us). Classify on the spot when the
+        # discovery object carries no category; structural two-sided
+        # strategies (graduation's exempt list) stay free to quote/arb.
+        from auramaur.strategy.classifier import ensure_category
+        market_category = market.category or ensure_category(
+            market.question, market.description)
+        pre_checks.append(await check_blocked_category(
+            market_category, rc.blocked_categories,
+            applies=signal.strategy_source not in set(
+                self.settings.graduation.exempt_strategies),
+        ))
 
         # ----------------------------------------------------------------
         # Name-the-gap gate: a significant LLM divergence must name the

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -138,7 +138,8 @@ async def test_evaluate_passing_case(mock_kill):
 
     assert decision.approved is True
     assert decision.position_size > 0
-    assert len(decision.checks) == 17  # 15 pre + mispricing_named + max_stake
+    # 15 pre + mispricing_named + blocked_category + max_stake
+    assert len(decision.checks) == 18
     assert all(c.passed for c in decision.checks)
 
 
@@ -245,3 +246,66 @@ async def test_max_stake_check_runs_after_sizing(mock_kill):
     assert stake_check.passed is True
     # The stake check's value should be the actual position_size, not 0 or the signal's recommended_size
     assert stake_check.value == decision.position_size
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_blocked_category_enforced_at_gateway_for_all_entry_paths(mock_kill):
+    """Regression (2026-06-10): news_speed bought $42 of politics_us live —
+    blocked_categories was only an engine-level SELECTION filter that
+    analyze_market paths never traverse. It is now risk check #17 at the
+    single gateway: directional strategies blocked everywhere, structural
+    two-sided strategies (graduation's exempt list) still free."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(blocked_categories=["politics_us", "sports"])
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+    market = _make_market(category="politics_us")
+
+    # news_speed (the live offender): blocked.
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    sig.strategy_source = "news_speed"
+    d = await manager.evaluate(sig, market, available_cash=500.0)
+    assert d.approved is False
+    assert any(c.name == "blocked_category" and not c.passed for c in d.checks)
+
+    # llm: blocked too.
+    sig2 = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    d2 = await manager.evaluate(sig2, market, available_cash=500.0)
+    assert any(c.name == "blocked_category" and not c.passed for c in d2.checks)
+
+    # arbitrage (structural, exempt): passes the category check.
+    sig3 = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    sig3.strategy_source = "arbitrage"
+    d3 = await manager.evaluate(sig3, market, available_cash=500.0)
+    assert not any(c.name == "blocked_category" and not c.passed for c in d3.checks)
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_blocked_category_classifies_uncategorized_markets(mock_kill):
+    """A discovery object with category='' is classified on the spot — empty
+    categories were the original gate leak (156 politics_us markets hid as
+    blank strings)."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(blocked_categories=["politics_us"])
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    market = _make_market(category="politics_us")
+    market.category = ""
+    market.question = "Will the Republican Party control the Senate after the 2026 election?"
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    sig.strategy_source = "news_speed"
+    d = await manager.evaluate(sig, market, available_cash=500.0)
+    blocked = next(c for c in d.checks if c.name == "blocked_category")
+    assert blocked.passed is False
+    assert blocked.value == "politics_us"  # classified on the spot


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.