### PR TITLE
fix(nlp): persist the daily Claude-call budget across restarts and consumers

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -3120,6 +3120,11 @@ class AuramaurBot:
         db_path = self._components["db"].db_path
         if db_path != "auramaur.db":
             console.print(f"  [yellow]Instance: {db_path}[/]")
+        # Persistent Claude-budget counter lives in the same sqlite file —
+        # point it at this instance's path (multi-instance runs use
+        # auramaur_N.db and must not share a budget row file-side).
+        from auramaur.nlp import call_budget
+        call_budget.set_db_path(db_path)
 
         # Show real balance — use reconciler for live, paper for paper mode.
         # In live mode we never fall back to paper.balance — that would show

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -83,8 +83,6 @@ class ClaudeAnalyzer:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
         self._model = settings.nlp.model
-        self._daily_calls = 0
-        self._daily_calls_date = ""
 
     async def _call_claude_cli(self, prompt: str, *, effort: str | None = None) -> str:
         """Call Claude via the CLI using the Max+ subscription.
@@ -97,16 +95,12 @@ class ClaudeAnalyzer:
 
         Retries up to 3 times on transient failures (timeout, non-zero exit).
         """
-        from datetime import date
+        from auramaur.nlp import call_budget
 
         use_effort = effort or self._settings.nlp.effort_primary
 
-        today = date.today().isoformat()
-        if self._daily_calls_date != today:
-            self._daily_calls = 0
-            self._daily_calls_date = today
         budget = self._settings.nlp.daily_claude_call_budget
-        if budget > 0 and self._daily_calls >= budget:
+        if budget > 0 and call_budget.calls_today() >= budget:
             raise RuntimeError(
                 f"Daily Claude call budget ({budget}) exhausted"
             )
@@ -132,10 +126,9 @@ class ClaudeAnalyzer:
                     log.error("claude_cli.error", returncode=proc.returncode, stderr=err_msg, attempt=attempt)
                     raise RuntimeError(f"Claude CLI failed (rc={proc.returncode}): {err_msg}")
 
-                self._daily_calls += 1
                 log.info(
                     "claude_cli.call",
-                    daily_calls=self._daily_calls,
+                    daily_calls=call_budget.record_call(),
                     budget=budget,
                 )
                 return stdout.decode().strip()
@@ -160,8 +153,9 @@ class ClaudeAnalyzer:
         from functools import partial
 
         from auramaur.nlp.llm_router import route
+        from auramaur.nlp import call_budget
         claude_fn = partial(self._call_claude_cli, effort=effort)
-        return await route(self._settings, self._daily_calls, prompt, claude_fn)
+        return await route(self._settings, call_budget.calls_today(), prompt, claude_fn)
 
     # ------------------------------------------------------------------
     # Core estimation methods

