### PR TITLE
fix(exec): marketable live entries + visible, recorded TTL cancels

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2767,8 +2767,42 @@ class AuramaurBot:
                                 age = (datetime.now(timezone.utc) - ts).total_seconds()
                                 if age > ttl:
                                     cancelled = await live_exchange.cancel_order(order_id)
+                                    if not cancelled:
+                                        # Cancel can race a fill — keep the order
+                                        # tracked so the next status poll resolves
+                                        # it instead of dropping it on the floor.
+                                        log.warning(
+                                            "order_monitor.ttl_cancel_failed",
+                                            exchange=exchange_name,
+                                            order_id=order_id,
+                                            age_seconds=round(age),
+                                        )
+                                        continue
                                     pending.pop(order_id, None)
                                     self._clear_exit_suppression(exchange_name, order, "ttl_cancelled")
+                                    # Without this status write the trades row
+                                    # stays 'pending' forever even though the
+                                    # collateral was released (#94).
+                                    db = self._components.get("db")
+                                    if db is not None:
+                                        try:
+                                            await db.execute(
+                                                "UPDATE trades SET status = 'cancelled' WHERE order_id = ?",
+                                                (order_id,),
+                                            )
+                                            await db.commit()
+                                        except Exception as e:
+                                            log.debug(
+                                                "order_monitor.ttl_db_error",
+                                                order_id=order_id,
+                                                error=str(e),
+                                            )
+                                    from auramaur.monitoring.display import show_order_unfilled
+                                    show_order_unfilled(
+                                        order.side.value, order.size, order.price,
+                                        age, exchange=exchange_name,
+                                        market_id=order.market_id,
+                                    )
                                     log.info(
                                         "order_monitor.live_ttl_cancel",
                                         exchange=exchange_name,
@@ -2785,7 +2819,68 @@ class AuramaurBot:
                             )
             except Exception as e:
                 log.debug("order_monitor.error", error=str(e))
+
+            try:
+                await self._reconcile_orphaned_pending_trades(live_clients)
+            except Exception as e:
+                log.debug("order_monitor.orphan_sweep_error", error=str(e))
+
             await asyncio.sleep(30)
