### PR TITLE
fix(kalshi): settlements finally reach the ledger — venue-feed sweep + backfill CLI

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -3017,6 +3017,29 @@ class AuramaurBot:
                 return
             try:
                 resolved = await tracker.check_resolutions()
+
+                # Kalshi settlements sweep: the venue's settlements feed is
+                # the only reliable booking source there — the syncer drops
+                # settled positions from `portfolio` before the Gamma-style
+                # detection path can see them, which is how Kalshi realized
+                # P&L went entirely unrecorded until 2026-06-12.
+                kalshi = (self._components.get("exchanges") or {}).get("kalshi")
+                if kalshi is not None:
+                    try:
+                        from auramaur.broker.kalshi_settlements import (
+                            sweep_kalshi_settlements,
+                        )
+                        booked = await sweep_kalshi_settlements(
+                            self._components["db"], kalshi)
+                        booked_ok = [b for b in booked if b.get("booked")]
+                        if booked_ok:
+                            resolved += len(booked_ok)
+                            log.info("kalshi_settlements.swept",
+                                     booked=len(booked_ok))
+                    except Exception as e:
+                        log.warning("kalshi_settlements.sweep_error",
+                                    error=str(e))
+
                 if resolved > 0:
                     from datetime import datetime, timezone
                     now_str = datetime.now(timezone.utc).strftime("%H:%M:%S")

--- a/auramaur/broker/kalshi_settlements.py
+++ b/auramaur/broker/kalshi_settlements.py
@@ -1,0 +1,160 @@
+"""Kalshi settlements sweep — book venue-reported settlements into the ledger.
+
+Kalshi realized P&L was NEVER recorded (discovered 2026-06-12): the
+resolution tracker keyed off ``market.status``, a field no Market object
+carried, and the position syncer reconciled settled positions out of the
+``portfolio`` table before any P&L could be booked. Wins and losses simply
+evaporated into the cash balance, unmeasured — which made the "is Kalshi
+worth its fees?" question unanswerable.
+
+The venue's ``GET /portfolio/settlements`` feed is authoritative and
+complete, so one idempotent sweep serves as both the LIVE booking path
+(runs every resolution cycle; new settlements get ledger rows) and the
+HISTORICAL backfill (the first run walks the full feed). The ledger's
+``source_ref`` uniqueness (``kalshi-settle:{ticker}:{settled_time}``) makes
+re-runs no-ops.
+
+Cost basis comes from our own records (cost_basis, falling back to filled
+trades); a settlement whose cost we never recorded is reported but NOT
+booked — a fabricated cost would poison the venue scorecard this sweep
+exists to build. daily_stats is intentionally not touched: backfilled
+settlements belong to their own (past) days, and pnl_ledger carries
+``realized_at`` for that.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from auramaur.broker.ledger import record_ledger_event
+from auramaur.db.database import Database
+
+log = structlog.get_logger()
+
+_MAX_PAGES = 25  # 200/page → up to 5000 settlements; far beyond current history
+
+
+async def sweep_kalshi_settlements(
+    db: Database, kalshi_client, *, dry_run: bool = False,
+    max_pages: int = _MAX_PAGES,
+) -> list[dict]:
+    """Book venue-reported Kalshi settlements missing from the ledger.
+
+    Returns the bookings performed (or planned, when ``dry_run``); entries
+    whose cost basis is unknown carry ``"booked": False`` and a reason.
+    """
+    settlements = await _fetch_all_settlements(kalshi_client, max_pages)
+    if not settlements:
+        return []
+
+    results: list[dict] = []
+    for st in settlements:
+        ticker = getattr(st, "ticker", "") or ""
+        settled_time = getattr(st, "settled_time", None)
+        result = (getattr(st, "result", "") or "").lower()
+        revenue_cents = getattr(st, "revenue", 0) or 0
+        yes_count = float(getattr(st, "yes_count", 0) or 0)
+        no_count = float(getattr(st, "no_count", 0) or 0)
+        if not ticker or settled_time is None:
+            continue
+
+        settled_iso = settled_time.isoformat()
+        source_ref = f"kalshi-settle:{ticker}:{settled_iso}"
+        if await db.fetchone(
+                "SELECT 1 FROM pnl_ledger WHERE source_ref = ?", (source_ref,)):
+            continue  # already booked (idempotent re-runs)
+
+        token = "YES" if yes_count >= no_count else "NO"
+        qty = max(yes_count, no_count)
+        revenue = revenue_cents / 100.0
+
+        cost = await _cost_basis(db, ticker)
+        if cost is None:
+            log.warning("kalshi_settlements.no_cost_basis", ticker=ticker,
+                        revenue=revenue, settled=settled_iso)
+            results.append({
+                "ticker": ticker, "result": result, "qty": qty,
+                "revenue": revenue, "pnl": None, "settled": settled_iso,
+                "booked": False, "reason": "no cost basis on record",
+            })
+            continue
+
+        pnl = round(revenue - cost, 4)
+        results.append({
+            "ticker": ticker, "result": result, "qty": qty,
+            "revenue": revenue, "pnl": pnl, "settled": settled_iso,
+            "booked": not dry_run, "reason": "",
+        })
+        if dry_run:
+            continue
+
+        await record_ledger_event(
+            db, market_id=ticker, kind="settlement", token=token, qty=qty,
+            pnl=pnl, fees=0.0, is_paper=False, source_ref=source_ref,
+            realized_at=settled_iso,
+        )
+        # Close out our records the way _settle_position does, minus
+        # daily_stats (see module docstring).
+        await db.execute(
+            """UPDATE cost_basis SET realized_pnl = realized_pnl + ?, size = 0,
+               updated_at = datetime('now')
+               WHERE market_id = ? AND is_paper = 0""",
+            (pnl, ticker),
+        )
+        await db.execute(
+            "DELETE FROM portfolio WHERE market_id = ? AND is_paper = 0",
+            (ticker,),
+        )
+        await db.commit()
+        log.info("kalshi_settlements.booked", ticker=ticker, pnl=pnl,
+                 settled=settled_iso)
+
+    return results
+
+
+async def _fetch_all_settlements(kalshi_client, max_pages: int) -> list:
+    """Walk the paginated settlements feed via the client's SDK."""
+    api = getattr(kalshi_client, "_portfolio_api", None)
+    call = getattr(kalshi_client, "_call", None)
+    if api is None or call is None:
+        return []
+    out: list = []
+    cursor = None
+    for _ in range(max_pages):
+        try:
+            resp = await call(api.get_settlements, limit=200, cursor=cursor)
+        except Exception as e:
+            log.warning("kalshi_settlements.fetch_error", error=str(e))
+            break
+        batch = getattr(resp, "settlements", None) or []
+        out.extend(batch)
+        cursor = getattr(resp, "cursor", None)
+        if not cursor or not batch:
+            break
+    return out
+
+
+async def _cost_basis(db: Database, ticker: str) -> float | None:
+    """Dollar cost of the settled position from our own records.
+
+    cost_basis is authoritative when it still carries size; otherwise fall
+    back to net filled BUY notional from trades. Returns None when neither
+    source knows the position — the caller reports instead of guessing.
+    """
+    row = await db.fetchone(
+        """SELECT size, avg_cost FROM cost_basis
+           WHERE market_id = ? AND is_paper = 0 AND size > 0""",
+        (ticker,),
+    )
+    if row is not None:
+        return round(float(row["size"]) * float(row["avg_cost"]), 4)
+    trow = await db.fetchone(
+        """SELECT SUM(CASE WHEN side = 'BUY' THEN size * price
+                           ELSE -size * price END) AS net
+           FROM trades WHERE market_id = ? AND is_paper = 0
+           AND status = 'filled'""",
+        (ticker,),
+    )
+    if trow is not None and trow["net"] is not None and trow["net"] > 0:
+        return round(float(trow["net"]), 4)
+    return None

