### PR TITLE
fix(market-maker): cancel previous quote legs before re-quoting

### DIFF
--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -244,6 +244,15 @@ class MarketMaker:
         if quote is None:
             return None, skip_reason
 
+        # Cancel the previous quote BEFORE posting its replacement. The
+        # overwrite below used to drop the old legs' order ids on the floor,
+        # leaking a resting GTC pair onto the book every refresh cycle —
+        # _cancel_stale_quotes never saw them again, only the silent TTL
+        # reaper (and, after a freeze, nobody) cleaned them up.
+        prior = self._active_quotes.pop(market.id, None)
+        if prior is not None:
+            await self._cancel_quote(prior)
+
         # Place the two-sided quote
         is_live = self._settings.is_live
         result = await self._place_two_sided(quote, is_live)
@@ -500,28 +509,30 @@ class MarketMaker:
 
         for market_id in stale_market_ids:
             quote = self._active_quotes.pop(market_id)
-
-            # Cancel bid leg
-            if quote.bid_order_id and not quote.bid_order_id.startswith("PAPER"):
-                try:
-                    await self._exchange.cancel_order(quote.bid_order_id)
-                except Exception as e:
-                    log.debug("market_maker.cancel_bid_error", order_id=quote.bid_order_id, error=str(e))
-
-            # Cancel ask leg
-            if quote.ask_order_id and not quote.ask_order_id.startswith("PAPER"):
-                try:
-                    await self._exchange.cancel_order(quote.ask_order_id)
-                except Exception as e:
-                    log.debug("market_maker.cancel_ask_error", order_id=quote.ask_order_id, error=str(e))
-
-            # Clean up pending order tracking
-            self._pending_orders.pop(quote.bid_order_id, None)
-            self._pending_orders.pop(quote.ask_order_id, None)
-
+            await self._cancel_quote(quote)
             cancelled += 1
 
         return cancelled
+
+    async def _cancel_quote(self, quote) -> None:
+        """Cancel both legs of a quote and drop its pending-order tracking."""
+        # Cancel bid leg
+        if quote.bid_order_id and not quote.bid_order_id.startswith("PAPER"):
+            try:
+                await self._exchange.cancel_order(quote.bid_order_id)
+            except Exception as e:
+                log.debug("market_maker.cancel_bid_error", order_id=quote.bid_order_id, error=str(e))
+
+        # Cancel ask leg
+        if quote.ask_order_id and not quote.ask_order_id.startswith("PAPER"):
+            try:
+                await self._exchange.cancel_order(quote.ask_order_id)
+            except Exception as e:
+                log.debug("market_maker.cancel_ask_error", order_id=quote.ask_order_id, error=str(e))
+
+        # Clean up pending order tracking
+        self._pending_orders.pop(quote.bid_order_id, None)
+        self._pending_orders.pop(quote.ask_order_id, None)
 
     def _update_inventory(self, market_id: str, side: str, size: float) -> None:
         """Track net inventory position.

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -131,3 +131,58 @@ def test_select_skips_dead_book_but_keeps_real_spread():
     ids = [m.id for m in suitable]
     assert "dead" not in ids
     assert ids == ["real"]
+
+
+@pytest.mark.asyncio
+async def test_requote_cancels_previous_legs_before_replacing():
+    """Re-quoting a market must cancel the prior quote's legs first.
+
+    The overwrite of _active_quotes used to orphan the old legs' order ids —
+    a resting GTC pair leaked onto the book every refresh cycle (observed
+    live 2026-06-10: three stacked identical quote pairs ~36s apart)."""
+    from unittest.mock import AsyncMock
+
+    mm = _maker()
+    mm._settings = SimpleNamespace(is_live=True, market_maker=mm._settings.market_maker)
+
+    placed: list[str] = []
+    counter = {"n": 0}
+
+    async def place_order(order):
+        counter["n"] += 1
+        oid = f"live-{counter['n']}"
+        placed.append(oid)
+        return SimpleNamespace(order_id=oid, status="pending", is_paper=False)
+
+    cancelled: list[str] = []
+
+    async def cancel_order(order_id):
+        cancelled.append(order_id)
+        return True
+
+    book = OrderBook(
+        bids=[OrderBookLevel(price=0.40, size=100)],
+        asks=[OrderBookLevel(price=0.46, size=100)],
+    )
+    mm._exchange = SimpleNamespace(
+        place_order=place_order,
+        cancel_order=cancel_order,
+        get_order_book=AsyncMock(return_value=book),
+    )
+    market = Market(
+        id="m1",
+        question="Will this happen?",
+        clob_token_yes="yes",
+        clob_token_no="no",
+    )
+
+    result1, _ = await mm._quote_market(market)
+    assert result1 and result1.get("success")
+    first_legs = placed[:2]
+    assert cancelled == []  # nothing to replace yet
+
+    result2, _ = await mm._quote_market(market)
+    assert result2 and result2.get("success")
+    # The first quote's two legs were cancelled before the new pair posted.
+    assert cancelled == first_legs
+    assert len(placed) == 4


### PR DESCRIPTION
## Problem

`_quote_market` overwrites `_active_quotes[market_id]` on every refresh (~30s), orphaning the previous quote's order ids without cancelling them — a resting GTC pair leaks onto the book each cycle. `_cancel_stale_quotes` only sees the latest quote, so the leaked pairs were cleaned up exclusively by the order monitor's (until #95, silent) 120s TTL reaper. Tonight's event-loop freeze removed even that backstop: the startup reap showed **three stacked identical quote pairs** (~36s apart, market `0x6966…`) that had been resting for 84 minutes — stale prices on the book with live collateral behind them.

## Fix

Extract leg cancellation into `_cancel_quote()` (shared with `_cancel_stale_quotes`) and cancel the prior quote **before** posting its replacement. The book now carries at most one MM quote pair per market, owned end-to-end by the MM.

## Tests

New async test: re-quoting cancels exactly the first quote's two legs before the new pair posts. Full suite: **635 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)