### PR TITLE
fix(market_maker): cancel surviving leg on partial quote placement

### DIFF
--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -484,7 +484,43 @@ class MarketMaker:
         if ask_result.status in ("paper", "filled"):
             self._update_inventory(quote.market_id, "ask", ask_result.filled_size)
 
-        success = bid_result.status not in ("rejected",) and ask_result.status not in ("rejected",)
+        bid_live = bid_result.status not in ("rejected",)
+        ask_live = ask_result.status not in ("rejected",)
+
+        # Partial placement: one leg rested, the other was rejected — usually a
+        # post-only leg that would cross a moved book. A one-legged quote is
+        # naked directional exposure the MM never wants, and leaving it here is
+        # how duplicates stack: success would be False below, so _quote_market
+        # never records the quote in _active_quotes, so the resting leg is never
+        # cancelled on refresh and a fresh pair stacks on top every cycle (the
+        # orphaned-BUY cash-lock). Cancel the survivor now for a clean slate and
+        # retry next cycle. The periodic order-monitor reconcile backstops a
+        # cancel that itself fails.
+        if bid_live != ask_live:
+            survivor_id = bid_result.order_id if bid_live else ask_result.order_id
+            survivor_status = bid_result.status if bid_live else ask_result.status
+            if (
+                survivor_status not in ("paper", "filled")
+                and survivor_id
+                and not str(survivor_id).startswith("PAPER")
+            ):
+                try:
+                    await self._exchange.cancel_order(survivor_id)
+                except Exception as e:
+                    log.debug(
+                        "market_maker.partial_leg_cancel_error",
+                        order_id=survivor_id, error=str(e),
+                    )
+            self._pending_orders.pop(bid_result.order_id, None)
+            self._pending_orders.pop(ask_result.order_id, None)
+            log.warning(
+                "market_maker.partial_quote_cancelled",
+                market_id=quote.market_id,
+                bid_status=bid_result.status,
+                ask_status=ask_result.status,
+            )
+
+        success = bid_live and ask_live
 
         log.info(
             "market_maker.quote_placed",

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -239,3 +239,53 @@ def test_select_live_mode_requires_allowlist():
     mm_paper = _maker(is_live=False)
     ids_paper = [m.id for m in mm_paper._select_mm_markets([unknown, allowed])]
     assert set(ids_paper) == {"unknown", "allowed"}
+
+
+@pytest.mark.asyncio
+async def test_partial_quote_cancels_surviving_leg():
+    """If one leg is rejected (e.g. a post-only leg that would cross a moved
+    book), the surviving leg must be cancelled. Otherwise it rests untracked —
+    success is False so _active_quotes never records it — and the next refresh
+    stacks a fresh pair on top, the orphaned-BUY cash-lock root cause."""
+    from unittest.mock import AsyncMock
+
+    mm = _maker()
+    mm._settings = SimpleNamespace(is_live=True, market_maker=mm._settings.market_maker)
+
+    placed: list[str] = []
+    counter = {"n": 0}
+
+    async def place_order(order):
+        counter["n"] += 1
+        oid = f"live-{counter['n']}"
+        placed.append(oid)
+        # Bid (1st) rests; ask (2nd) rejected by post-only crossing the book.
+        status = "pending" if counter["n"] % 2 == 1 else "rejected"
+        return SimpleNamespace(order_id=oid, status=status, filled_size=0, is_paper=False)
+
+    cancelled: list[str] = []
+
+    async def cancel_order(order_id):
+        cancelled.append(order_id)
+        return True
+
+    book = OrderBook(
+        bids=[OrderBookLevel(price=0.40, size=100)],
+        asks=[OrderBookLevel(price=0.46, size=100)],
+    )
+    mm._exchange = SimpleNamespace(
+        place_order=place_order,
+        cancel_order=cancel_order,
+        get_order_book=AsyncMock(return_value=book),
+    )
+    market = Market(
+        id="m1",
+        question="Will this happen?",
+        clob_token_yes="yes",
+        clob_token_no="no",
+    )
+
+    result, _ = await mm._quote_market(market)
+    assert result and not result.get("success")   # partial => not a live quote
+    assert cancelled == ["live-1"]                 # surviving bid leg cancelled
+    assert "m1" not in mm._active_quotes           # nothing orphaned/tracked


### PR DESCRIPTION
Description redacted — previously contained operational figures (P&L / balances / position data) not suitable for a public repo. The technical change is in the diff.