### PR TITLE
[codex] Clean up test suite warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def pytest_sessionfinish(session, exitstatus):
     except ImportError:  # pragma: no cover
         return
     for obj in gc.get_objects():
-        if isinstance(obj, aiosqlite.Connection):
+        if type(obj) is aiosqlite.Connection:
             try:
                 obj._running = False
             except Exception:  # pragma: no cover

--- a/tests/test_claude_retry.py
+++ b/tests/test_claude_retry.py
@@ -26,38 +26,32 @@ def analyzer(settings):
 @pytest.mark.asyncio
 async def test_retry_on_timeout(analyzer):
     """Subprocess times out twice, then succeeds on third attempt."""
-    call_count = 0
-
-    async def mock_communicate():
-        nonlocal call_count
-        call_count += 1
-        if call_count <= 2:
-            raise asyncio.TimeoutError("timed out")
-        return (b'{"probability": 0.7, "confidence": "HIGH", "reasoning": "ok"}', b"")
-
     mock_proc = AsyncMock()
-    mock_proc.communicate = mock_communicate
+    mock_proc.communicate = AsyncMock(side_effect=[
+        asyncio.TimeoutError("timed out"),
+        asyncio.TimeoutError("timed out"),
+        (b'{"probability": 0.7, "confidence": "HIGH", "reasoning": "ok"}', b""),
+    ])
     mock_proc.returncode = 0
 
     with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
-         patch("asyncio.wait_for", side_effect=[
-             asyncio.TimeoutError("timed out"),
-             asyncio.TimeoutError("timed out"),
-             (b'{"probability": 0.7, "confidence": "HIGH", "reasoning": "ok"}', b""),
-         ]), \
          patch("asyncio.sleep", new_callable=AsyncMock):
         result = await analyzer._call_claude_cli("test prompt")
         assert "probability" in result
+        assert mock_proc.communicate.await_count == 3
 
 
 @pytest.mark.asyncio
 async def test_retry_exhausted_raises(analyzer):
     """All 3 attempts fail — should raise."""
-    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec, \
-         patch("asyncio.wait_for", side_effect=asyncio.TimeoutError("timed out")), \
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError("timed out"))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
          patch("asyncio.sleep", new_callable=AsyncMock):
         with pytest.raises((asyncio.TimeoutError, TimeoutError)):
             await analyzer._call_claude_cli("test prompt")
+        assert mock_proc.communicate.await_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_kraken_llm_signal.py
+++ b/tests/test_kraken_llm_signal.py
@@ -98,9 +98,11 @@ def test_llm_view_unknown_pair_returns_none():
 
 
 def test_llm_view_skipped_analysis_returns_none():
-    agg = MagicMock(); agg.gather = AsyncMock(return_value=[])
+    agg = MagicMock()
+    agg.gather = AsyncMock(return_value=[])
     analysis = SimpleNamespace(probability=0.5, confidence="LOW", skipped_reason="thin evidence")
-    analyzer = MagicMock(); analyzer.analyze = AsyncMock(return_value=analysis)
+    analyzer = MagicMock()
+    analyzer.analyze = AsyncMock(return_value=analysis)
     bot = SimpleNamespace(_components={
         "aggregator": agg, "analyzer": analyzer, "cache": None, "calibration": None,
     })
@@ -115,7 +117,7 @@ def test_llm_view_skipped_analysis_returns_none():
 if __name__ == "__main__":
     test_conf_floor()
     test_llm_exit_reason()
-    test_llm_view_records_and_throttles()
+    test_llm_view_returns_and_throttles()
     test_llm_view_unknown_pair_returns_none()
     test_llm_view_skipped_analysis_returns_none()
     print("ok")


### PR DESCRIPTION
## Summary

This PR tightens a few test-suite edges found during a quick repo health pass.

- Fixes the Claude retry tests so the mocked subprocess `communicate()` coroutine is actually awaited while still exercising retry behavior.
- Fixes a stale direct-run call in `tests/test_kraken_llm_signal.py` after the test was renamed.
- Narrows the `aiosqlite` cleanup hook to exact leaked connection objects, avoiding teardown warnings from unrelated objects during GC inspection.

## Impact

The test suite now runs cleanly without runtime/deprecation warnings from these paths, and the retry tests assert that all expected attempts occurred.

## Validation

- `.venv/bin/python -m pytest -q` -> `659 passed`
- `.venv/bin/python -m ruff check tests/conftest.py tests/test_claude_retry.py tests/test_kraken_llm_signal.py` -> passed
- `.venv/bin/python -m ruff check . --select F821` -> passed