### PR TITLE
feat(engine): rejection cooldown — bench risk-rejected markets

### DIFF
--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -330,6 +330,15 @@ CREATE TABLE IF NOT EXISTS order_build_drops (
     reason TEXT DEFAULT ''
 );
 
+CREATE TABLE IF NOT EXISTS signal_rejections (
+    market_id TEXT PRIMARY KEY,
+    exchange TEXT DEFAULT '',
+    rejected_at TEXT NOT NULL DEFAULT (datetime('now')),
+    yes_price REAL NOT NULL DEFAULT 0,
+    reason TEXT DEFAULT '',
+    streak INTEGER NOT NULL DEFAULT 1
+);
+
 CREATE TABLE IF NOT EXISTS slippage_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     market_id TEXT NOT NULL,

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -188,6 +188,76 @@ class TradingEngine:
             return market_id.rsplit("-", 1)[0]
         return market_id
 
+    async def _apply_rejection_cooldown(self, candidates: list) -> tuple[list, int]:
+        """Drop candidates with a fresh risk rejection. Returns (kept, benched).
+
+        Three things lift the bench, all of them "new information" signals:
+        the cooldown expiring, the yes-price moving by at least the reprice
+        threshold since the rejection, or an active news flag on the market.
+        """
+        try:
+            cooldown_min = int(self.settings.nlp.rejection_cooldown_minutes)
+            reprice = float(self.settings.nlp.rejection_reprice_threshold)
+        except Exception:
+            return candidates, 0
+        if cooldown_min <= 0 or not candidates:
+            return candidates, 0
+        try:
+            rows = await self.db.fetchall(
+                """SELECT market_id, yes_price FROM signal_rejections
+                   WHERE rejected_at > datetime('now', ?)""",
+                (f"-{cooldown_min} minutes",),
+            )
+        except Exception:
+            return candidates, 0  # Table may not exist yet
+        benched = {r["market_id"]: r["yes_price"] for r in rows}
+        if not benched:
+            return candidates, 0
+        flagged = set(self._news_flagged.keys())
+        kept = [
+            m for m in candidates
+            if m.id not in benched
+            or m.id in flagged
+            or abs(m.outcome_yes_price - benched[m.id]) >= reprice
+        ]
+        benched_count = len(candidates) - len(kept)
+        if benched_count > 0:
+            log.info("engine.rejection_benched", count=benched_count, exchange=self.exchange_name)
+        return kept, benched_count
+
+    async def _record_rejection_state(self, market, approved: bool, reason: str) -> None:
+        """Track the risk verdict for the rejection cooldown.
+
+        A rejection benches the market (upsert refreshes the clock and bumps
+        the streak); an approval clears it — the market earned its way back.
+        """
+        try:
+            if approved:
+                await self.db.execute(
+                    "DELETE FROM signal_rejections WHERE market_id = ?",
+                    (market.id,),
+                )
+            else:
+                await self.db.execute(
+                    """INSERT INTO signal_rejections
+                       (market_id, exchange, rejected_at, yes_price, reason, streak)
+                       VALUES (?, ?, datetime('now'), ?, ?, 1)
+                       ON CONFLICT(market_id) DO UPDATE SET
+                           rejected_at = excluded.rejected_at,
+                           yes_price = excluded.yes_price,
+                           reason = excluded.reason,
+                           streak = streak + 1""",
+                    (
+                        market.id,
+                        market.exchange or self.exchange_name or "",
+                        market.outcome_yes_price,
+                        (reason or "")[:200],
+                    ),
+                )
+            await self.db.commit()
+        except Exception as e:
+            log.debug("engine.rejection_record_error", market_id=market.id, error=str(e))
+
     async def _get_available_cash(self) -> float:
         """Get available cash from syncer, exchange, or paper balance."""
         syncer = getattr(self, '_components_syncer', None)
@@ -598,6 +668,7 @@ class TradingEngine:
             strategy=signal.strategy_source,
             graduation=getattr(decision, "graduation_status", ""),
             mispricing=getattr(signal, "mispricing_reason", ""))
+        await self._record_rejection_state(market, decision.approved, decision.reason)
 
         if not decision.approved or decision.position_size <= 0:
             return {"market": market, "signal": signal, "decision": decision, "order": None}
@@ -949,6 +1020,15 @@ class TradingEngine:
                 log.info("engine.held_filtered", count=held_filtered)
                 filtered_count += held_filtered
 
