### PR TITLE
fix(correlation): rotate scan window + prune resolved relationships

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1370,6 +1370,40 @@ class AuramaurBot:
                 log.error("feedback.error", error=str(e))
             await asyncio.sleep(3600)  # Every hour
 
+    @staticmethod
+    def _rotate_scan_window(universe, offset, window):
+        """Return (slice, next_offset) for a rolling window over ``universe``.
+
+        Advances a cursor across the full market list so relationship detection
+        covers niche/low-volume markets over time instead of only the
+        top-by-volume head. Wraps at the end. Empty/short universes are handled.
+        """
+        if not universe:
+            return [], 0
+        if offset >= len(universe):
+            offset = 0
+        return universe[offset:offset + window], offset + window
+
+    async def _prune_resolved_relationships(self, db) -> int:
+        """Delete market_relationships whose either leg has resolved/closed.
+
+        market_relationships was never pruned, so it filled with resolved
+        markets (entailment then found ~no live conditional pairs to evaluate).
+        A leg with markets.active = 0 is settled on the venue; drop the pair.
+        Returns the number of relationship rows removed.
+        """
+        try:
+            cur = await db.execute(
+                """DELETE FROM market_relationships
+                   WHERE market_id_a IN (SELECT id FROM markets WHERE active = 0)
+                      OR market_id_b IN (SELECT id FROM markets WHERE active = 0)"""
+            )
+            await db.commit()
+            return int(getattr(cur, "rowcount", 0) or 0)
+        except Exception as e:
+            log.debug("correlation.prune_error", error=str(e))
+            return 0
+
     async def _task_correlation_scan(self) -> None:
         """Scan for correlated markets and execute conditional / divergence arbs.
 
@@ -1387,9 +1421,12 @@ class AuramaurBot:
         risk_manager: RiskManager = self._components["risk_manager"]
         engines: dict[str, TradingEngine] = self._components["engines"]
 
+        db: Database = self._components["db"]
         scan_interval = 120              # act on arbs every 2 minutes
         relationship_refresh_cycles = 15  # refresh LLM relationships ~every 30 min
         cycle = 0
+        scan_offset = 0
+        scan_window = 10  # markets analyzed per refresh (== detector batch_size)
 
         while self._running:
             if await self._check_kill_switch():
@@ -1398,9 +1435,24 @@ class AuramaurBot:
                 # Refresh semantic relationships infrequently to bound LLM cost;
                 # the detector also TTL-caches per market internally.
                 if cycle % relationship_refresh_cycles == 0:
-                    markets = await discovery.get_markets(limit=20)
-                    if markets:
-                        await correlator.detect_relationships(markets)
+                    # Rotate the analysis window across the BROAD universe rather
+                    # than re-feeding the top-by-volume head every cycle. Conditional
+                    # / entailment pairs live in niche, lower-volume markets that
+                    # never entered a top-20 window — so that pool only ever decayed
+                    # (newest conditional was 3 days stale, mostly resolved legs).
+                    # The window advances each refresh and wraps; the 24h TTL-cache
+                    # dedups, so over a full pass every market is analyzed ~once.
+                    # Budget-neutral: same LLM batch size, just a different slice.
+                    universe = await discovery.get_markets(limit=300)
+                    window, scan_offset = self._rotate_scan_window(
+                        universe, scan_offset, scan_window)
+                    if window:
+                        await correlator.detect_relationships(window, batch_size=len(window))
+                    # Prune relationships whose markets have resolved/closed so
+                    # entailment's conditional pool reflects only live markets.
+                    pruned = await self._prune_resolved_relationships(db)
+                    if pruned:
+                        log.info("correlation.pruned_resolved", count=pruned)
                 cycle += 1
 
                 # Generate and execute arbitrage signals (cheap DB read).

--- a/tests/test_correlation_scan.py
+++ b/tests/test_correlation_scan.py
@@ -1,0 +1,77 @@
+"""Tests for correlation-scan window rotation + resolved-relationship pruning.
+
+The relationship detector used to re-feed only the top-by-volume head every
+cycle, so niche conditional/entailment pairs were never discovered, and
+market_relationships was never pruned, so it filled with resolved markets.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from auramaur.bot import AuramaurBot
+from auramaur.db.database import Database
+
+
+# ---------------------------------------------------------------------------
+# _rotate_scan_window — pure rolling window
+# ---------------------------------------------------------------------------
+
+def test_rotate_window_advances_and_wraps():
+    u = list(range(25))
+    w1, off1 = AuramaurBot._rotate_scan_window(u, 0, 10)
+    assert w1 == list(range(0, 10)) and off1 == 10
+    w2, off2 = AuramaurBot._rotate_scan_window(u, off1, 10)
+    assert w2 == list(range(10, 20)) and off2 == 20
+    # Past the end → tail slice, offset advances beyond len
+    w3, off3 = AuramaurBot._rotate_scan_window(u, off2, 10)
+    assert w3 == list(range(20, 25)) and off3 == 30
+    # Next call wraps back to the start
+    w4, off4 = AuramaurBot._rotate_scan_window(u, off3, 10)
+    assert w4 == list(range(0, 10)) and off4 == 10
+
+
+def test_rotate_window_empty_universe():
+    assert AuramaurBot._rotate_scan_window([], 50, 10) == ([], 0)
+
+
+# ---------------------------------------------------------------------------
+# _prune_resolved_relationships — drop pairs with a resolved leg
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prune_drops_relationships_with_resolved_leg():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        # Two live markets, one resolved (active=0).
+        for mid, active in (("LIVE_A", 1), ("LIVE_B", 1), ("DEAD", 0)):
+            await db.execute(
+                """INSERT INTO markets (id, exchange, question, category, active,
+                   outcome_yes_price, outcome_no_price, last_updated)
+                   VALUES (?, 'polymarket', 'q', 'other', ?, 0.5, 0.5, datetime('now'))""",
+                (mid, active),
+            )
+        # Relationship between two live markets (keep) + one touching the dead one (drop).
+        await db.execute(
+            """INSERT INTO market_relationships
+               (market_id_a, market_id_b, relationship_type, strength, description, detected_at)
+               VALUES ('LIVE_A','LIVE_B','conditional',1.0,'x',datetime('now'))"""
+        )
+        await db.execute(
+            """INSERT INTO market_relationships
+               (market_id_a, market_id_b, relationship_type, strength, description, detected_at)
+               VALUES ('LIVE_A','DEAD','conditional',1.0,'x',datetime('now'))"""
+        )
+        await db.commit()
+
+        bot = AuramaurBot(settings=MagicMock())
+        removed = await bot._prune_resolved_relationships(db)
+
+        assert removed == 1
+        remaining = await db.fetchall("SELECT market_id_a, market_id_b FROM market_relationships")
+        assert [(r["market_id_a"], r["market_id_b"]) for r in remaining] == [("LIVE_A", "LIVE_B")]
+    finally:
+        await db.close()


