### PR TITLE
chore(logging): stop logging expected conditions at error level

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -38,6 +38,7 @@ from auramaur.monitoring.logger import setup_logging
 from auramaur.nlp.analyzer import ClaudeAnalyzer
 from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
+from auramaur.nlp.errors import BudgetExhausted
 from auramaur.risk.manager import RiskManager
 from auramaur.risk.portfolio import PortfolioTracker
 from auramaur.strategy.arbitrage_scanner import (
@@ -1670,6 +1671,9 @@ class AuramaurBot:
                                 level="info",
                             )
 
+            except BudgetExhausted as e:
+                # Expected daily-budget throttle, not a failure — skip quietly.
+                log.debug("depth.budget_skipped", error=str(e))
             except Exception as e:
                 log.error("depth.error", error=str(e))
             await asyncio.sleep(1800)  # Every 30 minutes

--- a/auramaur/broker/reconciler.py
+++ b/auramaur/broker/reconciler.py
@@ -62,7 +62,9 @@ class PositionReconciler:
         try:
             trades = await self._exchange.clob_call(client.get_trades)
         except Exception as e:
-            log.error("reconciler.trades_error", error=str(e))
+            # Usually a transient CLOB/network hiccup (status_code=None); the
+            # next reconcile pass recovers. Warn rather than error.
+            log.warning("reconciler.trades_error", error=str(e))
             return []
 
         if not trades:

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -448,7 +448,13 @@ class PolymarketClient:
                 )
                 order.dry_run = True
                 return await self._paper.execute(order)