+
+    async def _reconcile_orphaned_pending_trades(self, live_clients) -> None:
+        """Resolve live trades rows stuck in status='pending'.
+
+        A row goes orphaned when its order left ``_live_pending`` without a
+        terminal DB write — a TTL cancel before that path wrote status back
+        (#94), or a restart that dropped the in-memory tracking. The order is
+        long gone on-chain (collateral released) but the DB still says
+        pending, which poisons anything that reads order history. Ask the
+        exchange for the true terminal status and write it back, a few rows
+        per pass to keep API load flat.
+
+        ``get_order_status`` maps unknown/aged-out orders to 'cancelled', so
+        rows whose orders the CLOB no longer indexes resolve too.
+        """
+        db = self._components.get("db")
+        if db is None or not live_clients:
+            return
+
+        tracked: set[str] = set()
+        clients_by_name: dict[str, object] = {}
+        for name, client in live_clients:
+            tracked.update(getattr(client, "_live_pending", {}).keys())
+            clients_by_name[name] = client
+
+        rows = await db.fetchall(
+            """SELECT order_id, exchange FROM trades
+               WHERE is_paper = 0 AND status = 'pending'
+                 AND order_id IS NOT NULL AND order_id != ''
+                 AND timestamp < datetime('now', '-10 minutes')
+               ORDER BY timestamp ASC LIMIT 25"""
+        )
+        fixed = 0
+        for row in rows:
+            order_id = row["order_id"]
+            if order_id in tracked or order_id.startswith("PAPER"):
+                continue
+            client = clients_by_name.get(row["exchange"] or "polymarket")
+            if client is None or not hasattr(client, "get_order_status"):
+                continue
+            try:
+                result = await client.get_order_status(order_id)
+            except Exception:
+                continue
+            if result.status in ("filled", "cancelled", "expired", "rejected"):
+                await db.execute(
+                    "UPDATE trades SET status = ? WHERE order_id = ?",
+                    (result.status, order_id),
+                )
+                fixed += 1
+            if fixed >= 5:
+                break
+        if fixed:
+            await db.commit()
+            log.info("order_monitor.orphans_reconciled", count=fixed)
 
     async def _task_resolution_checker(self) -> None:
         """Poll for resolved markets and record calibration outcomes.

--- a/auramaur/broker/router.py
+++ b/auramaur/broker/router.py
@@ -72,13 +72,31 @@ class SmartOrderRouter:
         edge_pct = abs(signal.edge)
         spread = book.spread
 
+        # Crossing budget: how far above the signal's reference price a BUY may
+        # lift the ask and still clear the minimum-edge floor. The CLOB has no
+        # true market orders — every order is a GTC limit — so a "market" order
+        # priced at the (stale) reference price just rests until the TTL
+        # reaper kills it. Marketable means priced at the actual best ask.
+        try:
+            min_edge_pct = float(self._settings.risk.min_edge_pct)
+        except Exception:
+            min_edge_pct = 2.5
+        try:
+            max_cross = float(self._settings.execution.entry_max_cross_cents) / 100.0
+        except Exception:
+            max_cross = 0.04
+
         # Determine order type via decision matrix
         # On 0% fee exchanges (Polymarket reward tier), limit orders are almost
         # always better — you get price improvement for free.
         #   - spread < $0.01: limit order (tight market, capture the spread)
         #   - edge > 40%:     market order (urgency overrides price)
-        #   - otherwise:      limit order with price improvement (+1 tick)
+        #   - otherwise:      limit order with price improvement (+1 tick),
+        #                     lifting the ask instead when it costs less than
+        #                     entry_max_cross_cents and the post-cross edge
+        #                     still clears the minimum-edge floor
         has_book = spread is not None and (book.best_bid is not None or book.best_ask is not None)
+        crossed_to_ask = False
 
         if not has_book:
             # No book data — fall back to market order
@@ -91,13 +109,18 @@ class SmartOrderRouter:
                 reason="no_book",
             )
         elif edge_pct > 40.0:
-            # Very high urgency — cross immediately
+            # Very high urgency — cross immediately. Price at the real ask
+            # (capped by the edge budget) so the order is actually marketable.
             order_type = OrderType.MARKET
             limit_price = base_order.price
+            if base_order.side == OrderSide.BUY and book.best_ask is not None:
+                budget_price = base_order.price + max(0.0, edge_pct - min_edge_pct) / 100.0
+                limit_price = max(0.01, min(0.99, round(min(book.best_ask, budget_price), 2)))
             log.info(
                 "router.market_order",
                 market_id=market.id,
                 edge_pct=round(edge_pct, 2),
+                limit_price=limit_price,
                 reason="high_urgency",
             )
         else:
@@ -106,9 +129,34 @@ class SmartOrderRouter:
                 book, base_order.side, base_order.token
             )
 
+            # Lift the ask when it's cheap enough: a maker quote at bid+1 tick
+            # only fills if flow comes to us within the order TTL, which on
+            # quiet books makes the fill a coin flip. Paying ≤max_cross more
+            # for certainty is the better trade whenever the remaining edge
+            # still clears the floor.
+            if base_order.side == OrderSide.BUY and book.best_ask is not None:
+                cross_cost_pts = (book.best_ask - base_order.price) * 100.0
+                if (
+                    book.best_ask - candidate_price <= max_cross + 1e-9
+                    and cross_cost_pts <= edge_pct - min_edge_pct
+                ):
+                    crossed_to_ask = True
+                    order_type = OrderType.LIMIT
+                    limit_price = max(0.01, min(0.99, round(book.best_ask, 2)))
+                    log.info(
+                        "router.crossed_to_ask",
+                        market_id=market.id,
+                        edge_pct=round(edge_pct, 2),
+                        candidate=candidate_price,
+                        ask=book.best_ask,
+                        cross_cost_pts=round(cross_cost_pts, 2),
+                    )
+
             # Sanity check: limit price shouldn't deviate >30% from fair price
             fair_price = base_order.price
-            if fair_price > 0 and abs(candidate_price - fair_price) / fair_price > 0.30:
+            if crossed_to_ask:
+                pass
+            elif fair_price > 0 and abs(candidate_price - fair_price) / fair_price > 0.30:
                 # Book too thin — use market order at fair price
                 order_type = OrderType.MARKET
                 limit_price = fair_price
@@ -139,7 +187,9 @@ class SmartOrderRouter:
         # accidentally take, which keeps us on the maker-reward side of the
         # fee schedule and flushes out any router/pricing mistakes loudly
         # (rejection) instead of quietly (taker fill at a worse price).
-        want_post_only = order_type == OrderType.LIMIT
+        # A deliberate cross-to-ask is the opposite intent: it must be allowed
+        # to take, so it never sets post_only.
+        want_post_only = order_type == OrderType.LIMIT and not crossed_to_ask
 
         # Build the final order with refined price / type
         routed_order = base_order.model_copy(

--- a/auramaur/monitoring/display.py
+++ b/auramaur/monitoring/display.py
@@ -152,6 +152,21 @@ def show_order_dropped(market_id: str, reason: str) -> None:
     )
 
 
+def show_order_unfilled(side: str, size: float, price: float, age_seconds: float,
+                        exchange: str = "", market_id: str = "") -> None:
+    """A live order TTL-expired without filling — the entry the strategy
+    reported as ORDER LIVE never became a position. Without this line the
+    cancel is invisible: cash quietly snaps back and the terminal says
+    nothing."""
+    side_color = "green" if side == "BUY" else "red"
+    ex = f"[magenta]{exchange}[/] " if exchange else ""
+    console.print(
+        f"         [yellow]ORDER UNFILLED[/] [bold red]LIVE[/] {ex}[{side_color}]{side}[/] "
+        f"${size * price:.2f} ({size:.1f} tokens @ ${price:.3f}) "
+        f"cancelled after {age_seconds:.0f}s [dim]{market_id[:16]}[/]"
+    )
+
+
 def show_cycle_summary(signals: int, trades: int, elapsed: float, exchange: str = "") -> None:
     # Empty cycles are the steady state — the periodic status line is the
     # heartbeat. Only narrate cycles that actually did something.

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -13,6 +13,9 @@ execution:
   live: false
   paper_initial_balance: 111.0
   limit_order_ttl_seconds: 120
+  # Max cents above the reference price the router may pay to lift the ask;
+  # crossing additionally requires post-cross edge >= risk.min_edge_pct.
+  entry_max_cross_cents: 4
   spread_capture_min_bps: 50
   stop_loss_pct: 30.0
   profit_target_pct: 50.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -26,6 +26,11 @@ class ExecutionConfig(BaseModel):
     live: bool = False
     paper_initial_balance: float = 1000.0
     limit_order_ttl_seconds: int = 120
+    # Max cents the router may pay above the signal's reference price to lift
+    # the ask (marketable entry) instead of resting a maker quote at bid+1
+    # that the TTL reaper usually kills unfilled. The cross also has to leave
+    # net edge above risk.min_edge_pct, so this cap only binds on wide edges.
+    entry_max_cross_cents: int = 4
     spread_capture_min_bps: int = 50
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0

--- a/tests/test_order_monitor.py
+++ b/tests/test_order_monitor.py
@@ -262,3 +262,160 @@ async def test_order_monitor_polls_all_live_exchanges():
     assert kalshi._live_pending == {}
     poly.get_order_status.assert_awaited_once_with("poly-1")
     kalshi.get_order_status.assert_awaited_once_with("kalshi-1")
+
+
+@pytest.mark.asyncio
+async def test_ttl_cancel_writes_cancelled_status_to_db():
+    """A TTL-cancelled live order must not leave its trades row 'pending'.
+
+    The on-chain cancel releases the collateral, so without the status write
+    the DB claims an open order that no longer exists (#94: 26 orphaned rows,
+    $194 of phantom pending buys).
+    """
+    settings = MagicMock()
+    settings.execution.limit_order_ttl_seconds = 60
+
+    bot = AuramaurBot(settings=settings)
+    bot._running = True
+
+    stale_order = Order(
+        market_id="m1",
+        exchange="polymarket",
+        token_id="tok_yes",
+        token=TokenType.YES,
+        side=OrderSide.BUY,
+        size=10,
+        price=0.50,
+        dry_run=False,
+    )
+    stale_order.created_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    exchange = SimpleNamespace(
+        _live_pending={"live-1": stale_order},
+        get_order_status=AsyncMock(return_value=OrderResult(
+            order_id="live-1", market_id="m1", status="pending",
+            filled_size=0, filled_price=0.50, is_paper=False,
+        )),
+        cancel_order=AsyncMock(return_value=True),
+    )
+    paper = SimpleNamespace(
+        pending_orders=[],
+        check_fills=AsyncMock(return_value=[]),
+        cancel_expired=AsyncMock(return_value=0),
+    )
+    db = AsyncMock()
+    bot._components = {
+        "paper": paper,
+        "exchange": exchange,
+        "discovery": AsyncMock(),
+        "pnl_tracker": AsyncMock(),
+        "db": db,
+    }
+
+    async def stop_after_loop(_seconds):
+        bot._running = False
+
+    with patch("asyncio.sleep", new=AsyncMock(side_effect=stop_after_loop)):
+        await bot._task_order_monitor()
+
+    assert "live-1" not in exchange._live_pending
+    update_calls = [
+        c for c in db.execute.await_args_list
+        if "UPDATE trades SET status = 'cancelled'" in c.args[0]
+    ]
+    assert len(update_calls) == 1
+    assert update_calls[0].args[1] == ("live-1",)
+    db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ttl_cancel_failure_keeps_order_tracked():
+    """A failed cancel (e.g. racing a fill) keeps the order in _live_pending
+    so the next status poll resolves it, instead of dropping it untracked."""
+    settings = MagicMock()
+    settings.execution.limit_order_ttl_seconds = 60
+
+    bot = AuramaurBot(settings=settings)
+    bot._running = True
+
+    stale_order = Order(
+        market_id="m1",
+        exchange="polymarket",
+        token_id="tok_yes",
+        token=TokenType.YES,
+        side=OrderSide.BUY,
+        size=10,
+        price=0.50,
+        dry_run=False,
+    )
+    stale_order.created_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    exchange = SimpleNamespace(
+        _live_pending={"live-1": stale_order},
+        get_order_status=AsyncMock(return_value=OrderResult(
+            order_id="live-1", market_id="m1", status="pending",
+            filled_size=0, filled_price=0.50, is_paper=False,
+        )),
+        cancel_order=AsyncMock(return_value=False),
+    )
+    paper = SimpleNamespace(
+        pending_orders=[],
+        check_fills=AsyncMock(return_value=[]),
+        cancel_expired=AsyncMock(return_value=0),
+    )
+    db = AsyncMock()
+    bot._components = {
+        "paper": paper,
+        "exchange": exchange,
+        "discovery": AsyncMock(),
+        "pnl_tracker": AsyncMock(),
+        "db": db,
+    }
+
+    async def stop_after_loop(_seconds):
+        bot._running = False
+
+    with patch("asyncio.sleep", new=AsyncMock(side_effect=stop_after_loop)):
+        await bot._task_order_monitor()
+
+    assert "live-1" in exchange._live_pending
+    cancelled_writes = [
+        c for c in db.execute.await_args_list
+        if "UPDATE trades SET status = 'cancelled'" in str(c.args[0])
+    ]
+    assert cancelled_writes == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_orphaned_pending_trades():
+    """DB rows stuck 'pending' with no in-memory tracking get resolved via the
+    exchange's authoritative order status."""
+    settings = MagicMock()
+    bot = AuramaurBot(settings=settings)
+
+    exchange = SimpleNamespace(
+        _live_pending={"still-tracked": object()},
+        get_order_status=AsyncMock(return_value=OrderResult(
+            order_id="orphan-1", market_id="m1", status="cancelled",
+            filled_size=0, filled_price=0, is_paper=False,
+        )),
+    )
+    db = AsyncMock()
+    db.fetchall = AsyncMock(return_value=[
+        {"order_id": "still-tracked", "exchange": "polymarket"},
+        {"order_id": "PAPER-abc123", "exchange": "polymarket"},
+        {"order_id": "orphan-1", "exchange": "polymarket"},
+    ])
+    bot._components = {"db": db}
+
+    await bot._reconcile_orphaned_pending_trades([("polymarket", exchange)])
+
+    # Only the genuine orphan is queried and rewritten
+    exchange.get_order_status.assert_awaited_once_with("orphan-1")
+    update_calls = [
+        c for c in db.execute.await_args_list
+        if c.args[0].startswith("UPDATE trades SET status = ?")
+    ]
+    assert len(update_calls) == 1
+    assert update_calls[0].args[1] == ("cancelled", "orphan-1")
+    db.commit.assert_awaited_once()

