### PR TITLE
fix(reconciler): fall back to avg_cost when CLOB marks a live position at $0

### DIFF
--- a/auramaur/broker/reconciler.py
+++ b/auramaur/broker/reconciler.py
@@ -159,6 +159,23 @@ class PositionReconciler:
                 # Fall back to current price — treats the dust as flat P&L.
                 avg_cost = current_price if current_price > 0 else 0.5
 
+            # The CLOB get_market `price` field comes back 0/missing for
+            # thinly-traded tokens, but these positions are ACTIVE and held.
+            # Marking them at $0 understates the portfolio and fabricates a
+            # -100% unrealized loss — and portfolio value feeds the risk gates
+            # (drawdown / daily-loss) and Kelly sizing. Fall back to avg_cost
+            # (the real fill price) so the mark is flat P&L, not a phantom total
+            # loss. Matched positions still get a live book price from
+            # _sync_live; this floor only catches the reconciler-only positions
+            # (no market row) that never reach it.
+            if current_price <= 0:
+                log.info(
+                    "reconciler.zero_price_fallback",
+                    market_id=market_id or condition_id[:16],
+                    avg_cost=round(avg_cost, 4),
+                )
+                current_price = avg_cost
+
             positions.append(ReconciledPosition(
                 market_id=market_id or condition_id[:16],
                 condition_id=condition_id,

--- a/tests/test_reconciler_mark.py
+++ b/tests/test_reconciler_mark.py
@@ -1,0 +1,79 @@
+"""Reconciler must not mark an ACTIVE held position at $0.
+
+The CLOB ``get_market`` ``price`` field comes back 0/missing for thinly-traded
+tokens. The reconciler discovers these positions from on-chain trades and
+(for ones with no DB market row) persists them via ``_merge_new_positions``,
+carrying the reconciler's ``current_price``. With no fallback, 47 live
+Polymarket positions (~$244 cost) were marked $0 — understating the portfolio
+and fabricating -100% unrealized losses that feed the risk gates and Kelly.
+
+The fix: when the CLOB price is 0, fall back to avg_cost (the real fill price).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.broker.reconciler import PositionReconciler
+
+
+def _exchange(trades, market_info):
+    async def clob_call(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    client = SimpleNamespace(
+        get_trades=lambda: trades,
+        get_market=lambda cid: market_info,
+    )
+    return SimpleNamespace(
+        _clob_client=client,
+        _init_clob_client=lambda: None,
+        _settings=SimpleNamespace(polymarket_proxy_address="0xPROXY"),
+        clob_call=clob_call,
+        register_market_tokens=lambda *a, **k: None,
+    )
+
+
+def _trade(asset_id="TOKNO", price="0.06", size="100", outcome="NO"):
+    return {
+        "status": "CONFIRMED",
+        "market": "0xCOND",
+        "outcome": outcome,
+        "trader_side": "TAKER",
+        "asset_id": asset_id,
+        "side": "BUY",
+        "size": size,
+        "price": price,
+        "maker_orders": [],
+    }
+
+
+async def _run(token_price):
+    market_info = {
+        "question": "Q?",
+        "market_slug": "q",
+        "tokens": [{"token_id": "TOKNO", "price": token_price, "outcome": "No"}],
+    }
+    recon = PositionReconciler(_exchange([_trade()], market_info), db=None)
+    recon._find_market_id = AsyncMock(return_value="mkt1")
+    return await recon.reconcile()
+
+
+@pytest.mark.asyncio
+async def test_zero_clob_price_falls_back_to_avg_cost():
+    positions = await _run(token_price=0)
+    assert len(positions) == 1
+    # avg_cost = total_cost/net = 6.0/100 = 0.06; must NOT be marked $0.
+    assert positions[0].current_price == pytest.approx(0.06)
+    assert positions[0].avg_cost == pytest.approx(0.06)
+
+
+@pytest.mark.asyncio
+async def test_nonzero_clob_price_is_kept():
+    positions = await _run(token_price=0.045)
+    assert len(positions) == 1
+    # A real CLOB price must be used as-is, not overridden by the fallback.
+    assert positions[0].current_price == pytest.approx(0.045)


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.