### PR TITLE
fix(risk): paper-forced signals bypass live-only gates (allowlist + divergence)

### DIFF
--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -65,6 +65,17 @@ class RiskManager:
         # blocks unexplained divergences without spending an LLM call.
         self.gap_auditor = None
 
+    def _paper_forced_strategy(self, strategy_source: str) -> bool:
+        """True if this strategy is paper-forced by its own config flag
+        (e.g. bias_harvest/entailment_arb/resolution_lens carry ``paper: true``).
+
+        ``is True`` is deliberate: it only trips on a genuine bool, so a
+        MagicMock settings object in tests (whose attributes are truthy) does
+        NOT read as paper-forced.
+        """
+        cfg = getattr(self.settings, strategy_source or "", None)
+        return getattr(cfg, "paper", False) is True
+
     async def evaluate(
         self,
         signal: Signal,
@@ -143,6 +154,24 @@ class RiskManager:
         cat_exp = category_exposure.get(market.category, 0.0)
 
         # ----------------------------------------------------------------
+        # Will this entry be paper-traded? — global paper mode, a per-strategy
+        # paper-forced pillar (bias_harvest/entailment_arb/resolution_lens), or
+        # a graduation-demoted/unproven cell. Paper exploration must BYPASS the
+        # live-only gates (category allowlist + divergence-adverse filter) so
+        # paper-forced strategies build a complete pnl_ledger record across all
+        # categories for the graduation ladder to evaluate; genuine live entries
+        # keep every gate. The blocklist still applies to paper — decided-no-edge
+        # categories never even paper-trade. `cell` is cached, so computing it
+        # here and reusing it below is free.
+        cell = await self.graduation.decide(
+            signal.strategy_source, market.category or "")
+        is_paper_entry = (
+            not self.settings.is_live
+            or self._paper_forced_strategy(signal.strategy_source)
+            or cell.force_paper
+        )
+
+        # ----------------------------------------------------------------
         # Run pre-sizing checks (max_stake validated after sizing)
         # ----------------------------------------------------------------
         pre_checks: list[CheckResult] = [
@@ -154,7 +183,8 @@ class RiskManager:
             await check_min_edge(signal.edge, regime.min_edge_pct),
             await check_divergence_band(
                 signal.claude_prob, signal.market_prob, signal.claude_confidence,
-                rc.divergence_filter_enabled, rc.divergence_adverse_low,
+                rc.divergence_filter_enabled and not is_paper_entry,
+                rc.divergence_adverse_low,
                 rc.divergence_adverse_high, rc.divergence_require_confidence),
             await check_min_liquidity(max(market.liquidity, market.volume), rc.min_liquidity),
             await check_max_spread(market.spread, rc.max_spread_pct),
@@ -191,7 +221,7 @@ class RiskManager:
         # demonstrated edge in; unknown/'other' markets stay paper-only, so
         # a classifier gap costs opportunity, not money. The fresh keyword
         # classification stays the #17 tripwire for confidently-bad labels.
-        if self.settings.is_live:
+        if not is_paper_entry:
             pre_checks.append(await check_category_allowlist(
                 market.category or "", rc.allowed_categories_live,
                 applies=category_applies,
@@ -290,11 +320,10 @@ class RiskManager:
             else "; ".join(c.reason for c in failed)
         )
 
-        # Graduation ladder: the cell's measured record decides whether this
-        # ENTRY trades live, on probation size, or paper-forced. Applied after
-        # all checks so it can only restrict an already-approved trade.
-        cell = await self.graduation.decide(
-            signal.strategy_source, market.category or "")
+        # Graduation ladder: the cell's measured record (decided above) sets
+        # whether this ENTRY trades live, on probation size, or paper-forced.
+        # Applied after all checks so it can only restrict an already-approved
+        # trade.
         if all_passed and cell.size_multiplier != 1.0:
             position_size = position_size * cell.size_multiplier
 

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -405,6 +405,40 @@ async def test_live_allowlist_fails_closed_on_other_and_unknown(mock_kill):
 
 @pytest.mark.asyncio
 @patch("auramaur.risk.manager.check_kill_switch")
+async def test_paper_forced_strategy_bypasses_live_only_gates(mock_kill):
+    """A paper-forced exploration pillar (cfg.paper=True) must NOT be gated by
+    the live-only category allowlist or the divergence-adverse filter, so it can
+    build a complete paper record across all categories for the graduation
+    ladder. Genuine live entries still hit both gates (tested above)."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(is_live=True, allowed_categories_live=["crypto"])
+    # genuine bool -> _paper_forced_strategy trips (MagicMock attrs would not)
+    settings.resolution_lens = MagicMock()
+    settings.resolution_lens.paper = True
+    settings.risk.divergence_filter_enabled = True  # would reject MEDIUM in-band
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    market = _make_market(category="other")   # NOT on the allowlist
+    # 10% divergence, MEDIUM confidence -> the divergence filter WOULD reject a
+    # live forecast here.
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50,
+                       confidence=Confidence.MEDIUM)
+    sig.strategy_source = "resolution_lens"
+    d = await manager.evaluate(sig, market, available_cash=500.0)
+
+    failed = [c.name for c in d.checks if not c.passed]
+    assert "category_allowlist" not in [c.name for c in d.checks]  # gate not run
+    assert "divergence_band" not in failed                          # bypassed
+    assert d.approved is True
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
 async def test_live_allowlist_passes_allowed_category(mock_kill):
     """An allowlisted stored label trades live even when the fresh keyword
     classification is inconclusive ('other') — eligibility hangs on the


### PR DESCRIPTION
## Why
The provisional pillars (bias_harvest, entailment_arb, resolution_lens) are paper-forced to build a `pnl_ledger` record for the July graduation decision — but they emit **~0 paper entries**. Today's #124/#125 unblocked candidate *discovery* (resolution_lens now finds **32 gap≥0.4 mispricings**), but the signals then die at the **risk gate**:

- The risk manager keys its **live-only gates** off the **global** `is_live` flag.
- The session runs **globally live** (so arb/market-making can trade), so paper-forced exploration signals hit those gates and are rejected before becoming paper trades.

Measured live for resolution_lens: **123 `risk_rejected` / 0 entries**, split between `category 'other' not allowed for live` (27×) and `divergence … MEDIUM < HIGH` (75×+).

## Fix
Compute `is_paper_entry` early — **global paper OR a per-strategy paper-forced pillar OR a graduation-demoted/unproven cell** — and skip the two live-only gates when set:
- **category allowlist** (its own docstring already says "paper mode never calls this");
- **divergence-adverse filter** (a forecast-adverse-selection guard, misapplied to MEDIUM-confidence *structural* signals).

Live entries keep **every** gate. The **blocklist still applies to paper** — decided-no-edge categories (sports/politics_us/entertainment) never even paper-trade. The graduation `cell` is now computed once (cached) and reused for both the bypass decision and the final size/`force_paper`.

`_paper_forced_strategy` uses `is True` so a MagicMock `settings` in tests doesn't read as paper-forced.

## Tests
- `test_paper_forced_strategy_bypasses_live_only_gates` — a paper-forced pillar in `other` with a MEDIUM in-band divergence is approved (both gates skipped).
- Existing live-allowlist fail-closed + divergence tests still pass (live entries unaffected). 59 green across risk/graduation/provisional suites.

## Context
Final piece of the July-pipeline unblock: #124 (entailment fetch) + #125 (lens lexical pre-filter) fixed *discovery*; this fixes *admission* so the paper record actually accrues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)