### PR TITLE
fix(exchange): event-loop-safe CLOB calls — stalled socket froze the live bot 84 min

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -794,13 +794,14 @@ class AuramaurBot:
         sell_size = pos.size
         try:
             from py_clob_client_v2 import BalanceAllowanceParams, AssetType
-            exchange._init_clob_client()
-            bal = exchange._clob_client.get_balance_allowance(
+            await exchange.clob_call(exchange._init_clob_client)
+            bal = await exchange.clob_call(
+                exchange._clob_client.get_balance_allowance,
                 BalanceAllowanceParams(
                     asset_type=AssetType.CONDITIONAL,
                     token_id=token_id,
                     signature_type=2,
-                )
+                ),
             )
             onchain = int(bal.get("balance", 0)) / 1e6
             if onchain < sell_size:
@@ -2899,10 +2900,22 @@ class AuramaurBot:
                  AND timestamp < datetime('now', '-10 minutes')
                ORDER BY timestamp ASC LIMIT 25"""
         )
+        # Placeholder ids from failed/odd submissions — not real orders. Asking
+        # the exchange about them 400s on every pass forever (the 'unknown'
+        # kalshi row did exactly that); mark them terminal instead.
+        sentinel_ids = {"unknown", "ERROR", "BLOCKED", "INSUFFICIENT_BALANCE",
+                        "SKIP_DUP", "POST_ONLY_REJECTED"}
         fixed = 0
         for row in rows:
             order_id = row["order_id"]
             if order_id in tracked or order_id.startswith("PAPER"):
+                continue
+            if order_id in sentinel_ids:
+                await db.execute(
+                    "UPDATE trades SET status = 'error' WHERE order_id = ? AND status = 'pending'",
+                    (order_id,),
+                )
+                fixed += 1
                 continue
             client = clients_by_name.get(row["exchange"] or "polymarket")
             if client is None or not hasattr(client, "get_order_status"):

--- a/auramaur/broker/reconciler.py
+++ b/auramaur/broker/reconciler.py
@@ -54,13 +54,13 @@ class PositionReconciler:
         3. Look up market info for each position
         4. Match to our DB market IDs
         """
-        self._exchange._init_clob_client()
+        await self._exchange.clob_call(self._exchange._init_clob_client)
         client = self._exchange._clob_client
         proxy = self._exchange._settings.polymarket_proxy_address.lower()
 
         # Step 1: Get all trades
         try:
-            trades = client.get_trades()
+            trades = await self._exchange.clob_call(client.get_trades)
         except Exception as e:
             log.error("reconciler.trades_error", error=str(e))
             return []
@@ -191,7 +191,12 @@ class PositionReconciler:
             return self._market_cache[condition_id]
 
         try:
-            info = self._exchange._clob_client.get_market(condition_id)
+            # Via clob_call, not directly: this exact call, run bare on the
+            # event loop, stalled on a dead socket on 2026-06-10 and froze
+            # the whole live bot for 84 minutes.
+            info = await self._exchange.clob_call(
+                self._exchange._clob_client.get_market, condition_id,
+            )
             if info:
                 self._market_cache[condition_id] = info
                 return info

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 from pathlib import Path
 
@@ -51,6 +52,29 @@ class PolymarketClient:
         # get_sellable_token_id() can read it safely even before any market
         # tokens have been registered.
         self._market_token_map: dict[str, set[str]] = {}
+        # Serializes py_clob_client calls (the SDK is not thread-safe).
+        self._clob_lock = asyncio.Lock()
+        # Deadline for any single CLOB HTTP call; instance attr so tests can
+        # shrink it.
+        self._call_timeout = 20.0
+
+    async def clob_call(self, fn, *args, timeout: float | None = None, **kwargs):
+        """Run a blocking py_clob_client call off the event loop, with a deadline.
+
+        The SDK is synchronous HTTP with no default timeout. Called directly
+        from async code, one stalled socket freezes the entire event loop —
+        no exits, no risk checks, no kill-switch polling (2026-06-10: a
+        stalled get_market call froze the live bot for 84 minutes until ^C).
+        Worker thread + wait_for means a stall costs one abandoned thread and
+        a TimeoutError instead. The SDK is not thread-safe, so calls
+        serialize behind one lock; a timed-out call releases the lock and
+        abandons its thread.
+        """
+        async with self._clob_lock:
+            return await asyncio.wait_for(
+                asyncio.to_thread(fn, *args, **kwargs),
+                timeout if timeout is not None else self._call_timeout,
+            )
 
     def _load_real_positions(self) -> None:
         """Load actual on-chain positions from CLOB trade history."""
@@ -317,7 +341,7 @@ class PolymarketClient:
             price=order.price,
         )
 
-        self._init_clob_client()
+        await self.clob_call(self._init_clob_client)
 
         # Pre-submit collateral guard for BUYs. An unfilled limit order locks its
         # notional as collateral; once prior resting orders consume the balance,
