### PR TITLE
chore: genericize illustrative figures in comments and test docstrings

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -850,8 +850,8 @@ class AuramaurBot:
         # Marketable exit: a SELL only fills by crossing down to the real bid.
         # Pricing at the snapshot — or anywhere inside the spread — rests above
         # the bid, TTL-cancels, and the cleared exit suppression re-posts it
-        # next pass: the Obama winner looped that way for 2 days, and market
-        # 1287614 the same (bid 0.27 vs a 0.48 mark, order resting at 0.45).
+        # next pass: a held winner looped that way unfilled for days against a
+        # wide-spread book.
         # So take the bid outright when it's within the slippage band and above
         # the junk floor; otherwise skip. Returning False (no order placed)
         # leaves the portfolio monitor's exit-failure suppression set, which

--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -123,9 +123,9 @@ class PositionSyncer:
                 # outcome label only works when it literally is YES/NO. For
                 # anything else ("Something"/"Nothing", "Up"/"Down", team
                 # names) the old YES-default marked the position at the wrong
-                # outcome's price — the Obama "Something" held at ~$0.105 was
-                # marked at "Nothing"'s $0.885, a phantom +$77 whose exit the
-                # bot chased for two days.
+                # outcome's price — e.g. a low-priced held side marked at its
+                # complement's high price, a phantom gain whose exit the bot
+                # then chased for days.
                 direct_price: float | None = None
                 if token_id and token_id == (row["clob_token_no"] or ""):
                     token = TokenType.NO

--- a/auramaur/monitoring/attribution.py
+++ b/auramaur/monitoring/attribution.py
@@ -265,8 +265,9 @@ class PerformanceAttributor:
                           -- NULLIF(...,0): the Kraken spec book writes cost_basis
                           -- rows with avg_cost=0, so a plain COALESCE (NULL-only)
                           -- treated cost as $0 and booked the whole position value
-                          -- as "unrealized" (+$246 vs the true -$3.85). Fall back
-                          -- to the position's own avg_price when cost basis is 0.
+                          -- as "unrealized" (a large phantom gain vs a small true
+                          -- loss). Fall back to the position's own avg_price when
+                          -- cost basis is 0.
                           (COALESCE(p.current_price, p.avg_price)
                            - COALESCE(NULLIF(cb.avg_cost, 0), p.avg_price)) * p.size
                       ) AS unrealized_pnl

--- a/auramaur/nlp/gap_audit.py
+++ b/auramaur/nlp/gap_audit.py
@@ -2,8 +2,8 @@
 
 Measured fact (edge_vs_market.py + the divergence-bucket P&L): when the
 model disagrees with the market and cannot say WHY the market is wrong,
-the market is usually right — the 10-20% divergence bucket realized
--$5.90/market at a 22% win rate. This module makes the disagreement
+the market is usually right — the mid-divergence (10-20%) bucket realized
+a net loss at a low win rate in backtest. This module makes the disagreement
 justify itself.
 
 The estimation pipeline is deliberately PRICE-BLIND (anti-anchoring), so

--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -372,9 +372,9 @@ async def check_mispricing_named(
 ) -> CheckResult:
     """Fail when a significant LLM divergence has no nameable mechanism.
 
-    The 10-20% divergence bucket realized -$5.90/market at 22% win — when
-    the model can't say WHY the market is wrong, the market is usually
-    right. ``mispricing_reason`` is "<mechanism>: <reason>" from the gap
+    The mid-divergence (10-20%) bucket realized a net loss at a low win rate
+    in backtest — when the model can't say WHY the market is wrong, the market
+    is usually right. ``mispricing_reason`` is "<mechanism>: <reason>" from the gap
     audit (or pre-named by the originating strategy); "none"/empty blocks.
     """
     if not enabled or not applies or divergence_abs < min_divergence:

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -244,9 +244,9 @@ class PortfolioTracker:
         The held token id is authoritative. The YES/NO label defaults to YES
         for markets whose outcomes aren't literally Yes/No ("Nothing"/
         "Something", team names), so marking off the label prices those
-        positions at the wrong outcome — the Obama "Something" held at
-        ~$0.105 was marked at "Nothing"'s $0.895, and the phantom +$77
-        PROFIT_TARGET exit looped unfilled for days. When the market's
+        positions at the wrong outcome — a low-priced held side marked at
+        its complement's high price, and the phantom-gain PROFIT_TARGET exit
+        looped unfilled for days. When the market's
         tokens are known but ours matches neither, return None: the live
         syncer marks unresolved tokens off their own order book, and
         re-marking from the label here would clobber that with the wrong

--- a/config/settings.py
+++ b/config/settings.py
@@ -26,10 +26,9 @@ class ExecutionConfig(BaseModel):
     live: bool = False
     # Paper book capital. Sized for headroom, not realism: the provisional
     # paper-forced strategies must hold enough concurrent positions across
-    # (strategy x category) cells to accrue >=20 settled events each for the
-    # graduation decision. At ~$10/paper-entry, $5k is ~500 concurrent slots, so
-    # paper cash is never the binding constraint (it was: a $111 book left $1.30
-    # free and rejected ~1k entries/day). Recycles on settlement (see #132).
+    # (strategy x category) cells to accrue the graduation sample. Sized so
+    # paper cash is never the binding constraint on entries; a too-small book
+    # starves them. Recycles on settlement (see #132).
     paper_initial_balance: float = 5000.0
     limit_order_ttl_seconds: int = 120
     # Max cents the router may pay above the signal's reference price to lift