+        # Bench markets the risk gateway recently rejected — their verdict
+        # can't flip until something moves, so re-analyzing them every cycle
+        # (the recently-analyzed fallback above resurrects them once the
+        # 15-minute window lapses) is pure evidence+LLM burn. Applied after
+        # that fallback so a fully-benched venue stays quiet rather than
+        # re-running its dud markets.
+        fresh_candidates, benched_count = await self._apply_rejection_cooldown(fresh_candidates)
+        filtered_count += benched_count
+
         show_scan_results(len(markets), len(fresh_candidates), filtered_count, exchange=self.exchange_name)
 
         # Smart ranking — prioritize markets most likely to be mispriced
@@ -1122,6 +1202,7 @@ class TradingEngine:
                 graduation=getattr(decision, "graduation_status", ""),
                 mispricing=getattr(tc.signal, "mispricing_reason", ""),
             )
+            await self._record_rejection_state(tc.market, decision.approved, decision.reason)
 
             result = {"market": tc.market, "signal": tc.signal, "decision": decision, "order": None}
             results.append(result)
@@ -1375,6 +1456,7 @@ class TradingEngine:
             strategy=signal.strategy_source,
             graduation=getattr(decision, "graduation_status", ""),
             mispricing=getattr(signal, "mispricing_reason", ""))
+            await self._record_rejection_state(market, decision.approved, decision.reason)
 
             result = {"market": market, "signal": signal, "decision": decision, "order": None}
             results.append(result)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -111,6 +111,11 @@ intervals:
 nlp:
   cache_ttl_breaking_seconds: 900
   cache_ttl_slow_seconds: 7200
+  # Rejection cooldown: bench risk-rejected markets instead of re-burning an
+  # evidence pass + LLM call on them every cycle. A reprice >= the threshold
+  # or a news flag lifts the bench immediately.
+  rejection_cooldown_minutes: 240
+  rejection_reprice_threshold: 0.03
   model: "opus"
   max_tokens: 4096
   # API intensity: "low", "medium", or "full_blast"

--- a/config/settings.py
+++ b/config/settings.py
@@ -179,6 +179,16 @@ class NLPConfig(BaseModel):
     # fresh, price-stable cached result are reused and excluded from the batch.
     strategic_cache_enabled: bool = True
 
+    # Lever 6: rejection cooldown. A risk-rejected market re-entered the
+    # candidate pool as soon as the 15-minute recently-analyzed window lapsed,
+    # so the same dud markets burned a fresh evidence pass + LLM call every
+    # ~20 minutes all day (on Kalshi this was the entire signal stream). The
+    # verdict can't flip until something moves, so bench the market until the
+    # cooldown expires, it reprices by the escape threshold, or a news flag
+    # promotes it — the cooldown must never blind the bot to new information.
+    rejection_cooldown_minutes: int = 240
+    rejection_reprice_threshold: float = 0.03  # abs yes-price move that lifts the bench early
+
     # Info-content tuning — maximize signal per token sent to the LLM.
     # Evidence is globally re-ranked (recency x authority x relevance) before
     # truncation, so the model sees the best N items, not the first N.

