### PR TITLE
fix(settlement): settled-but-unredeemed legs must not resurrect or re-settle

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -261,6 +261,44 @@ class PositionSyncer:
     # Reconciliation
     # ------------------------------------------------------------------
 
+    async def _settled_keys(self, is_paper_flag: int) -> set[tuple[str, str]]:
+        """(market_id, token) pairs whose settlement is already in the ledger.
+
+        A settled-but-unredeemed position still sits in the wallet, so every
+        sync resurrected it into portfolio at a $0 mark — a phantom -100%
+        "unrealized" loss on a leg whose P&L is already realized (and, once
+        the venue sweep re-settled the zombie, daily_stats/cost_basis would
+        double-count). Settled keys stay out of portfolio; redeem-check
+        tracks the wallet side until on-chain redemption empties it.
+        """
+        try:
+            rows = await self._db.fetchall(
+                "SELECT source_ref FROM pnl_ledger WHERE kind = 'settlement'")
+        except Exception:
+            return set()
+        keys: set[tuple[str, str]] = set()
+        suffix = f":{is_paper_flag}"
+        for r in rows or []:
+            ref = r["source_ref"] or ""
+            # source_ref format: settle:{market_id}:{token}:{is_paper}
+            if ref.startswith("settle:") and ref.endswith(suffix):
+                parts = ref.split(":")
+                if len(parts) == 4:
+                    keys.add((parts[1], parts[2]))
+        return keys
+
+    def _drop_settled(self, positions: list[LivePosition],
+                      settled: set[tuple[str, str]]) -> list[LivePosition]:
+        kept = []
+        for pos in positions:
+            token = pos.token.value if pos.token else "YES"
+            if (pos.market_id, token) in settled:
+                log.debug("sync.skip_settled", market_id=pos.market_id,
+                          token=token)
+                continue
+            kept.append(pos)
+        return kept
+
     async def _merge_new_positions(self, positions: list[LivePosition]) -> None:
         """Add newly discovered positions to the portfolio table.
 
@@ -270,6 +308,8 @@ class PositionSyncer:
         """
         now = datetime.now(timezone.utc).isoformat()
         is_paper_flag = 0 if self._settings.is_live else 1
+        positions = self._drop_settled(
+            positions, await self._settled_keys(is_paper_flag))
         for pos in positions:
             side = OrderSide.BUY.value
             token = pos.token.value if pos.token else "YES"
@@ -317,6 +357,15 @@ class PositionSyncer:
 
         now = datetime.now(timezone.utc).isoformat()
         is_paper_flag = 0 if self._settings.is_live else 1
+
+        # Settled-but-unredeemed legs must not resurrect: dropping them from
+        # the incoming list ALSO routes their existing portfolio rows into
+        # the stale-delete below, so zombies get purged on the next sync.
+        positions = self._drop_settled(
+            positions, await self._settled_keys(is_paper_flag))
+        if not positions:
+            log.debug("sync.reconcile.skip_all_settled")
+            return
 
         # Scope reconciliation to Polymarket rows in the CURRENT mode only.
         # Mixing modes would let a live sync (which returns empty when the

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -139,7 +139,9 @@ class ResolutionTracker:
                 settled = await self.settle_via_venue(self._proxy_address)
                 resolved_count += len(settled)
             except Exception as e:
-                log.debug("resolution.venue_sweep_error", error=str(e))
+                # Warning, not debug: a silently-failing sweep looks identical
+                # to "nothing to settle" and the stuck positions never clear.
+                log.warning("resolution.venue_sweep_error", error=str(e))
 
         if resolved_count > 0:
             log.info("resolution.cycle_complete", newly_resolved=resolved_count)
@@ -182,6 +184,15 @@ class ResolutionTracker:
         for vp in venue_positions:
             row = by_token_id.get(vp.asset_id)
             if row is None:
+                continue
+            # Already settled in a prior pass (the wallet still holds the
+            # tokens until redemption, so the syncer can resurrect the row).
+            # Only the ledger insert is idempotent — re-running settlement
+            # would re-add the P&L to daily_stats and cost_basis.
+            held_token = row["token"] or "YES"
+            ref = f"settle:{row['market_id']}:{held_token}:0"
+            if await self._db.fetchone(
+                    "SELECT 1 FROM pnl_ledger WHERE source_ref = ?", (ref,)):
                 continue
             # cur_price/is_winner are relative to OUR held side; map back to
             # the market-level YES outcome the settlement path expects.

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -400,3 +400,32 @@ async def test_venue_sweep_ignores_unmatched_and_no_proxy(monkeypatch):
 
     assert await tracker.settle_via_venue("0xproxy") == []
     assert await tracker.settle_via_venue("") == []
