### PR TITLE
fix(strategic): normalize aliased result keys so batches actually parse

### DIFF
--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -1063,14 +1063,39 @@ class StrategicAnalyzer:
 
         text = text.strip()
 
+        def _norm_item(it: dict) -> dict:
+            # The model varies field names vs the schema (observed: id/p_yes and
+            # a numeric confidence). Map common aliases so items validate instead
+            # of being dropped — the dominant cause of strategic.parse_failed.
+            d = dict(it)
+            if "market_id" not in d:
+                for alt in ("id", "ticker", "marketId"):
+                    if alt in d:
+                        d["market_id"] = d[alt]
+                        break
+            if "probability" not in d:
+                for alt in ("p_yes", "prob", "fair_prob", "yes_prob", "p"):
+                    if alt in d:
+                        d["probability"] = d[alt]
+                        break
+            c = d.get("confidence")
+            if isinstance(c, (int, float)):  # 0-1 float -> tier label
+                d["confidence"] = "HIGH" if c >= 0.7 else "LOW" if c < 0.4 else "MEDIUM"
+            return d
+
         def _coerce(data):
             # The model frequently returns a BARE ARRAY of per-market results
-            # ([{market_id, probability, ...}, ...]) instead of the full object
-            # ({"markets": [...], ...}). Treat a list as the markets payload —
+            # ([{...}, ...]) instead of the full object ({"markets": [...], ...}).
+            # Treat a list as the markets payload (normalizing item keys) —
             # otherwise StrategicAnalysis(**list) blew up and every batch was
             # discarded (100% strategic.parse_failed, pure wasted LLM spend).
             if isinstance(data, list):
-                return StrategicAnalysis(markets=data)
+                items = [_norm_item(it) for it in data if isinstance(it, dict)]
+                return StrategicAnalysis(markets=items)
+            if isinstance(data.get("markets"), list):
+                data = dict(data)
+                data["markets"] = [_norm_item(it) for it in data["markets"]
+                                   if isinstance(it, dict)]
             return StrategicAnalysis(**data)
 
         # Try direct parse (object or array)

--- a/tests/test_llm_efficiency.py
+++ b/tests/test_llm_efficiency.py
@@ -234,6 +234,15 @@ class TestStrategicParseAndThrottle:
         assert [r.market_id for r in out.markets] == ["m1"]
         assert out.markets[0].probability == 0.3
 
+    def test_parse_normalizes_aliased_keys(self):
+        # Real-world Gemini output: id/p_yes + numeric confidence (not the schema
+        # field names) — these must be normalized, not dropped.
+        raw = '[{"id": "KX-1", "p_yes": 0.09, "confidence": 0.85, "reasoning": "x"}]'
+        out = StrategicAnalyzer._parse_strategic_response(raw)
+        assert out.markets[0].market_id == "KX-1"
+        assert out.markets[0].probability == 0.09
+        assert out.markets[0].confidence == "HIGH"  # 0.85 -> tier
+
     def test_parse_still_accepts_object(self):
         raw = '{"markets": [{"market_id": "m2", "probability": 0.7}], "world_model_update": "x"}'
         out = StrategicAnalyzer._parse_strategic_response(raw)


### PR DESCRIPTION
Follow-up to #139: the array-coercion was necessary but insufficient — the model returns items with non-schema field names (id/p_yes/numeric confidence), so pydantic rejected them and batches still parse-failed. Normalizes common aliases (id->market_id, p_yes/prob/fair_prob->probability) and coerces numeric confidence to a tier, for both array and object shapes. Converts the throttled strategic spend into usable output. Test added with real-world Gemini field names.