### PR TITLE
risk: enforce graduation ladder + hard absolute per-market stake ceiling

### DIFF
--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -110,6 +110,14 @@ class RiskManager:
         if max_stake <= 1.0:
             max_stake = equity * max_stake
 
+        # Hard absolute ceiling — binds LAST, after the equity conversion and any
+        # regime scaling. The 2%-of-equity cap grows as the book grows and the
+        # regime can scale it up, so without this the documented per-market limit
+        # silently drifts (a $40 news_speed entry at ~3.3% of equity got through
+        # on 2026-06-15). Clamping here flows into both the Kelly cap below
+        # (max_stake=min(max_stake, cash)) and the post-sizing max_stake check.
+        max_stake = min(max_stake, rc.max_stake_abs_ceiling)
+
         # Kelly sizes against the full deployable cash; max_stake is the
         # ceiling that actually binds. The previous min(cash, max_stake*3)
         # double-capped: with fraction<=0.55 and edge capped at ±20% (so

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -36,7 +36,12 @@ execution:
 
 risk:
   max_drawdown_pct: 15.0
-  max_stake_per_market: 0.02
+  max_stake_per_market: 0.02   # <=1.0 => fraction of equity (2%)
+  # Hard $ ceiling applied AFTER the equity conversion and regime scaling, so the
+  # per-market cap can't drift as the book grows or the regime scales up. Matches
+  # the documented $25/market limit (a $40 entry at ~3.3% equity slipped through
+  # 2026-06-15 before this clamp existed).
+  max_stake_abs_ceiling: 25.0
   daily_loss_limit: 200.0
   max_open_positions: 500
   min_edge_pct: 2.5
@@ -102,7 +107,13 @@ graduation:
   # on current data enforce would paper-force most of the llm book (cells
   # are unproven at n<20 or negative) — that is the redesign's intent, but
   # flip it consciously.
-  mode: "observe"
+  # FLIPPED to enforce 2026-06-15: the ledger showed an unproven, 0-for-15
+  # (-$3.86 live) news_speed cell sizing a $40 live entry under observe. No
+  # directional cell has a proven positive live record yet, so enforce
+  # paper-forces directional books until they earn live capital on the
+  # ledger; arbitrage/market_maker stay live (exempt). Entries only — open
+  # positions are never stranded (exits bypass the risk manager).
+  mode: "enforce"
   min_events: 20
   window_days: 90
   probation_multiplier: 0.5

--- a/config/settings.py
+++ b/config/settings.py
@@ -60,6 +60,12 @@ class ExecutionConfig(BaseModel):
 class RiskConfig(BaseModel):
     max_drawdown_pct: float = 15.0
     max_stake_per_market: float = 25.0
+    # Hard absolute ceiling on per-market stake, in dollars. max_stake_per_market
+    # is interpreted as a fraction of EQUITY when <= 1.0, which grows as the book
+    # grows; the regime scaler can lift it further. This is the final clamp so the
+    # documented per-market cap actually binds regardless of equity/regime
+    # (a $40 entry at ~3.3% of equity slipped through before, 2026-06-15).
+    max_stake_abs_ceiling: float = 25.0
     daily_loss_limit: float = 200.0
     max_open_positions: int = 200
     min_edge_pct: float = 5.0

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -152,6 +152,37 @@ async def test_evaluate_passing_case(mock_kill):
 
 @pytest.mark.asyncio
 @patch("auramaur.risk.manager.check_kill_switch")
+async def test_per_market_stake_clamped_to_absolute_ceiling(mock_kill):
+    """2%-of-equity * regime can exceed the documented cap as the book grows;
+    the absolute ceiling must bind so per-market stake never drifts past it."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    # max_stake as a FRACTION (0.50 = 50% of equity) — huge against a big
+    # bankroll. The $25 absolute ceiling must clamp it.
+    settings = _make_settings(max_stake_per_market=0.50, min_edge_pct=2.5)
+    settings.risk.max_stake_abs_ceiling = 25.0
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    # Strong signal + large cash: Kelly wants far more than $25.
+    signal = _make_signal(edge=20.0, claude_prob=0.70, market_prob=0.50)
+    market = _make_market()
+
+    decision = await manager.evaluate(signal, market, available_cash=5000.0)
+
+    assert decision.approved is True
+    assert decision.position_size > 0
+    # Without the ceiling this would size to thousands (50% of $5000 equity);
+    # the clamp holds it at the documented $25.
+    assert decision.position_size <= 25.0 + 1e-9
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
 async def test_evaluate_fails_on_low_edge(mock_kill):
     from auramaur.risk.checks import CheckResult
     mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.