### PR TITLE
fix(nlp): 15s busy-timeout on the call-budget counter

### DIFF
--- a/auramaur/nlp/call_budget.py
+++ b/auramaur/nlp/call_budget.py
@@ -41,7 +41,11 @@ def set_db_path(path: str) -> None:
 
 
 def _conn() -> sqlite3.Connection:
-    conn = sqlite3.connect(_db_path, timeout=2)
+    # 15s busy-timeout: the bot's scan/settlement cycles hold the write lock
+    # for multi-second stretches and 2s lost the race twice within 90s of
+    # deploy. Callers sit inside multi-second LLM calls, so waiting is free;
+    # losing the write silently undercounts the budget instead.
+    conn = sqlite3.connect(_db_path, timeout=15)
     conn.execute(
         """CREATE TABLE IF NOT EXISTS llm_call_counter (
                day TEXT PRIMARY KEY,


### PR DESCRIPTION
Follow-up to #116, caught by the monitor within minutes of deploy: two `database is locked` warnings in 90s — the 2s busy-timeout loses to the bot's multi-second scan/settlement write transactions. Callers sit inside multi-second LLM calls, so a longer wait is free, while a lost write silently undercounts the budget this counter exists to enforce. Tests: 706 pass (no behavior change beyond the timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)