### PR TITLE
fix(orders): reconcile orphaned live orders periodically, not just at startup

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2791,24 +2791,39 @@ class AuramaurBot:
         discovery: MarketDiscovery = self._components["discovery"]
         ttl = self.settings.execution.limit_order_ttl_seconds
 
-        # One-time startup reconcile: pull orphaned live orders left resting by a
-        # prior session into _live_pending so the TTL-cancel below can reap them
-        # and release their locked collateral.
-        reconciled_ids: set[int] = set()
-        for client in [primary_exchange, *exchanges.values()]:
-            if (
-                client is not None
-                and hasattr(client, "reconcile_open_orders")
-                and id(client) not in reconciled_ids
-            ):
-                reconciled_ids.add(id(client))
-                try:
-                    await client.reconcile_open_orders()
-                except Exception as e:
-                    log.debug("order_monitor.reconcile_error", error=str(e))
+        # Reconcile orphaned live orders into _live_pending so the TTL-cancel
+        # below can reap them and release their locked collateral. Runs at
+        # startup AND periodically: a one-time startup pass only recovers orphans
+        # from a *prior* session, but orders are also orphaned mid-session — a
+        # lost cancel during a network blip leaves a resting CLOB order untracked
+        # (e.g. cancel-replace whose cancel never lands stacks duplicate BUYs),
+        # which then locks collateral until the next restart. A periodic re-pull
+        # self-heals those within one interval; reconcile skips already-tracked
+        # ids, so it only captures genuine orphans.
+        async def _reconcile_orphans() -> None:
+            seen: set[int] = set()
+            for client in [primary_exchange, *exchanges.values()]:
+                if (
+                    client is not None
+                    and hasattr(client, "reconcile_open_orders")
+                    and id(client) not in seen
+                ):
+                    seen.add(id(client))
+                    try:
+                        await client.reconcile_open_orders()
+                    except Exception as e:
+                        log.debug("order_monitor.reconcile_error", error=str(e))
+
+        await _reconcile_orphans()
+        reconcile_every = 10  # cycles; loop sleeps 30s => re-pull orphans ~5 min
+        cycle = 0
 
         while self._running:
             try:
+                # Periodic orphan re-pull (see _reconcile_orphans above).
+                if cycle and cycle % reconcile_every == 0:
+                    await _reconcile_orphans()
+                cycle += 1
                 # Paper order monitoring
                 if paper.pending_orders:
                     prices: dict[str, float] = {}

--- a/tests/test_order_monitor.py
+++ b/tests/test_order_monitor.py
@@ -419,3 +419,46 @@ async def test_reconcile_orphaned_pending_trades():
     assert len(update_calls) == 1
     assert update_calls[0].args[1] == ("cancelled", "orphan-1")
     db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_order_monitor_reconciles_orphans_periodically():
+    """Orphaned live orders created mid-session (e.g. a lost cancel during a
+    network blip leaving a resting BUY untracked) must be re-pulled into
+    _live_pending periodically, not only at startup — otherwise their locked
+    collateral is stuck until the next restart (the $27 cash-lock incident)."""
+    settings = MagicMock()
+    settings.execution.limit_order_ttl_seconds = 60
+
+    bot = AuramaurBot(settings=settings)
+    bot._running = True
+
+    exchange = SimpleNamespace(
+        _live_pending={},
+        reconcile_open_orders=AsyncMock(return_value=0),
+        get_order_status=AsyncMock(),
+    )
+    paper = SimpleNamespace(
+        pending_orders=[],
+        check_fills=AsyncMock(return_value=[]),
+        cancel_expired=AsyncMock(return_value=0),
+    )
+    bot._components = {
+        "paper": paper,
+        "exchange": exchange,
+        "discovery": AsyncMock(),
+        "db": AsyncMock(),
+    }
+
+    calls = {"n": 0}
+
+    async def stop_after_n(_seconds):
+        calls["n"] += 1
+        if calls["n"] >= 12:  # let ~12 loop cycles run (reconcile_every=10)
+            bot._running = False
+
+    with patch("asyncio.sleep", new=AsyncMock(side_effect=stop_after_n)):
+        await bot._task_order_monitor()
+
+    # Startup pass + at least one periodic re-pull (at cycle 10) => >= 2.
+    assert exchange.reconcile_open_orders.await_count >= 2


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.