### PR TITLE
feat(ops): build-staleness guard — announce running SHA, warn when checkout moves past the process

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2682,6 +2682,25 @@ class AuramaurBot:
             if equity is not None:
                 await equity.close()
 
+    async def _task_build_guard(self) -> None:
+        """Warn when the on-disk checkout moves past the running process.
+
+        The 2026-06 category leak traded for a day on pre-fix code because
+        the merged fix sat on disk while the long-lived process kept running
+        the old build. Checks every 5 minutes; the guard rate-limits its own
+        alerts (hourly per the quiet-feed rules).
+        """
+        from auramaur.monitoring.build_info import BuildStalenessGuard
+        guard = BuildStalenessGuard(
+            alert=lambda msg: console.print(f"[bold red]⚠ STALE BUILD: {msg}[/]")
+        )
+        while self._running:
+            try:
+                guard.check()
+            except Exception as e:
+                log.debug("build_guard.error", error=str(e))
+            await asyncio.sleep(300)
+
     async def _task_order_monitor(self) -> None:
         """Monitor pending limit orders for fills and expiry."""
         from datetime import datetime, timezone
@@ -3018,6 +3037,14 @@ class AuramaurBot:
         mode = "LIVE" if self.settings.is_live else "PAPER"
         show_banner(mode, "0.1.0")
 
+        # Announce which build this process runs. The 2026-06 category leak
+        # traded for a day on pre-fix code because nothing said the running
+        # process was older than the checkout.
+        from auramaur.monitoring.build_info import STARTUP_SHA
+        if STARTUP_SHA:
+            console.print(f"  [dim]Build: {STARTUP_SHA}[/]")
+            log.info("bot.build", sha=STARTUP_SHA, mode=mode)
+
         await self._init_components()
         self._running = True
 
@@ -3143,6 +3170,11 @@ class AuramaurBot:
         )
         self._watchdog.beat()
         self._watchdog.start()
+
+        # Build-staleness guard: warns when the checkout on disk moves past
+        # the running process (merged fix, no restart — the 2026-06 leak).
+        tasks.append(asyncio.create_task(
+            self._task_build_guard(), name="build_guard"))
 
         # Redemption check — only meaningful with a Polymarket proxy wallet
         if self.settings.polymarket_proxy_address:

