### PR TITLE
feat(bot): cancel resting live orders on graceful shutdown

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -3162,6 +3162,11 @@ class AuramaurBot:
         self._running = False
         console.print("\n[dim]Shutting down...[/]")
 
+        try:
+            await self._cancel_resting_live_orders()
+        except Exception as e:
+            log.debug("shutdown.cancel_sweep_error", error=str(e))
+
         for name, comp in self._components.items():
             if hasattr(comp, "close"):
                 try:
@@ -3180,3 +3185,56 @@ class AuramaurBot:
             self._lock_file = None
 
         console.print("[dim]Stopped.[/]")
+
+    async def _cancel_resting_live_orders(self) -> None:
+        """Cancel live orders still resting on the book before exit.
+
+        GTC orders outlive the process, so every restart used to inherit the
+        prior session's market-maker quotes and in-flight entries — collateral
+        stayed locked until the startup reconciler and the TTL reaper mopped
+        them up minutes into the next session. Cancel on the way out instead,
+        and write the trades rows terminal so shutdown doesn't mint new
+        orphaned 'pending' rows. Best-effort: a failed cancel is the next
+        session's reconciler problem, exactly as before.
+        """
+        clients: dict[int, tuple[str, object]] = {}
+        primary = self._components.get("exchange")
+        if primary is not None and hasattr(primary, "_live_pending"):
+            clients[id(primary)] = ("polymarket", primary)
+        for name, client in (self._components.get("exchanges") or {}).items():
+            if client is not None and hasattr(client, "_live_pending"):
+                clients.setdefault(id(client), (name, client))
+
+        db = self._components.get("db")
+        cancelled = 0
+        for exchange_name, client in clients.values():
+            for order_id in list(getattr(client, "_live_pending", {}).keys()):
+                try:
+                    ok = await client.cancel_order(order_id)
+                except Exception as e:
+                    log.debug(
+                        "shutdown.cancel_error",
+                        exchange=exchange_name,
+                        order_id=order_id,
+                        error=str(e),
+                    )
+                    continue
+                if not ok:
+                    continue
+                cancelled += 1
+                if db is not None:
+                    try:
+                        await db.execute(
+                            "UPDATE trades SET status = 'cancelled' WHERE order_id = ?",
+                            (order_id,),
+                        )
+                    except Exception:
+                        pass
+        if cancelled and db is not None:
+            try:
+                await db.commit()
+            except Exception:
+                pass
+        if cancelled:
+            console.print(f"[dim]Cancelled {cancelled} resting live orders[/]")
+            log.info("shutdown.orders_cancelled", count=cancelled)

--- a/tests/test_shutdown_cancel.py
+++ b/tests/test_shutdown_cancel.py
@@ -1,0 +1,81 @@
+"""Graceful shutdown cancels resting live orders.
+
+GTC orders outlive the process: every restart inherited the prior session's
+market-maker quotes and in-flight entries, locking collateral until the
+startup reconciler + TTL reaper mopped them up minutes later.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.bot import AuramaurBot
+
+
+def _bot_with(components: dict) -> AuramaurBot:
+    bot = AuramaurBot(settings=MagicMock())
+    bot._components = components
+    bot._lock_file = None
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_all_resting_live_orders():
+    poly = SimpleNamespace(
+        _live_pending={"mm-bid-1": object(), "mm-ask-1": object()},
+        cancel_order=AsyncMock(return_value=True),
+    )
+    kalshi = SimpleNamespace(
+        _live_pending={"kx-1": object()},
+        cancel_order=AsyncMock(return_value=True),
+    )
+    db = AsyncMock()
+    bot = _bot_with({
+        "exchange": poly,
+        "exchanges": {"polymarket": poly, "kalshi": kalshi},
+        "db": db,
+    })
+
+    await bot.shutdown()
+
+    assert poly.cancel_order.await_count == 2
+    kalshi.cancel_order.assert_awaited_once_with("kx-1")
+    update_calls = [
+        c for c in db.execute.await_args_list
+        if c.args[0].startswith("UPDATE trades SET status = 'cancelled'")
+    ]
+    assert {c.args[1][0] for c in update_calls} == {"mm-bid-1", "mm-ask-1", "kx-1"}
+    db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_survives_cancel_failures():
+    """A cancel that errors or is refused must not break shutdown or write a
+    false 'cancelled' status — the next session's reconciler inherits it."""
+    poly = SimpleNamespace(
+        _live_pending={"bad-1": object(), "refused-1": object()},
+        cancel_order=AsyncMock(side_effect=[Exception("api down"), False]),
+    )
+    db = AsyncMock()
+    bot = _bot_with({"exchange": poly, "db": db})
+
+    await bot.shutdown()  # must not raise
+
+    update_calls = [
+        c for c in db.execute.await_args_list
+        if c.args[0].startswith("UPDATE trades SET status = 'cancelled'")
+    ]
+    assert update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_shutdown_noop_without_live_orders():
+    poly = SimpleNamespace(_live_pending={}, cancel_order=AsyncMock())
+    bot = _bot_with({"exchange": poly, "db": AsyncMock()})
+
+    await bot.shutdown()
+
+    poly.cancel_order.assert_not_awaited()


### PR DESCRIPTION
## Problem

GTC orders outlive the process. Every restart inherited the previous session's resting orders — visible after #95 as the startup burst of `ORDER UNFILLED` reaps (tonight: one exit SELL aged 998s + four market-maker quote legs aged ~128s), with collateral locked until the startup reconciler and the 120s TTL reaper mopped up minutes into the new session.

## Fix

`shutdown()` now sweeps every exchange client's `_live_pending` (primary + the exchanges map, deduped), cancels each resting order, and writes the `trades` row to `cancelled` so shutdown can't mint new orphaned `pending` rows. Prints a one-line `Cancelled N resting live orders` summary.

Best-effort by design: an errored or refused cancel is skipped (no false DB write) and left to the next session's startup reconciler — the exact path that previously handled *all* of them.

## Tests

3 new tests (multi-exchange sweep + DB writes, failure tolerance, no-op). Full suite: **628 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)