### PR TITLE
fix(sync): avg_cost floor in _sync_live when the market row has no price

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -153,6 +153,15 @@ class PositionSyncer:
                 else:
                     current_price = yes_price
 
+                # No usable market price — a stale or never-scanned market row
+                # carries 0 for both sides. Fall back to avg_cost so an ACTIVE
+                # held position isn't marked $0: a phantom -100% loss that
+                # distorts portfolio value, the risk gates, and Kelly. Mirrors
+                # the reconciler floor; real book/market marks still win when
+                # present (this only fires when current_price resolved to 0).
+                if current_price <= 0:
+                    current_price = float(row["avg_cost"] or 0)
+
                 category = row["category"] or ""
 
                 positions.append(

--- a/tests/test_sync_token_mark.py
+++ b/tests/test_sync_token_mark.py
@@ -137,6 +137,34 @@ def test_unknown_label_empty_book_falls_back_to_yes_price():
     asyncio.run(run())
 
 
+def test_no_price_data_market_falls_back_to_avg_cost():
+    """A stale/never-scanned market row carries 0 for both prices. An ACTIVE
+    held position must NOT be marked $0 (a phantom -100% loss) — fall back to
+    avg_cost."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # Market row with NO usable price data on either side.
+            await db.execute(
+                """INSERT INTO markets (id, question, outcome_yes_price,
+                                        outcome_no_price, clob_token_yes,
+                                        clob_token_no, last_updated)
+                   VALUES ('m1', 'Q?', 0, 0, '', '', datetime('now'))""",
+            )
+            await _seed_holding(db, "m1", "YES", "tok-1", size=40.0, avg_cost=0.58)
+            await db.commit()
+
+            positions = await _syncer(db, OrderBook())._sync_live()
+            assert len(positions) == 1
+            # Marked at avg_cost (0.58), not $0.
+            assert abs(positions[0].current_price - 0.58) < 1e-9
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
 def test_markets_table_has_clob_token_columns():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.