### PR TITLE
fix(entailment_arb): fetch conditional-pair legs directly, not via the scan

### DIFF
--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -192,11 +192,35 @@ class EntailmentArbPillar:
             "SELECT market_id_a, market_id_b FROM market_relationships "
             "WHERE relationship_type = 'conditional'",
         )
+        # Load each leg DIRECTLY rather than intersecting with the scan window.
+        # The scan is the top-N markets by VOLUME; conditional pairs are mostly
+        # niche/low-volume markets, so both legs almost never co-occur in by_id
+        # and the strategy evaluated ~none of its 50+ ready pairs. Prefer the
+        # freshly-scanned market when present, else fetch it once (cached for
+        # this cycle). Dead/illiquid legs are filtered by _real_book.
+        fetch_cache: dict[str, Market | None] = {}
+
+        async def _leg(mid: str) -> Market | None:
+            if mid in by_id:
+                return by_id[mid]
+            if mid not in fetch_cache:
+                try:
+                    fetch_cache[mid] = await self._discovery.get_market(mid)
+                except Exception as e:
+                    log.debug("entailment.leg_fetch_error", market_id=mid, error=str(e))
+                    fetch_cache[mid] = None
+            return fetch_cache[mid]
+
         out = []
         for r in rows or []:
-            a, b = by_id.get(r["market_id_a"]), by_id.get(r["market_id_b"])
-            if a is not None and b is not None:
+            a = await _leg(r["market_id_a"])
+            b = await _leg(r["market_id_b"])
+            if (a is not None and b is not None
+                    and self._real_book(a) and self._real_book(b)):
                 out.append((a, b))
+        if out:
+            log.info("entailment.conditional_pairs", evaluable=len(out),
+                     total=len(rows or []))
         return out
 
     async def _verify_llm(self, a: Market, b: Market):

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -290,6 +290,38 @@ def test_llm_verification_gates_fuzzy_pairs():
     asyncio.run(run())
 
 
+def test_conditional_pairs_fetched_outside_scan_window():
+    """Pre-computed conditional pairs are niche/low-volume and rarely land in
+    the top-N-by-volume scan window; _conditional_pairs must fetch each leg
+    directly rather than intersect with by_id, or the strategy stays silent
+    (root cause of entailment_arb emitting zero signals)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            a = _market("ca", "Will A happen?", 0.30)
+            b = _market("cb", "Will B happen?", 0.50)
+            await db.execute(
+                "INSERT INTO market_relationships (market_id_a, market_id_b, "
+                "relationship_type, strength) VALUES ('ca', 'cb', 'conditional', 0.9)")
+            await db.commit()
+
+            # Scan window (get_markets) returns NEITHER leg — both must be
+            # fetched directly via get_market.
+            pillar = _pillar(db, _settings(), markets=[])
+            pillar._discovery.get_market = AsyncMock(
+                side_effect=lambda mid: {"ca": a, "cb": b}.get(mid))
+
+            pairs = await pillar._conditional_pairs(by_id={})
+            assert len(pairs) == 1
+            assert {pairs[0][0].id, pairs[0][1].id} == {"ca", "cb"}
+            assert pillar._discovery.get_market.await_count == 2
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
 def test_llm_low_confidence_blocks():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
## Why
`entailment_arb` has emitted **zero signals since it shipped** — starving the July graduation decision of any data for this pillar.

**Root cause:** `_conditional_pairs` only evaluated a pre-computed pair when **both** legs were in `by_id` — the per-cycle scan, which is `discovery.get_markets(order="volume")`, i.e. the **top-N markets by volume**. Conditional pairs are mostly niche/low-volume markets, so both legs almost never co-occur in that slice. Evidence: **55 of 57** `conditional` relationships have both legs active and ready, but the strategy evaluated ~none of them, every cycle.

## Fix
Load each leg **directly** — prefer the freshly-scanned market when present, else fetch it once per cycle (cached) via `discovery.get_market`. Dead/illiquid legs are still filtered by `_real_book`. All ready conditional pairs are now evaluable regardless of their volume rank.

Scoped: the `ladder_pairs` path is still scan-window-bound (smaller, separate follow-up) — the conditional path was the large ready win.

## Tests
- `test_conditional_pairs_fetched_outside_scan_window` — a pair whose legs are absent from the scan is still evaluated via direct fetch.
- Full entailment suite green (10 passed).

## Context
One of two silent provisional strategies found while auditing the July pipeline. The other, `resolution_lens`, has a related-but-different coverage problem (long-tail single-market scan) — proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)