@@ -353,12 +377,13 @@ class PolymarketClient:
             # For SELL orders: approve the specific conditional token if not yet approved
             if order.side == OrderSide.SELL and order.token_id not in self._approved_tokens:
                 try:
-                    self._clob_client.update_balance_allowance(
+                    await self.clob_call(
+                        self._clob_client.update_balance_allowance,
                         BalanceAllowanceParams(
                             asset_type=AssetType.CONDITIONAL,
                             token_id=order.token_id,
                             signature_type=2,
-                        )
+                        ),
                     )
                     self._approved_tokens.add(order.token_id)
                     log.info("clob_client.token_approved", token_id=order.token_id[:20])
@@ -374,8 +399,13 @@ class PolymarketClient:
                 side=clob_side,
             )
 
-            signed_order = self._submit_clob_order(
+            # Longer deadline for the actual submit: a timeout here is
+            # ambiguous (the order may have landed) — the startup
+            # reconciler picks up any such stray on the next session.
+            signed_order = await self.clob_call(
+                self._submit_clob_order,
                 ord_args, want_post_only, ClobOrderType, order,
+                timeout=30.0,
             )
 
             order_id = str(signed_order.get("orderID", signed_order.get("id", "unknown")))
@@ -440,8 +470,9 @@ class PolymarketClient:
         """
         try:
             from py_clob_client_v2 import AssetType, BalanceAllowanceParams
-            resp = self._clob_client.get_balance_allowance(
-                BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=2)
+            resp = await self.clob_call(
+                self._clob_client.get_balance_allowance,
+                BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=2),
             )
             # A non-dict / balance-less response means "unknown" — fail open rather
             # than treat it as zero collateral (which would block every BUY).
@@ -452,7 +483,10 @@ class PolymarketClient:
             log.debug("order.balance_probe_failed", error=str(e))
             return None
 
-        reserved = self._reserved_buy_collateral_from_open_orders()
+        try:
+            reserved = await self.clob_call(self._reserved_buy_collateral_from_open_orders)
+        except Exception:
+            reserved = None
         if reserved is None:
             # Authoritative view unavailable — fall back to orders we placed this
             # session. Less complete (misses orphans) but better than no guard.
@@ -507,8 +541,8 @@ class PolymarketClient:
         if not self._is_live_enabled():
             return 0
         try:
-            self._init_clob_client()
-            orders = self._clob_client.get_open_orders()
+            await self.clob_call(self._init_clob_client)
+            orders = await self.clob_call(self._clob_client.get_open_orders)
         except Exception as e:
             log.warning("order.reconcile_failed", error=str(e))
             return 0
@@ -567,9 +601,9 @@ class PolymarketClient:
         or cancelled. We return a terminal "cancelled" result so callers can
         drop it from their pending-order tracking instead of re-polling forever.
         """
-        self._init_clob_client()
+        await self.clob_call(self._init_clob_client)
         try:
-            raw = self._clob_client.get_order(order_id)
+            raw = await self.clob_call(self._clob_client.get_order, order_id)
         except Exception as e:
             log.error("order_status.error", order_id=order_id, error=str(e))
             raise
@@ -612,9 +646,9 @@ class PolymarketClient:
         ``self._clob_client.cancel(order_id)`` raised AttributeError on every
         call, so live cancels silently never happened.)
         """
-        self._init_clob_client()
+        await self.clob_call(self._init_clob_client)
         try:
-            resp = self._clob_client.cancel_orders([order_id])
+            resp = await self.clob_call(self._clob_client.cancel_orders, [order_id])
             not_canceled = resp.get("not_canceled", {}) if isinstance(resp, dict) else {}
             if order_id in not_canceled:
                 log.warning("order_cancel.rejected", order_id=order_id,
@@ -639,11 +673,12 @@ class PolymarketClient:
         """
         if not token_id:
             return 0
-        self._init_clob_client()
+        await self.clob_call(self._init_clob_client)
         try:
             from py_clob_client_v2 import OrderMarketCancelParams
