### PR TITLE
fix(fred): correct Job Openings series id JOLTS -> JTSJOL

### DIFF
--- a/auramaur/data_sources/fred.py
+++ b/auramaur/data_sources/fred.py
@@ -18,7 +18,7 @@ _DEFAULT_SERIES: dict[str, str] = {
     "UNRATE": "Unemployment Rate",
     "PAYEMS": "Total Nonfarm Payrolls",
     "ICSA": "Initial Jobless Claims",
-    "JOLTS": "Job Openings (JOLTS)",
+    "JTSJOL": "Job Openings (JOLTS)",
     # Prices
     "CPIAUCSL": "Consumer Price Index (CPI)",
     "CPILFESL": "Core CPI (ex Food & Energy)",


### PR DESCRIPTION
## Problem

`_DEFAULT_SERIES` in `auramaur/data_sources/fred.py` used `"JOLTS"` as a FRED series id, but that id does not exist. Every fetch cycle 400'd on it (`HTTP 400: "The series does not exist."`) — dozens of caught exceptions per hour (logged `fred_series_failed`), and economics-category markets ran without the job-openings input. Failing since at least April.

## Fix

`"JOLTS"` → `"JTSJOL"` (Job Openings: Total Nonfarm). Description keeps `(JOLTS)` so query keyword matching on "jolts" still resolves via the description string.

## Verification

Against the live FRED API:
- `JOLTS` → `HTTP 400: The series does not exist`
- `JTSJOL` → OK, latest obs `2026-04-01 = 7618.0`

All other series ids in the dict are valid and untouched.

Assisted-by: Claude (Anthropic)