### PR TITLE
fix(resolution): settle markets resolved-but-still-active (past end_date)

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -261,22 +261,33 @@ class ResolutionTracker:
                     return result == "yes"
                 return market.outcome_yes_price > 0.5
 
-        # For everything else, the exchange must have flagged the market
-        # inactive (closed/resolved on Polymarket's side).  A still-active
-        # market is by definition not resolved, regardless of price.
-        if market.active:
+        # The exchange's active flag is the primary resolution signal, but on
+        # Polymarket it lags the actual outcome: a market stays active=True for
+        # a while after resolving, price pinned to 0/1. A market is therefore
+        # eligible for the price check when it is inactive OR already past its
+        # end_date. A still-trading market — active AND before its end_date — is
+        # never resolved regardless of price; that guard is what stops an early
+        # 95/5 market from being settled prematurely and feeding a fake outcome
+        # into calibration. (Paper positions settle ONLY through this path, so
+        # the stale active flag was stranding them indefinitely.)
+        end = getattr(market, "end_date", None)
+        if end is not None and end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        past_end_date = end is not None and datetime.now(timezone.utc) > end
+        if market.active and not past_end_date:
             return None
 
-        # Inactive + tightly converged price → resolution.  The threshold
-        # is intentionally tight (0.99/0.01) to avoid declaring a winner
-        # on markets that closed early or paused with non-trivial spread.
+        # Eligible (inactive, or past end_date) + tightly converged price →
+        # resolution.  The threshold is intentionally tight (0.99/0.01) so a
+        # market that merely closed/paused with a non-trivial spread isn't
+        # declared a winner.
         yes_price = market.outcome_yes_price
         if yes_price >= 0.99:
             return True
         if yes_price <= 0.01:
             return False
 
-        # Inactive but price ambiguous — wait for clearer signal.
+        # Eligible but price ambiguous (e.g. closed awaiting oracle) — wait.
         return None
 
     # ------------------------------------------------------------------

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,6 +21,7 @@ def _make_market(
     active: bool = False,
     yes_price: float = 1.0,
     exchange: str = "polymarket",
+    end_date=None,
 ) -> Market:
     return Market(
         id=market_id,
@@ -28,6 +30,7 @@ def _make_market(
         active=active,
         outcome_yes_price=yes_price,
         outcome_no_price=1.0 - yes_price,
+        end_date=end_date,
     )
 
 
@@ -65,6 +68,29 @@ def _make_discovery(market: Market | None):
 class TestDetectResolution:
     def test_active_market_returns_none(self):
         market = _make_market(active=True, yes_price=0.65)
+        assert ResolutionTracker._detect_resolution(market, "polymarket") is None
+
+    def test_active_past_end_date_pinned_resolves(self):
+        """Polymarket's active flag lags resolution: a market past its end_date
+        with a pinned price IS resolved even though active=True. (Paper
+        positions settle only through this path — the stale flag stranded them.)"""
+        past = datetime.now(timezone.utc) - timedelta(days=2)
+        market = _make_market(active=True, yes_price=0.0, end_date=past)
+        assert ResolutionTracker._detect_resolution(market, "polymarket") is False
+        market_yes = _make_market(active=True, yes_price=1.0, end_date=past)
+        assert ResolutionTracker._detect_resolution(market_yes, "polymarket") is True
+
+    def test_active_pre_end_date_pinned_stays_none(self):
+        """The premature-settlement guard: a still-trading market (active and
+        BEFORE end_date) is never resolved, even at an extreme price."""
+        future = datetime.now(timezone.utc) + timedelta(days=10)
+        market = _make_market(active=True, yes_price=0.99, end_date=future)
+        assert ResolutionTracker._detect_resolution(market, "polymarket") is None
+
+    def test_active_past_end_date_ambiguous_stays_none(self):
+        """Past end_date but price mid (closed awaiting oracle) — still wait."""
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        market = _make_market(active=True, yes_price=0.55, end_date=past)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is None
 
     def test_resolved_yes(self):


### PR DESCRIPTION
Description redacted — contained operational figures not suitable for a public repo. Technical change is in the diff.