### PR TITLE
feat(safety): operational live-readiness preflight + auramaur health + CI guard

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -3341,6 +3341,34 @@ class AuramaurBot:
         if exchange_filter:
             console.print(f"  [cyan]Exchange filter: {exchange_filter} only[/]")
 
+        # Operational live-readiness preflight. If any BLOCK condition is present
+        # while armed live, force new ENTRIES to paper (exits bypass the risk
+        # manager, so held positions can still get out). Same checks as
+        # `auramaur health`; a "refuse to fool itself" gate.
+        if self.settings.is_live:
+            try:
+                from auramaur.monitoring.live_gate import preflight
+                report = await preflight(self.settings, self._components["db"])
+                if not report.live_allowed:
+                    rm = self._components.get("risk_manager")
+                    if rm is not None:
+                        rm.live_entries_blocked = True
+                    blocked = ", ".join(b.name for b in report.blocks)
+                    log.error("live_gate.entries_blocked",
+                              blocks=[f"{b.name}: {b.detail}" for b in report.blocks])
+                    console.print(f"  [bold red]LIVE ENTRIES BLOCKED by preflight:[/] "
+                                  f"{blocked} — exits stay live")
+                    alerts = self._components.get("alerts")
+                    if alerts is not None:
+                        await alerts.send(
+                            f"LIVE ENTRIES BLOCKED by preflight: {blocked}", level="critical")
+                else:
+                    log.info("live_gate.passed", warnings=len(report.warnings))
+                    if report.warnings:
+                        console.print(f"  [yellow]preflight OK, {len(report.warnings)} warning(s)[/]")
+            except Exception as e:
+                log.error("live_gate.error", error=str(e))
+
         tasks = [
             asyncio.create_task(self._task_kill_switch_monitor(), name="kill_switch"),
             asyncio.create_task(self._task_cache_cleanup(), name="cache_cleanup"),

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -556,6 +556,42 @@ def redeem_check():
     asyncio.run(_check())
 
 
+@main.command("health")
+def health():
+    """Operational live-readiness preflight — is it safe to arm live now?
+
+    Runs the live_gate checks (kill switch, DB, fee model, drawdown, mark
+    integrity, LLM budget, arming gates) and prints a verdict. Exit code 0 if
+    live is allowed, 1 if any BLOCK condition is present.
+    """
+    import sys
+
+    async def _run() -> int:
+        from auramaur.monitoring.live_gate import preflight
+
+        settings = Settings()
+        db = Database()
+        await db.connect()
+        try:
+            report = await preflight(settings, db)
+        finally:
+            await db.close()
+
+        colour = {"OK": "green", "WARN": "yellow", "BLOCK": "red"}
+        for r in report.results:
+            console.print(f"  [{colour[r.severity]}]{r.severity:<5}[/] {r.name}: {r.detail}")
+        if report.live_allowed:
+            warns = len(report.warnings)
+            console.print(f"\n[bold green]LIVE ALLOWED[/]"
+                          + (f" ([yellow]{warns} warning(s)[/])" if warns else ""))
+            return 0
+        console.print("\n[bold red]LIVE BLOCKED[/] — "
+                      + ", ".join(b.name for b in report.blocks))
+        return 1
+
+    sys.exit(asyncio.run(_run()))
+
+
 @main.command("pnl")
 @click.option("--paper", "paper", is_flag=True, default=False,
               help="Show the paper book instead of live.")

--- a/auramaur/monitoring/live_gate.py
+++ b/auramaur/monitoring/live_gate.py
@@ -1,0 +1,139 @@
+"""Operational live-readiness preflight — gate ARMING live trading.
+
+Distinct from monitoring/readiness.py, which measures whether a strategy has
+*earned* live capital on edge. This answers a different question: is it
+operationally SAFE to place live orders right now?
+
+A BLOCK-severity result means new live ENTRIES must be suppressed (the bot
+downgrades them to paper); EXITS always stay live so held positions can get out.
+WARN degrades visibility but does not block. The whole point is a system that
+refuses to fool itself: no live capital when the cost model, marks, or risk
+state are untrustworthy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from auramaur.db.database import Database
+
+Severity = Literal["OK", "WARN", "BLOCK"]
+
+
+@dataclass
+class GateResult:
+    name: str
+    severity: Severity
+    detail: str
+
+
+@dataclass
+class PreflightReport:
+    results: list[GateResult] = field(default_factory=list)
+
+    @property
+    def live_allowed(self) -> bool:
+        return not any(r.severity == "BLOCK" for r in self.results)
+
+    @property
+    def blocks(self) -> list[GateResult]:
+        return [r for r in self.results if r.severity == "BLOCK"]
+
+    @property
+    def warnings(self) -> list[GateResult]:
+        return [r for r in self.results if r.severity == "WARN"]
+
+
+async def preflight(settings, db: Database) -> PreflightReport:
+    """Run the operational live-readiness checks. Never raises — a check that
+    can't evaluate degrades to WARN rather than crashing the gate."""
+    report = PreflightReport()
+
+    def add(name: str, severity: Severity, detail: str) -> None:
+        report.results.append(GateResult(name, severity, detail))
+
+    # 1. Kill switch — halts ALL trading by design.
+    if Path("KILL_SWITCH").exists():
+        add("kill_switch", "BLOCK", "KILL_SWITCH file present")
+    else:
+        add("kill_switch", "OK", "absent")
+
+    # 2. Database reachable — the ledger and risk state live here.
+    try:
+        await db.fetchone("SELECT 1")
+        add("database", "OK", "reachable")
+    except Exception as e:
+        add("database", "BLOCK", f"query failed: {str(e)[:80]}")
+
+    # 3. Fee model sane — the cost model must be real, or every crossing edge is
+    #    overstated. Block if fees look disabled.
+    try:
+        from auramaur.strategy.signals import POLYMARKET_TAKER_FEES
+        fees = settings.arbitrage.exchange_fees
+        kalshi_fee = float(fees.get("kalshi", 0.0) or 0.0)
+        poly_ok = any(v > 0 for v in POLYMARKET_TAKER_FEES.values())
+        if kalshi_fee <= 0 or not poly_ok:
+            add("fee_model", "BLOCK",
+                f"fee model looks disabled (kalshi={kalshi_fee}, poly_taker_nonzero={poly_ok})")
+        else:
+            add("fee_model", "OK", f"kalshi={kalshi_fee}, polymarket per-category taker")
+    except Exception as e:
+        add("fee_model", "BLOCK", f"unavailable: {str(e)[:80]}")
+
+    # 4. Drawdown — never arm fresh entries through a breached drawdown limit.
+    try:
+        from auramaur.risk.portfolio import PortfolioTracker
+        dd = await PortfolioTracker(db).get_drawdown()
+        maxdd = float(settings.risk.max_drawdown_pct)
+        if dd >= maxdd:
+            add("drawdown", "BLOCK", f"{dd:.1f}% >= limit {maxdd:.1f}%")
+        elif dd >= maxdd * 0.8:
+            add("drawdown", "WARN", f"{dd:.1f}% nearing limit {maxdd:.1f}%")
+        else:
+            add("drawdown", "OK", f"{dd:.1f}% (limit {maxdd:.1f}%)")
+    except Exception as e:
+        add("drawdown", "WARN", f"could not compute: {str(e)[:80]}")
+
+    # 5. Mark integrity — live positions priced <=0 mean the risk gates
+    #    (drawdown/exposure/Kelly) are acting on fiction (the zero-mark bug).
+    try:
+        row = await db.fetchone(
+            "SELECT COUNT(*) AS n FROM portfolio "
+            "WHERE is_paper = 0 AND size > 0 "
+            "AND (current_price IS NULL OR current_price <= 0)"
+        )
+        zero = int(row["n"]) if row else 0
+        if zero > 5:
+            add("position_marks", "BLOCK", f"{zero} live positions marked <=0")
+        elif zero > 0:
+            add("position_marks", "WARN", f"{zero} live positions marked <=0")
+        else:
+            add("position_marks", "OK", "no zero-marked live positions")
+    except Exception as e:
+        add("position_marks", "WARN", f"could not check: {str(e)[:80]}")
+
+    # 6. LLM budget — WARN only: the live surface (arb/MM) needs no LLM; only
+    #    directional (paper-forced) does.
+    try:
+        from auramaur.nlp import call_budget
+        budget = int(settings.nlp.daily_claude_call_budget)
+        used = call_budget.calls_today()
+        if budget > 0 and used >= budget:
+            add("llm_budget", "WARN",
+                f"daily LLM budget spent ({used}/{budget}) — directional degraded, arb/MM unaffected")
+        else:
+            add("llm_budget", "OK", f"{used}/{budget}")
+    except Exception as e:
+        add("llm_budget", "WARN", f"could not check: {str(e)[:80]}")
+
+    # 7. Three-gate state (informational): the standing live arming gates.
+    add(
+        "live_gates",
+        "OK" if settings.is_live else "WARN",
+        f"AURAMAUR_LIVE={settings.auramaur_live} execution.live={settings.execution.live} "
+        f"=> is_live={settings.is_live}",
+    )
+
+    return report

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -64,6 +64,10 @@ class RiskManager:
         # wired by the bot after the analyzer exists. None -> the gate
         # blocks unexplained divergences without spending an LLM call.
         self.gap_auditor = None
+        # Set by the operational live-readiness preflight (monitoring/live_gate):
+        # when a BLOCK condition is present, force every ENTRY to paper. Exits
+        # bypass evaluate() entirely, so held positions can still get out.
+        self.live_entries_blocked = False
 
     def _paper_forced_strategy(self, strategy_source: str) -> bool:
         """True if this strategy is paper-forced by its own config flag
@@ -167,6 +171,7 @@ class RiskManager:
             signal.strategy_source, market.category or "")
         is_paper_entry = (
             not self.settings.is_live
+            or self.live_entries_blocked  # operational preflight BLOCK
             or self._paper_forced_strategy(signal.strategy_source)
             or cell.force_paper
         )

--- a/tests/test_live_gate.py
+++ b/tests/test_live_gate.py
@@ -1,0 +1,108 @@
+"""Tests for the operational live-readiness preflight + the config CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+import yaml
+
+from auramaur.db.database import Database
+from auramaur.monitoring.live_gate import GateResult, PreflightReport, preflight
+from config.settings import Settings
+
+
+def test_report_live_allowed_logic():
+    rep = PreflightReport(results=[GateResult("a", "OK", "x"), GateResult("b", "WARN", "y")])
+    assert rep.live_allowed
+    assert rep.warnings and not rep.blocks
+    rep.results.append(GateResult("c", "BLOCK", "z"))
+    assert not rep.live_allowed
+    assert [b.name for b in rep.blocks] == ["c"]
+
+
+async def _db() -> Database:
+    db = Database(":memory:")
+    await db.connect()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_clean_state_allows_live(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # no KILL_SWITCH in this cwd
+    db = await _db()
+    try:
+        rep = await preflight(Settings(), db)
+        assert rep.live_allowed, [b.detail for b in rep.blocks]
+        sev = {r.name: r.severity for r in rep.results}
+        assert sev["kill_switch"] == "OK"
+        assert sev["fee_model"] == "OK"
+        assert sev["position_marks"] == "OK"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_blocks(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "KILL_SWITCH").write_text("")  # in tmp cwd — never the real file
+    db = await _db()
+    try:
+        rep = await preflight(Settings(), db)
+        assert not rep.live_allowed
+        assert any(b.name == "kill_switch" for b in rep.blocks)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_disabled_fee_model_blocks(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    s = Settings()
+    s.arbitrage.exchange_fees = {"kalshi": 0.0, "polymarket": 0.0}  # fees disabled
+    db = await _db()
+    try:
+        rep = await preflight(s, db)
+        assert not rep.live_allowed
+        assert any(b.name == "fee_model" for b in rep.blocks)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_zero_marked_live_positions_block(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = await _db()
+    try:
+        for i in range(6):  # > 5 zero-marked live positions => BLOCK
+            await db.execute(
+                """INSERT INTO portfolio
+                   (market_id, exchange, side, size, avg_price, current_price,
+                    token, is_paper, updated_at)
+                   VALUES (?, 'polymarket', 'BUY', 10, 0.5, 0, 'YES', 0, datetime('now'))""",
+                (f"m{i}",),
+            )
+        await db.commit()
+        rep = await preflight(Settings(), db)
+        assert not rep.live_allowed
+        assert any(b.name == "position_marks" for b in rep.blocks)
+    finally:
+        await db.close()
+
+
+def test_committed_defaults_yaml_is_not_live():
+    """The TRACKED config/defaults.yaml must ship with execution.live: false.
+
+    Reads the committed blob (not the working tree) so a local live override
+    can't satisfy or break the guard — this catches accidentally committing it.
+    """
+    out = subprocess.run(
+        ["git", "show", "HEAD:config/defaults.yaml"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    cfg = yaml.safe_load(out.stdout)
+    assert cfg.get("execution", {}).get("live") is False, (
+        "committed config/defaults.yaml must have execution.live: false — "
+        "the local live override must never be committed"
+    )


### PR DESCRIPTION
Builds the "excellent-engineering" item #1: a gate that makes the system refuse to fool itself — no live capital when the cost model, marks, or risk state are untrustworthy. Distinct from `monitoring/readiness.py` (which measures *earned edge*); this checks *operational safety to arm live now*.

## What
- **`monitoring/live_gate.preflight(settings, db)`** → `PreflightReport`. Checks (each OK / WARN / BLOCK): kill switch, DB reachable, **fee model sane** (kalshi>0 + Polymarket per-category taker present), **drawdown** vs limit, **live-position mark integrity** (zero/none marks → the risk gates act on fiction otherwise), LLM budget, and the three arming gates. `live_allowed = no BLOCK`. Never raises.
- **`auramaur health`** — runs it, prints the verdict, exit 1 if BLOCKED. "A single command that says whether live trading is allowed."
- **Startup blocker** — when armed live, a BLOCK forces new **entries** to paper via `RiskManager.live_entries_blocked`; **exits bypass `evaluate()`, so held positions still get out**. Loud log + alert. (A blanket `execution.live=False` would wrongly kill exits too — this gates entries only.)
- **CI guard** — test asserts the **committed** `config/defaults.yaml` has `execution.live: false` (reads the git blob, immune to the local override) — closes the tracked-file footgun (folds in item (b)).

## Verified live
`auramaur health` against the running system returns LIVE ALLOWED (2 warnings) and correctly surfaced 4 zero-marked positions (WARN, below the BLOCK-5 threshold) + spent LLM budget (WARN, not BLOCK — arb/MM need no LLM). Fee model shows `kalshi=0.07, polymarket per-category taker`.

## Tests
Per-gate (kill switch, disabled fees, zero-marks, clean state), report logic, and the committed-config guard. Full risk/graduation suite green (75).

WARN vs BLOCK severities are deliberate: budget/transient issues degrade but don't halt the live surface; only genuine safety faults (kill switch, broken fees, breached drawdown, broken marks) block entries.