### PR TITLE
fix(arb): kill switches that kill — real enabled flags, category-gated correlation arb, pairing guard

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1376,6 +1376,26 @@ class AuramaurBot:
                         sell_market = await arb_executor._load_market(sell_signal.market_id)
                         if not buy_market or not sell_market:
                             continue
+                        # Same category policy as every other book: this
+                        # path executes through the exempt 'arbitrage'
+                        # strategy_source, so the gateway's category checks
+                        # never see it (it quoted KBO baseball live
+                        # 2026-06-12). Both legs must clear the gates.
+                        from auramaur.strategy.classifier import ensure_category
+                        risk_cfg = self.settings.risk
+                        blocked = set(risk_cfg.blocked_categories)
+                        allowed = (set(risk_cfg.allowed_categories_live)
+                                   if self.settings.is_live else None)
+                        leg_cats = [
+                            ensure_category(m.question, m.description, m.category)
+                            for m in (buy_market, sell_market)
+                        ]
+                        if any(c in blocked for c in leg_cats) or (
+                                allowed is not None
+                                and any(c not in allowed for c in leg_cats)):
+                            log.debug("arbitrage.category_gated",
+                                      categories=leg_cats)
+                            continue
                         await self._execute_conditional_arb(
                             buy_signal, sell_signal, buy_market, sell_market,
                             opp, risk_manager, engines,
@@ -1861,6 +1881,23 @@ class AuramaurBot:
         engine = engines.get(exchange_name)
         if engine is None:
             log.debug("arb_scanner.no_engine", exchange=exchange_name)
+            return
+
+        # Cross-attempt pairing guard (2026-06-12): re-quoting a market whose
+        # previous attempt PARTIALLY filled completes the pair at the new
+        # cycle's worse prices — observed live locking 0.82 + 0.21 = $1.03
+        # against a $1.00 payout. If we already hold either token of this
+        # market, skip: the one-sided leg is the exit machinery's problem,
+        # not a fresh "arb".
+        db: Database = self._components["db"]
+        is_paper_flag = 0 if self.settings.is_live else 1
+        held = await db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? AND is_paper = ? "
+            "AND size > 0",
+            (market.id, is_paper_flag),
+        )
+        if held is not None:
+            log.info("arb_scanner.skip_partial_inventory", market_id=market.id)
             return
 
         alerts: AlertManager = self._components["alerts"]
@@ -3228,7 +3265,9 @@ class AuramaurBot:
 
         if self._components.get("attributor"):
             tasks.append(asyncio.create_task(self._task_attribution_update(), name="attribution"))
-        if self._components.get("correlator"):
+        # Correlation-arb executes through the exempt 'arbitrage' source and
+        # had no off switch at all; it shares the arbitrage book's flag.
+        if self._components.get("correlator") and self.settings.arbitrage.enabled:
             tasks.append(asyncio.create_task(self._task_correlation_scan(), name="correlation"))
         if self._components.get("websocket"):
             tasks.append(asyncio.create_task(self._task_price_monitor(), name="price_monitor"))
@@ -3237,8 +3276,11 @@ class AuramaurBot:
         if self._components.get("feedback"):
             tasks.append(asyncio.create_task(self._task_performance_feedback(), name="performance_feedback"))
 
-        # Arb scanner always runs (handles single-exchange gracefully)
-        tasks.append(asyncio.create_task(self._task_arb_scanner(), name="arb_scanner"))
+        # Arb scanner — arbitrage.enabled was a dead flag (the task ran
+        # unconditionally), discovered 2026-06-12 when disabling it via
+        # config did nothing while the book locked a -3% cross-attempt pair.
+        if self.settings.arbitrage.enabled:
+            tasks.append(asyncio.create_task(self._task_arb_scanner(), name="arb_scanner"))
         tasks.append(asyncio.create_task(self._task_depth_research(), name="depth_research"))
 
         # Favorite-longshot bias harvest (paper-forced until proven)

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -58,8 +58,11 @@ def run(agent: bool, hybrid: bool, exchange: str | None):
         else:
             console.print("[bold yellow]AGENT MODE[/] — paper trading")
     if hybrid:
-        if settings.hybrid.market_maker_auto_enable:
-            settings.market_maker.enabled = True
+        # NOTE: --hybrid used to force market_maker.enabled = True here
+        # (hybrid.market_maker_auto_enable), silently reverting an explicit
+        # config disable on every restart — it cost three blind restarts
+        # during the 2026-06-12 incident before anyone found it. Book
+        # enablement now lives in exactly one place: market_maker.enabled.
         mode = "[bold red]LIVE TRADING[/]" if settings.is_live else "paper trading"
         console.print(f"[bold cyan]HYBRID MODE[/] — {mode}")
         # The full per-book picture (modes, gates, graduation, ledger) is the

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -479,7 +479,6 @@ hybrid:
   llm_domain_filter: true
   llm_whitelist_min_accuracy: 0.50
   llm_whitelist_min_trades: 5
-  market_maker_auto_enable: true
 
 logging:
   level: "INFO"

