### PR TITLE
fix(fees): model Polymarket per-category TAKER fees on crossing paths

### DIFF
--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -17,6 +17,7 @@ import structlog
 from auramaur.exchange.models import Market
 from auramaur.exchange.protocols import MarketDiscovery
 from auramaur.nlp.errors import BudgetExhausted
+from auramaur.strategy.signals import taker_fee_rate
 
 log = structlog.get_logger()
 
@@ -248,17 +249,26 @@ class ArbitrageScanner:
                     # Identify cheap/expensive sides for fee calc
                     if market_a.outcome_yes_price <= market_b.outcome_yes_price:
                         cheap_exchange, expensive_exchange = name_a, name_b
+                        cheap_mkt, exp_mkt = market_a, market_b
                     else:
                         cheap_exchange, expensive_exchange = name_b, name_a
+                        cheap_mkt, exp_mkt = market_b, market_a
 
-                    # Fee-aware profit: buy YES cheap, buy NO on expensive side
-                    # Gross profit = spread (one side resolves $1, other $0)
-                    # Fees: each leg's fee applies to the profit from that leg
-                    fee_cheap = self._exchange_fees.get(cheap_exchange, 0.0)
-                    fee_expensive = self._exchange_fees.get(expensive_exchange, 0.0)
-                    # Worst case: profit is taxed at the higher fee on the winning leg
-                    max_fee_rate = max(fee_cheap, fee_expensive)
-                    net_profit = spread * (1.0 - max_fee_rate)
+                    # Fee-aware profit: buy YES cheap, buy NO on the expensive side.
+                    # Both legs are CROSSING (taker) buys, so each pays its real
+                    # taker fee: rate * price * (1-price) per share (p(1-p) is
+                    # symmetric, so the NO leg uses the expensive YES price). The
+                    # Polymarket rate is per-category (was modeled as 0, which
+                    # overstated every cross-exchange arb that crosses a Poly leg).
+                    cheap_yes = cheap_mkt.outcome_yes_price
+                    exp_yes = exp_mkt.outcome_yes_price
+                    fee_cheap = (taker_fee_rate(cheap_exchange, cheap_mkt.category,
+                                                self._exchange_fees)
+                                 * cheap_yes * (1.0 - cheap_yes))
+                    fee_expensive = (taker_fee_rate(expensive_exchange, exp_mkt.category,
+                                                    self._exchange_fees)
+                                     * exp_yes * (1.0 - exp_yes))
+                    net_profit = spread - fee_cheap - fee_expensive
                     profit_pct = net_profit * 100
 
                     if profit_pct < self._min_profit_after_fees_pct:
@@ -506,8 +516,6 @@ class ArbitrageScanner:
         opportunities: list[NegRiskArbOpportunity] = []
 
         for exchange_name, markets in markets_by_exchange.items():
-            fee = self._exchange_fees.get(exchange_name, 0.0)
-
             # Group mutually-exclusive legs by their NegRisk grouping key.
             groups: dict[str, list[Market]] = {}
             for m in markets:
@@ -523,6 +531,11 @@ class ArbitrageScanner:
                 # Skip groups with unpriced legs — can't trust the sum.
                 if any(leg.outcome_no_price <= 0 for leg in legs):
                     continue
+
+                # Per-category taker rate (legs of one group share a category);
+                # Polymarket NegRisk legs were modeled fee-free (0.0) before.
+                fee = taker_fee_rate(exchange_name, legs[0].category,
+                                     self._exchange_fees)
 
                 total_no_cost = sum(leg.outcome_no_price for leg in legs)
                 # Exactly one outcome wins: its NO pays $0, the other (n-1) pay

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -33,7 +33,7 @@ from auramaur.risk.manager import RiskManager
 from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.order_flow import OrderFlowTracker
 from auramaur.strategy.protocols import MarketAnalyzer, TradeCandidate
-from auramaur.strategy.signals import detect_edge
+from auramaur.strategy.signals import detect_edge, taker_fee_rate
 
 log = structlog.get_logger()
 
