### PR TITLE
fix(risk): exempt books (MM + arb) respect the category blocklist and live allowlist

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -361,6 +361,12 @@ class AuramaurBot:
             analyzer=analyzer,
             exchange_fees=s.arbitrage.exchange_fees,
             min_profit_after_fees_pct=s.arbitrage.min_profit_after_fees_pct,
+            # An arb is hedged only when BOTH legs fill — a single-leg fill
+            # is directional inventory in a banned market (caught quoting
+            # KBO baseball live 2026-06-12). Same gates as the MM.
+            blocked_categories=s.risk.blocked_categories,
+            allowed_categories_live=(s.risk.allowed_categories_live
+                                     if s.is_live else None),
         )
 
         # News reactor — monitors RSS for breaking news, triggers fast analysis

--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -137,6 +137,8 @@ class ArbitrageScanner:
         analyzer: Any = None,
         exchange_fees: dict[str, float] | None = None,
         min_profit_after_fees_pct: float = 1.5,
+        blocked_categories: list[str] | None = None,
+        allowed_categories_live: list[str] | None = None,
     ) -> None:
         """Initialize with the discoveries dict from bot components.
 
@@ -148,11 +150,34 @@ class ArbitrageScanner:
                           e.g. {"polymarket": 0.0, "kalshi": 0.07}
             min_profit_after_fees_pct: Minimum profit % after fees to flag
                                        as an opportunity.
+            blocked_categories: categories never scanned (an arb is hedged
+                only when BOTH legs fill — a single-leg fill is directional
+                inventory in a banned market; observed live 2026-06-12
+                quoting KBO baseball).
+            allowed_categories_live: when set (live mode), only these
+                categories are scanned — same fail-closed policy as the
+                directional books. None disables the allowlist (paper).
         """
         self._discoveries = discoveries
         self._analyzer = analyzer
         self._exchange_fees = exchange_fees or {}
         self._min_profit_after_fees_pct = min_profit_after_fees_pct
