### PR TITLE
fix(resolution_lens): loosen eligibility in paper mode for accrual

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -93,11 +93,19 @@ class ResolutionLensPillar:
 
     def _eligible(self, m: Market) -> bool:
         cfg = self._settings.resolution_lens
+        # While paper-forced the strategy can't reach the venue, so the
+        # live-trading eligibility guards (hold horizon, fillable liquidity)
+        # don't apply and the strict values starve accrual. Use the loosened
+        # paper thresholds; they revert to strict automatically if paper is
+        # flipped to graduate the cell to live.
+        min_liq = cfg.paper_min_liquidity if cfg.paper else cfg.min_liquidity
+        min_hours = (cfg.paper_min_hours_to_resolution if cfg.paper
+                     else cfg.min_hours_to_resolution)
         if not m.active or not (0.0 < m.outcome_yes_price < 1.0):
             return False
         if (m.exchange or "polymarket") != "polymarket":
             return False
-        if m.liquidity < cfg.min_liquidity:
+        if m.liquidity < min_liq:
             return False
         if m.spread and m.spread * 100.0 > cfg.max_spread_pct:
             return False
@@ -109,7 +117,7 @@ class ResolutionLensPillar:
             return False
         end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
         hours = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
-        return cfg.min_hours_to_resolution <= hours <= cfg.max_days_to_resolution * 24.0
+        return min_hours <= hours <= cfg.max_days_to_resolution * 24.0
 
     async def _verdict(self, m: Market):
         """Cached lens verdict (criteria are static — cache forever)."""

--- a/config/settings.py
+++ b/config/settings.py
@@ -367,6 +367,16 @@ class ResolutionLensConfig(BaseModel):
     min_hours_to_resolution: float = 12.0
     max_days_to_resolution: float = 90.0
     interval_seconds: int = 1800
+    # Paper-phase eligibility: while the cell is hard paper-forced (paper=True)
+    # it can never reach the venue, so the live-trading guards (hold horizon,
+    # liquidity for fillability) don't apply — and the strict live values starve
+    # accrual (only ~92 of 3700 lexical candidates pass; most rejected as
+    # <12h-to-resolve or <$1k liquidity). Loosen them in paper to build the
+    # graduation record: short-dated markets also SETTLE fast, so paper events
+    # accrue quickly. Auto-reverts to the strict values above if paper is
+    # flipped to graduate the cell to live.
+    paper_min_hours_to_resolution: float = 1.0
+    paper_min_liquidity: float = 250.0
 
 
 class GraduationConfig(BaseModel):

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -128,6 +128,25 @@ def test_lens_triggers():
     assert not has_lens_trigger("Bitcoin up or down this week?")
 
 
+def test_eligible_loosens_thresholds_in_paper_mode():
+    """A short-dated, lower-liquidity market is eligible while paper-forced
+    (venue guards don't apply) but rejected once flipped to live."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # ~2h to resolution, $400 liquidity: fails live (12h / $1000),
+        # passes paper (1h / $250).
+        m = _market(days_out=2.0 / 24.0, liquidity=400.0)
+
+        paper = _pillar(db, _settings(paper=True), [m])
+        assert paper._eligible(m) is True
+
+        live = _pillar(db, _settings(paper=False), [m])
+        assert live._eligible(m) is False
+
+    asyncio.run(run())
+
+
 # ----------------------------------------------------------------------
 # Lens pillar
 # ----------------------------------------------------------------------


### PR DESCRIPTION
While paper-forced, lens can't reach the venue, so the live eligibility guards (hold horizon, fillable liquidity) don't apply — but the strict values starved the paper record (most lexical candidates rejected as too-soon or too-illiquid; tiny eligible set the verdict cache exhausts in the first cycles). Adds paper_min_hours_to_resolution / paper_min_liquidity, used in _eligible when paper is set; reverts to strict automatically if the cell graduates to live. Short-dated markets settle fast, so paper events accrue quickly. Tests added; suite green.