+
+
+@pytest.mark.asyncio
+async def test_venue_sweep_skips_already_settled_token(monkeypatch):
+    """A settled-but-unredeemed leg resurrected by the syncer must NOT
+    settle twice — only the ledger insert is idempotent; daily_stats and
+    cost_basis would double-count."""
+    row = {"market_id": "m1", "token": "NO", "token_id": "tok-no-1",
+           "size": 20.0, "avg_price": 0.62, "side": "BUY", "is_paper": 0}
+    db = _make_sweep_db([row])
+
+    async def _fetchone(sql, params=None):
+        if "pnl_ledger" in sql:
+            assert params == ("settle:m1:NO:0",)
+            return {"1": 1}  # settlement already recorded
+        return row
+    db.fetchone = AsyncMock(side_effect=_fetchone)
+
+    tracker = ResolutionTracker(db=db, calibration=None, discoveries={},
+                                proxy_address="0xproxy")
+
+    async def _fake_fetch(proxy, **kw):
+        return [_make_venue_position("tok-no-1", is_winner=True)]
+    monkeypatch.setattr("auramaur.broker.redeemer.fetch_redeemable_positions",
+                        _fake_fetch)
+
+    assert await tracker.settle_via_venue("0xproxy") == []
+    executed_sql = " ".join(str(c.args[0]) for c in db.execute.call_args_list)
+    assert "DELETE FROM portfolio" not in executed_sql

--- a/tests/test_sync_settled_skip.py
+++ b/tests/test_sync_settled_skip.py
@@ -1,0 +1,62 @@
+"""The syncer must not resurrect settled-but-unredeemed positions.
+
+Settled legs stay in the on-chain wallet until redemption, so every sync
+re-created their portfolio rows at a $0 mark — phantom -100% unrealized on
+P&L that is already realized in the ledger.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.broker.sync import PositionSyncer
+from auramaur.exchange.models import LivePosition, TokenType
+
+
+def _bare_syncer(ledger_refs: list[str]) -> PositionSyncer:
+    s = PositionSyncer.__new__(PositionSyncer)
+    db = AsyncMock()
+    db.fetchall = AsyncMock(
+        return_value=[{"source_ref": r} for r in ledger_refs])
+    s._db = db
+    return s
+
+
+def _pos(market_id: str, token: TokenType = TokenType.NO) -> LivePosition:
+    return LivePosition(market_id=market_id, token_id="t", token=token,
+                        size=10.0, avg_cost=0.5, current_price=0.0)
+
+
+@pytest.mark.asyncio
+async def test_settled_keys_parses_ledger_refs():
+    s = _bare_syncer([
+        "settle:m1:NO:0",         # live settlement -> filtered
+        "settle:m2:YES:1",        # paper settlement -> ignored for live
+        "exit:m3:YES:0",          # not a settlement ref format
+    ])
+    assert await s._settled_keys(0) == {("m1", "NO")}
+    assert await s._settled_keys(1) == {("m2", "YES")}
+
+
+@pytest.mark.asyncio
+async def test_drop_settled_filters_only_settled_leg():
+    s = _bare_syncer(["settle:m1:NO:0"])
+    settled = await s._settled_keys(0)
+    kept = s._drop_settled(
+        [_pos("m1", TokenType.NO),   # settled -> dropped
+         _pos("m1", TokenType.YES),  # other leg of same market -> kept
+         _pos("m2", TokenType.NO)],  # different market -> kept
+        settled)
+    assert [(p.market_id, p.token) for p in kept] == [
+        ("m1", TokenType.YES), ("m2", TokenType.NO)]
+
+
+@pytest.mark.asyncio
+async def test_settled_keys_survives_db_error():
+    s = PositionSyncer.__new__(PositionSyncer)
+    db = AsyncMock()
+    db.fetchall = AsyncMock(side_effect=RuntimeError("no table"))
+    s._db = db
+    assert await s._settled_keys(0) == set()


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.