-            log.error("order.live_error", error=err_str, market_id=order.market_id)
+            # "not enough balance / allowance" is an expected capital constraint
+            # (the live book is fully deployed), not a fault — log it at warning
+            # like paper.insufficient_balance, reserving error for real failures.
+            if "not enough balance" in err_str.lower() or "allowance" in err_str.lower():
+                log.warning("order.insufficient_balance", error=err_str, market_id=order.market_id)
+            else:
+                log.error("order.live_error", error=err_str, market_id=order.market_id)
             return OrderResult(
                 order_id="ERROR",
                 market_id=order.market_id,

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -101,7 +101,8 @@ class ClaudeAnalyzer:
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0 and call_budget.calls_today() >= budget:
-            raise RuntimeError(
+            from auramaur.nlp.errors import BudgetExhausted
+            raise BudgetExhausted(
                 f"Daily Claude call budget ({budget}) exhausted"
             )
 

--- a/auramaur/nlp/ensemble_analyzer.py
+++ b/auramaur/nlp/ensemble_analyzer.py
@@ -347,7 +347,8 @@ class EnsembleAnalyzer:
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0 and call_budget.calls_today() >= budget:
-            raise RuntimeError(f"Daily Claude call budget ({budget}) exhausted")
+            from auramaur.nlp.errors import BudgetExhausted
+            raise BudgetExhausted(f"Daily Claude call budget ({budget}) exhausted")
 
         max_attempts = 3
         backoff_seconds = [5, 10, 20]

--- a/auramaur/nlp/errors.py
+++ b/auramaur/nlp/errors.py
@@ -1,0 +1,14 @@
+"""Shared NLP/LLM error types."""
+
+from __future__ import annotations
+
+
+class BudgetExhausted(RuntimeError):
+    """Raised when a daily LLM/agent call budget is exhausted.
+
+    Subclasses RuntimeError so existing ``except RuntimeError`` / ``except
+    Exception`` handlers keep catching it unchanged. Callers that treat budget
+    throttling as an *expected* condition (not a failure) can catch this
+    specifically and log it quietly instead of at error level — the daily
+    budget cap is a deliberate conservation control, not a fault.
+    """

--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -1065,5 +1065,8 @@ class StrategicAnalyzer:
             except (json.JSONDecodeError, Exception):
                 pass
 
-        log.error("strategic.parse_failed", text_preview=text[:300])
+        # Recoverable: caller falls back to an empty StrategicAnalysis. The LLM
+        # occasionally returns prose instead of JSON — worth visibility, not an
+        # error-level alarm.
+        log.warning("strategic.parse_failed", text_preview=text[:300])
         return StrategicAnalysis()

--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -237,11 +237,12 @@ class AgentAnalyzer:
         self._timeout_seconds: int = 600  # 10 minutes for thorough analysis
 
     def _check_budget(self) -> None:
-        """Enforce daily Claude call budget.  Raises RuntimeError if exhausted."""
+        """Enforce daily Claude call budget. Raises BudgetExhausted if spent."""
         from auramaur.nlp import call_budget
+        from auramaur.nlp.errors import BudgetExhausted
         budget = self.settings.nlp.daily_claude_call_budget
         if budget > 0 and call_budget.calls_today() >= budget:
-            raise RuntimeError(
+            raise BudgetExhausted(
                 f"Daily agent call budget ({budget}) exhausted"
             )
 

--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -16,6 +16,7 @@ import structlog
 
 from auramaur.exchange.models import Market
 from auramaur.exchange.protocols import MarketDiscovery
+from auramaur.nlp.errors import BudgetExhausted
 
 log = structlog.get_logger()
 
@@ -365,6 +366,10 @@ class ArbitrageScanner:
                     )
                 return results
 
+            except BudgetExhausted as e:
+                # Expected throttle, not a failure — the word-overlap fallback
+                # below still matches pairs without an LLM call.
+                log.debug("arb_scanner.llm_budget_skipped", error=str(e))
             except Exception as e:
                 log.error("arb_scanner.llm_match_failed", error=str(e))
                 # Fall through to word-overlap fallback

--- a/tests/test_claude_retry.py
+++ b/tests/test_claude_retry.py
@@ -56,13 +56,22 @@ async def test_retry_exhausted_raises(analyzer):
 
 @pytest.mark.asyncio
 async def test_no_retry_on_budget(settings):
-    """Budget exhausted raises immediately, no retries."""
+    """Budget exhausted raises BudgetExhausted immediately, no retries.
+
+    BudgetExhausted subclasses RuntimeError so existing `except RuntimeError`
+    handlers keep working, while callers can catch it specifically to treat the
+    throttle as expected (logged at debug, not error)."""
+    from unittest.mock import patch
+
+    from auramaur.nlp.errors import BudgetExhausted
+
+    assert issubclass(BudgetExhausted, RuntimeError)  # backward-compat contract
+
     settings.nlp.daily_claude_call_budget = 1
     a = ClaudeAnalyzer(settings=settings)
     # Simulate one call already made today (persistent counter)
-    from unittest.mock import patch
     with patch("auramaur.nlp.call_budget.calls_today", return_value=1):
-        with pytest.raises(RuntimeError, match="budget"):
+        with pytest.raises(BudgetExhausted, match="budget"):
             await a._call_claude_cli("test prompt")
 
 


### PR DESCRIPTION
## Why

Every health check showed a wall of `error`-level events that were all **benign** — expected throttles and transient conditions. Logging them at `error` buries genuine problems.

| Event (was error) | Real cause | New level |
|---|---|---|
| `arb_scanner.llm_match_failed` | `Daily Claude call budget exhausted` | debug (`arb_scanner.llm_budget_skipped`) |
| `depth.error` | `Daily agent call budget exhausted` | debug (`depth.budget_skipped`) |
| `order.live_error` | `not enough balance / allowance` | warning (`order.insufficient_balance`) |
| `reconciler.trades_error` | transient `Request exception!` | warning |
| `strategic.parse_failed` | LLM returned prose not JSON (recoverable) | warning |

## Change

- New **`BudgetExhausted(RuntimeError)`** raised by the three budget gates (analyzer, ensemble_analyzer, agent_analyzer). Subclasses `RuntimeError`, so every existing `except RuntimeError`/`except Exception` handler is unchanged; `arb_scanner` and the depth task catch it specifically and log at debug. The budget cap is a deliberate conservation control, not a fault.
- `order.live_error`: insufficient-balance/allowance → `warning`, reserving `error` for genuine placement failures (real API errors still error).
- `reconciler.trades_error`, `strategic.parse_failed` → `warning`.

No behavior change beyond log levels. `test_no_retry_on_budget` tightened to assert `BudgetExhausted` **and** the RuntimeError-subclass backward-compat contract. 31 tests pass across budget/order suites.

## Effect

The recurring ~35/window `arb_scanner.llm_match_failed` + the depth/reconciler/order noise drop out of the error stream, so the next genuine error will actually stand out.

Assisted-by: Claude (Anthropic)