### PR TITLE
fix(kalshi): derive YES asks from NO bids in the order book (stops entry churn)

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -431,26 +431,35 @@ class KalshiClient:
             # API returns orderbook_fp (dollar strings) or orderbook (cents)
             book = data.get("orderbook_fp", data.get("orderbook", {}))
 
-            bids = []
-            for level in (book.get("yes_dollars") or book.get("yes") or book.get("var_true") or []):
+            def _level_price(level) -> tuple[float, float]:
+                """Return (price_in_dollars, size) for a raw book level."""
                 if isinstance(level, list):
                     # [price_str, size_str] in dollars
-                    bids.append(OrderBookLevel(price=float(level[0]), size=float(level[1])))
-                elif isinstance(level, dict):
-                    price = float(level.get("price", 0))
-                    if price > 1:
-                        price = price / 100
-                    bids.append(OrderBookLevel(price=price, size=float(level.get("count", 0))))
+                    return float(level[0]), float(level[1])
+                price = float(level.get("price", 0))
+                if price > 1:  # cents API
+                    price = price / 100
+                return price, float(level.get("count", 0))
+
+            # Kalshi only publishes RESTING BIDS on each side: `yes` = bids to
+            # buy YES, `no` = bids to buy NO. There is no explicit ask array.
+            #   - YES bids map directly to our book bids.
+            #   - A NO bid at price p is an offer to SELL YES at (1 - p), so it
+            #     becomes a YES ask at (1 - p). Without this conversion, asks
+            #     held the raw NO-bid prices, and best_ask = min(asks) collapsed
+            #     to the cheapest longshot NO bid (~$0.01). The router then
+            #     crossed every BUY entry to that phantom 1c ask, the order
+            #     rested forever, TTL-cancelled, and re-approved next cycle —
+            #     an unfillable churn loop on illiquid tail bins.
+            bids = []
+            for level in (book.get("yes_dollars") or book.get("yes") or book.get("var_true") or []):
+                price, size = _level_price(level)
+                bids.append(OrderBookLevel(price=price, size=size))
 
             asks = []
             for level in (book.get("no_dollars") or book.get("no") or book.get("var_false") or []):
-                if isinstance(level, list):
-                    asks.append(OrderBookLevel(price=float(level[0]), size=float(level[1])))
-                elif isinstance(level, dict):
-                    price = float(level.get("price", 0))
-                    if price > 1:
-                        price = price / 100
-                    asks.append(OrderBookLevel(price=price, size=float(level.get("count", 0))))
+                no_price, size = _level_price(level)
+                asks.append(OrderBookLevel(price=round(1.0 - no_price, 4), size=size))
 
             return OrderBook(bids=bids, asks=asks)
         except Exception as e:

--- a/tests/test_orderbook_parse.py
+++ b/tests/test_orderbook_parse.py
@@ -84,3 +84,47 @@ async def test_fetch_error_returns_empty_book():
 
     assert book.bids == []
     assert book.asks == []
+
+
+# ---------------------------------------------------------------------------
+# Kalshi: the book publishes resting BIDS on each side. `yes` = YES bids,
+# `no` = NO bids. A NO bid at p is an offer to sell YES at (1 - p), so asks
+# must be derived as (1 - no_price). Modelled on a live KXGDPYEAR tail bin.
+# ---------------------------------------------------------------------------
+
+def _kalshi_client(payload: dict):
+    import json
+    from unittest.mock import AsyncMock
+    from auramaur.exchange.kalshi import KalshiClient
+
+    c = KalshiClient.__new__(KalshiClient)
+    c._init_api = lambda: None
+    c._markets_api = MagicMock()
+    resp = MagicMock(raw_data=json.dumps(payload))
+    c._call = AsyncMock(return_value=resp)
+    return c
+
+
+@pytest.mark.asyncio
+async def test_kalshi_ask_derived_from_no_bid():
+    """best_ask must be (1 - best NO bid), not the raw NO-bid price.
+
+    Regression for the zero-price churn loop: with the raw NO-bid price,
+    best_ask = min(no_bids) collapsed to the cheapest longshot bid (~0.01),
+    yielding a negative spread and an unfillable 1c entry that re-approved
+    every cycle.
+    """
+    c = _kalshi_client({
+        "orderbook": {
+            # YES bids: best is 0.07
+            "yes": [["0.01", "922"], ["0.07", "1500"]],
+            # NO bids: best is 0.86 -> YES ask 0.14; a 0.01 longshot bid -> 0.99
+            "no": [["0.01", "4401"], ["0.86", "2"], ["0.45", "777"]],
+        }
+    })
+
+    book = await c.get_order_book("KXGDPYEAR-30-B2.3")
+
+    assert book.best_bid == 0.07
+    assert book.best_ask == 0.14          # 1 - 0.86, NOT the raw 0.01 NO bid
+    assert book.spread == pytest.approx(0.07)   # positive, not -0.06


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.