--- a/auramaur/nlp/call_budget.py
+++ b/auramaur/nlp/call_budget.py
@@ -1,0 +1,92 @@
+"""Persistent daily Claude-call counter — survives restarts, shared cross-process.
+
+The budget counter used to live in-memory on each analyzer instance
+(`self._daily_calls`), which broke it twice over:
+
+* Every restart reset it to zero, so the router kept treating the Claude
+  budget as fresh — on 2026-06-12 the bot restarted five times and the
+  nominal 80-call/day budget was effectively ignored (the Gemini handoff
+  at ``claude_budget_threshold`` never engaged).
+* Three classes (ClaudeAnalyzer, StrategicAnalyzer, EnsembleAnalyzer) each
+  kept a private counter, so the "daily budget" was really up to 3x the
+  configured number.
+
+One row per day in the bot's own sqlite file fixes both. Helpers are
+synchronous on purpose: they run a sub-millisecond statement on a
+short-lived WAL connection, callers sit inside multi-second LLM calls, and
+keeping them sync means no analyzer constructor has to grow an async
+``Database`` dependency. Every sqlite failure degrades to a process-local
+in-memory count — the budget gets restart-blind again, but analysis never
+breaks on a locked/missing file.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+
+import structlog
+
+log = structlog.get_logger()
+
+_db_path = "auramaur.db"  # same working-directory convention as Database
+_mem_calls = 0
+_mem_day = ""
+
+
+def set_db_path(path: str) -> None:
+    """Point the counter at the instance's sqlite file (bot startup)."""
+    global _db_path
+    _db_path = path
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(_db_path, timeout=2)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS llm_call_counter (
+               day TEXT PRIMARY KEY,
+               claude_calls INTEGER NOT NULL DEFAULT 0
+           )"""
+    )
+    return conn
+
+
+def calls_today() -> int:
+    """Claude calls recorded today across all processes and restarts."""
+    today = date.today().isoformat()
+    try:
+        with _conn() as conn:
+            row = conn.execute(
+                "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
+                (today,),
+            ).fetchone()
+            return int(row[0]) if row else 0
+    except sqlite3.Error as e:
+        log.debug("call_budget.read_error", error=str(e))
+        return _mem_calls if _mem_day == today else 0
+
+
+def record_call() -> int:
+    """Count one successful Claude call; returns today's new total."""
+    global _mem_calls, _mem_day
+    today = date.today().isoformat()
+    if _mem_day != today:
+        _mem_day, _mem_calls = today, 0
+    _mem_calls += 1
+    try:
+        with _conn() as conn:
+            conn.execute(
+                """INSERT INTO llm_call_counter (day, claude_calls)
+                   VALUES (?, 1)
+                   ON CONFLICT(day) DO UPDATE SET
+                       claude_calls = claude_calls + 1""",
+                (today,),
+            )
+            row = conn.execute(
+                "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
+                (today,),
+            ).fetchone()
+            return int(row[0])
+    except sqlite3.Error as e:
+        log.warning("call_budget.write_error", error=str(e))
+        return _mem_calls

--- a/auramaur/nlp/ensemble_analyzer.py
+++ b/auramaur/nlp/ensemble_analyzer.py
@@ -64,8 +64,6 @@ class EnsembleAnalyzer:
         self._db = db
         self._models = settings.llm_ensemble.models
         self._model_weights: dict[str, float] = {}
-        self._daily_calls = 0
-        self._daily_calls_date = ""
 
     # ------------------------------------------------------------------
     # Weight management
@@ -345,13 +343,10 @@ class EnsembleAnalyzer:
 
         Same as ClaudeAnalyzer._call_claude_cli but with configurable --model flag.
         """
-        today = date.today().isoformat()
-        if self._daily_calls_date != today:
-            self._daily_calls = 0
-            self._daily_calls_date = today
+        from auramaur.nlp import call_budget
 
         budget = self._settings.nlp.daily_claude_call_budget
-        if budget > 0 and self._daily_calls >= budget:
+        if budget > 0 and call_budget.calls_today() >= budget:
             raise RuntimeError(f"Daily Claude call budget ({budget}) exhausted")
 
         max_attempts = 3
@@ -378,11 +373,10 @@ class EnsembleAnalyzer:
                     err_msg = stderr.decode().strip()
                     raise RuntimeError(f"Claude CLI ({model}) failed (rc={proc.returncode}): {err_msg}")
 
-                self._daily_calls += 1
                 log.info(
                     "ensemble.model_call",
                     model=model,
-                    daily_calls=self._daily_calls,
+                    daily_calls=call_budget.record_call(),
                 )
 
                 raw_text = stdout.decode().strip()

--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -273,8 +273,6 @@ class StrategicAnalyzer:
         self._db = db
         self._cache = NLPCache(db)
         self._world_model = self._load_world_model()
-        self._daily_calls = 0
-        self._daily_calls_date = ""
 
         # Initialize LLM ensemble if enabled
         self._ensemble = None
@@ -949,12 +947,6 @@ class StrategicAnalyzer:
                 ``nlp.effort_primary``.
         """
         import asyncio