--- a/tests/test_router_crossing.py
+++ b/tests/test_router_crossing.py
@@ -1,0 +1,125 @@
+"""Router cross-to-ask: marketable entries within the edge budget.
+
+A maker quote at bid+1 tick only fills if flow comes to us before the TTL
+reaper cancels the order — on quiet books most entries died unfilled (and
+silently). When lifting the ask costs little relative to the signal's edge,
+the router should pay for certainty instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.broker.router import SmartOrderRouter
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderBook,
+    OrderBookLevel,
+    OrderSide,
+    OrderType,
+    Signal,
+    TokenType,
+)
+
+
+def _book(best_bid: float, best_ask: float) -> OrderBook:
+    return OrderBook(
+        bids=[OrderBookLevel(price=best_bid, size=500.0)],
+        asks=[OrderBookLevel(price=best_ask, size=500.0)],
+    )
+
+
+def _settings(max_cross_cents: int = 4, min_edge_pct: float = 2.5) -> MagicMock:
+    settings = MagicMock()
+    settings.execution.entry_max_cross_cents = max_cross_cents
+    settings.risk.min_edge_pct = min_edge_pct
+    return settings
+
+
+def _router(book: OrderBook, base_price: float, settings=None) -> SmartOrderRouter:
+    exchange = MagicMock()
+    exchange.prepare_order = MagicMock(
+        return_value=Order(
+            market_id="m1",
+            exchange="polymarket",
+            token_id="tok",
+            side=OrderSide.BUY,
+            token=TokenType.YES,
+            size=10.0,
+            price=base_price,
+            dry_run=True,
+        )
+    )
+    exchange.get_order_book = AsyncMock(return_value=book)
+    return SmartOrderRouter(settings if settings is not None else _settings(), exchange)
+
+
+def _signal(edge: float) -> Signal:
+    return Signal(
+        market_id="m1",
+        claude_prob=0.6,
+        claude_confidence="HIGH",
+        market_prob=0.45,
+        edge=edge,
+    )
+
+
+@pytest.mark.asyncio
+async def test_crosses_to_ask_within_budget():
+    """Cheap cross + plenty of edge -> lift the ask as a plain (taker) limit."""
+    router = _router(_book(0.20, 0.24), base_price=0.22)
+    order = await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.24
+    assert order.post_only is False
+
+
+@pytest.mark.asyncio
+async def test_no_cross_when_edge_too_thin():
+    """Crossing would eat the edge below the floor -> stay maker at bid+1."""
+    router = _router(_book(0.20, 0.24), base_price=0.22)
+    # Cross cost is 2 pts; edge 4.0 - min_edge 2.5 leaves only 1.5 pts budget.
+    order = await router.route(_signal(edge=4.0), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.21  # best_bid + 1 tick
+    assert order.post_only is True
+
+
+@pytest.mark.asyncio
+async def test_no_cross_when_spread_too_wide():
+    """Ask further than entry_max_cross_cents from our quote -> stay maker."""
+    router = _router(_book(0.20, 0.30), base_price=0.22)
+    order = await router.route(_signal(edge=20.0), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.21
+    assert order.post_only is True
+
+
+@pytest.mark.asyncio
+async def test_high_urgency_prices_at_real_ask():
+    """edge > 40 used to submit at the stale reference price, which just
+    rested on the book until the TTL reaper killed it. It must price at the
+    actual ask to be marketable."""
+    router = _router(_book(0.40, 0.55), base_price=0.40)
+    order = await router.route(_signal(edge=56.8), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.order_type == OrderType.MARKET
+    assert order.price == 0.55
+    assert order.post_only is False
+
+
+@pytest.mark.asyncio
+async def test_high_urgency_capped_by_edge_budget():
+    """Even urgent orders never pay past the price where edge hits the floor."""
+    router = _router(_book(0.10, 0.90), base_price=0.20)
+    order = await router.route(_signal(edge=42.5), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.order_type == OrderType.MARKET
+    # budget = 0.20 + (42.5 - 2.5)/100 = 0.60, well below the 0.90 ask
+    assert order.price == 0.60


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.