### PR TITLE
feat(router): taker-or-skip entries — skip signals with no realizable edge at the ask

### DIFF
--- a/auramaur/broker/router.py
+++ b/auramaur/broker/router.py
@@ -17,6 +17,19 @@ from auramaur.exchange.models import (
 log = structlog.get_logger()
 
 
+class UnmarketableSignal(Exception):
+    """The signal cannot be executed at a price that clears the minimum-edge
+    floor — there is no realizable edge at the book, so the trade is skipped.
+
+    Edge is measured against a reference price, but the only price a taker
+    can actually get is the ask. Entries that can't cross within budget used
+    to post passively at bid+1 tick: those filled ~25-29% of the time before
+    the TTL reaper killed them, and the fills were adversely selected (a
+    resting bid fills when flow moves against the thesis). Skipping is the
+    honest outcome — the edge was never realizable.
+    """
+
+
 class SmartOrderRouter:
     """Builds optimally-priced orders by inspecting the order book.
 
@@ -41,13 +54,17 @@ class SmartOrderRouter:
         1. Call ``exchange.prepare_order()`` to get the base order (handles
            Polymarket token swap logic).
         2. Fetch the order book for the relevant token.
-        3. Decision matrix:
-           - spread >= 0.03 AND edge > 10%  -> LIMIT at best_bid + 0.01
-             (capture spread, patient fill)
-           - spread < 0.03 OR edge > 20%    -> MARKET (cross spread, fast
-             execution)
-        4. Adjust price based on order book depth.
-        5. Return ``Order`` with optimal price and type.
+        3. BUY entries are taker-or-skip: price at the best ask when the
+           realizable edge (edge minus cross cost) clears the minimum-edge
+           floor and the ask is within ``entry_max_cross_cents`` of the
+           reference price (the cents cap is waived above 40% edge);
+           otherwise raise :class:`UnmarketableSignal`.
+        4. SELL orders keep the passive path (limit one tick inside the
+           book, market-order fallbacks) — exits must get out, and "no
+           fill" is not an acceptable outcome for them.
+
+        Raises ``UnmarketableSignal`` when a BUY entry has no realizable
+        edge at the book. Returns None when no base order could be built.
         """
         base_order = self._exchange.prepare_order(
             signal=signal,
@@ -86,20 +103,54 @@ class SmartOrderRouter:
         except Exception:
             max_cross = 0.04
 
-        # Determine order type via decision matrix
-        # On 0% fee exchanges (Polymarket reward tier), limit orders are almost
-        # always better — you get price improvement for free.
-        #   - spread < $0.01: limit order (tight market, capture the spread)
-        #   - edge > 40%:     market order (urgency overrides price)
-        #   - otherwise:      limit order with price improvement (+1 tick),
-        #                     lifting the ask instead when it costs less than
-        #                     entry_max_cross_cents and the post-cross edge
-        #                     still clears the minimum-edge floor
+        # Determine order type.
+        # BUY entries are taker-or-skip. Passive entries (bid+1 tick) filled
+        # 25-29% of the time before the TTL reaper killed them, and a resting
+        # bid only fills when flow moves against the thesis — the survivors
+        # are adversely selected. The realizable price for an entry is the
+        # ask: if the edge measured THERE doesn't clear the floor, the signal
+        # has no executable edge and the trade is skipped (recorded upstream
+        # as a rejection, with cooldown). SELLs keep the passive path — exits
+        # must get out, so "no fill" is not an acceptable outcome for them.
         has_book = spread is not None and (book.best_bid is not None or book.best_ask is not None)
         crossed_to_ask = False
 
-        if not has_book:
-            # No book data — fall back to market order
+        if base_order.side == OrderSide.BUY:
+            if book.best_ask is None:
+                # Dead or one-sided book: nothing to take, and a resting bid
+                # on a market with no sellers is a pure coin flip.
+                raise UnmarketableSignal(
+                    f"no asks on the book for {market.id} — dead or one-sided market"
+                )
+            ask = book.best_ask
+            cross_cost_pts = (ask - base_order.price) * 100.0
+            realizable_edge = edge_pct - cross_cost_pts
+            if realizable_edge < min_edge_pct:
+                raise UnmarketableSignal(
+                    f"edge at the ask {realizable_edge:.2f}% below minimum "
+                    f"{min_edge_pct:.2f}% (ref {base_order.price:.2f}, ask {ask:.2f})"
+                )
+            # Cents cap: never chase more than entry_max_cross_cents above
+            # the reference price. Very high edges (>40%) waive the cap —
+            # the proportional floor above still bounds them.
+            if edge_pct <= 40.0 and (ask - base_order.price) > max_cross + 1e-9:
+                raise UnmarketableSignal(
+                    f"ask {ask:.2f} is {round((ask - base_order.price) * 100)}c above "
+                    f"reference {base_order.price:.2f} (cap {round(max_cross * 100)}c)"
+                )
+            crossed_to_ask = True
+            order_type = OrderType.LIMIT
+            limit_price = max(0.01, min(0.99, round(ask, 2)))
+            log.info(
+                "router.crossed_to_ask",
+                market_id=market.id,
+                edge_pct=round(edge_pct, 2),
+                realizable_edge=round(realizable_edge, 2),
+                ask=ask,
+                cross_cost_pts=round(cross_cost_pts, 2),
+            )
+        elif not has_book:
+            # SELL with no book data — fall back to market order
             order_type = OrderType.MARKET
             limit_price = base_order.price
             log.info(
@@ -109,13 +160,9 @@ class SmartOrderRouter:
                 reason="no_book",
             )
         elif edge_pct > 40.0:
-            # Very high urgency — cross immediately. Price at the real ask
-            # (capped by the edge budget) so the order is actually marketable.
+            # Very high urgency SELL — cross immediately at the reference.
             order_type = OrderType.MARKET
             limit_price = base_order.price
-            if base_order.side == OrderSide.BUY and book.best_ask is not None:
-                budget_price = base_order.price + max(0.0, edge_pct - min_edge_pct) / 100.0
-                limit_price = max(0.01, min(0.99, round(min(book.best_ask, budget_price), 2)))
             log.info(
                 "router.market_order",
                 market_id=market.id,
@@ -124,39 +171,14 @@ class SmartOrderRouter:
                 reason="high_urgency",
             )
         else:
-            # Limit order — prefer price improvement on 0% fee exchange
+            # SELL limit order — price one tick inside the book
             candidate_price = self._compute_limit_price(
                 book, base_order.side, base_order.token
             )
 
-            # Lift the ask when it's cheap enough: a maker quote at bid+1 tick
-            # only fills if flow comes to us within the order TTL, which on
-            # quiet books makes the fill a coin flip. Paying ≤max_cross more
-            # for certainty is the better trade whenever the remaining edge
-            # still clears the floor.
-            if base_order.side == OrderSide.BUY and book.best_ask is not None:
-                cross_cost_pts = (book.best_ask - base_order.price) * 100.0
-                if (
-                    book.best_ask - candidate_price <= max_cross + 1e-9
-                    and cross_cost_pts <= edge_pct - min_edge_pct
-                ):
-                    crossed_to_ask = True
-                    order_type = OrderType.LIMIT
-                    limit_price = max(0.01, min(0.99, round(book.best_ask, 2)))
-                    log.info(
-                        "router.crossed_to_ask",
-                        market_id=market.id,
-                        edge_pct=round(edge_pct, 2),
-                        candidate=candidate_price,
-                        ask=book.best_ask,
-                        cross_cost_pts=round(cross_cost_pts, 2),
-                    )
-
             # Sanity check: limit price shouldn't deviate >30% from fair price
             fair_price = base_order.price
-            if crossed_to_ask:
-                pass
-            elif fair_price > 0 and abs(candidate_price - fair_price) / fair_price > 0.30:
+            if fair_price > 0 and abs(candidate_price - fair_price) / fair_price > 0.30:
                 # Book too thin — use market order at fair price
                 order_type = OrderType.MARKET
                 limit_price = fair_price

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -28,7 +28,7 @@ from auramaur.nlp.analyzer import ClaudeAnalyzer
 from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
-from auramaur.broker.router import SmartOrderRouter
+from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
 from auramaur.risk.manager import RiskManager
 from auramaur.strategy.classifier import classify_market, ensure_category
 from auramaur.strategy.order_flow import OrderFlowTracker
@@ -699,10 +699,35 @@ class TradingEngine:
         regardless of global live mode — it can only restrict, never arm.
         """
         is_live = self.settings.is_live and not force_paper
-        if self.router:
-            order = await self.router.route(signal, market, size_dollars, is_live)
-        else:
-            order = self.exchange.prepare_order(signal, market, size_dollars, is_live)
+        try:
+            if self.router:
+                order = await self.router.route(signal, market, size_dollars, is_live)
+            else:
+                order = self.exchange.prepare_order(signal, market, size_dollars, is_live)
+        except UnmarketableSignal as skip:
+            # No realizable edge at the book. This gate runs before the
+            # paper/live split on purpose: paper fills simulate at the
+            # reference price, so letting paper books keep these trades
+            # would graduate strategies on fills live could never get.
+            show_order_dropped(market.id, f"unmarketable: {skip}")
+            log.info(
+                "engine.entry_unmarketable",
+                market_id=market.id,
+                strategy=signal.strategy_source,
+                reason=str(skip),
+            )
+            try:
+                # Shorter block than build failures: the book can move.
+                await self.db.execute(
+                    """INSERT OR REPLACE INTO order_build_drops
+                       (market_id, blocked_until, reason)
+                       VALUES (?, datetime('now', '+30 minutes'), ?)""",
+                    (market.id, f"unmarketable: {skip}"),
+                )
+                await self.db.commit()
+            except Exception:
+                pass
+            return None
 
         if order is None:
             show_order_dropped(market.id, f"order build failed (${size_dollars:.2f} — could not build a valid order)")

--- a/tests/test_post_only.py
+++ b/tests/test_post_only.py
@@ -57,8 +57,10 @@ def test_limit_price_joins_bbo_on_one_cent_spread_sell():
 
 
 @pytest.mark.asyncio
-async def test_router_sets_post_only_on_limit_orders():
-    """Router should set post_only=True on any LIMIT order it emits."""
+async def test_router_sets_post_only_on_passive_sell_limits():
+    """SELLs keep the passive path; the router must set post_only=True on
+    the maker limit it emits (BUY entries are taker-or-skip and never post
+    passively anymore)."""
     settings = MagicMock()
     exchange = MagicMock()
     exchange.prepare_order = MagicMock(
@@ -66,7 +68,7 @@ async def test_router_sets_post_only_on_limit_orders():
             market_id="m1",
             exchange="polymarket",
             token_id="tok",
-            side=OrderSide.BUY,
+            side=OrderSide.SELL,
             token=TokenType.YES,
             size=10.0,
             price=0.45,
@@ -89,12 +91,14 @@ async def test_router_sets_post_only_on_limit_orders():
     order = await router.route(signal, market, size_dollars=10.0, is_live=False)
     assert order is not None
     assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.49  # best_ask - 1 tick, maker side
     assert order.post_only is True
 
 
 @pytest.mark.asyncio
-async def test_router_does_not_set_post_only_on_market_orders():
-    """High-urgency edge -> MARKET, which should not carry post_only."""
+async def test_router_does_not_set_post_only_on_crossed_entries():
+    """A BUY entry crosses to the ask — it must be allowed to take, so it
+    never carries post_only."""
     settings = MagicMock()
     exchange = MagicMock()
     exchange.prepare_order = MagicMock(
@@ -119,10 +123,11 @@ async def test_router_does_not_set_post_only_on_market_orders():
         claude_prob=0.9,
         claude_confidence="HIGH",
         market_prob=0.50,
-        edge=50.0,  # > 40 triggers MARKET
+        edge=50.0,
     )
 
     order = await router.route(signal, market, size_dollars=10.0, is_live=False)
     assert order is not None
-    assert order.order_type == OrderType.MARKET
+    assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.51  # at the ask
     assert order.post_only is False

--- a/tests/test_router_crossing.py
+++ b/tests/test_router_crossing.py
@@ -1,9 +1,11 @@
-"""Router cross-to-ask: marketable entries within the edge budget.
+"""Router taker-or-skip: BUY entries execute at the ask or not at all.
 
-A maker quote at bid+1 tick only fills if flow comes to us before the TTL
-reaper cancels the order — on quiet books most entries died unfilled (and
-silently). When lifting the ask costs little relative to the signal's edge,
-the router should pay for certainty instead.
+Passive entries (bid+1 tick) filled 25-29% of the time before the TTL
+reaper killed them, and a resting bid only fills when flow moves against
+the thesis — the survivors are adversely selected. The realizable price
+for an entry is the ask: when the edge measured there doesn't clear the
+minimum-edge floor (or the ask is past the cents cap), the router raises
+UnmarketableSignal instead of posting a coin-flip maker quote.
 """
 
 from __future__ import annotations
@@ -12,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from auramaur.broker.router import SmartOrderRouter
+from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
 from auramaur.exchange.models import (
     Market,
     Order,
@@ -25,10 +27,10 @@ from auramaur.exchange.models import (
 )
 
 
-def _book(best_bid: float, best_ask: float) -> OrderBook:
+def _book(best_bid: float | None, best_ask: float | None) -> OrderBook:
     return OrderBook(
-        bids=[OrderBookLevel(price=best_bid, size=500.0)],
-        asks=[OrderBookLevel(price=best_ask, size=500.0)],
+        bids=[OrderBookLevel(price=best_bid, size=500.0)] if best_bid else [],
+        asks=[OrderBookLevel(price=best_ask, size=500.0)] if best_ask else [],
     )
 
 
@@ -39,14 +41,15 @@ def _settings(max_cross_cents: int = 4, min_edge_pct: float = 2.5) -> MagicMock:
     return settings
 
 
-def _router(book: OrderBook, base_price: float, settings=None) -> SmartOrderRouter:
+def _router(book: OrderBook, base_price: float, settings=None,
+            side: OrderSide = OrderSide.BUY) -> SmartOrderRouter:
     exchange = MagicMock()
     exchange.prepare_order = MagicMock(
         return_value=Order(
             market_id="m1",
             exchange="polymarket",
             token_id="tok",
-            side=OrderSide.BUY,
+            side=side,
             token=TokenType.YES,
             size=10.0,
             price=base_price,
@@ -79,47 +82,116 @@ async def test_crosses_to_ask_within_budget():
 
 
 @pytest.mark.asyncio
-async def test_no_cross_when_edge_too_thin():
-    """Crossing would eat the edge below the floor -> stay maker at bid+1."""
+async def test_skips_when_edge_at_ask_below_floor():
+    """Crossing would eat the edge below the floor -> skip, don't post a
+    passive quote. Cross cost is 2 pts; edge 4.0 leaves 2.0 < 2.5 floor."""
     router = _router(_book(0.20, 0.24), base_price=0.22)
-    # Cross cost is 2 pts; edge 4.0 - min_edge 2.5 leaves only 1.5 pts budget.
-    order = await router.route(_signal(edge=4.0), Market(id="m1", question="Q?"), 10.0, False)
-    assert order is not None
-    assert order.order_type == OrderType.LIMIT
-    assert order.price == 0.21  # best_bid + 1 tick
-    assert order.post_only is True
+    with pytest.raises(UnmarketableSignal, match="edge at the ask"):
+        await router.route(_signal(edge=4.0), Market(id="m1", question="Q?"), 10.0, False)
 
 
 @pytest.mark.asyncio
-async def test_no_cross_when_spread_too_wide():
-    """Ask further than entry_max_cross_cents from our quote -> stay maker."""
+async def test_skips_when_ask_past_cents_cap():
+    """Ask further than entry_max_cross_cents above reference -> skip
+    (8c chase vs a 4c cap), even though the proportional edge would survive."""
     router = _router(_book(0.20, 0.30), base_price=0.22)
-    order = await router.route(_signal(edge=20.0), Market(id="m1", question="Q?"), 10.0, False)
+    with pytest.raises(UnmarketableSignal, match="above"):
+        await router.route(_signal(edge=20.0), Market(id="m1", question="Q?"), 10.0, False)
+
+
+@pytest.mark.asyncio
+async def test_skips_on_dead_book():
+    """No asks at all (dead or one-sided market) -> skip. The old fallback
+    posted a 'market' order at the stale reference, which on the CLOB is
+    just another resting limit that dies at TTL."""
+    router = _router(_book(0.20, None), base_price=0.22)
+    with pytest.raises(UnmarketableSignal, match="no asks"):
+        await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 10.0, False)
+
+
+@pytest.mark.asyncio
+async def test_takes_price_improvement_when_ask_below_reference():
+    """Ask below the reference price is free improvement -> take it; the
+    negative cross cost ADDS to the realizable edge (4 + 2 = 6 >= 2.5)."""
+    router = _router(_book(0.18, 0.20), base_price=0.22)
+    order = await router.route(_signal(edge=4.0), Market(id="m1", question="Q?"), 10.0, False)
     assert order is not None
     assert order.order_type == OrderType.LIMIT
-    assert order.price == 0.21
-    assert order.post_only is True
+    assert order.price == 0.20
+    assert order.post_only is False
 
 
 @pytest.mark.asyncio
 async def test_high_urgency_prices_at_real_ask():
     """edge > 40 used to submit at the stale reference price, which just
     rested on the book until the TTL reaper killed it. It must price at the
-    actual ask to be marketable."""
+    actual ask to be marketable (cents cap waived above 40% edge)."""
     router = _router(_book(0.40, 0.55), base_price=0.40)
     order = await router.route(_signal(edge=56.8), Market(id="m1", question="Q?"), 10.0, False)
     assert order is not None
-    assert order.order_type == OrderType.MARKET
+    assert order.order_type == OrderType.LIMIT
     assert order.price == 0.55
     assert order.post_only is False
 
 
 @pytest.mark.asyncio
-async def test_high_urgency_capped_by_edge_budget():
-    """Even urgent orders never pay past the price where edge hits the floor."""
+async def test_high_urgency_still_skips_below_floor():
+    """Even urgent orders skip when the ask is past the price where edge
+    hits the floor. The old behavior posted at the budget price (0.60),
+    which rested below the 0.90 ask — unfillable."""
     router = _router(_book(0.10, 0.90), base_price=0.20)
-    order = await router.route(_signal(edge=42.5), Market(id="m1", question="Q?"), 10.0, False)
+    with pytest.raises(UnmarketableSignal, match="edge at the ask"):
+        await router.route(_signal(edge=42.5), Market(id="m1", question="Q?"), 10.0, False)
+
+
+@pytest.mark.asyncio
+async def test_engine_records_unmarketable_skip():
+    """The engine converts UnmarketableSignal into a recorded drop (30-min
+    cooldown in order_build_drops) and places no order — for paper AND live,
+    so paper books can't graduate on fills live could never get."""
+    from auramaur.db.database import Database
+    from auramaur.strategy.engine import TradingEngine
+
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings = MagicMock()
+        settings.is_live = False
+        router = MagicMock()
+        router.route = AsyncMock(
+            side_effect=UnmarketableSignal("edge at the ask 1.80% below minimum 2.26%")
+        )
+        exchange = MagicMock()
+        exchange.place_order = AsyncMock()
+
+        engine = TradingEngine(
+            settings=settings, db=db, discovery=MagicMock(),
+            aggregator=MagicMock(), analyzer=MagicMock(), cache=MagicMock(),
+            risk_manager=MagicMock(), exchange=exchange, router=router,
+        )
+
+        result = await engine._build_and_place_order(
+            _signal(edge=4.0), Market(id="m1", question="Q?"), 5.0
+        )
+
+        assert result is None
+        exchange.place_order.assert_not_awaited()
+        row = await db.fetchone(
+            "SELECT reason, blocked_until FROM order_build_drops WHERE market_id='m1'"
+        )
+        assert row is not None
+        assert "unmarketable" in row["reason"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sell_keeps_passive_path():
+    """SELLs (exits) are not gated — they post one tick inside the book as
+    maker orders. 'No fill' is not an acceptable outcome for an exit."""
+    router = _router(_book(0.40, 0.50), base_price=0.45, side=OrderSide.SELL)
+    order = await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 10.0, False)
     assert order is not None
-    assert order.order_type == OrderType.MARKET
-    # budget = 0.20 + (42.5 - 2.5)/100 = 0.60, well below the 0.90 ask
-    assert order.price == 0.60
+    assert order.order_type == OrderType.LIMIT
+    assert order.price == 0.49  # best_ask - 1 tick
+    assert order.post_only is True


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.