-        from datetime import date
-
-        today = date.today().isoformat()
-        if self._daily_calls_date != today:
-            self._daily_calls = 0
-            self._daily_calls_date = today
 
         use_model = model or self._model
         use_effort = effort or self._settings.nlp.effort_primary
@@ -992,13 +984,13 @@ class StrategicAnalyzer:
                     err = stderr.decode().strip()
                     raise RuntimeError(f"Claude CLI ({use_model}) failed (rc={proc.returncode}): {err}")
 
-                self._daily_calls += 1
+                from auramaur.nlp import call_budget
                 log.info(
                     "strategic.claude_call",
                     model=use_model,
                     effort=use_effort,
                     cached_prefix=bool(system_prompt),
-                    daily_calls=self._daily_calls,
+                    daily_calls=call_budget.record_call(),
                 )
                 return stdout.decode().strip()
 
@@ -1019,7 +1011,8 @@ class StrategicAnalyzer:
 
         # route() calls the fn with just the prompt; bind the extra CLI options.
         claude_fn = partial(self._call_claude_cli, system_prompt=system_prompt, effort=effort)
-        return await route(self._settings, self._daily_calls, prompt, claude_fn)
+        from auramaur.nlp import call_budget
+        return await route(self._settings, call_budget.calls_today(), prompt, claude_fn)
 
     async def _call_ensemble_extra(
         self, prompt: str, extra_models: list[str], *, system_prompt: str | None = None,

--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -235,18 +235,12 @@ class AgentAnalyzer:
         self._model = settings.nlp.model
         self._max_turns: int = 15  # Enough room for deep research
         self._timeout_seconds: int = 600  # 10 minutes for thorough analysis
-        # Daily budget tracking (resets each calendar day)
-        self._daily_calls: int = 0
-        self._daily_calls_date: str = ""
 
     def _check_budget(self) -> None:
         """Enforce daily Claude call budget.  Raises RuntimeError if exhausted."""
-        today = date.today().isoformat()
-        if self._daily_calls_date != today:
-            self._daily_calls = 0
-            self._daily_calls_date = today
+        from auramaur.nlp import call_budget
         budget = self.settings.nlp.daily_claude_call_budget
-        if budget > 0 and self._daily_calls >= budget:
+        if budget > 0 and call_budget.calls_today() >= budget:
             raise RuntimeError(
                 f"Daily agent call budget ({budget}) exhausted"
             )
@@ -266,7 +260,8 @@ class AgentAnalyzer:
             batch = markets[i:i + _MAX_MARKETS_PER_CALL]
             try:
                 candidates, entity_map = await self._run_agent(batch)
-                self._daily_calls += 1
+                from auramaur.nlp import call_budget
+                call_budget.record_call()
                 all_candidates.extend(candidates)
                 self._update_world_model_from_entities(entity_map)
             except RuntimeError:
@@ -578,7 +573,8 @@ Respond with JSON:
 
             self._max_turns = old_turns
             self._timeout_seconds = old_timeout
-            self._daily_calls += 1
+            from auramaur.nlp import call_budget
+            call_budget.record_call()
 
             # Parse single-market response
             fenced = re.search(r"```(?:json)?\s*([\s\S]*?)```", raw)

--- a/tests/test_call_budget.py
+++ b/tests/test_call_budget.py
@@ -1,0 +1,60 @@
+"""Tests for the persistent daily Claude-call counter.
+
+Regression (2026-06-12): the counter was in-memory per analyzer instance —
+five restarts in one day reset it five times, so the 80-call budget and the
+Gemini handoff threshold were effectively ignored. Worse, four classes each
+kept a private counter, multiplying the real budget by up to 4x.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from auramaur.nlp import call_budget
+
+
+def _use_tmp_db(tmp_path):
+    call_budget.set_db_path(str(tmp_path / "test.db"))
+
+
+def test_counts_persist_across_simulated_restarts(tmp_path):
+    _use_tmp_db(tmp_path)
+    assert call_budget.calls_today() == 0
+    assert call_budget.record_call() == 1
+    assert call_budget.record_call() == 2
+
+    # "Restart": a fresh reader against the same file (module state is
+    # irrelevant — the DB row is the source of truth).
+    call_budget.set_db_path(str(tmp_path / "test.db"))
+    assert call_budget.calls_today() == 2
+
+
+def test_counter_is_shared_not_per_consumer(tmp_path):
+    """Four analyzers recording into one row means the budget is global."""
+    _use_tmp_db(tmp_path)
+    for _ in range(4):
+        call_budget.record_call()
+    assert call_budget.calls_today() == 4
+
+
+def test_day_rollover_scopes_to_today(tmp_path):
+    _use_tmp_db(tmp_path)
+    import sqlite3
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.execute("CREATE TABLE IF NOT EXISTS llm_call_counter (day TEXT PRIMARY KEY, claude_calls INTEGER NOT NULL DEFAULT 0)")
+    conn.execute("INSERT INTO llm_call_counter VALUES ('2020-01-01', 99)")
+    conn.commit(); conn.close()
+    assert call_budget.calls_today() == 0  # yesterday's row doesn't count
+    assert call_budget.record_call() == 1
+
+
+def test_sqlite_failure_degrades_to_memory(tmp_path):
+    """A locked/missing file must never break analysis — falls back to a
+    process-local count (restart-blind, but functional)."""
+    call_budget.set_db_path(str(tmp_path / "nodir" / "missing.db"))
+    call_budget._mem_calls, call_budget._mem_day = 0, ""
+    n1 = call_budget.record_call()
+    n2 = call_budget.record_call()
+    assert (n1, n2) == (1, 2)
+    assert call_budget.calls_today() == 2
+    assert call_budget._mem_day == date.today().isoformat()

--- a/tests/test_claude_retry.py
+++ b/tests/test_claude_retry.py
@@ -59,13 +59,11 @@ async def test_no_retry_on_budget(settings):
     """Budget exhausted raises immediately, no retries."""
     settings.nlp.daily_claude_call_budget = 1
     a = ClaudeAnalyzer(settings=settings)
-    # Simulate one call already made today
-    from datetime import date
-    a._daily_calls = 1
-    a._daily_calls_date = date.today().isoformat()
-
-    with pytest.raises(RuntimeError, match="budget"):
-        await a._call_claude_cli("test prompt")
+    # Simulate one call already made today (persistent counter)
+    from unittest.mock import patch
+    with patch("auramaur.nlp.call_budget.calls_today", return_value=1):
+        with pytest.raises(RuntimeError, match="budget"):
+            await a._call_claude_cli("test prompt")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Found 2026-06-12 after five same-day restarts: the daily Claude-call budget counter lived **in-memory on each analyzer instance**, so

- every restart zeroed it — the Gemini handoff at `claude_budget_threshold` never engaged, and the nominal 80-call/day budget was effectively ignored exactly when conserving Claude credits mattered most (Max session capped);
- **four** classes (ClaudeAnalyzer, StrategicAnalyzer, EnsembleAnalyzer, AgentAnalyzer) each kept a private counter, so the real ceiling was up to 4× the configured number.

## What

`nlp/call_budget.py` — one `llm_call_counter` row per day in the instance's own sqlite file. `calls_today()` / `record_call()` are shared by all four consumers, all processes (CLI included), and restarts. Sync by design: sub-ms statements on a short-lived WAL connection, called from inside multi-second LLM calls, so no constructor grows an async `Database` dependency. Any sqlite failure degrades to a process-local count — restart-blind again, but analysis never breaks on a locked file. Bot startup points it at the instance db path (multi-instance `auramaur_N.db` safe).

All four `_daily_calls` sites replaced; the router now sees the true cross-restart count.

## Verification

New tests: persistence across simulated restarts, shared-not-per-consumer counting, day rollover, sqlite-failure memory fallback. Updated the one coupled retry test. Full suite: **706 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)