### PR TITLE
fix(nlp): call-budget counter — cached connection, DDL once, no writes on the read path

### DIFF
--- a/auramaur/nlp/call_budget.py
+++ b/auramaur/nlp/call_budget.py
@@ -7,22 +7,28 @@ The budget counter used to live in-memory on each analyzer instance
   budget as fresh — on 2026-06-12 the bot restarted five times and the
   nominal 80-call/day budget was effectively ignored (the Gemini handoff
   at ``claude_budget_threshold`` never engaged).
-* Three classes (ClaudeAnalyzer, StrategicAnalyzer, EnsembleAnalyzer) each
-  kept a private counter, so the "daily budget" was really up to 3x the
+* Four classes (Claude/Strategic/Ensemble/Agent analyzers) each kept a
+  private counter, so the "daily budget" was really up to 4x the
   configured number.
 
 One row per day in the bot's own sqlite file fixes both. Helpers are
-synchronous on purpose: they run a sub-millisecond statement on a
-short-lived WAL connection, callers sit inside multi-second LLM calls, and
-keeping them sync means no analyzer constructor has to grow an async
-``Database`` dependency. Every sqlite failure degrades to a process-local
-in-memory count — the budget gets restart-blind again, but analysis never
-breaks on a locked/missing file.
+synchronous on purpose: sub-millisecond statements, callers sit inside
+multi-second LLM calls, and no analyzer constructor has to grow an async
+``Database`` dependency.
+
+Connection handling matters here (learned the hard way — #117's timeout
+bump didn't stop the lock warnings): the first cut opened a NEW connection
+per call and ran ``CREATE TABLE IF NOT EXISTS`` every time — a DDL write
+even on the read path — colliding with the bot's long write transactions.
+Now one cached connection per process runs the DDL once, reads never
+write, and a locked write is retried once before degrading to the
+process-local in-memory count (restart-blind, but analysis never breaks).
 """
 
 from __future__ import annotations
 
 import sqlite3
+import time
 from datetime import date
 
 import structlog
@@ -30,6 +36,7 @@ import structlog
 log = structlog.get_logger()
 
 _db_path = "auramaur.db"  # same working-directory convention as Database
+_conn_cache: sqlite3.Connection | None = None
 _mem_calls = 0
 _mem_day = ""
 
@@ -37,36 +44,49 @@ _mem_day = ""
 def set_db_path(path: str) -> None:
     """Point the counter at the instance's sqlite file (bot startup)."""
     global _db_path
+    if path != _db_path:
+        _reset_conn()
     _db_path = path
 
 
 def _conn() -> sqlite3.Connection:
-    # 15s busy-timeout: the bot's scan/settlement cycles hold the write lock
-    # for multi-second stretches and 2s lost the race twice within 90s of
-    # deploy. Callers sit inside multi-second LLM calls, so waiting is free;
-    # losing the write silently undercounts the budget instead.
-    conn = sqlite3.connect(_db_path, timeout=15)
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS llm_call_counter (
-               day TEXT PRIMARY KEY,
-               claude_calls INTEGER NOT NULL DEFAULT 0
-           )"""
-    )
-    return conn
+    """One cached connection per process; schema created once."""
+    global _conn_cache
+    if _conn_cache is None:
+        conn = sqlite3.connect(_db_path, timeout=15, check_same_thread=False)
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS llm_call_counter (
+                   day TEXT PRIMARY KEY,
+                   claude_calls INTEGER NOT NULL DEFAULT 0
+               )"""
+        )
+        conn.commit()
+        _conn_cache = conn
+    return _conn_cache
+
+
+def _reset_conn() -> None:
+    global _conn_cache
+    if _conn_cache is not None:
+        try:
+            _conn_cache.close()
+        except sqlite3.Error:
+            pass
+        _conn_cache = None
 
 
 def calls_today() -> int:
     """Claude calls recorded today across all processes and restarts."""
     today = date.today().isoformat()
     try:
-        with _conn() as conn:
-            row = conn.execute(
-                "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
-                (today,),
-            ).fetchone()
-            return int(row[0]) if row else 0
+        row = _conn().execute(
+            "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
+            (today,),
+        ).fetchone()
+        return int(row[0]) if row else 0
     except sqlite3.Error as e:
         log.debug("call_budget.read_error", error=str(e))
+        _reset_conn()
         return _mem_calls if _mem_day == today else 0
 
 
@@ -77,8 +97,9 @@ def record_call() -> int:
     if _mem_day != today:
         _mem_day, _mem_calls = today, 0
     _mem_calls += 1
-    try:
-        with _conn() as conn:
+    for attempt in (1, 2):
+        try:
+            conn = _conn()
             conn.execute(
                 """INSERT INTO llm_call_counter (day, claude_calls)
                    VALUES (?, 1)
@@ -86,11 +107,16 @@ def record_call() -> int:
                        claude_calls = claude_calls + 1""",
                 (today,),
             )
+            conn.commit()
             row = conn.execute(
                 "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
                 (today,),
             ).fetchone()
             return int(row[0])
-    except sqlite3.Error as e:
-        log.warning("call_budget.write_error", error=str(e))
-        return _mem_calls
+        except sqlite3.Error as e:
+            _reset_conn()
+            if attempt == 1:
+                time.sleep(1.0)
+                continue
+            log.warning("call_budget.write_error", error=str(e))
+    return _mem_calls


### PR DESCRIPTION
Second follow-up to #116. #117 bumped the busy-timeout but warnings continued (~every 10-20 min) because the timeout wasn't the flaw: each call opened a fresh connection and ran `CREATE TABLE IF NOT EXISTS` — a DDL write even on reads — colliding with the bot's long write transactions, and connections leaked. Now: one cached connection per process, DDL exactly once, pure-read `calls_today()`, and `record_call()` reconnects + retries once on a locked write before falling back to the in-memory count. Tests: 706 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)