### PR TITLE
fix(exit): cross to the bid within a slippage band, else skip + back off

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -846,26 +846,37 @@ class AuramaurBot:
             return False
 
         sell_price = max(0.01, min(0.99, round(pos.current_price, 2)))
-        # Marketable exit: a SELL at the snapshot price sits at/above the ask,
-        # rests until the TTL reaper cancels it, and the cleared exit
-        # suppression re-posts it next pass — the Obama winner looped like
-        # that for 2 days (35 cancelled SELLs, no fill). Take the real bid
-        # when it's within the cross-down budget; otherwise post at the
-        # budget floor, which still sits inside the spread instead of on top
-        # of the ask. Best-effort: no book, no change.
+        # Marketable exit: a SELL only fills by crossing down to the real bid.
+        # Pricing at the snapshot — or anywhere inside the spread — rests above
+        # the bid, TTL-cancels, and the cleared exit suppression re-posts it
+        # next pass: the Obama winner looped that way for 2 days, and market
+        # 1287614 the same (bid 0.27 vs a 0.48 mark, order resting at 0.45).
+        # So take the bid outright when it's within the slippage band and above
+        # the junk floor; otherwise skip. Returning False (no order placed)
+        # leaves the portfolio monitor's exit-failure suppression set, which
+        # backs the retry off until restart or resolution instead of looping.
         try:
-            max_cross = float(self.settings.execution.exit_max_cross_cents) / 100.0
+            max_slip = float(self.settings.execution.exit_max_cross_cents) / 100.0
         except Exception:
-            max_cross = 0.03
+            max_slip = 0.10
+        try:
+            min_bid = float(self.settings.execution.exit_min_bid_price)
+        except Exception:
+            min_bid = 0.05
         try:
             book = await exchange.get_order_book(token_id)
+        except Exception as e:
+            # Genuine fetch error (network/API) — best-effort: post at the
+            # snapshot. This is the transient path, not the wide-spread loop.
+            log.debug("exit.book_unavailable", market_id=pos.market_id, error=str(e))
+            book = None
+        if book is not None:
             best_bid = book.best_bid
             best_ask = book.best_ask
-            # Mark-vs-book sanity: when even the budget floor sits far above
-            # the best ask, the snapshot is not what this token's book will
-            # pay (mislabeled side, stale mark) — the order can only rest
-            # until the TTL reaper kills it. Skip instead of looping.
-            if best_ask is not None and (sell_price - max_cross) > best_ask + 0.10:
+            # Mark-vs-book sanity: when the snapshot sits far above the best
+            # ask, the mark is fiction (mislabeled side, stale price) — even
+            # the bid is meaningless. Clearer signal than bid_too_thin.
+            if best_ask is not None and (sell_price - max_slip) > best_ask + 0.10:
                 log.warning(
                     "exit.mark_book_divergence",
                     market_id=pos.market_id,
@@ -874,19 +885,42 @@ class AuramaurBot:
                     best_bid=best_bid,
                 )
                 return False
