### PR TITLE
fix(exec): marketable exits + terminal cosmetics

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -821,6 +821,33 @@ class AuramaurBot:
             return False
 
         sell_price = max(0.01, min(0.99, round(pos.current_price, 2)))
+        # Marketable exit: a SELL at the snapshot price sits at/above the ask,
+        # rests until the TTL reaper cancels it, and the cleared exit
+        # suppression re-posts it next pass — the Obama winner looped like
+        # that for 2 days (35 cancelled SELLs, no fill). Take the real bid
+        # when it's within the cross-down budget; otherwise post at the
+        # budget floor, which still sits inside the spread instead of on top
+        # of the ask. Best-effort: no book, no change.
+        try:
+            max_cross = float(self.settings.execution.exit_max_cross_cents) / 100.0
+        except Exception:
+            max_cross = 0.03
+        try:
+            book = await exchange.get_order_book(token_id)
+            best_bid = book.best_bid
+            if best_bid is not None and best_bid > 0:
+                marketable = max(best_bid, sell_price - max_cross)
+                if marketable < sell_price:
+                    log.info(
+                        "exit.priced_to_bid",
+                        market_id=pos.market_id,
+                        snapshot=sell_price,
+                        bid=best_bid,
+                        price=round(marketable, 2),
+                    )
+                sell_price = max(0.01, min(0.99, round(marketable, 2)))
+        except Exception as e:
+            log.debug("exit.book_unavailable", market_id=pos.market_id, error=str(e))
         sell_order = Order(
             market_id=pos.market_id,
             token_id=token_id,
@@ -2797,11 +2824,25 @@ class AuramaurBot:
                                                 order_id=order_id,
                                                 error=str(e),
                                             )
+                                    # Reconciled orphans carry the CLOB condition
+                                    # hash as market_id — resolve it to the real
+                                    # market id so the terminal line is readable.
+                                    display_market = order.market_id
+                                    if display_market.startswith("0x") and db is not None:
+                                        try:
+                                            row = await db.fetchone(
+                                                "SELECT id FROM markets WHERE condition_id = ?",
+                                                (display_market,),
+                                            )
+                                            if row:
+                                                display_market = str(row["id"])
+                                        except Exception:
+                                            pass
                                     from auramaur.monitoring.display import show_order_unfilled
                                     show_order_unfilled(
                                         order.side.value, order.size, order.price,
                                         age, exchange=exchange_name,
-                                        market_id=order.market_id,
+                                        market_id=display_market,
                                     )
                                     log.info(
                                         "order_monitor.live_ttl_cancel",

--- a/auramaur/monitoring/display.py
+++ b/auramaur/monitoring/display.py
@@ -213,8 +213,11 @@ def show_portfolio(balance: float, pnl: float, positions: int, drawdown: float, 
 
 
 def show_claude_thinking(market_id: str, stage: str = "primary") -> None:
+    # Concurrent evidence passes interleave these lines, so an untagged
+    # "Asking Claude..." is unattributable — show which market each belongs to.
     label = "Asking Claude" if stage == "primary" else "Second opinion"
-    console.print(f"         [dim]{label}...[/]")
+    tag = f" {market_id[:16]}" if market_id else ""
+    console.print(f"         [dim]{label}...{tag}[/]")
 
 
 def show_cache_hit() -> None:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -16,6 +16,9 @@ execution:
   # Max cents above the reference price the router may pay to lift the ask;
   # crossing additionally requires post-cross edge >= risk.min_edge_pct.
   entry_max_cross_cents: 4
+  # Max cents below the snapshot price an exit SELL may cross down to take
+  # the real bid (otherwise exits rest at the ask and TTL-cancel forever).
+  exit_max_cross_cents: 3
   spread_capture_min_bps: 50
   stop_loss_pct: 30.0
   profit_target_pct: 50.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -31,6 +31,11 @@ class ExecutionConfig(BaseModel):
     # that the TTL reaper usually kills unfilled. The cross also has to leave
     # net edge above risk.min_edge_pct, so this cap only binds on wide edges.
     entry_max_cross_cents: int = 4
+    # Exit twin of entry_max_cross_cents: max cents below the position's
+    # snapshot price a SELL may cross down to hit the real bid. Without it
+    # exits posted at the snapshot price sit at/above the ask and TTL-cancel
+    # forever (the 2-day Obama-winner loop).
+    exit_max_cross_cents: int = 3
     spread_capture_min_bps: int = 50
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -1,0 +1,91 @@
+"""Marketable exit pricing: SELLs cross down to the real bid within budget.
+
+A SELL posted at the position's snapshot price sits at/above the ask, rests
+until the TTL reaper cancels it, and the cleared exit suppression re-posts
+it next pass — the Obama winner looped like that for 2 days (35 cancelled
+SELLs, no fill). Exits must take the bid when it's within the cross-down
+budget, or at worst post at the budget floor inside the spread.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.bot import AuramaurBot
+from auramaur.exchange.models import (
+    OrderBook,
+    OrderBookLevel,
+    OrderResult,
+    TokenType,
+)
+
+
+def _book(best_bid: float | None, best_ask: float | None) -> OrderBook:
+    return OrderBook(
+        bids=[OrderBookLevel(price=best_bid, size=500.0)] if best_bid else [],
+        asks=[OrderBookLevel(price=best_ask, size=500.0)] if best_ask else [],
+    )
+
+
+def _setup(book: OrderBook, current_price: float = 0.90):
+    settings = MagicMock()
+    settings.is_live = False
+    settings.execution.exit_max_cross_cents = 3
+
+    bot = AuramaurBot(settings=settings)
+    db = AsyncMock()
+    db.fetchone = AsyncMock(return_value={"token_id": "tok-1"})
+    bot._components = {"db": db}
+
+    exchange = SimpleNamespace(
+        get_order_book=AsyncMock(return_value=book),
+        place_order=AsyncMock(return_value=OrderResult(
+            order_id="x1", market_id="m1", status="pending", is_paper=False,
+        )),
+    )
+    pos = SimpleNamespace(
+        market_id="m1",
+        size=100.0,
+        current_price=current_price,
+        token=TokenType.YES,
+        unrealized_pnl=76.0,
+    )
+    reason = SimpleNamespace(value="profit_target")
+    alerts = SimpleNamespace(send=AsyncMock())
+    return bot, pos, reason, exchange, alerts
+
+
+@pytest.mark.asyncio
+async def test_exit_takes_bid_within_budget():
+    bot, pos, reason, exchange, alerts = _setup(_book(0.88, 0.91), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is True
+    order = exchange.place_order.await_args.args[0]
+    assert order.price == 0.88  # bid is 2 cents below snapshot, within the 3-cent budget
+
+
+@pytest.mark.asyncio
+async def test_exit_caps_cross_at_budget_floor():
+    bot, pos, reason, exchange, alerts = _setup(_book(0.80, 0.91), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is True
+    order = exchange.place_order.await_args.args[0]
+    assert order.price == 0.87  # bid too deep — post at snapshot minus 3-cent budget
+
+
+@pytest.mark.asyncio
+async def test_exit_keeps_snapshot_price_without_book():
+    bot, pos, reason, exchange, alerts = _setup(_book(None, None), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is True
+    order = exchange.place_order.await_args.args[0]
+    assert order.price == 0.90


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.