### PR TITLE
fix(llm): stop wasted strategic spend — parse arrays, throttle cadence, dedup deep research

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1628,6 +1628,8 @@ class AuramaurBot:
         on markets where the strategic batch found potential edge but
         confidence was low or the market is high-value.
         """
+        from datetime import datetime, timezone
+
         from auramaur.strategy.agent_analyzer import AgentAnalyzer
 
         depth_agent: AgentAnalyzer = self._components["depth_agent"]
@@ -1636,6 +1638,13 @@ class AuramaurBot:
         engine = engines.get("polymarket")
         if engine is None:
             return
+
+        # Dedup: deep_research is the heaviest LLM call (multi-turn web research).
+        # A persistent high-edge/low-confidence market would otherwise be
+        # re-researched every cycle for hours; remember what we've researched and
+        # skip repeats within the window.
+        researched: dict[str, datetime] = {}
+        research_ttl = 86400.0  # 24h
 
         while self._running:
             if await self._check_kill_switch():
@@ -1653,17 +1662,27 @@ class AuramaurBot:
                        FROM signals s
                        JOIN markets m ON s.market_id = m.id
                        WHERE s.timestamp > datetime('now', '-6 hours')
-                         AND ABS(s.edge) >= 8
+                         AND ABS(s.edge) >= 12
                          AND s.claude_confidence IN ('LOW', 'MEDIUM_LOW', 'MEDIUM')
                          AND m.active = 1
                          AND m.exchange = 'polymarket'
+                         AND COALESCE(m.liquidity, 0) >= 1000
                        ORDER BY ABS(s.edge) DESC
                        LIMIT 3"""
                 )
 
+                now_ts = datetime.now(timezone.utc)
+                researched = {k: v for k, v in researched.items()
+                              if (now_ts - v).total_seconds() < research_ttl}
                 for row in rows:
                     if await self._check_kill_switch():
                         return
+
+                    # Skip markets researched within the dedup window.
+                    last = researched.get(row["market_id"])
+                    if last is not None and (now_ts - last).total_seconds() < research_ttl:
+                        continue
+                    researched[row["market_id"]] = now_ts
 
                     # Build market from DB + enrich from Gamma
                     from auramaur.exchange.models import Market

--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -273,6 +273,7 @@ class StrategicAnalyzer:
         self._db = db
         self._cache = NLPCache(db)
         self._world_model = self._load_world_model()
+        self._last_batch_at = None  # throttle: last batch+adversarial LLM run
 
         # Initialize LLM ensemble if enabled
         self._ensemble = None
@@ -658,6 +659,19 @@ class StrategicAnalyzer:
         evidence_map: dict[str, list[NewsItem]],
     ) -> StrategicAnalysis:
         """Batch analysis + adversarial review in one context-rich flow."""
+        # Cadence throttle: the engine calls this per scan cycle, but with
+        # directional signals paper-forced the marginal value of re-batching
+        # every ~10 min is low. Outside the interval, serve only fresh cached
+        # results and skip BOTH LLM calls (batch + adversarial).
+        interval = getattr(self._settings.nlp, "strategic_min_interval_seconds", 0)
+        if interval and markets and self._last_batch_at is not None:
+            elapsed = (datetime.now(timezone.utc) - self._last_batch_at).total_seconds()
+            if elapsed < interval:
+                cached, _, _ = await self._partition_cached(markets, evidence_map)
+                return StrategicAnalysis(markets=cached)
+        if markets:
+            self._last_batch_at = datetime.now(timezone.utc)
+
         primary = await self.analyze_batch(markets, evidence_map)
 
         if not primary.markets or self._settings.nlp.skip_second_opinion:
@@ -1049,21 +1063,30 @@ class StrategicAnalyzer:
 
         text = text.strip()
 
-        # Try direct parse
-        try:
-            data = json.loads(text)
+        def _coerce(data):
+            # The model frequently returns a BARE ARRAY of per-market results
+            # ([{market_id, probability, ...}, ...]) instead of the full object
+            # ({"markets": [...], ...}). Treat a list as the markets payload —
+            # otherwise StrategicAnalysis(**list) blew up and every batch was
+            # discarded (100% strategic.parse_failed, pure wasted LLM spend).
+            if isinstance(data, list):
+                return StrategicAnalysis(markets=data)
             return StrategicAnalysis(**data)
+
+        # Try direct parse (object or array)
+        try:
+            return _coerce(json.loads(text))
         except (json.JSONDecodeError, Exception):
             pass
 
