### PR TITLE
fix(sync): mark the token actually held, not a YES-default guess

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -104,7 +104,8 @@ class PositionSyncer:
             # Filter is_paper=0 so paper fills don't leak into live sync.
             rows = await self._db.fetchall(
                 """SELECT cb.market_id, cb.token, cb.token_id, cb.size, cb.avg_cost,
-                          m.outcome_yes_price, m.outcome_no_price, m.category
+                          m.outcome_yes_price, m.outcome_no_price, m.category,
+                          m.clob_token_yes, m.clob_token_no
                    FROM cost_basis cb
                    LEFT JOIN markets m ON cb.market_id = m.id
                    WHERE cb.size > 0 AND cb.is_paper = 0"""
@@ -113,12 +114,41 @@ class PositionSyncer:
             for row in rows:
                 market_id = row["market_id"]
                 raw_token = (row["token"] or "YES").upper()
-                token = TokenType(raw_token) if raw_token in ("YES", "NO") else TokenType.YES
-
-                # Use the correct price for the token we hold
+                token_id = row["token_id"] or ""
                 yes_price = float(row["outcome_yes_price"] or 0)
                 no_price = float(row["outcome_no_price"] or 0)
-                if token == TokenType.NO:
+
+                # Resolve which SIDE the held token is. Matching token_id
+                # against the market's CLOB token ids is authoritative; the
+                # outcome label only works when it literally is YES/NO. For
+                # anything else ("Something"/"Nothing", "Up"/"Down", team
+                # names) the old YES-default marked the position at the wrong
+                # outcome's price — the Obama "Something" held at ~$0.105 was
+                # marked at "Nothing"'s $0.885, a phantom +$77 whose exit the
+                # bot chased for two days.
+                direct_price: float | None = None
+                if token_id and token_id == (row["clob_token_no"] or ""):
+                    token = TokenType.NO
+                elif token_id and token_id == (row["clob_token_yes"] or ""):
+                    token = TokenType.YES
+                elif raw_token in ("YES", "NO"):
+                    token = TokenType(raw_token)
+                else:
+                    # Side unknown — price the token we actually hold straight
+                    # off its own book instead of guessing an outcome.
+                    token = TokenType.YES
+                    direct_price = await self._price_held_token(token_id)
+                    if direct_price is None:
+                        log.warning(
+                            "sync.unresolved_token_side",
+                            market_id=market_id,
+                            token_label=raw_token,
+                        )
+
+                # Use the correct price for the token we hold
+                if direct_price is not None:
+                    current_price = direct_price
+                elif token == TokenType.NO:
                     current_price = no_price if no_price > 0.01 else (1.0 - yes_price) if yes_price > 0 else 0.0
                 else:
                     current_price = yes_price
@@ -143,6 +173,26 @@ class PositionSyncer:
             log.error("sync.live.error", error=str(e))
 
         return positions
+
+    async def _price_held_token(self, token_id: str) -> float | None:
+        """Mark an outcome token directly off its own CLOB book.
+
+        Used when neither the token-id match nor the YES/NO label can tell
+        which side we hold. The book midpoint is what the token is actually
+        worth right now; on a one-sided book fall back to the bid — the
+        price an exit could realize. Returns None when there is no book.
+        """
+        if not token_id:
+            return None
+        try:
+            book = await self._exchange.get_order_book(token_id)
+        except Exception as e:
+            log.debug("sync.token_book_error", token_id=token_id[:20], error=str(e))
+            return None
+        mid = book.midpoint
+        if mid is not None:
+            return mid
+        return book.best_bid
 
     async def _get_live_balance(self) -> float:
         """Return *spendable* pUSD: gross collateral minus collateral already

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -84,6 +84,8 @@ class Database:
             await self._migrate_v16_to_v17()
         if from_version < 18:
             await self._migrate_v17_to_v18()
+        if from_version < 19:
+            await self._migrate_v18_to_v19()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -426,6 +428,22 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 18")
         await self._db.commit()
         log.info("database.migrated", from_version=17, to_version=18)
+
+    async def _migrate_v18_to_v19(self) -> None:
+        """Add CLOB outcome-token columns to markets.
+
+        Needed to resolve which SIDE a held token is: outcome labels like
+        "Something"/"Nothing" aren't YES/NO, and the position syncer's
+        YES-default marked such holdings at the wrong outcome's price.
+        """
+        for column_def in ("clob_token_yes TEXT DEFAULT ''", "clob_token_no TEXT DEFAULT ''"):
+            try:
+                await self._db.execute(f"ALTER TABLE markets ADD COLUMN {column_def}")
+            except Exception:
+                pass  # Column already exists
+        await self._db.execute("UPDATE schema_version SET version = 19")
+        await self._db.commit()
+        log.info("database.migrated", from_version=18, to_version=19)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS markets (
     outcome_no_price REAL,
     volume REAL DEFAULT 0,
     liquidity REAL DEFAULT 0,
+    clob_token_yes TEXT DEFAULT '',
+    clob_token_no TEXT DEFAULT '',
     last_updated TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -348,15 +348,18 @@ class TradingEngine:
             await self.db.execute(
                 """INSERT OR REPLACE INTO markets
                    (id, exchange, condition_id, question, description, category, end_date, active,
-                    outcome_yes_price, outcome_no_price, volume, liquidity, last_updated)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    outcome_yes_price, outcome_no_price, volume, liquidity,
+                    clob_token_yes, clob_token_no, last_updated)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     market.id, market.exchange or self.exchange_name or "polymarket",
                     market.condition_id, market.question,
                     market.description, category,
                     market.end_date.isoformat() if market.end_date else None,
                     int(market.active), market.outcome_yes_price, market.outcome_no_price,