--- a/auramaur/monitoring/build_info.py
+++ b/auramaur/monitoring/build_info.py
@@ -1,0 +1,126 @@
+"""Which build is this process actually running?
+
+The 2026-06 category leak kept trading for a full day after the fix merged
+(#93, 2026-06-10) because the long-lived bot process was never restarted —
+the code on disk and the code in memory diverged silently. This module reads
+the git HEAD once at import time (≈ process start) and again on demand, so
+the bot can announce its build at startup and a periodic guard can warn when
+the on-disk tree has moved past the running process.
+
+Pure file reads, no git subprocess: it must be cheap and safe to call from a
+periodic tick, and must never take the bot down — every failure path returns
+"" and the guard treats that as "unknown, stay quiet".
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+_SHA_LEN = 12
+
+
+def _repo_root(start: Path | None = None) -> Path | None:
+    """Walk up from this file (or *start*) to the directory holding .git."""
+    p = (start or Path(__file__)).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def read_git_head(root: Path | None = None) -> str:
+    """Return the short SHA the checkout currently points at, '' if unknown.
+
+    Handles plain checkouts, detached HEAD, packed refs, and linked
+    worktrees (where .git is a *file* pointing at the real gitdir and refs
+    live in the shared common dir).
+    """
+    try:
+        repo = root or _repo_root()
+        if repo is None:
+            return ""
+        git = repo / ".git"
+        if git.is_file():  # linked worktree: "gitdir: /path/.git/worktrees/x"
+            target = git.read_text().strip().partition(":")[2].strip()
+            if not target:
+                return ""
+            git = (repo / target).resolve() if not Path(target).is_absolute() \
+                else Path(target)
+        common = git
+        commondir = git / "commondir"
+        if commondir.exists():  # worktree gitdir: refs live in the common dir
+            common = (git / commondir.read_text().strip()).resolve()
+
+        head = (git / "HEAD").read_text().strip()
+        if not head.startswith("ref: "):
+            return head[:_SHA_LEN]  # detached HEAD: literal SHA
+        ref = head[5:].strip()
+        ref_path = common / ref
+        if ref_path.exists():
+            return ref_path.read_text().strip()[:_SHA_LEN]
+        packed = common / "packed-refs"
+        if packed.exists():
+            for line in packed.read_text().splitlines():
+                line = line.strip()
+                if line.endswith(f" {ref}"):
+                    return line.split(" ", 1)[0][:_SHA_LEN]
+        return ""
+    except OSError:
+        return ""
+
+
+# Captured when the process first imports this module — i.e. the build the
+# running interpreter actually loaded, regardless of what lands on disk later.
+STARTUP_SHA: str = read_git_head()
+
+
+class BuildStalenessGuard:
+    """Warns when the on-disk checkout has moved past the running process.
+
+    ``check()`` is called from a periodic bot task. It compares the SHA
+    captured at process start with the current on-disk HEAD; on mismatch it
+    alerts (loudly, but rate-limited to once per ``realert_seconds`` per the
+    quiet-feed rules) and logs a structured warning. Returns True when stale
+    so callers/tests can branch on it.
+    """
+
+    def __init__(self, alert=None, realert_seconds: float = 3600.0,
+                 startup_sha: str | None = None,
+                 read_head=read_git_head,
+                 clock=time.monotonic):
+        self._alert = alert or (lambda msg: None)
+        self._realert_seconds = realert_seconds
+        self._startup_sha = (STARTUP_SHA if startup_sha is None
+                             else startup_sha)
+        self._read_head = read_head
+        self._clock = clock
+        self._last_alert_at: float | None = None
+        self._last_alerted_sha = ""
+
+    def check(self) -> bool:
+        disk_sha = self._read_head()
+        if not self._startup_sha or not disk_sha:
+            return False  # unknown build (no .git, packaged install): stay quiet
+        if disk_sha == self._startup_sha:
+            self._last_alert_at = None
+            self._last_alerted_sha = ""
+            return False
+        now = self._clock()
+        due = (self._last_alert_at is None
+               or disk_sha != self._last_alerted_sha
+               or now - self._last_alert_at >= self._realert_seconds)
+        if due:
+            msg = (f"running build {self._startup_sha} but the checkout is "
+                   f"now at {disk_sha} — restart the bot to pick up merged "
+                   f"fixes")
+            self._alert(msg)
+            log.warning("bot.stale_build", running=self._startup_sha,
+                        on_disk=disk_sha)
+            self._last_alert_at = now
+            self._last_alerted_sha = disk_sha
+        return True

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,0 +1,136 @@
+"""Tests for the build-staleness guard (process build vs on-disk checkout).
+
+Regression context: the 2026-06 category leak traded for a day on pre-fix
+code because the merged fix sat on disk while the long-lived bot process
+kept running the old build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from auramaur.monitoring.build_info import (
+    BuildStalenessGuard, read_git_head,
+)
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def _make_repo(tmp_path: Path, sha: str = SHA_A, *, packed: bool = False,
+               detached: bool = False) -> Path:
+    git = tmp_path / ".git"
+    (git / "refs" / "heads").mkdir(parents=True)
+    if detached:
+        (git / "HEAD").write_text(f"{sha}\n")
+    else:
+        (git / "HEAD").write_text("ref: refs/heads/main\n")
+        if packed:
+            (git / "packed-refs").write_text(
+                "# pack-refs with: peeled fully-peeled sorted\n"
+                f"{sha} refs/heads/main\n")
+        else:
+            (git / "refs" / "heads" / "main").write_text(f"{sha}\n")
+    return tmp_path
+
+
+def test_read_git_head_ref(tmp_path):
+    assert read_git_head(_make_repo(tmp_path)) == SHA_A[:12]
+
+
+def test_read_git_head_packed_refs(tmp_path):
+    assert read_git_head(_make_repo(tmp_path, packed=True)) == SHA_A[:12]
+
+
+def test_read_git_head_detached(tmp_path):
+    assert read_git_head(_make_repo(tmp_path, detached=True)) == SHA_A[:12]
+
+
+def test_read_git_head_linked_worktree(tmp_path):
+    """In a linked worktree .git is a FILE pointing at the real gitdir, and
+    refs live in the shared common dir."""
+    main = _make_repo(tmp_path / "main")
+    wt_gitdir = tmp_path / "main" / ".git" / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/main\n")
+    (wt_gitdir / "commondir").write_text("../..\n")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".git").write_text(f"gitdir: {wt_gitdir}\n")
+    assert read_git_head(wt) == SHA_A[:12]
+
+
+def test_read_git_head_no_repo(tmp_path):
+    assert read_git_head(tmp_path) == ""
+
+
+def test_guard_quiet_when_build_matches():
+    alerts: list[str] = []
+    guard = BuildStalenessGuard(alert=alerts.append, startup_sha=SHA_A[:12],
+                                read_head=lambda: SHA_A[:12])
+    assert guard.check() is False
+    assert alerts == []
+
+
+def test_guard_alerts_on_mismatch_and_rate_limits():
+    alerts: list[str] = []
+    now = [0.0]
+    guard = BuildStalenessGuard(alert=alerts.append, startup_sha=SHA_A[:12],
+                                read_head=lambda: SHA_B[:12],
+                                realert_seconds=3600.0,
+                                clock=lambda: now[0])
+    assert guard.check() is True
+    assert len(alerts) == 1
+    assert SHA_A[:12] in alerts[0] and SHA_B[:12] in alerts[0]
+
+    # Repeated checks within the window stay quiet (still stale though).
+    now[0] = 300.0
+    assert guard.check() is True
+    assert len(alerts) == 1
+
+    # After the re-alert window it speaks again.
+    now[0] = 3601.0
+    assert guard.check() is True
+    assert len(alerts) == 2
+
+
+def test_guard_realerts_immediately_on_new_sha():
+    """A SECOND merge while already stale is new information — no rate limit."""
+    alerts: list[str] = []
+    disk = [SHA_B[:12]]
+    guard = BuildStalenessGuard(alert=alerts.append, startup_sha=SHA_A[:12],
+                                read_head=lambda: disk[0],
+                                realert_seconds=3600.0,
+                                clock=lambda: 0.0)
+    assert guard.check() is True
+    disk[0] = "c" * 12
+    assert guard.check() is True
+    assert len(alerts) == 2
+
+
+def test_guard_quiet_when_build_unknown():
+    """No .git (packaged install) → unknown build → never alert."""
+    alerts: list[str] = []
+    guard = BuildStalenessGuard(alert=alerts.append, startup_sha="",
+                                read_head=lambda: SHA_B[:12])
+    assert guard.check() is False
+    guard2 = BuildStalenessGuard(alert=alerts.append, startup_sha=SHA_A[:12],
+                                 read_head=lambda: "")
+    assert guard2.check() is False
+    assert alerts == []
+
+
+def test_guard_resets_after_restart_catchup():
+    """If disk returns to the running SHA (e.g. revert), the alarm clears."""
+    alerts: list[str] = []
+    disk = [SHA_B[:12]]
+    guard = BuildStalenessGuard(alert=alerts.append, startup_sha=SHA_A[:12],
+                                read_head=lambda: disk[0],
+                                clock=lambda: 0.0)
+    assert guard.check() is True
+    disk[0] = SHA_A[:12]
+    assert guard.check() is False
+    # Going stale again re-alerts immediately (state was reset).
+    disk[0] = SHA_B[:12]
+    assert guard.check() is True
+    assert len(alerts) == 2


### PR DESCRIPTION
## Why

The 2026-06 category leak kept trading for a full day **after** the gateway fix merged (#93): the fix sat on disk while the long-lived bot process kept running pre-fix code. Nothing said the running process was older than the checkout. This is the second time a needed-restart went unnoticed (#104/#105 also required one).

## What

- `auramaur/monitoring/build_info.py` — `read_git_head()` resolves the checkout's short SHA via pure file reads (no git subprocess; handles detached HEAD, packed refs, linked worktrees). `STARTUP_SHA` is captured at import = the build the interpreter actually loaded.
- Startup banner now prints `Build: <sha>` and logs `bot.build`.
- New `build_guard` bot task (5-min tick): `BuildStalenessGuard` compares the startup SHA with on-disk HEAD and alerts `⚠ STALE BUILD: running <a> but the checkout is now at <b> — restart the bot to pick up merged fixes`. Rate-limited to hourly (quiet-feed), immediate re-alert if the disk SHA changes again, silent when the build is unknown (packaged install), clears if disk returns to the running SHA.

## Verification

10 new tests cover HEAD resolution (ref/packed/detached/worktree/none) and guard behavior (match, mismatch + rate limit, new-SHA re-alert, unknown build, reset). Full suite: 669 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)