### PR TITLE
fix(resolution_lens): select candidates by lexical pre-filter, not volume scan

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -155,13 +155,73 @@ class ResolutionLensPillar:
         )
         return row is not None
 
+    # -- candidate selection ----------------------------------------------
+
+    async def _lexical_candidates(self) -> list[Market]:
+        """Select candidates by fine-print LEXICAL shape across the FULL markets
+        table, not the top-N-by-volume scan.
+
+        resolution_lens mines the long tail — niche markets with tricky
+        resolution criteria — but the per-cycle scan is the top markets by
+        VOLUME, the mainstream where fine print rarely diverges, re-scanned
+        every cycle. So it never reached its own opportunity set and emitted
+        zero signals. The markets table caches question + description (the fine
+        print) + price + liquidity + end_date for ~all markets — everything
+        ``_eligible`` and the LLM lens need — so we filter the whole universe
+        cheaply by trigger keywords here and let the precise ``has_lens_trigger``
+        regex + ``_eligible`` refine. Per-cycle LLM work stays bounded by
+        ``max_llm_calls_per_cycle``; the lens_verdicts cache advances coverage
+        across cycles.
+        """
+        rows = await self._db.fetchall(
+            """SELECT id, question, description, category, end_date,
+                      outcome_yes_price, outcome_no_price, liquidity,
+                      clob_token_yes, clob_token_no
+               FROM markets
+               WHERE active = 1 AND exchange = 'polymarket'
+                 AND (question LIKE '%announce%' OR question LIKE '%official%'
+                      OR question LIKE '%confirm%' OR question LIKE '%permanent%'
+                      OR question LIKE '%exactly%' OR question LIKE '%ceasefire%'
+                      OR question LIKE '%declare%' OR question LIKE '%ranked%'
+                      OR question LIKE '%lasting%' OR question LIKE '%between %'
+                      OR question LIKE '%state%' OR question LIKE '% #%')""",
+        )
+        out: list[Market] = []
+        for r in rows or []:
+            if not has_lens_trigger(r["question"]):
+                continue
+            end = None
+            if r["end_date"]:
+                try:
+                    end = datetime.fromisoformat(str(r["end_date"]).replace("Z", "+00:00"))
+                except (ValueError, AttributeError):
+                    pass
+            out.append(Market(
+                id=r["id"], exchange="polymarket",
+                question=r["question"] or "", description=r["description"] or "",
+                category=r["category"] or "",
+                outcome_yes_price=r["outcome_yes_price"] or 0.0,
+                outcome_no_price=r["outcome_no_price"] or 0.0,
+                liquidity=r["liquidity"] or 0.0, volume=r["liquidity"] or 0.0,
+                clob_token_yes=r["clob_token_yes"] or "",
+                clob_token_no=r["clob_token_no"] or "",
+                end_date=end, active=True,
+            ))
+        return out
+
     # -- main cycle --------------------------------------------------------
 
     async def run_once(self) -> int:
         cfg = self._settings.resolution_lens
         if not cfg.enabled:
             return 0
-        markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        # Lexical pre-filter over the whole universe; fall back to the volume
+        # scan only if the markets table is empty (cold start).
+        markets = await self._lexical_candidates()
+        if markets:
+            log.info("lens.candidates", lexical=len(markets))
+        else:
+            markets = await self._discovery.get_markets(limit=cfg.scan_limit)
         calls = 0
         entered = 0
         for m in markets:

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -319,3 +319,39 @@ def test_gap_audit_caching():
         await db.close()
 
     asyncio.run(run())
+
+
+def test_lexical_candidates_scan_whole_table_not_volume_top():
+    """Candidates are selected by fine-print lexical shape across the FULL
+    markets table — not the top-N-by-volume scan — so the long-tail markets
+    the lens targets are reachable (root cause of zero signals)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            async def _ins(mid, q, exchange="polymarket", active=1, liq=5000.0):
+                await db.execute(
+                    "INSERT INTO markets (id, exchange, question, description, "
+                    "category, end_date, outcome_yes_price, outcome_no_price, "
+                    "liquidity, clob_token_yes, clob_token_no, active, last_updated) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?, datetime('now'))",
+                    (mid, exchange, q,
+                     "Long fine-print resolution criteria describing the strict "
+                     "written bar that must be met for YES to resolve.",
+                     "politics_intl",
+                     (datetime.now(timezone.utc) + timedelta(days=20)).isoformat(),
+                     0.30, 0.70, liq, "ty", "tn", active))
+            await _ins("hit", "Will Iran officially announce a permanent ceasefire?")
+            await _ins("plain", "Will Bitcoin go up tomorrow?")            # no trigger
+            await _ins("inactive", "Will X officially confirm it?", active=0)
+            await _ins("kalshi", "Will Y officially announce?", exchange="kalshi")
+            await db.commit()
+
+            pillar = _pillar(db, _settings(), markets=[])
+            cands = await pillar._lexical_candidates()
+            assert {m.id for m in cands} == {"hit"}
+            assert cands[0].description  # fine print loaded from the cache
+        finally:
+            await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Why
`resolution_lens` has emitted **zero signals since it shipped** — the second silent provisional pillar starving the July graduation decision.

**Root cause:** `run_once` scanned `discovery.get_markets(limit=scan_limit)` — the **top-N markets by volume**, re-scanned every cycle. The lens mines the **long tail** (niche markets with tricky resolution criteria, where fine print diverges from the headline), so it never reached its own opportunity set and re-examined the same mainstream markets forever.

## Fix
Add `_lexical_candidates()`: filter the **full** `markets` table by the trigger keywords (refined by the precise `has_lens_trigger` regex) and build `Market` objects from the cached rows. The table caches `question` + `description` (the fine print) + price + liquidity + end_date for ~all markets — everything `_eligible` and the LLM lens need — so **no per-candidate refetch**. `run_once` uses these; it falls back to the volume scan only on a cold start (empty table).

Cost stays bounded: per-cycle LLM work is capped by `max_llm_calls_per_cycle` (5), and the `lens_verdicts` cache advances coverage across cycles. On live data this surfaces **~545 liquidity-qualified fine-print candidates** vs ~0 reachable before.

## Tests
- `test_lexical_candidates_scan_whole_table_not_volume_top` — selects by lexical shape across the full table; skips plain/inactive/non-poly markets; loads the cached description.
- Full lens suite green (8 passed); existing `run_once` tests survive via the cold-start fallback.

## Context
Companion to #124 (entailment_arb direct-fetch). Both provisional pillars were silent because they relied on the volume scan to surface niche targets it never contained; both now query directly for their opportunity set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)