### PR TITLE
fix(risk): mark positions by held token id — YES-defaulted labels priced the wrong outcome

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -836,6 +836,20 @@ class AuramaurBot:
         try:
             book = await exchange.get_order_book(token_id)
             best_bid = book.best_bid
+            best_ask = book.best_ask
+            # Mark-vs-book sanity: when even the budget floor sits far above
+            # the best ask, the snapshot is not what this token's book will
+            # pay (mislabeled side, stale mark) — the order can only rest
+            # until the TTL reaper kills it. Skip instead of looping.
+            if best_ask is not None and (sell_price - max_cross) > best_ask + 0.10:
+                log.warning(
+                    "exit.mark_book_divergence",
+                    market_id=pos.market_id,
+                    snapshot=sell_price,
+                    best_ask=best_ask,
+                    best_bid=best_bid,
+                )
+                return False
             if best_bid is not None and best_bid > 0:
                 marketable = max(best_bid, sell_price - max_cross)
                 if marketable < sell_price:

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -236,6 +236,44 @@ class PortfolioTracker:
     # Exit checks
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _resolve_mark_price(pos: Position, market) -> float | None:
+        """Price of the token the position actually holds, or None to keep
+        the stored mark.
+
+        The held token id is authoritative. The YES/NO label defaults to YES
+        for markets whose outcomes aren't literally Yes/No ("Nothing"/
+        "Something", team names), so marking off the label prices those
+        positions at the wrong outcome — the Obama "Something" held at
+        ~$0.105 was marked at "Nothing"'s $0.895, and the phantom +$77
+        PROFIT_TARGET exit looped unfilled for days. When the market's
+        tokens are known but ours matches neither, return None: the live
+        syncer marks unresolved tokens off their own order book, and
+        re-marking from the label here would clobber that with the wrong
+        outcome's price every cycle.
+        """
+        clob_yes = market.clob_token_yes or ""
+        clob_no = market.clob_token_no or ""
+        token = pos.token
+        if pos.token_id and pos.token_id == clob_yes:
+            token = TokenType.YES
+        elif pos.token_id and pos.token_id == clob_no:
+            token = TokenType.NO
+        elif pos.token_id and (clob_yes or clob_no):
+            log.warning(
+                "check_exits.unresolved_token_side",
+                market_id=pos.market_id,
+                token_label=pos.token.value,
+            )
+            return None
+        if token == TokenType.NO:
+            return (
+                market.outcome_no_price
+                if market.outcome_no_price > 0.01
+                else 1.0 - market.outcome_yes_price
+            )
+        return market.outcome_yes_price
+
     async def check_exits(
         self,
         settings,
@@ -281,31 +319,29 @@ class PortfolioTracker:
                 # leave it untouched for that venue (we still need `market` below
                 # for end_date / profit-target logic).
                 if exchange != "ibkr":
-                    # Use the correct price for the token we actually hold
-                    if pos.token == TokenType.NO:
-                        pos.current_price = (
-                            market.outcome_no_price
-                            if market.outcome_no_price > 0.01
-                            else 1.0 - market.outcome_yes_price
-                        )
+                    new_mark = self._resolve_mark_price(pos, market)
+                    if new_mark is None:
+                        # Side unresolved — keep the stored mark (the live
+                        # syncer prices such tokens off their own book).
+                        pass
                     else:
-                        pos.current_price = market.outcome_yes_price
-                    update_sql = (
-                        """UPDATE portfolio
-                           SET current_price = ?,
-                               unrealized_pnl = (? - avg_price) * size,
-                               updated_at = datetime('now')
-                           WHERE market_id = ?"""
-                    )
-                    update_params: list[object] = [pos.current_price, pos.current_price, pos.market_id]
-                    if exchange:
-                        update_sql += " AND exchange = ?"
-                        update_params.append(exchange)
-                    if mode_flag is not None:
-                        update_sql += " AND is_paper = ?"
-                        update_params.append(mode_flag)
-                    await self.db.execute(update_sql, tuple(update_params))
-                    prices_updated = True
+                        pos.current_price = new_mark
+                        update_sql = (
+                            """UPDATE portfolio
+                               SET current_price = ?,
+                                   unrealized_pnl = (? - avg_price) * size,
+                                   updated_at = datetime('now')
+                               WHERE market_id = ?"""
+                        )
+                        update_params: list[object] = [pos.current_price, pos.current_price, pos.market_id]
+                        if exchange:
+                            update_sql += " AND exchange = ?"
+                            update_params.append(exchange)
+                        if mode_flag is not None:
+                            update_sql += " AND is_paper = ?"
+                            update_params.append(mode_flag)
+                        await self.db.execute(update_sql, tuple(update_params))
+                        prices_updated = True
             except Exception as e:
                 log.debug("check_exits.price_error", market_id=pos.market_id, error=str(e))
                 continue

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -89,3 +89,29 @@ async def test_exit_keeps_snapshot_price_without_book():
     assert ok is True
     order = exchange.place_order.await_args.args[0]
     assert order.price == 0.90
+
+
+@pytest.mark.asyncio
+async def test_exit_skips_when_mark_contradicts_book():
+    """Snapshot $0.90 but the token's book asks $0.13: the mark is fiction
+    (wrong-side label, stale price). Posting at the budget floor ($0.87) can
+    only rest and TTL out — skip the order entirely."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.07, 0.13), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is False
+    exchange.place_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exit_posts_on_wide_but_plausible_spread():
+    """A wide spread whose ask is near the snapshot is legitimate — the
+    divergence gate must not block it (floor 0.87 < ask 0.95 + 0.10)."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.80, 0.95), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is True
+    order = exchange.place_order.await_args.args[0]
+    assert order.price == 0.87  # budget floor, inside the spread

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -49,12 +49,16 @@ def _make_position(market_id: str, avg_price: float, size: float = 10.0,
 
 
 def _make_market(market_id: str, yes_price: float, end_date: datetime | None = None,
-                 active: bool = True):
+                 active: bool = True, no_price: float | None = None,
+                 clob_yes: str = "", clob_no: str = ""):
     m = MagicMock()
     m.id = market_id
     m.outcome_yes_price = yes_price
+    m.outcome_no_price = no_price if no_price is not None else round(1.0 - yes_price, 4)
     m.end_date = end_date
     m.active = active
+    m.clob_token_yes = clob_yes
+    m.clob_token_no = clob_no
     return m
 
 
@@ -259,6 +263,106 @@ async def test_binary_exits_skipped_for_ibkr_options(settings):
         tracker = PortfolioTracker(db=db, settings=settings)
         exits = await tracker.check_exits(settings, gamma, exchange="ibkr")
         assert exits == []  # no edge-erosion / time-decay for options
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_token_id_overrides_yes_label(settings):
+    """A position whose outcome label defaulted to YES but whose held token id
+    is the market's NO-slot token must be marked at the NO price. The Obama
+    "Something" held at $0.105 was marked at "Nothing"'s $0.895 — a phantom
+    +$77 that fired PROFIT_TARGET every cycle."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings.is_live = True
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('obama', 'polymarket', 'BUY', 100, 0.126, 0.895,
+                       'politics_us', 'YES', 'tok_something', 0)"""
+        )
+        await db.commit()
+
+        gamma = AsyncMock()
+        gamma.get_market = AsyncMock(return_value=_make_market(
+            "obama", 0.895, no_price=0.105,
+            clob_yes="tok_nothing", clob_no="tok_something",
+        ))
+
+        tracker = PortfolioTracker(db=db, settings=settings)
+        exits = await tracker.check_exits(settings, gamma, exchange="polymarket")
+
+        # Real P&L is (0.105-0.126)*100 = -$2.10 (-17%): no exit fires.
+        assert exits == []
+        row = await db.fetchone("SELECT current_price FROM portfolio WHERE market_id='obama'")
+        assert row["current_price"] == pytest.approx(0.105)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unresolved_token_keeps_stored_mark(settings):
+    """When the market's CLOB tokens are known but the held token matches
+    neither, the stored mark (set by the syncer off the token's own book)
+    must not be clobbered with the label outcome's price."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings.is_live = True
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('m1', 'polymarket', 'BUY', 100, 0.126, 0.10,
+                       'test', 'YES', 'tok_unknown', 0)"""
+        )
+        await db.commit()
+
+        gamma = AsyncMock()
+        gamma.get_market = AsyncMock(return_value=_make_market(
+            "m1", 0.895, no_price=0.105,
+            clob_yes="tok_a", clob_no="tok_b",
+        ))
+
+        tracker = PortfolioTracker(db=db, settings=settings)
+        exits = await tracker.check_exits(settings, gamma, exchange="polymarket")
+
+        assert exits == []
+        row = await db.fetchone("SELECT current_price FROM portfolio WHERE market_id='m1'")
+        assert row["current_price"] == pytest.approx(0.10)  # untouched
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_label_used_when_market_tokens_unknown(settings):
+    """No CLOB token ids on the market (e.g. Kalshi) — the YES/NO label keeps
+    driving the mark, as before."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings.is_live = True
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('m1', 'polymarket', 'BUY', 10, 0.50, 0.50,
+                       'test', 'NO', 'tok_x', 0)"""
+        )
+        await db.commit()
+
+        gamma = AsyncMock()
+        gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.45, no_price=0.55))
+
+        tracker = PortfolioTracker(db=db, settings=settings)
+        exits = await tracker.check_exits(settings, gamma, exchange="polymarket")
+
+        assert exits == []
+        row = await db.fetchone("SELECT current_price FROM portfolio WHERE market_id='m1'")
+        assert row["current_price"] == pytest.approx(0.55)  # NO-side price
     finally:
         await db.close()
 


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.