-            if best_bid is not None and best_bid > 0:
-                marketable = max(best_bid, sell_price - max_cross)
-                if marketable < sell_price:
-                    log.info(
-                        "exit.priced_to_bid",
-                        market_id=pos.market_id,
-                        snapshot=sell_price,
-                        bid=best_bid,
-                        price=round(marketable, 2),
-                    )
-                sell_price = max(0.01, min(0.99, round(marketable, 2)))
-        except Exception as e:
-            log.debug("exit.book_unavailable", market_id=pos.market_id, error=str(e))
+            # No buyers at all — nothing to cross into; redeem at resolution.
+            if best_bid is None or best_bid <= 0:
+                log.warning(
+                    "exit.no_bid", market_id=pos.market_id, snapshot=sell_price,
+                )
+                return False
+            # Junk bid below the absolute floor — redeeming beats dumping.
+            if best_bid < min_bid:
+                log.warning(
+                    "exit.bid_below_floor",
+                    market_id=pos.market_id,
+                    snapshot=sell_price,
+                    bid=best_bid,
+                    floor=min_bid,
+                )
+                return False
+            # Bid too far under the mark to accept the slippage — back off.
+            if best_bid < sell_price - max_slip:
+                log.warning(
+                    "exit.bid_too_thin",
+                    market_id=pos.market_id,
+                    snapshot=sell_price,
+                    bid=best_bid,
+                    max_slip=max_slip,
+                )
+                return False
+            # Cross to the bid: a marketable SELL that actually fills.
+            if best_bid < sell_price:
+                log.info(
+                    "exit.priced_to_bid",
+                    market_id=pos.market_id,
+                    snapshot=sell_price,
+                    bid=best_bid,
+                    price=round(best_bid, 2),
+                )
+            sell_price = max(0.01, min(0.99, round(best_bid, 2)))
         sell_order = Order(
             market_id=pos.market_id,
             token_id=token_id,

--- a/config/settings.py
+++ b/config/settings.py
@@ -31,11 +31,18 @@ class ExecutionConfig(BaseModel):
     # that the TTL reaper usually kills unfilled. The cross also has to leave
     # net edge above risk.min_edge_pct, so this cap only binds on wide edges.
     entry_max_cross_cents: int = 4
-    # Exit twin of entry_max_cross_cents: max cents below the position's
-    # snapshot price a SELL may cross down to hit the real bid. Without it
-    # exits posted at the snapshot price sit at/above the ask and TTL-cancel
-    # forever (the 2-day Obama-winner loop).
-    exit_max_cross_cents: int = 3
+    # Exit twin of entry_max_cross_cents: the slippage band for marketable
+    # exits. A SELL only fills by crossing down to the real bid; pricing at the
+    # snapshot (or anywhere inside the spread) rests above the bid and
+    # TTL-cancels forever (the 2-day Obama-winner loop; market 1287614). So we
+    # take the bid outright when it is within this many cents of the snapshot,
+    # otherwise skip and let the portfolio monitor back off until the book
+    # tightens or the position redeems at resolution.
+    exit_max_cross_cents: int = 10
+    # Absolute floor on the bid an exit will cross into. Below this, redeeming
+    # at resolution beats dumping into a near-zero buyer (the "junk 1c bid"
+    # guard), regardless of the slippage band above.
+    exit_min_bid_price: float = 0.05
     spread_capture_min_bps: int = 50
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -1,10 +1,13 @@
-"""Marketable exit pricing: SELLs cross down to the real bid within budget.
+"""Marketable exit pricing: SELLs cross down to the real bid, or skip.
 
-A SELL posted at the position's snapshot price sits at/above the ask, rests
-until the TTL reaper cancels it, and the cleared exit suppression re-posts
-it next pass — the Obama winner looped like that for 2 days (35 cancelled
-SELLs, no fill). Exits must take the bid when it's within the cross-down
-budget, or at worst post at the budget floor inside the spread.
+A SELL only fills by crossing down to the real bid. Posted at the snapshot
+price — or anywhere inside the spread — it sits above the bid, rests until the
+TTL reaper cancels it, and the cleared exit suppression re-posts it next pass:
+the Obama winner looped that way for 2 days (35 cancelled SELLs, no fill), and
+market 1287614 the same (bid 0.27 vs a 0.48 mark). So exits take the bid when
+it's within the slippage band and above the junk floor; otherwise they skip,
+and returning False leaves the monitor's suppression set so the retry backs
+off instead of looping.
 """
 
 from __future__ import annotations
@@ -30,10 +33,11 @@ def _book(best_bid: float | None, best_ask: float | None) -> OrderBook:
     )
 
 
-def _setup(book: OrderBook, current_price: float = 0.90):
+def _setup(book: OrderBook, current_price: float = 0.90, max_slip_cents: int = 10):
     settings = MagicMock()
     settings.is_live = False
-    settings.execution.exit_max_cross_cents = 3
+    settings.execution.exit_max_cross_cents = max_slip_cents
+    settings.execution.exit_min_bid_price = 0.05
 
     bot = AuramaurBot(settings=settings)
     db = AsyncMock()
@@ -59,30 +63,72 @@ def _setup(book: OrderBook, current_price: float = 0.90):
 
 
 @pytest.mark.asyncio
-async def test_exit_takes_bid_within_budget():
+async def test_exit_takes_bid_within_band():
+    """Bid 2c below the snapshot, well within the band — cross to the bid."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.88, 0.91), current_price=0.90)
 
     ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
     assert ok is True
     order = exchange.place_order.await_args.args[0]
-    assert order.price == 0.88  # bid is 2 cents below snapshot, within the 3-cent budget
+    assert order.price == 0.88  # the real bid, marketable
 
 
 @pytest.mark.asyncio
-async def test_exit_caps_cross_at_budget_floor():
-    bot, pos, reason, exchange, alerts = _setup(_book(0.80, 0.91), current_price=0.90)
+async def test_exit_crosses_to_bid_not_a_resting_floor():
+    """A bid 5c under the snapshot, inside a 10c band, fills at the bid (0.85)
+    — never at a 'budget floor' (0.87) that would only rest above the bid."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.85, 0.95), current_price=0.90)
 
     ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
     assert ok is True
     order = exchange.place_order.await_args.args[0]
-    assert order.price == 0.87  # bid too deep — post at snapshot minus 3-cent budget
+    assert order.price == 0.85  # crosses to the bid, not 0.87
 
 
 @pytest.mark.asyncio
-async def test_exit_keeps_snapshot_price_without_book():
+async def test_exit_skips_when_bid_below_band():
+    """Bid 0.70 is 20c under the 0.90 mark — beyond the 10c band. Selling here
+    would dump well under the mark, so skip and back off (the 1287614 case)."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.70, 0.95), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is False
+    exchange.place_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exit_skips_junk_bid_below_floor():
+    """A near-zero bid within the band is still junk: redeem at resolution
+    rather than dump into a 2c buyer."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.02, 0.20), current_price=0.12)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is False
+    exchange.place_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exit_skips_when_book_has_no_bid():
+    """An empty bid side has nothing to cross into — skip, don't rest a SELL
+    at the snapshot that can only TTL-cancel."""
     bot, pos, reason, exchange, alerts = _setup(_book(None, None), current_price=0.90)
+
+    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+
+    assert ok is False
+    exchange.place_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exit_best_effort_when_book_fetch_errors():
+    """A genuine book fetch error (network/API) is the transient path, not the
+    wide-spread loop — fall back to posting at the snapshot price."""
+    bot, pos, reason, exchange, alerts = _setup(_book(0.88, 0.91), current_price=0.90)
+    exchange.get_order_book = AsyncMock(side_effect=RuntimeError("clob timeout"))
 
     ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
@@ -94,24 +140,10 @@ async def test_exit_keeps_snapshot_price_without_book():
 @pytest.mark.asyncio
 async def test_exit_skips_when_mark_contradicts_book():
     """Snapshot $0.90 but the token's book asks $0.13: the mark is fiction
-    (wrong-side label, stale price). Posting at the budget floor ($0.87) can
-    only rest and TTL out — skip the order entirely."""
+    (wrong-side label, stale price). Skip the order entirely."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.07, 0.13), current_price=0.90)
 
     ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
     assert ok is False
     exchange.place_order.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_exit_posts_on_wide_but_plausible_spread():
-    """A wide spread whose ask is near the snapshot is legitimate — the
-    divergence gate must not block it (floor 0.87 < ask 0.95 + 0.10)."""
-    bot, pos, reason, exchange, alerts = _setup(_book(0.80, 0.95), current_price=0.90)
-
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
-
-    assert ok is True
-    order = exchange.place_order.await_args.args[0]
-    assert order.price == 0.87  # budget floor, inside the spread


### PR DESCRIPTION
## Problem

Exit SELLs only fill by crossing down to the real **bid**. The prior logic priced at `max(best_bid, snapshot - exit_max_cross_cents)`: when the bid sat more than the 3¢ budget below the mark, the budget *floor* won the `max()` and the order rested above the bid, TTL-cancelled, and the cleared exit suppression re-posted it every pass.

Market **1287614** looped exactly this way — bid 0.27 vs a 0.48 mark, order resting at 0.45, cancelled every ~140s — the same failure mode as the 2-day Obama-winner loop. The old divergence guard only inspected the **ask** side, so a wide bid-side gap slipped straight through.

## Fix

Take the bid outright when it's within `exit_max_cross_cents` of the snapshot **and** above `exit_min_bid_price` (junk-bid floor); otherwise skip. Returning `False` places no order, so the portfolio monitor's exit-failure suppression stays set and the retry **backs off** until the book tightens or the position redeems — instead of re-posting an unmarketable SELL forever.

- `exit_max_cross_cents` repurposed as the slippage band, default **3 → 10**
- new `exit_min_bid_price` (default **0.05**) absolute junk-bid floor
- genuine book-fetch errors still fall back to the snapshot (transient path preserved)
- distinct log signals: `priced_to_bid`, `bid_too_thin`, `bid_below_floor`, `no_bid`, `mark_book_divergence`
- tests rewritten for the take-bid-or-skip contract (7/7 pass)

## Verification

Ran the new `_execute_poly_exit` against the **real live book** for 1287614 (bid 0.27 / mark 0.35) with a stubbed `place_order`: it now crosses to the bid at **0.27** (a marketable sell that fills) instead of the old 0.32 resting order that looped. Restarted the live bot on this code; new paths confirmed firing in prod.

Assisted-by: Claude (Anthropic)