### PR DESCRIPTION
## Problem (entailment's structural dead-end)

Entailment settles for conditional pairs from `market_relationships`, but that pool only ever **decayed**:
- The detector re-fed `discovery.get_markets(limit=20)` every refresh and analyzes `batch_size=10` — so only the **top-by-volume head** was ever examined. Conditional/entailment pairs live in **niche, lower-volume markets** that never entered that window.
- `market_relationships` was **never pruned**, so it filled with resolved-market corpses.

Net (from the earlier dig): newest conditional pair was 3 days stale, ~33/37 legs already resolved, only **2 evaluable pairs** — both sub-gap. Entailment accrued zero, structurally.

## Fix (two budget-neutral changes in `_task_correlation_scan`)

1. **Rotate the analysis window** across the broad universe: `get_markets(limit=300)`, advance a cursor each refresh, wrap. Over a full pass every market is analyzed ~once; the 24h TTL-cache dedups. **Same LLM batch size per refresh** — just a different slice — so no extra budget, but niche markets finally get seen.
2. **Prune** `market_relationships` whose either leg has `markets.active=0` (resolved on the venue — now reliably flagged since the settlement fix #132), so the pool reflects live markets.

Extracted `_rotate_scan_window` (pure) and `_prune_resolved_relationships` for unit tests. Arb execution also benefits (fresher/cleaner relationship signals).

## Tests

- `test_rotate_window_advances_and_wraps`, `test_rotate_window_empty_universe`
- `test_prune_drops_relationships_with_resolved_leg`
- Full arb/correlation/entailment suite green (39 pass).

## Note

This refreshes the *pool*; it can't manufacture conditional pairs that don't exist among current markets. But entailment will now see live niche candidates as they appear, instead of a frozen, mostly-resolved set. Effect builds over a 24h rotation pass.

Assisted-by: Claude (Anthropic)