@@ -1442,9 +1442,11 @@ class TradingEngine:
             if abs(raw_edge) < 0.001:
                 continue
             side = OrderSide.BUY if raw_edge > 0 else OrderSide.SELL
-            # Fee coefficient applies to per-contract P*(1-P), not a flat
-            # percentage (see detect_edge in signals.py).
-            fee_rate = exchange_fees.get(market.exchange or self.exchange_name, 0.0)
+            # Taker fee coefficient applies to per-contract P*(1-P), not a flat
+            # percentage. Polymarket is per-category (see taker_fee_rate); this
+            # is a crossing execution path so the taker rate is the right one.
+            fee_rate = taker_fee_rate(
+                market.exchange or self.exchange_name, market.category, exchange_fees)
             edge = abs(raw_edge) - fee_rate * market_prob * (1.0 - market_prob)
 
             signal = Signal(

--- a/auramaur/strategy/signals.py
+++ b/auramaur/strategy/signals.py
@@ -14,6 +14,9 @@ log = structlog.get_logger()
 
 # Fallback fee rates — callers should prefer passing exchange_fees from config.
 # Kept as a default so standalone calls (tests, REPL) still work.
+# NOTE polymarket=0.0 here is the MAKER rate; takers pay a per-category rate —
+# see POLYMARKET_TAKER_FEES and taker_fee_rate() below. Resolve via taker_fee_rate
+# rather than reading this dict directly for any crossing (taker) execution.
 EXCHANGE_FEES: dict[str, float] = {
     "polymarket": 0.0,
     "kalshi": 0.07,
@@ -21,6 +24,40 @@ EXCHANGE_FEES: dict[str, float] = {
 }
 
 POLYMARKET_FEE_PCT = 0.0
+
+# Polymarket TAKER fee coefficients by category. Makers are NEVER charged; takers
+# pay  fee = rate * price * (1 - price)  per share (same quadratic shape as the
+# Kalshi coefficient). https://docs.polymarket.com/trading/fees (2026-06).
+POLYMARKET_TAKER_FEES: dict[str, float] = {
+    "crypto": 0.07,
+    "sports": 0.03,
+    "tech": 0.04, "politics": 0.04, "politics_us": 0.04, "politics_intl": 0.04,
+    "finance": 0.04, "mentions": 0.04,
+    "economics": 0.05, "culture": 0.05, "weather": 0.05, "other": 0.05,
+    "science": 0.05, "legal": 0.05, "entertainment": 0.05,
+    "geopolitics": 0.0,
+}
+# Conservative default for an unmapped/unknown category — err toward charging the
+# fee (understating it is the bug this fixes).
+POLYMARKET_DEFAULT_TAKER_FEE = 0.05
+
+
+def taker_fee_rate(
+    exchange: str | None,
+    category: str | None = None,
+    exchange_fees: dict[str, float] | None = None,
+) -> float:
+    """Per-share TAKER fee coefficient for the ``rate * p*(1-p)`` formula.
+
+    Polymarket takers pay a per-category rate (makers pay 0 and bypass this —
+    maker-only strategies like bias_harvest / the post-only market-maker never
+    net a fee). Other venues use the flat per-exchange coefficient.
+    """
+    if (exchange or "polymarket") == "polymarket":
+        return POLYMARKET_TAKER_FEES.get(
+            (category or "").lower(), POLYMARKET_DEFAULT_TAKER_FEE)
+    fees = exchange_fees if exchange_fees is not None else EXCHANGE_FEES
+    return fees.get(exchange or "", 0.0)
 
 
 def _blend_estimates(
@@ -188,8 +225,10 @@ def detect_edge(
     # percentage haircut: 0.07 -> at most ~1.75pt (at P=0.5), ~1.1pt at the
     # extremes. Treating it as flat 7pt made nearly every Kalshi edge negative.
     # Polymarket (0.0) is unaffected.
-    fees = exchange_fees if exchange_fees is not None else EXCHANGE_FEES
-    fee_rate = fees.get(market.exchange, 0.0)
+    # Crossing (taker) execution: net the per-category Polymarket taker fee (or
+    # the flat per-exchange coefficient elsewhere). Maker-only strategies don't
+    # reach this path, so this conservatively assumes the edge will be taken.
+    fee_rate = taker_fee_rate(market.exchange, market.category, exchange_fees)
     net_edge = edge - fee_rate * market_prob * (1.0 - market_prob)
 
     if net_edge <= 0:

--- a/config/settings.py
+++ b/config/settings.py
@@ -645,6 +645,10 @@ class ArbitrageConfig(BaseModel):
     max_arb_size: float = 25.0
     cross_exchange_auto_execute: bool = True
     negrisk_auto_execute: bool = False
+    # Flat per-exchange TAKER fee coefficients (fee = rate * P*(1-P)).
+    # polymarket=0.0 here is only the MAKER rate; Polymarket TAKERS pay a
+    # per-category rate resolved by signals.taker_fee_rate() (POLYMARKET_TAKER_FEES),
+    # NOT this entry. Crossing/taker code paths must go through taker_fee_rate.
     exchange_fees: dict[str, float] = Field(default_factory=lambda: {
         "polymarket": 0.0,
         "kalshi": 0.07,

--- a/tests/test_cross_arb.py
+++ b/tests/test_cross_arb.py
@@ -18,11 +18,13 @@ from auramaur.strategy.arbitrage_scanner import ArbOpportunity, ArbitrageScanner
 # ---------------------------------------------------------------------------
 
 
-def _make_market(exchange: str, yes_price: float, question: str = "Will X happen?") -> Market:
+def _make_market(exchange: str, yes_price: float, question: str = "Will X happen?",
+                 category: str = "other") -> Market:
     return Market(
         id=f"{exchange}_123",
         exchange=exchange,
         question=question,
+        category=category,
         outcome_yes_price=yes_price,
         outcome_no_price=round(1.0 - yes_price, 4),
         volume=10000,
@@ -52,7 +54,9 @@ class TestFeeAwareProfit:
 
     @pytest.mark.asyncio
     async def test_cross_exchange_arb_detected_with_fees(self):
-        """A 10% spread should produce ~9.3% profit after 7% Kalshi fee."""
+        """10% spread, both legs taker. Poly cheap@0.40 (cat 'other' -> 0.05):
+        0.05*0.4*0.6=0.012. Kalshi exp@0.50: 0.07*0.25=0.0175. Net 0.10 - 0.012
+        - 0.0175 = 0.0705 = 7.05%."""
         poly = _make_market("polymarket", 0.40, "Will X happen?")
         kalshi = _make_market("kalshi", 0.50, "Will X happen?")
         scanner = self._make_scanner([poly], [kalshi])
@@ -62,15 +66,14 @@ class TestFeeAwareProfit:
         assert len(cross) == 1
 
         opp = cross[0]
-        # Spread = 0.10, after 7% fee on profit: 0.10 * 0.93 = 0.093 = 9.3%
         assert opp.spread == pytest.approx(0.10, abs=0.001)
-        assert opp.expected_profit_pct == pytest.approx(9.3, abs=0.1)
+        assert opp.expected_profit_pct == pytest.approx(7.05, abs=0.1)
 
     @pytest.mark.asyncio
-    async def test_small_spread_filtered_by_min_profit(self):
-        """A 3.5% spread with 7% fee = ~3.255% profit. Should pass default 1.5% min."""
+    async def test_moderate_spread_passes_min_profit(self):
+        """A 10% spread nets ~7% after both legs' taker fees — clears 1.5% min."""
         poly = _make_market("polymarket", 0.50, "Will Y happen?")
-        kalshi = _make_market("kalshi", 0.535, "Will Y happen?")
+        kalshi = _make_market("kalshi", 0.60, "Will Y happen?")
         scanner = self._make_scanner([poly], [kalshi])
 
         opps = await scanner.scan()
@@ -171,9 +174,10 @@ class TestFeeAwareProfit:
 
     @pytest.mark.asyncio
     async def test_zero_fees_full_profit(self):
-        """With no fees on either exchange, profit = spread."""
-        poly = _make_market("polymarket", 0.40, "Will A happen?")
-        kalshi = _make_market("kalshi", 0.50, "Will A happen?")
+        """With genuinely fee-free legs, profit = spread. Polymarket is fee-free
+        only for the geopolitics category (makers aside); Kalshi via override."""
+        poly = _make_market("polymarket", 0.40, "Will A happen?", category="geopolitics")
+        kalshi = _make_market("kalshi", 0.50, "Will A happen?", category="geopolitics")
         scanner = self._make_scanner(
             [poly], [kalshi],
             fees={"polymarket": 0.0, "kalshi": 0.0},

--- a/tests/test_negrisk_arb.py
+++ b/tests/test_negrisk_arb.py
@@ -10,12 +10,19 @@ from auramaur.exchange.models import Market
 from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
 
 
-def _leg(idx: int, no_price: float, group: str = "evt_1", neg_risk: bool = True) -> Market:
-    """One outcome of a NegRisk event, priced by its NO price."""
+def _leg(idx: int, no_price: float, group: str = "evt_1", neg_risk: bool = True,
+         category: str = "geopolitics") -> Market:
+    """One outcome of a NegRisk event, priced by its NO price.
+
+    Defaults to the geopolitics category (Polymarket taker fee 0) so fee-agnostic
+    detection tests keep their original payout math; pass a fee-bearing category
+    to exercise the fee.
+    """
     return Market(
         id=f"poly_{group}_{idx}",
         exchange="polymarket",
         question=f"Will candidate {idx} win?",
+        category=category,
         outcome_yes_price=round(1.0 - no_price, 4),
         outcome_no_price=no_price,
         clob_token_no=f"tok_no_{idx}",
@@ -39,8 +46,10 @@ def _scanner(markets: list[Market], min_profit: float = 1.5) -> ArbitrageScanner
 
 @pytest.mark.asyncio
 async def test_negrisk_arb_detected_when_no_legs_underpriced():
-    """3 outcomes with NO prices summing to 1.8 < (N-1)=2 is risk-free profit."""
-    legs = [_leg(0, 0.6), _leg(1, 0.6), _leg(2, 0.6)]
+    """3 outcomes with NO prices summing to 1.8 < (N-1)=2, net of the taker fee.
+    politics category -> 0.04 taker: guaranteed_payout = 2*(1-0.04)=1.92."""
+    legs = [_leg(0, 0.6, category="politics"), _leg(1, 0.6, category="politics"),
+            _leg(2, 0.6, category="politics")]
     scanner = _scanner(legs)
 
     opps = await scanner.scan_negrisk()
@@ -49,9 +58,9 @@ async def test_negrisk_arb_detected_when_no_legs_underpriced():
     opp = opps[0]
     assert opp.n_outcomes == 3
     assert opp.total_no_cost == pytest.approx(1.8)
-    assert opp.guaranteed_payout == pytest.approx(2.0)
-    # profit 0.2 on cost 1.8 -> ~11.1%
-    assert opp.expected_profit_pct == pytest.approx(0.2 / 1.8 * 100, rel=1e-3)
+    assert opp.guaranteed_payout == pytest.approx(1.92)
+    # profit 0.12 on cost 1.8 -> ~6.67%
+    assert opp.expected_profit_pct == pytest.approx(0.12 / 1.8 * 100, rel=1e-3)
 
 
 @pytest.mark.asyncio
@@ -66,11 +75,12 @@ async def test_no_arb_when_legs_sum_above_payout():
 
 @pytest.mark.asyncio
 async def test_fee_erodes_marginal_arb():
-    """A thin arb that clears with 0% fee is rejected once a fee applies."""
-    legs = [_leg(0, 0.655), _leg(1, 0.655), _leg(2, 0.655)]  # sum 1.965, profit ~1.8%
+    """A thin arb that clears fee-free is rejected once the category taker fee
+    applies. 'other' -> 0.05: net payout 2*(1-0.05)=1.9 < cost 1.965."""
+    legs = [_leg(0, 0.655, category="other"), _leg(1, 0.655, category="other"),
+            _leg(2, 0.655, category="other")]  # sum 1.965
     disc = AsyncMock()
     disc.get_markets = AsyncMock(return_value=legs)
-    # 5% fee on the (N-1) payout pushes net payout below cost.
     scanner = ArbitrageScanner(
         discoveries={"polymarket": disc},
         exchange_fees={"polymarket": 0.05},

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -51,10 +51,12 @@ def test_skipped_analysis():
 
 
 def test_edge_accounts_for_fees():
-    # 3% raw edge, 0% fee = 3% net edge (reward tier)
+    # 3% raw edge on a Polymarket market, unmapped category -> 0.05 taker rate,
+    # at P=0.50: fee = 0.05 * 0.5 * 0.5 = 0.0125 (1.25pt). Net edge 1.75%.
+    # (The directional signal path assumes crossing/taker execution.)
     signal = detect_edge(_make_market(0.50), _make_analysis(0.53))
     assert signal is not None
-    assert signal.edge == pytest.approx(3.0, abs=0.5)
+    assert signal.edge == pytest.approx(1.75, abs=0.1)
 
 
 def _make_kalshi_market(yes_price: float) -> Market:
@@ -171,3 +173,19 @@ def test_calibrated_probability_used_in_edge():
     # Edge should be based on 0.65, not 0.80
     assert signal is not None
     assert signal.claude_prob < 0.70  # Uses calibrated, not raw
+
+
+def test_taker_fee_rate_per_category_and_venue():
+    """Polymarket taker rate is per-category (makers bypass this); other venues
+    use the flat per-exchange coefficient."""
+    from auramaur.strategy.signals import taker_fee_rate
+
+    assert taker_fee_rate("polymarket", "crypto") == 0.07
+    assert taker_fee_rate("polymarket", "politics_us") == 0.04
+    assert taker_fee_rate("polymarket", "sports") == 0.03
+    assert taker_fee_rate("polymarket", "geopolitics") == 0.0
+    assert taker_fee_rate("polymarket", "zzz-unknown") == 0.05   # conservative default
+    assert taker_fee_rate("polymarket", None) == 0.05
+    # Non-poly venues use the flat coefficient from the fees map.
+    assert taker_fee_rate("kalshi", "crypto") == 0.07
+    assert taker_fee_rate("kalshi", None, {"kalshi": 0.03}) == 0.03


### PR DESCRIPTION
## Problem

Polymarket charges **takers** a per-category fee (`fee = rate·p·(1−p)` per share): crypto 0.07, sports 0.03, finance/politics/tech/mentions 0.04, econ/culture/weather/other 0.05, geopolitics 0. **Makers are free.** The bot modeled polymarket as a flat `0.0`, so every **crossing (taker)** execution overstated net edge — most damaging on the **live cross-exchange arb**, which crossed Polymarket legs fee-free and could "detect" arbs that lose money after fees.

(Surfaced by an external review; the machinery was already quadratic & per-exchange — the gap was the Polymarket rate and maker/taker awareness.)

## Fix
- `signals.taker_fee_rate(exchange, category)` — per-category Poly taker rate (conservative 0.05 for unmapped categories), flat coefficient for other venues. **Maker-only strategies (bias_harvest passive limits, post-only MM) bypass this and pay 0.**
- `detect_edge` + the engine strategic path net the category taker fee (crossing/taker paths).
- **cross-exchange arb**: nets real **per-leg quadratic** taker fees off the spread (was `spread·(1−max_flat_rate)` with poly=0); negrisk uses the per-category rate.

Source: https://docs.polymarket.com/trading/fees (2026-06).

## Tests
- `taker_fee_rate` unit test (per-category + per-venue).
- Cross-arb / negrisk / signals tests updated to the corrected math (e.g. a 10% cross-exchange spread now nets ~7% after both legs' taker fees, was modeled ~9.3%). Full arb+signals suite green (41).