--- a/auramaur/broker/kalshi_settlements.py
+++ b/auramaur/broker/kalshi_settlements.py
@@ -114,9 +114,20 @@ async def sweep_kalshi_settlements(
 
 async def _fetch_all_settlements(kalshi_client, max_pages: int) -> list:
     """Walk the paginated settlements feed via the client's SDK."""
+    # The SDK client is lazily constructed; outside the bot's order paths
+    # nothing has triggered it yet (the first CLI dry-run returned a silent
+    # empty list this way — silence must not look like "nothing to settle").
+    init = getattr(kalshi_client, "_init_api", None)
+    if callable(init):
+        try:
+            init()
+        except Exception as e:
+            log.warning("kalshi_settlements.init_error", error=str(e))
+            return []
     api = getattr(kalshi_client, "_portfolio_api", None)
     call = getattr(kalshi_client, "_call", None)
     if api is None or call is None:
+        log.warning("kalshi_settlements.client_unavailable")
         return []
     out: list = []
     cursor = None

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -869,6 +869,68 @@ def settle_stale(write: bool):
     asyncio.run(_run())
 
 
+@main.command("kalshi-settlements")
+@click.option("--write", is_flag=True,
+              help="Book the settlements into the ledger (default dry-run).")
+def kalshi_settlements(write: bool):
+    """Backfill/book Kalshi settlements from the venue's settlement feed.
+
+    Kalshi realized P&L was never recorded (the tracker keyed off a Market
+    field that didn't exist, and the syncer dropped settled positions before
+    booking). This walks GET /portfolio/settlements and books every
+    settlement missing from pnl_ledger, idempotently (source_ref dedupes).
+    Settlements whose cost basis we never recorded are listed but skipped.
+    The bot also runs this sweep automatically every resolution cycle.
+    """
+
+    async def _run():
+        from auramaur.broker.kalshi_settlements import sweep_kalshi_settlements
+        from auramaur.exchange.kalshi import KalshiClient
+        from auramaur.exchange.paper import PaperTrader
+
+        settings = Settings()
+        db = Database()
+        await db.connect()
+        try:
+            paper = PaperTrader(db=db)
+            client = KalshiClient(settings=settings, paper_trader=paper)
+            rows = await sweep_kalshi_settlements(db, client, dry_run=not write)
+            if not rows:
+                console.print("[green]No unbooked Kalshi settlements found.[/]")
+                return
+            t = Table(title=f"{'Booked' if write else 'Would book (dry run)'} "
+                            f"Kalshi settlements")
+            t.add_column("Settled", width=10)
+            t.add_column("Ticker", max_width=30)
+            t.add_column("Result", width=6)
+            t.add_column("Qty", justify="right")
+            t.add_column("Revenue", justify="right")
+            t.add_column("P&L", justify="right")
+            total, skipped = 0.0, 0
+            for r in sorted(rows, key=lambda x: x["settled"]):
+                if r["pnl"] is None:
+                    skipped += 1
+                    t.add_row(r["settled"][:10], r["ticker"][:30], r["result"],
+                              f"{r['qty']:.0f}", f"${r['revenue']:.2f}",
+                              "[yellow]skip: no cost[/]")
+                    continue
+                total += r["pnl"]
+                color = "green" if r["pnl"] >= 0 else "red"
+                t.add_row(r["settled"][:10], r["ticker"][:30], r["result"],
+                          f"{r['qty']:.0f}", f"${r['revenue']:.2f}",
+                          f"[{color}]{r['pnl']:+.2f}[/]")
+            console.print(t)
+            color = "green" if total >= 0 else "red"
+            console.print(f"[bold]Net realized: [{color}]${total:+.2f}[/][/]"
+                          + (f"  ({skipped} skipped, no cost basis)" if skipped else ""))
+            if not write:
+                console.print("\n[dim]Re-run with [cyan]--write[/] to book.[/]")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
 @main.command("repair-pnl")
 @click.option("--write", is_flag=True,
               help="Persist resolution_pnl rows and rebuild category_stats dollar fields.")

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -865,6 +865,13 @@ class KalshiClient:
                 volume=volume,
                 liquidity=liquidity,
                 spread=spread,
+                # Settlement signals for the resolution tracker: it keys off
+                # market.status ("settled"/"finalized") and prefers the
+                # venue's explicit result side over price inference. These
+                # were never populated, so no Kalshi position ever settled
+                # into the ledger.
+                status=status,
+                result=str(_get("result", "") or "").lower(),
             )
         except Exception as e:
             log.warning("kalshi.parse_error", error=str(e))

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -46,6 +46,13 @@ class Market(BaseModel):
     # guaranteed-profit arb. neg_risk_market_id is the grouping key.
     neg_risk: bool = False
     neg_risk_market_id: str = ""