--- a/tests/test_rejection_cooldown.py
+++ b/tests/test_rejection_cooldown.py
@@ -1,0 +1,201 @@
+"""Rejection cooldown: risk-rejected markets are benched from re-analysis.
+
+Before this, a rejected market re-entered the candidate pool as soon as the
+15-minute recently-analyzed window lapsed, so the same dud markets burned a
+fresh evidence pass + LLM call every ~20 minutes all day — on Kalshi that
+was the entire signal stream. The verdict can't flip until something moves:
+bench until the cooldown expires, the market reprices, or news flags it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.strategy.engine import TradingEngine
+
+
+def _market(market_id: str, yes_price: float = 0.20, exchange: str = "polymarket") -> Market:
+    return Market(
+        id=market_id,
+        exchange=exchange,
+        question=f"Q {market_id}?",
+        outcome_yes_price=yes_price,
+        outcome_no_price=1.0 - yes_price,
+    )
+
+
+async def _engine(db: Database, cooldown_min: int = 240, reprice: float = 0.03) -> TradingEngine:
+    engine = TradingEngine.__new__(TradingEngine)
+    engine.db = db
+    engine.exchange_name = "polymarket"
+    engine._news_flagged = {}
+    settings = MagicMock()
+    settings.nlp.rejection_cooldown_minutes = cooldown_min
+    settings.nlp.rejection_reprice_threshold = reprice
+    engine.settings = settings
+    return engine
+
+
+def test_rejection_benches_market_until_cooldown():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            market = _market("m1", yes_price=0.20)
+
+            await engine._record_rejection_state(market, approved=False, reason="Edge 0.5% below minimum")
+
+            kept, benched = await engine._apply_rejection_cooldown([market])
+            assert kept == []
+            assert benched == 1
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_reprice_lifts_the_bench():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db, reprice=0.03)
+            await engine._record_rejection_state(_market("m1", yes_price=0.20), approved=False, reason="r")
+
+            moved = _market("m1", yes_price=0.24)  # 4 pts > 3 pt threshold
+            kept, benched = await engine._apply_rejection_cooldown([moved])
+            assert kept == [moved]
+            assert benched == 0
+
+            still = _market("m1", yes_price=0.21)  # 1 pt < threshold
+            kept, benched = await engine._apply_rejection_cooldown([still])
+            assert kept == []
+            assert benched == 1
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_news_flag_lifts_the_bench():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            market = _market("m1", yes_price=0.20)
+            await engine._record_rejection_state(market, approved=False, reason="r")
+
+            engine._news_flagged = {"m1": 0.0}
+            kept, benched = await engine._apply_rejection_cooldown([market])
+            assert kept == [market]
+            assert benched == 0
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_approval_clears_the_bench():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            market = _market("m1", yes_price=0.20)
+            await engine._record_rejection_state(market, approved=False, reason="r")
+            await engine._record_rejection_state(market, approved=True, reason="")
+
+            kept, benched = await engine._apply_rejection_cooldown([market])
+            assert kept == [market]
+            assert benched == 0
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_expired_rejection_no_longer_benches():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            market = _market("m1", yes_price=0.20)
+            await engine._record_rejection_state(market, approved=False, reason="r")
+            # Age the rejection past the cooldown window
+            await db.execute(
+                "UPDATE signal_rejections SET rejected_at = datetime('now', '-241 minutes') WHERE market_id = 'm1'"
+            )
+            await db.commit()
+
+            kept, benched = await engine._apply_rejection_cooldown([market])
+            assert kept == [market]
+            assert benched == 0
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_repeat_rejections_bump_streak_and_refresh_clock():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            market = _market("m1", yes_price=0.20)
+            await engine._record_rejection_state(market, approved=False, reason="first")
+            await engine._record_rejection_state(market, approved=False, reason="second")
+
+            row = await db.fetchone("SELECT streak, reason FROM signal_rejections WHERE market_id = 'm1'")
+            assert row["streak"] == 2
+            assert row["reason"] == "second"
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_unbenched_markets_pass_through():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db)
+            await engine._record_rejection_state(_market("m1"), approved=False, reason="r")
+            benched_market = _market("m1")
+            clean_market = _market("m2")
+
+            kept, benched = await engine._apply_rejection_cooldown([benched_market, clean_market])
+            assert kept == [clean_market]
+            assert benched == 1
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_cooldown_disabled_is_a_noop():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            engine = await _engine(db, cooldown_min=0)
+            market = _market("m1")
+            await engine._record_rejection_state(market, approved=False, reason="r")
+
+            kept, benched = await engine._apply_rejection_cooldown([market])
+            assert kept == [market]
+            assert benched == 0
+        finally:
+            await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Problem

A risk-rejected market re-enters the candidate pool as soon as the 15-minute recently-analyzed window lapses (the all-recently-analyzed fallback at the scan filter resurrects everything), so the same dud markets burn a fresh evidence pass + LLM call every ~20 minutes, all day. On Kalshi this is the *entire* signal stream — the same 4 tickers (`KXPERFORMBONDSON`, `KXACTORSONNYCROC`, `KXGDPYEAR`, …) re-rejected identically every cycle, where the 7% fee model guarantees the verdict can't flip without a reprice.

## Fix

New `signal_rejections` table tracks the latest risk verdict per market (with rejection streak for observability). All three risk-decision paths (`_execute_candidates`, legacy `analyze_market`, strategic batch) record it; an approval clears the bench.

The scan filter drops benched candidates until one of three "new information" signals lifts the bench:
- the cooldown expires (`nlp.rejection_cooldown_minutes`, default 240)
- the yes-price moves ≥ `nlp.rejection_reprice_threshold` (default 3 pts) since the rejection
- the market gets news-flagged (`flag_market_from_news` bypass)

So the cooldown can never blind the bot to news or a real repricing — those re-open analysis immediately.

## Risk posture

Pure candidate filter / LLM-spend lever. No risk check is touched; anything analyzed still passes through the full gateway unchanged.

## Tests

8 new tests against a real in-memory DB covering bench, reprice escape, news-flag escape, approval clearing, cooldown expiry, streak bump, pass-through, and disabled mode. Full suite: **611 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)