--- a/config/settings.py
+++ b/config/settings.py
@@ -633,7 +633,6 @@ class HybridConfig(BaseModel):
     llm_domain_filter: bool = True
     llm_whitelist_min_accuracy: float = 0.50
     llm_whitelist_min_trades: int = 5
-    market_maker_auto_enable: bool = True
 
 
 class LoggingConfig(BaseModel):

--- a/tests/test_arb_hardening.py
+++ b/tests/test_arb_hardening.py
@@ -1,0 +1,76 @@
+"""Tests for the 2026-06-12 arb hardening.
+
+- arbitrage.enabled actually gates the arb + correlation tasks (it was a
+  dead flag; disabling it via config did nothing while the book locked a
+  -3% cross-attempt pair).
+- _execute_internal_arb skips markets where we already hold inventory: a
+  partially-filled prior attempt must not be "completed" at the next
+  cycle's worse prices (observed live: 0.82 + 0.21 = $1.03 for a $1.00
+  payout).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.bot import AuramaurBot
+from auramaur.exchange.models import Market
+
+
+def _bare_bot(*, held_row, is_live=True):
+    bot = AuramaurBot.__new__(AuramaurBot)
+    db = AsyncMock()
+    db.fetchone = AsyncMock(return_value=held_row)
+    bot._components = {"db": db, "alerts": AsyncMock()}
+    bot.settings = SimpleNamespace(is_live=is_live)
+    return bot, db
+
+
+def _opp(market_id="m1"):
+    market = Market(id=market_id, question="Will X happen?",
+                    outcome_yes_price=0.17, outcome_no_price=0.82)
+    return SimpleNamespace(market_a=market, exchange_a="polymarket",
+                           expected_profit_pct=1.0, spread=0.01,
+                           price_a=0.17, price_b=0.82)
+
+
+@pytest.mark.asyncio
+async def test_internal_arb_skips_market_with_existing_inventory():
+    bot, db = _bare_bot(held_row={"1": 1})
+    engine = SimpleNamespace(_get_available_cash=AsyncMock(return_value=100.0))
+
+    await bot._execute_internal_arb(_opp(), risk_manager=AsyncMock(),
+                                    engines={"polymarket": engine})
+
+    # Early-returned on the inventory guard: cash/risk were never consulted.
+    engine._get_available_cash.assert_not_awaited()
+    sql, params = db.fetchone.call_args.args
+    assert "FROM portfolio" in sql and params == ("m1", 0)  # live -> is_paper=0
+
+
+@pytest.mark.asyncio
+async def test_internal_arb_inventory_guard_respects_paper_mode():
+    bot, db = _bare_bot(held_row={"1": 1}, is_live=False)
+    engine = SimpleNamespace(_get_available_cash=AsyncMock(return_value=100.0))
+    await bot._execute_internal_arb(_opp(), risk_manager=AsyncMock(),
+                                    engines={"polymarket": engine})
+    _, params = db.fetchone.call_args.args
+    assert params == ("m1", 1)  # paper -> is_paper=1
+
+
+def test_arbitrage_enabled_gates_arb_tasks_in_source():
+    """Structural check: both arb task creations sit behind the flag.
+
+    (Task creation happens deep in start(); rather than booting a bot, pin
+    the gating in source so a refactor can't silently drop it again.)"""
+    import inspect
+    import auramaur.bot as botmod
+    src = inspect.getsource(botmod)
+    arb_idx = src.index('name="arb_scanner"')
+    corr_idx = src.index('name="correlation"')
+    for idx in (arb_idx, corr_idx):
+        window = src[max(0, idx - 400):idx]
+        assert "self.settings.arbitrage.enabled" in window

--- a/tests/test_hybrid_config.py
+++ b/tests/test_hybrid_config.py
@@ -12,7 +12,6 @@ class TestHybridConfig:
         assert cfg.llm_domain_filter is True
         assert cfg.llm_whitelist_min_accuracy == 0.50
         assert cfg.llm_whitelist_min_trades == 5
-        assert cfg.market_maker_auto_enable is True
 
     def test_settings_has_hybrid(self):
         s = Settings()
@@ -24,14 +23,15 @@ class TestHybridConfig:
         assert s.hybrid.arb_scan_seconds == 60
         assert s.hybrid.news_cycle_seconds == 30
 
-    def test_market_maker_auto_enable(self):
+    def test_hybrid_does_not_override_book_enablement(self):
+        """Regression (2026-06-12): --hybrid force-set market_maker.enabled
+        = True via market_maker_auto_enable, silently reverting an explicit
+        config disable on every restart. Book enablement now lives in exactly
+        one place; the field is gone (and stale yaml keys are ignored)."""
         s = Settings()
+        assert not hasattr(HybridConfig(), "market_maker_auto_enable")
         s.market_maker.enabled = False
-        assert s.hybrid.market_maker_auto_enable is True
-        # Simulating CLI --hybrid behavior
-        if s.hybrid.market_maker_auto_enable:
-            s.market_maker.enabled = True
-        assert s.market_maker.enabled is True
+        assert s.market_maker.enabled is False
 
     def test_hybrid_coexists_with_analysis_mode(self):
         s = Settings()


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.