+    # Venue-reported lifecycle. Kalshi exposes an explicit settlement status
+    # ("settled"/"finalized") and a result side ("yes"/"no") — the resolution
+    # tracker keyed off `market.status` while no Market ever carried the
+    # field (getattr defaulted to None), so no Kalshi position was ever
+    # settled into the ledger. Empty for venues that don't report these.
+    status: str = ""
+    result: str = ""
     last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -249,9 +249,16 @@ class ResolutionTracker:
         prematurely and fed a fake outcome into calibration.
         """
         # Kalshi exposes an explicit settlement status — trust it first.
+        # (market.status/.result only exist as of the Market-model fields
+        # added 2026-06-12; before that getattr always returned None and no
+        # Kalshi position ever settled.) Prefer the venue's explicit result
+        # side over price inference.
         if exchange == "kalshi":
             status = getattr(market, "status", None)
             if status in ("settled", "finalized"):
+                result = getattr(market, "result", "")
+                if result in ("yes", "no"):
+                    return result == "yes"
                 return market.outcome_yes_price > 0.5
 
         # For everything else, the exchange must have flagged the market

--- a/tests/test_kalshi_settlements.py
+++ b/tests/test_kalshi_settlements.py
@@ -1,0 +1,126 @@
+"""Tests for the Kalshi settlements sweep (venue feed → ledger).
+
+Regression context (2026-06-12): Kalshi realized P&L was never recorded —
+the resolution tracker keyed off ``market.status``, a field the Market
+model didn't have, and the syncer dropped settled positions from portfolio
+before booking. The venue's settlements feed is the authoritative source.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.broker.kalshi_settlements import sweep_kalshi_settlements
+from auramaur.exchange.models import Market
+from auramaur.strategy.resolution_tracker import ResolutionTracker
+
+SETTLED_AT = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _settlement(ticker="KXTEST-1", result="yes", yes_count=10, no_count=0,
+                revenue=1000, settled_time=SETTLED_AT):
+    return SimpleNamespace(ticker=ticker, result=result, yes_count=yes_count,
+                           no_count=no_count, revenue=revenue,
+                           settled_time=settled_time)
+
+
+def _client(settlements, cursor=None):
+    """Mock KalshiClient exposing _portfolio_api + _call like the real one."""
+    api = SimpleNamespace(get_settlements=lambda **kw: None)
+
+    async def _call(fn, **kwargs):
+        return SimpleNamespace(settlements=settlements, cursor=cursor)
+
+    return SimpleNamespace(_portfolio_api=api, _call=_call)
+
+
+def _db(*, ledger_has=(), cost_row=None, trades_net=None):
+    db = AsyncMock()
+
+    async def _fetchone(sql, params=None):
+        if "pnl_ledger" in sql:
+            return {"1": 1} if params[0] in ledger_has else None
+        if "cost_basis" in sql:
+            return cost_row
+        if "FROM trades" in sql:
+            return {"net": trades_net}
+        return None
+
+    db.fetchone = AsyncMock(side_effect=_fetchone)
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_sweep_books_settlement_with_cost_basis(monkeypatch):
+    """A winning settlement books pnl = revenue − cost into the ledger and
+    closes out cost_basis/portfolio (daily_stats untouched by design)."""
+    recorded = []
+
+    async def _fake_record(db, **kw):
+        recorded.append(kw)
+
+    monkeypatch.setattr(
+        "auramaur.broker.kalshi_settlements.record_ledger_event", _fake_record)
+
+    db = _db(cost_row={"size": 10.0, "avg_cost": 0.62})
+    out = await sweep_kalshi_settlements(db, _client([_settlement()]))
+
+    assert len(out) == 1 and out[0]["booked"] is True
+    assert out[0]["pnl"] == pytest.approx(10.0 - 6.2)  # $10 revenue − $6.20 cost
+    assert recorded[0]["source_ref"] == f"kalshi-settle:KXTEST-1:{SETTLED_AT.isoformat()}"
+    assert recorded[0]["kind"] == "settlement"
+    assert recorded[0]["realized_at"] == SETTLED_AT.isoformat()
+    sqls = " ".join(str(c.args[0]) for c in db.execute.call_args_list)
+    assert "UPDATE cost_basis" in sqls and "DELETE FROM portfolio" in sqls
+
+
+@pytest.mark.asyncio
+async def test_sweep_idempotent_on_source_ref():
+    ref = f"kalshi-settle:KXTEST-1:{SETTLED_AT.isoformat()}"
+    db = _db(ledger_has={ref}, cost_row={"size": 10.0, "avg_cost": 0.62})
+    out = await sweep_kalshi_settlements(db, _client([_settlement()]))
+    assert out == []
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_unknown_cost_instead_of_guessing():
+    """No cost basis on record → reported but NOT booked. A fabricated cost
+    would poison the venue scorecard this sweep exists to build."""
+    db = _db(cost_row=None, trades_net=None)
+    out = await sweep_kalshi_settlements(db, _client([_settlement()]))
+    assert len(out) == 1
+    assert out[0]["booked"] is False and out[0]["pnl"] is None
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_falls_back_to_filled_trades_for_cost():
+    db = _db(cost_row=None, trades_net=6.2)
+    out = await sweep_kalshi_settlements(
+        db, _client([_settlement(result="no", yes_count=0, no_count=10,
+                                 revenue=0)]),
+        dry_run=True)
+    assert out[0]["pnl"] == pytest.approx(0.0 - 6.2)  # lost: $0 revenue
+    assert out[0]["booked"] is False  # dry run
+
+
+# --- Resolution-tracker detection now actually works for Kalshi ---
+
+def test_kalshi_market_carries_status_and_result():
+    m = Market(id="KXTEST-1", exchange="kalshi", question="?",
+               status="settled", result="no", outcome_yes_price=0.9)
+    # Venue result wins over price inference (price says YES, venue says NO).
+    assert ResolutionTracker._detect_resolution(m, "kalshi") is False
+
+
+def test_kalshi_unsettled_market_not_resolved():
+    m = Market(id="KXTEST-1", exchange="kalshi", question="?",
+               status="open", outcome_yes_price=0.99)
+    assert ResolutionTracker._detect_resolution(m, "kalshi") is None


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.