@@ -40,7 +39,7 @@ class ExecutionConfig(BaseModel):
     # Exit twin of entry_max_cross_cents: the slippage band for marketable
     # exits. A SELL only fills by crossing down to the real bid; pricing at the
     # snapshot (or anywhere inside the spread) rests above the bid and
-    # TTL-cancels forever (the 2-day Obama-winner loop; market 1287614). So we
+    # TTL-cancels forever (a held winner once looped this way for days). So we
     # take the bid outright when it is within this many cents of the snapshot,
     # otherwise skip and let the portfolio monitor back off until the book
     # tightens or the position redeems at resolution.

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -3,11 +3,10 @@
 A SELL only fills by crossing down to the real bid. Posted at the snapshot
 price — or anywhere inside the spread — it sits above the bid, rests until the
 TTL reaper cancels it, and the cleared exit suppression re-posts it next pass:
-the Obama winner looped that way for 2 days (35 cancelled SELLs, no fill), and
-market 1287614 the same (bid 0.27 vs a 0.48 mark). So exits take the bid when
-it's within the slippage band and above the junk floor; otherwise they skip,
-and returning False leaves the monitor's suppression set so the retry backs
-off instead of looping.
+a held winner looped that way unfilled for days against a wide-spread book. So
+exits take the bid when it's within the slippage band and above the junk floor;
+otherwise they skip, and returning False leaves the monitor's suppression set
+so the retry backs off instead of looping.
 """
 
 from __future__ import annotations
@@ -90,7 +89,7 @@ async def test_exit_crosses_to_bid_not_a_resting_floor():
 @pytest.mark.asyncio
 async def test_exit_skips_when_bid_below_band():
     """Bid 0.70 is 20c under the 0.90 mark — beyond the 10c band. Selling here
-    would dump well under the mark, so skip and back off (the 1287614 case)."""
+    would dump well under the mark, so skip and back off (the wide-spread case)."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.70, 0.95), current_price=0.90)
 
     ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -270,9 +270,9 @@ async def test_binary_exits_skipped_for_ibkr_options(settings):
 @pytest.mark.asyncio
 async def test_token_id_overrides_yes_label(settings):
     """A position whose outcome label defaulted to YES but whose held token id
-    is the market's NO-slot token must be marked at the NO price. The Obama
-    "Something" held at $0.105 was marked at "Nothing"'s $0.895 — a phantom
-    +$77 that fired PROFIT_TARGET every cycle."""
+    is the market's NO-slot token must be marked at the NO price. A low-priced
+    held side marked at its complement's high price is a phantom gain that
+    fires PROFIT_TARGET every cycle."""
     db = Database(":memory:")
     await db.connect()
     try:

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -183,8 +183,8 @@ class TestKalshiLivePositionAccounting:
                 """INSERT INTO portfolio
                    (market_id, exchange, side, size, avg_price, current_price,
                     unrealized_pnl, category, token, token_id, is_paper, updated_at)
-                   VALUES ('KXSTALE', 'kalshi', 'BUY', 144, 0.81, 0.0965,
-                           -102.0, 'other', 'NO', 'KXSTALE', 1, '2026-06-07 15:23:46')"""
+                   VALUES ('KXSTALE', 'kalshi', 'BUY', 100, 0.80, 0.10,
+                           -70.0, 'other', 'NO', 'KXSTALE', 1, '2026-01-01 00:00:00')"""
             )
             await db.execute(
                 """INSERT INTO markets (id, exchange, question, category, active,
@@ -194,7 +194,7 @@ class TestKalshiLivePositionAccounting:
             await db.execute(
                 """INSERT INTO cost_basis
                    (market_id, token, token_id, size, avg_cost, total_cost, is_paper, updated_at)
-                   VALUES ('KXSTALE', 'NO', 'KXSTALE', 144, 0.81, 116.6, 1, '2026-06-07 15:23:46')"""
+                   VALUES ('KXSTALE', 'NO', 'KXSTALE', 100, 0.80, 80.0, 1, '2026-01-01 00:00:00')"""
             )
             await db.commit()
 

--- a/tests/test_kalshi_pnl_tracking.py
+++ b/tests/test_kalshi_pnl_tracking.py
@@ -152,7 +152,7 @@ def test_venue_summary_ignores_zero_cost_basis():
     """cost_basis.avg_cost=0 (Kraken spec book) must fall back to avg_price.
 
     Otherwise unrealized = (current - 0) * size books the whole position value
-    as a gain (the +$246-vs-actual-(-$3.85) Kraken bug).
+    as a phantom gain instead of the true small loss (the Kraken avg_cost=0 bug).
     """
     async def run():
         db = Database(":memory:")

--- a/tests/test_sync_token_mark.py
+++ b/tests/test_sync_token_mark.py
@@ -1,9 +1,9 @@
 """Position marks must price the token actually held.
 
 Outcome labels like "Something"/"Nothing" aren't YES/NO, and the syncer's
-old YES-default marked such holdings at the first outcome's price: the
-Obama "Something" token (worth ~$0.105) was marked at "Nothing"'s $0.885 —
-a phantom +$77 whose fantasy-priced exit the bot chased for two days.
+old YES-default marked such holdings at the first outcome's price: a
+low-priced held side marked at its complement's high price — a phantom gain
+whose fantasy-priced exit the bot chased for days.
 
 Side resolution ladder: token_id match against the market's CLOB token ids
 (authoritative) → literal YES/NO label → price the held token off its own


### PR DESCRIPTION
Public-repo hygiene: replace specific account/position figures embedded in code comments and test docstrings with generic descriptions of the same mechanism. No behavior change. Tests green.