### PR TITLE
fix(risk): block on fresh classification too — stale stored categories dodged the gate

### DIFF
--- a/auramaur/nlp/relevance.py
+++ b/auramaur/nlp/relevance.py
@@ -13,11 +13,27 @@ to the next one and logs which backend actually ran.
 
 from __future__ import annotations
 
+import logging
 import math
+import os
 import re
+import warnings
 from functools import lru_cache
 
 import structlog
+
+# Quiet HF Hub chatter at import — it was spamming the trading terminal with
+# "unauthenticated requests" warnings + weight-loading progress bars from the
+# evidence-relevance embedder. Set BEFORE any huggingface_hub import so the
+# env vars take, and belt-and-suspenders the warning via both logging and the
+# warnings filter (the advisory is emitted via warnings.warn, not logging, so
+# the lazy logger-level tweak inside _get_embedder never caught it). Loading
+# still works without a token; this is purely cosmetic.
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+warnings.filterwarnings("ignore", message=r".*unauthenticated requests.*")
+warnings.filterwarnings("ignore", message=r".*HF_TOKEN.*")
 
 log = structlog.get_logger()
 
@@ -107,14 +123,6 @@ def _tfidf_scores(query: str, texts: list[str]) -> list[float] | None:
 @lru_cache(maxsize=2)
 def _get_embedder(model_name: str):
     """Lazily load and cache a SentenceTransformer; return None if unavailable."""
-    # Quiet the HF Hub chatter that was spamming the trading terminal
-    # ("unauthenticated requests" warnings + "Loading weights" progress
-    # bars). Loading still works without a token; these are cosmetic.
-    import logging as _logging
-    import os as _os
-    _os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
-    _os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
-    _logging.getLogger("huggingface_hub").setLevel(_logging.ERROR)
     try:
         from sentence_transformers import SentenceTransformer
     except Exception:

--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -399,6 +399,7 @@ async def check_mispricing_named(
 
 async def check_blocked_category(
     category: str, blocked: list[str], applies: bool = True,
+    fallback_category: str = "",
 ) -> CheckResult:
     """Fail when the market's category is blocked.
 
@@ -407,14 +408,25 @@ async def check_blocked_category(
     never pass through — caught live 2026-06-10 buying $42 of politics_us
     Senate control. Entries only by construction (exits never reach
     evaluate); structural two-sided strategies pass ``applies=False``.
+
+    Blocks if EITHER the stored ``category`` OR a freshly-classified
+    ``fallback_category`` is blocked: 247 active sports markets were stored
+    as 'other'/'politics_intl' (stale/wrong stored labels), dodging the
+    block while the classifier knew better. Trusting the stored label alone
+    was the residual leak.
     """
     if not applies:
         return CheckResult(name="blocked_category", passed=True, reason="",
                            value=category)
-    hit = bool(category) and category in set(blocked or [])
+    blocked_set = set(blocked or [])
+    offending = ""
+    if category and category in blocked_set:
+        offending = category
+    elif fallback_category and fallback_category in blocked_set:
+        offending = fallback_category
     return CheckResult(
         name="blocked_category",
-        passed=not hit,
-        reason=f"category '{category}' is blocked" if hit else "",
-        value=category,
+        passed=not offending,
+        reason=f"category '{offending}' is blocked" if offending else "",
+        value=offending or category,
     )

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -162,16 +162,19 @@ class RiskManager:
         # Blocked categories at the single gateway: the engine-level filter
         # only covers run_cycle's candidate selection — news_speed (via
         # analyze_market) and other entry paths sailed past it (caught live
-        # 2026-06-10 buying politics_us). Classify on the spot when the
-        # discovery object carries no category; structural two-sided
-        # strategies (graduation's exempt list) stay free to quote/arb.
-        from auramaur.strategy.classifier import ensure_category
-        market_category = market.category or ensure_category(
-            market.question, market.description)
+        # 2026-06-10 buying politics_us). Block on the stored category OR a
+        # fresh classification: 247 active sports markets carried stale
+        # 'other' labels that dodged the block, so trusting the stored label
+        # alone was the residual leak. Structural two-sided strategies
+        # (graduation's exempt list) stay free to quote/arb.
+        from auramaur.strategy.classifier import classify_market
+        fresh_category = classify_market(
+            market.question or "", market.description or "")
         pre_checks.append(await check_blocked_category(
-            market_category, rc.blocked_categories,
+            market.category or "", rc.blocked_categories,
             applies=signal.strategy_source not in set(
                 self.settings.graduation.exempt_strategies),
+            fallback_category=fresh_category,
         ))
 
         # ----------------------------------------------------------------

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -309,3 +309,30 @@ async def test_blocked_category_classifies_uncategorized_markets(mock_kill):
     blocked = next(c for c in d.checks if c.name == "blocked_category")
     assert blocked.passed is False
     assert blocked.value == "politics_us"  # classified on the spot
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_blocked_category_catches_stale_stored_label(mock_kill):
+    """Regression (2026-06-10): 247 active sports markets were stored as
+    'other'/'politics_intl' (stale labels), dodging the block because the
+    gateway trusted the stored category. The gate now blocks on a FRESH
+    classification too — a sports matchup stored as 'other' is blocked."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(blocked_categories=["sports", "politics_us"])
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    market = _make_market(category="other")  # stale stored label
+    market.question = "Warriors vs. Celtics"  # the real stored-as-other pattern
+    market.description = ""
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    d = await manager.evaluate(sig, market, available_cash=500.0)
+    assert d.approved is False
+    blocked = next(c for c in d.checks if c.name == "blocked_category")
+    assert blocked.passed is False
+    assert blocked.value == "sports"  # the fresh classification, not 'other'


### PR DESCRIPTION
## What you caught

Watching the live stream, a Chilean football market appeared mid-analysis. Investigation: the *traded* market was actually crypto (the football line was just interleaved in the strategic-batch display — no sports trade fired), **but it surfaced a real latent leak.**

The #93 gateway block trusted `market.category` when non-empty, classifying only when blank. **247 active markets carry stale/wrong stored labels** — "Warriors vs. Celtics" stored as `other`, "Jets vs Bruins" as `other` — that the keyword classifier correctly calls `sports`. Those dodged the block. The empty-category fix (#88) only touched blank labels, not present-but-wrong ones.

## Fix

The `blocked_category` gateway check now blocks if **either** the stored category **or** a fresh `classify_market()` result is in `blocked_categories`. Cheap regex, run per-evaluate. Stored data left untouched (some labels are intentional) — the gate just stops trusting a stale label for the two no-edge blocks. Exits unaffected.

## Bonus: finish the HF suppression

The "unauthenticated requests" advisory is emitted via `warnings.warn` (not `logging`), so #91's lazy logger tweak never caught it. Moved suppression to module import + a `warnings.filterwarnings` belt.

## Testing

Stale-stored-label regression (sports matchup stored as `other` → blocked via fresh classification). Full suite: **595 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)