### PR TITLE
feat(config): HF_TOKEN settable via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ KRAKEN_API_SECRET=
 # (config: gemini.enabled + gemini.model). Get a key at aistudio.google.com.
 GEMINI_API_KEY=
 
+# Hugging Face Hub — free read token for the evidence-relevance embedder
+# (sentence-transformers model downloads). Anonymous access works but is
+# rate-limited and warns on every load; a token lifts both.
+HF_TOKEN=
+
 # Data Sources
 NEWSAPI_KEY=
 REDDIT_CLIENT_ID=

--- a/config/settings.py
+++ b/config/settings.py
@@ -662,6 +662,14 @@ class Settings(BaseSettings):
     # Google Gemini — LLM fallback for off-hours / when Claude budget is low.
     gemini_api_key: str = ""
 
+    # Hugging Face Hub token — used by the sentence-transformers evidence
+    # embedder (nlp/relevance.py). Anonymous downloads work but are
+    # rate-limited and warn; a free read token lifts both. huggingface_hub
+    # reads HF_TOKEN from the process environment, not from our Settings, so
+    # model_post_init exports it (pydantic-settings parses .env into fields
+    # without touching os.environ).
+    hf_token: str = ""
+
     # Global risk-tolerance lever: 0=most conservative, 50=neutral, 100=YOLO.
     # Scales the whole prob/stat/risk surface at the RiskManager gateway.
     # From defaults.yaml (risk_tolerance:) and overridable via env RISK_TOLERANCE.
@@ -727,6 +735,17 @@ class Settings(BaseSettings):
         # unrelated stray var shouldn't crash Settings on startup.
         "extra": "ignore",
     }
+
+    def model_post_init(self, __context) -> None:
+        """Export pass-through tokens to the process environment.
+
+        huggingface_hub (via sentence-transformers) reads HF_TOKEN from
+        os.environ — pydantic-settings parses .env into fields without
+        touching the environment, so a token set only in .env would never
+        reach it. setdefault: a token already exported in the shell wins.
+        """
+        if self.hf_token and not os.environ.get("HF_TOKEN"):
+            os.environ["HF_TOKEN"] = self.hf_token
 
     @property
     def kill_switch_active(self) -> bool:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -143,3 +143,27 @@ def test_yaml_defaults_safe():
     assert raw["kelly"]["fraction"] <= 0.50, (
         "defaults.yaml kelly fraction must be <= 50%"
     )
+
+
+def test_hf_token_exported_to_environ(monkeypatch):
+    """hf_token from .env/constructor must reach os.environ — huggingface_hub
+    reads HF_TOKEN from the environment, not from Settings."""
+    import os
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    Settings(hf_token="hf_test123")
+    assert os.environ.get("HF_TOKEN") == "hf_test123"
+
+
+def test_hf_token_does_not_override_shell_env(monkeypatch):
+    """A token already exported in the shell wins over the .env value."""
+    import os
+    monkeypatch.setenv("HF_TOKEN", "hf_from_shell")
+    Settings(hf_token="hf_from_dotenv")
+    assert os.environ.get("HF_TOKEN") == "hf_from_shell"
+
+
+def test_hf_token_empty_leaves_environ_untouched(monkeypatch):
+    import os
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    Settings(hf_token="")
+    assert "HF_TOKEN" not in os.environ


### PR DESCRIPTION
## Problem

Setting `HF_TOKEN` in `.env` did nothing: pydantic-settings parses `.env` into declared Settings fields only (`extra: \"ignore\"`) and never writes to `os.environ`, while `huggingface_hub` reads `HF_TOKEN` from the process environment. So the sentence-transformers evidence embedder always ran anonymous — rate-limited downloads and the recurring `Warning: You are sending unauthenticated requests to the HF Hub` in the trading terminal.

## Fix

- Declare `hf_token: str = \"\"` on `Settings` (picked up case-insensitively from `.env` or the environment).
- Export it to `os.environ[\"HF_TOKEN\"]` in `Settings.model_post_init` — Settings is constructed at startup, well before the embedder lazy-loads. A token already exported in the shell wins.
- `.env.example` documents the new var.

Add `HF_TOKEN=hf_...` to your `.env` and the warning disappears on next restart.

## Tests

3 new tests (export, shell-env precedence, empty no-op). Full suite: **614 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)