-            resp = self._clob_client.cancel_market_orders(
-                OrderMarketCancelParams(asset_id=token_id)
+            resp = await self.clob_call(
+                self._clob_client.cancel_market_orders,
+                OrderMarketCancelParams(asset_id=token_id),
             )
             cancelled = resp.get("canceled", []) if isinstance(resp, dict) else []
             count = len(cancelled) if isinstance(cancelled, list) else 0
@@ -698,9 +733,9 @@ class PolymarketClient:
     async def get_order_book(self, token_id: str) -> OrderBook:
         """Get order book for a token (public, no auth needed)."""
         from auramaur.exchange.models import OrderBook, OrderBookLevel
-        self._init_clob_client()
         try:
-            raw = self._clob_client.get_order_book(token_id)
+            await self.clob_call(self._init_clob_client)
+            raw = await self.clob_call(self._clob_client.get_order_book, token_id)
             # py_clob_client_v2 returns a plain dict ({"bids": [...], "asks": [...]}),
             # not a dataclass — read by key, falling back to attribute access for
             # any client version that returns an OrderBookSummary object.

--- a/tests/test_clob_call.py
+++ b/tests/test_clob_call.py
@@ -1,0 +1,99 @@
+"""clob_call: blocking py_clob_client calls must not freeze the event loop.
+
+The SDK is synchronous HTTP with no default timeout. Run bare on the loop,
+one stalled socket froze the entire live bot for 84 minutes on 2026-06-10
+(stalled get_market inside the reconciler) — no exits, no risk checks, no
+kill-switch polling. clob_call pushes calls to a worker thread behind a
+lock (the SDK is not thread-safe) and bounds them with a deadline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from auramaur.exchange.client import PolymarketClient
+from auramaur.exchange.paper import PaperTrader
+from unittest.mock import MagicMock
+
+
+def _client() -> PolymarketClient:
+    client = PolymarketClient.__new__(PolymarketClient)
+    client._clob_lock = asyncio.Lock()
+    client._call_timeout = 0.2
+    return client
+
+
+@pytest.mark.asyncio
+async def test_clob_call_returns_result():
+    client = _client()
+    assert await client.clob_call(lambda a, b: a + b, 2, 3) == 5
+
+
+@pytest.mark.asyncio
+async def test_clob_call_times_out_instead_of_hanging():
+    client = _client()
+    with pytest.raises(asyncio.TimeoutError):
+        await client.clob_call(time.sleep, 1)
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_responsive_during_blocking_call():
+    """The whole point: a blocking SDK call must not stop the loop."""
+    client = _client()
+    client._call_timeout = 2.0
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        for _ in range(5):
+            await asyncio.sleep(0.02)
+            ticks += 1
+
+    blocking = asyncio.create_task(client.clob_call(time.sleep, 0.3))
+    await ticker()
+    await blocking
+    # Run bare on the loop, time.sleep(0.3) would have frozen the ticker;
+    # off-loop, all ticks land while the call is still blocking.
+    assert ticks == 5
+
+
+@pytest.mark.asyncio
+async def test_clob_call_serializes_not_thread_safe_sdk():
+    client = _client()
+    client._call_timeout = 2.0
+    concurrent = 0
+    peak = 0
+
+    def tracked():
+        nonlocal concurrent, peak
+        concurrent += 1
+        peak = max(peak, concurrent)
+        time.sleep(0.02)
+        concurrent -= 1
+
+    await asyncio.gather(*[client.clob_call(tracked) for _ in range(4)])
+    assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_releases_lock_for_next_call():
+    client = _client()
+    with pytest.raises(asyncio.TimeoutError):
+        await client.clob_call(time.sleep, 1)
+    # The abandoned call must not leave the lock held.
+    assert await asyncio.wait_for(client.clob_call(lambda: "ok"), 1.0) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_get_order_book_survives_hanging_sdk():
+    """A hung book fetch degrades to an empty book, not a frozen bot."""
+    client = _client()
+    client._init_clob_client = lambda: None
+    client._clob_client = MagicMock()
+    client._clob_client.get_order_book = lambda token_id: time.sleep(1)
+
+    book = await client.get_order_book("tok-1")
+    assert book.bids == [] and book.asks == []


### PR DESCRIPTION
## Problem

py_clob_client is **synchronous HTTP with no default timeout**, called bare on the asyncio event loop throughout the Polymarket paths. Tonight at 21:15:40 a `get_market` call inside the position reconciler stalled on a dead socket and the **entire bot froze for 84 minutes** (zero log lines 21:15:40 → ^C at 22:39) — no exits, no risk checks, no kill-switch polling, while live. This is also why the startup burst showed orders aged ~5,100s: nothing could reap them.

The Kalshi client already solved this exact problem (`asyncio.to_thread` + `_request_timeout`, with a comment saying why); the Polymarket client never did.

## Fix

New `PolymarketClient.clob_call()`: worker thread + `asyncio.wait_for` deadline (20s default; 30s for order submission, where a timeout is ambiguous and the startup reconciler picks up any stray). Calls serialize behind one lock — the SDK is not thread-safe. A stall now costs one abandoned thread and a `TimeoutError` that flows into each call site's existing error handling.

Converted every SDK call reachable from async code:
- `client.py`: submit, status, cancels (single/by-token), order book, balance probes, open-orders reconcile, sell-token approval
- `reconciler.py`: trade history + market lookup (**the actual freeze site**)
- `bot.py`: exit path's on-chain balance check

Also: the orphan sweep marks sentinel order ids (`unknown`, `ERROR`, …) terminal instead of asking the exchange about them — the `'unknown'` kalshi row was 400-ing on every monitor pass forever.

## Tests

6 new tests: result passthrough, timeout instead of hang, **event loop stays responsive during a blocking call**, serialization (peak concurrency 1), lock released after timeout, hung book fetch degrades to empty book. Full suite: **634 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)