-        # Extract JSON object
-        match = re.search(r"\{[\s\S]*\}", text)
-        if match:
-            try:
-                data = json.loads(match.group(0))
-                return StrategicAnalysis(**data)
-            except (json.JSONDecodeError, Exception):
-                pass
+        # Extract the first JSON array or object embedded in prose.
+        for pat in (r"\[[\s\S]*\]", r"\{[\s\S]*\}"):
+            match = re.search(pat, text)
+            if match:
+                try:
+                    return _coerce(json.loads(match.group(0)))
+                except (json.JSONDecodeError, Exception):
+                    continue
 
         # Recoverable: caller falls back to an empty StrategicAnalysis. The LLM
         # occasionally returns prose instead of JSON — worth visibility, not an

--- a/config/settings.py
+++ b/config/settings.py
@@ -191,6 +191,11 @@ class NLPConfig(BaseModel):
     # edge signal; "tool_use" forces it for every batched market;
     # "strategic_batch" disables the refinement path entirely.
     analysis_mode: Literal["strategic_batch", "tool_use", "auto"] = "auto"
+    # Min seconds between strategic batch+adversarial LLM runs. The engine calls
+    # it per scan cycle (~every 10 min) but directional signals are paper-forced,
+    # so per-cycle batching mostly burned budget; cap the cadence and serve
+    # cached results in between. 0 disables the throttle.
+    strategic_min_interval_seconds: int = 1800
     # Lever 3: tool-use refinement is the single heaviest call (multi-turn web).
     # Tightened from 5.0/4 — only strong edges earn a web-research pass, and at
     # most 2 per cycle — which is where most of the realized token burn lived.

--- a/tests/test_llm_efficiency.py
+++ b/tests/test_llm_efficiency.py
@@ -221,3 +221,52 @@ class TestStrategicCache:
         cached, to_analyze, _ = run(a._partition_cached([market], evidence), event_loop)
         assert cached == []  # disabled → no reuse
         assert len(to_analyze) == 1
+
+
+class TestStrategicParseAndThrottle:
+    """Parse robustness (bare array vs object) + batch cadence throttle."""
+
+    def test_parse_accepts_bare_array(self):
+        # The model frequently returns a bare array of per-market results;
+        # this used to 100% parse_fail and discard the (paid-for) batch.
+        raw = '[{"market_id": "m1", "probability": 0.3, "confidence": "MEDIUM"}]'
+        out = StrategicAnalyzer._parse_strategic_response(raw)
+        assert [r.market_id for r in out.markets] == ["m1"]
+        assert out.markets[0].probability == 0.3
+
+    def test_parse_still_accepts_object(self):
+        raw = '{"markets": [{"market_id": "m2", "probability": 0.7}], "world_model_update": "x"}'
+        out = StrategicAnalyzer._parse_strategic_response(raw)
+        assert [r.market_id for r in out.markets] == ["m2"]
+        assert out.world_model_update == "x"
+
+    def test_parse_array_in_fences_and_prose(self):
+        raw = 'Sure:\n```json\n[{"market_id":"m3","probability":0.5}]\n```\ndone'
+        out = StrategicAnalyzer._parse_strategic_response(raw)
+        assert [r.market_id for r in out.markets] == ["m3"]
+
+    def test_parse_garbage_returns_empty(self):
+        out = StrategicAnalyzer._parse_strategic_response("no json here at all")
+        assert out.markets == []
+
+    def test_batch_throttle_skips_llm_within_interval(self, db, event_loop):
+        s = Settings()
+        s.nlp.strategic_min_interval_seconds = 3600
+        s.nlp.skip_second_opinion = True  # isolate to the batch call
+        a = StrategicAnalyzer(settings=s, db=db)
+        market = _market("m1", 0.40)
+        evidence: dict = {}  # no evidence → avoids the compressor stub mismatch
+        calls = {"n": 0}
+
+        async def fake_llm(*args, **kwargs):
+            calls["n"] += 1
+            return '[{"market_id": "m1", "probability": 0.3, "confidence": "MEDIUM"}]'
+
+        a._call_llm = fake_llm  # type: ignore[assignment]
+
+        run(a.analyze_batch_with_adversarial([market], evidence), event_loop)
+        assert calls["n"] == 1  # first run hits the LLM
+
+        # Immediate second run is within the interval → served from cache, no call.
+        run(a.analyze_batch_with_adversarial([market], evidence), event_loop)
+        assert calls["n"] == 1


### PR DESCRIPTION
Audit found strategic batch analysis burning LLM calls for nothing: the model returns a bare JSON array of per-market results but the parser only accepted an object, so every batch was discarded (100% parse_failed). Fixes: (1) parse coerces a top-level array into markets= + array-aware prose extraction; (2) throttle the batch+adversarial pair via nlp.strategic_min_interval_seconds (default 1800) — engine calls it per scan cycle but directional is paper-forced, so serve cached results in between and skip both LLM calls; (3) deep_research (heaviest call) trigger tightened (edge>=12, liquidity>=1000) + 24h per-market dedup so a persistent edge isn't re-researched every cycle. Tests for array/object/prose parsing + throttle. Suite green.