-                    market.volume, market.liquidity, datetime.now(timezone.utc).isoformat(),
+                    market.volume, market.liquidity,
+                    market.clob_token_yes, market.clob_token_no,
+                    datetime.now(timezone.utc).isoformat(),
                 ),
             )
 

--- a/tests/test_sync_token_mark.py
+++ b/tests/test_sync_token_mark.py
@@ -1,0 +1,151 @@
+"""Position marks must price the token actually held.
+
+Outcome labels like "Something"/"Nothing" aren't YES/NO, and the syncer's
+old YES-default marked such holdings at the first outcome's price: the
+Obama "Something" token (worth ~$0.105) was marked at "Nothing"'s $0.885 —
+a phantom +$77 whose fantasy-priced exit the bot chased for two days.
+
+Side resolution ladder: token_id match against the market's CLOB token ids
+(authoritative) → literal YES/NO label → price the held token off its own
+book.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.sync import PositionSyncer
+from auramaur.db.database import Database
+from auramaur.exchange.models import OrderBook, OrderBookLevel, TokenType
+
+
+async def _seed_market(db: Database, market_id: str, yes_price: float,
+                       clob_yes: str = "", clob_no: str = "") -> None:
+    await db.execute(
+        """INSERT INTO markets (id, question, outcome_yes_price, outcome_no_price,
+                                clob_token_yes, clob_token_no, last_updated)
+           VALUES (?, 'Q?', ?, ?, ?, ?, datetime('now'))""",
+        (market_id, yes_price, 1.0 - yes_price, clob_yes, clob_no),
+    )
+
+
+async def _seed_holding(db: Database, market_id: str, token_label: str,
+                        token_id: str, size: float = 100.0, avg_cost: float = 0.126) -> None:
+    await db.execute(
+        """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost, total_cost, is_paper)
+           VALUES (?, ?, ?, ?, ?, ?, 0)""",
+        (market_id, token_label, token_id, size, avg_cost, size * avg_cost),
+    )
+
+
+def _syncer(db: Database, book: OrderBook | None = None) -> PositionSyncer:
+    syncer = PositionSyncer.__new__(PositionSyncer)
+    syncer._settings = MagicMock()
+    syncer._db = db
+    syncer._exchange = SimpleNamespace(
+        get_order_book=AsyncMock(return_value=book if book is not None else OrderBook()),
+    )
+    syncer._paper = MagicMock()
+    syncer._pnl = MagicMock()
+    return syncer
+
+
+def test_token_id_match_beats_label_default():
+    """Held token matches clob_token_no -> NO side, NO price — even though
+    the label ("Something") would have defaulted to YES before."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _seed_market(db, "m1", yes_price=0.895,
+                               clob_yes="tok-nothing", clob_no="tok-something")
+            await _seed_holding(db, "m1", "Something", "tok-something")
+            await db.commit()
+
+            positions = await _syncer(db)._sync_live()
+            assert len(positions) == 1
+            assert positions[0].token == TokenType.NO
+            assert abs(positions[0].current_price - 0.105) < 1e-9
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_unknown_label_priced_from_own_book():
+    """No CLOB token ids stored and a non-YES/NO label -> mark from the held
+    token's own book midpoint, not the first outcome's price."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _seed_market(db, "m1", yes_price=0.895)
+            await _seed_holding(db, "m1", "Something", "tok-something")
+            await db.commit()
+
+            book = OrderBook(
+                bids=[OrderBookLevel(price=0.07, size=100)],
+                asks=[OrderBookLevel(price=0.14, size=100)],
+            )
+            positions = await _syncer(db, book)._sync_live()
+            assert len(positions) == 1
+            assert abs(positions[0].current_price - 0.105) < 1e-9
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_plain_yes_label_unchanged():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _seed_market(db, "m1", yes_price=0.60)
+            await _seed_holding(db, "m1", "YES", "tok-1")
+            await db.commit()
+
+            positions = await _syncer(db)._sync_live()
+            assert len(positions) == 1
+            assert positions[0].token == TokenType.YES
+            assert abs(positions[0].current_price - 0.60) < 1e-9
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_unknown_label_empty_book_falls_back_to_yes_price():
+    """Self-heal unavailable (no book at all) -> old behavior, with a warning
+    logged, rather than a zero mark."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _seed_market(db, "m1", yes_price=0.895)
+            await _seed_holding(db, "m1", "Something", "tok-something")
+            await db.commit()
+
+            positions = await _syncer(db, OrderBook())._sync_live()
+            assert len(positions) == 1
+            assert abs(positions[0].current_price - 0.895) < 1e-9
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_markets_table_has_clob_token_columns():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            cols = {r["name"] for r in await db.fetchall("SELECT name FROM pragma_table_info('markets')")}
+            assert "clob_token_yes" in cols
+            assert "clob_token_no" in cols
+        finally:
+            await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.