+        self._blocked_categories = set(blocked_categories or [])
+        self._allowed_categories_live = (
+            set(allowed_categories_live) if allowed_categories_live is not None
+            else None)
+
+    def _category_ok(self, market: Market) -> bool:
+        """Category gate for scan candidates (stored label or fresh classify)."""
+        from auramaur.strategy.classifier import ensure_category
+        category = ensure_category(
+            market.question, market.description, market.category)
+        if category in self._blocked_categories:
+            return False
+        if (self._allowed_categories_live is not None
+                and category not in self._allowed_categories_live):
+            return False
+        return True
 
     async def scan(self) -> list[ArbOpportunity]:
         """Scan all exchanges for price mismatches on equivalent markets.
@@ -408,6 +433,7 @@ class ArbitrageScanner:
         if markets is None:
             try:
                 markets = await discovery.get_markets(active=True, limit=100)
+                markets = [m for m in markets if self._category_ok(m)]
             except Exception as e:
                 log.error("arb_scanner.internal_fetch_error", error=str(e))
                 return []
@@ -543,6 +569,7 @@ class ArbitrageScanner:
         async def _fetch_one(name: str, discovery: MarketDiscovery) -> tuple[str, list[Market]]:
             try:
                 markets = await discovery.get_markets(active=True, limit=100)
+                markets = [m for m in markets if self._category_ok(m)]
                 log.debug("arb_scanner.fetched", exchange=name, count=len(markets))
                 return (name, markets)
             except Exception as e:

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -181,7 +181,29 @@ class MarketMaker:
         suitable: list[Market] = []
         now = datetime.now(timezone.utc)
 
+        risk = self._settings.risk
+        blocked = set(risk.blocked_categories)
+        allowed_live = (set(risk.allowed_categories_live)
+                        if self._settings.is_live else None)
+
         for market in markets:
+            # Category gate. The MM is graduation-exempt and places orders
+            # outside the risk gateway, so until 2026-06-12 it was the last
+            # path with NO category policy at all — it filled $6.30 of a
+            # tennis match live (Stuttgart Open) hours after the allowlist
+            # shipped. "Structural two-sided" only holds while quotes stay
+            # flat; a one-sided fill IS directional inventory, so the MM
+            # respects the same blocklist (always) and live allowlist as
+            # every directional book. Classify on the spot when the
+            # discovery payload carries no category.
+            from auramaur.strategy.classifier import ensure_category
+            category = ensure_category(
+                market.question, market.description, market.category)
+            if category in blocked:
+                continue
+            if allowed_live is not None and category not in allowed_live:
+                continue
+
             # Must have both token IDs for two-sided quoting
             if not market.clob_token_yes or not market.clob_token_no:
                 continue

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -116,3 +116,34 @@ class TestArbitrageExecutor:
 
         pairs = run(executor.generate_arb_signals(), event_loop)
         assert len(pairs) == 0
+
+
+# --- Category gate (2026-06-12): exempt books still respect category bans ---
+
+def test_arb_category_gate_filters_blocked_and_non_allowlisted():
+    """The arb scanner was caught quoting KBO baseball live — an arb is
+    hedged only when both legs fill; a single-leg fill is directional sports
+    inventory. Blocked categories are never scanned; with the live allowlist
+    set, unknown/'other' markets are skipped too."""
+    from auramaur.exchange.models import Market
+    from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
+
+    def _mkt(mid, question, category=""):
+        return Market(id=mid, question=question, category=category)
+
+    kbo = _mkt("kbo", "KBO: SSG Landers vs. Samsung Lions")
+    labeled = _mkt("lab", "Will this happen?", category="sports")
+    unknown = _mkt("unk", "Will the gadget ship this quarter?")
+    crypto = _mkt("cry", "Will Bitcoin reach $200k?", category="crypto")
+
+    live = ArbitrageScanner(
+        discoveries={}, blocked_categories=["sports", "politics_us"],
+        allowed_categories_live=["crypto", "tech", "politics_intl"])
+    assert [m.id for m in [kbo, labeled, unknown, crypto]
+            if live._category_ok(m)] == ["cry"]
+
+    paper = ArbitrageScanner(
+        discoveries={}, blocked_categories=["sports", "politics_us"],
+        allowed_categories_live=None)
+    assert [m.id for m in [kbo, labeled, unknown, crypto]
+            if paper._category_ok(m)] == ["unk", "cry"]

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -8,9 +8,11 @@ from auramaur.exchange.models import Market, OrderBook, OrderBookLevel
 from auramaur.strategy.market_maker import MarketMaker
 
 
-def _maker(*, quote_size=10.0, max_inventory=50.0) -> MarketMaker:
+def _maker(*, quote_size=10.0, max_inventory=50.0, is_live=False,
+           blocked_categories=("sports", "politics_us"),
+           allowed_categories_live=("crypto", "tech", "politics_intl")) -> MarketMaker:
     settings = SimpleNamespace(
-        is_live=False,
+        is_live=is_live,
         market_maker=SimpleNamespace(
             min_spread_bps=40,
             max_spread_bps=1500,
@@ -18,6 +20,10 @@ def _maker(*, quote_size=10.0, max_inventory=50.0) -> MarketMaker:
             max_inventory=max_inventory,
             max_markets=5,
             refresh_seconds=30,
+        ),
+        risk=SimpleNamespace(
+            blocked_categories=list(blocked_categories),
+            allowed_categories_live=list(allowed_categories_live),
         ),
     )
     return MarketMaker(settings=settings, exchange=SimpleNamespace(), db=SimpleNamespace())
@@ -186,3 +192,50 @@ async def test_requote_cancels_previous_legs_before_replacing():
     # The first quote's two legs were cancelled before the new pair posted.
     assert cancelled == first_legs
     assert len(placed) == 4
+
+
+def test_select_rejects_blocked_category_markets():
+    """Regression (2026-06-12): the MM filled $6.30 of a tennis match live
+    ('Stuttgart Open: X vs Y') — it was the last order path with no category
+    policy. Blocked categories must never be quoted, whether the label is
+    stored or only derivable by classification."""
+    mm = _maker()
+
+    def _mkt(mid, question, category=""):
+        return Market(
+            id=mid, question=question, category=category,
+            clob_token_yes="yes", clob_token_no="no",
+            liquidity=10000, spread=0.05,
+        )
+
+    tennis = _mkt("tennis",
+                  "Stuttgart Open: Giovanni Mpetshi Perricard vs Alexander Bublik")
+    labeled = _mkt("labeled", "Will this happen?", category="sports")
+    fine = _mkt("fine", "Will Bitcoin reach $200k?", category="crypto")
+
+    ids = [m.id for m in mm._select_mm_markets([tennis, labeled, fine])]
+    assert ids == ["fine"]
+
+
+def test_select_live_mode_requires_allowlist():
+    """In live mode the MM only quotes allowlisted categories — unknown/
+    'other' markets are paper-only, same policy as the directional books."""
+    mm = _maker(is_live=True)
+
+    def _mkt(mid, question, category=""):
+        return Market(
+            id=mid, question=question, category=category,
+            clob_token_yes="yes", clob_token_no="no",
+            liquidity=10000, spread=0.05,
+        )
+
+    unknown = _mkt("unknown", "Will the gadget ship this quarter?")
+    allowed = _mkt("allowed", "Will Ethereum flip Bitcoin?", category="crypto")
+
+    ids = [m.id for m in mm._select_mm_markets([unknown, allowed])]
+    assert ids == ["allowed"]
+
+    # Paper mode keeps exploring unknown categories.
+    mm_paper = _maker(is_live=False)
+    ids_paper = [m.id for m in mm_paper._select_mm_markets([unknown, allowed])]
+    assert set(ids_paper) == {"unknown", "allowed"}


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.