### PR TITLE
fix(sync): floor reconciler-merge marks so live positions never persist at <=0

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -323,6 +323,17 @@ class PositionSyncer:
             side = OrderSide.BUY.value
             token = pos.token.value if pos.token else "YES"
             token_id = pos.token_id or ""
+            # Mark-integrity floor: never persist a live held position at <=0.
+            # Reconciler positions can arrive at current_price 0 when the token's
+            # price couldn't be resolved (e.g. the markets row lacks clob tokens,
+            # so side-resolution fails) — a phantom -100% that distorts the risk
+            # gates. Floor to avg_cost (mirrors _sync_live) and zero the matching
+            # unrealized so the books stay consistent. Real marks still win.
+            if pos.current_price > 0:
+                current_price, upnl = pos.current_price, pos.unrealized_pnl
+            else:
+                current_price = float(pos.avg_cost or 0)
+                upnl = 0.0
             await self._db.execute(
                 """INSERT INTO portfolio
                    (market_id, exchange, side, size, avg_price, current_price,
@@ -339,7 +350,7 @@ class PositionSyncer:
                        is_paper = excluded.is_paper,
                        updated_at = excluded.updated_at""",
                 (pos.market_id, side, pos.size, pos.avg_cost,
-                 pos.current_price, pos.unrealized_pnl, pos.category,
+                 current_price, upnl, pos.category,
                  token, token_id, is_paper_flag, now),
             )
         await self._db.commit()

--- a/tests/test_sync_mark_floor.py
+++ b/tests/test_sync_mark_floor.py
@@ -1,0 +1,68 @@
+"""Reconciler-merge must never persist a live held position at a <=0 mark.
+
+A reconciler position whose token price can't be resolved (e.g. the markets
+row lacks clob tokens, so side-resolution fails) arrives at current_price 0.
+_sync_live floors such marks to avg_cost; _merge_new_positions (the additive
+reconciler path) used to write the raw 0 straight through — a phantom -100%
+that distorts the risk gates. It must apply the same floor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.sync import PositionSyncer
+from auramaur.db.database import Database
+from auramaur.exchange.models import LivePosition, TokenType
+
+
+def _syncer(db: Database) -> PositionSyncer:
+    syncer = PositionSyncer.__new__(PositionSyncer)
+    syncer._settings = MagicMock()
+    syncer._settings.is_live = True  # is_paper_flag -> 0 (live rows)
+    syncer._db = db
+    syncer._exchange = SimpleNamespace(get_order_book=AsyncMock())
+    syncer._paper = MagicMock()
+    syncer._pnl = MagicMock()
+    return syncer
+
+
+async def _row(db: Database, market_id: str) -> dict:
+    return await db.fetchone(
+        "SELECT current_price, unrealized_pnl FROM portfolio "
+        "WHERE market_id = ? AND is_paper = 0",
+        (market_id,),
+    )
+
+
+def test_zero_mark_floors_to_avg_cost():
+    """A reconciler position at current_price 0 is floored to avg_cost and its
+    phantom -100% unrealized is zeroed; a healthy mark passes through intact."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            syncer = _syncer(db)
+            stranded = LivePosition(
+                market_id="mkt-stranded", token_id="tok-no", token=TokenType.NO,
+                size=12.1, avg_cost=0.82, current_price=0.0,
+            )
+            healthy = LivePosition(
+                market_id="999", token_id="tok-yes", token=TokenType.YES,
+                size=10.0, avg_cost=0.40, current_price=0.50,
+            )
+            await syncer._merge_new_positions([stranded, healthy])
+
+            s = await _row(db, "mkt-stranded")
+            assert abs(s["current_price"] - 0.82) < 1e-9, s["current_price"]
+            assert abs(s["unrealized_pnl"]) < 1e-9, s["unrealized_pnl"]
+
+            h = await _row(db, "999")
+            assert abs(h["current_price"] - 0.50) < 1e-9, h["current_price"]
+            assert abs(h["unrealized_pnl"] - 1.0) < 1e-9, h["unrealized_pnl"]
+        finally:
+            await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Problem
`_sync_live` floors a held position's mark to `avg_cost` when its token price can't be resolved, but `_merge_new_positions` (the additive reconciler path) wrote the raw `current_price` straight through. A reconciler position that *has* a `markets` row but whose side can't be resolved — because the markets row lacks clob tokens, so token-id side-resolution fails — resolves to 0 and was persisted as a phantom −100%. That fiction feeds the risk gates (drawdown / exposure / Kelly).

This is the gap between the prior keep-stored-mark and all-zero-price-floor fixes: the markets row has valid prices but the *held side* can't be matched, so neither earlier guard fires.

## Fix
Apply the same floor at the merge write: when `current_price <= 0`, mark at `avg_cost` and zero the matching unrealized so the books stay consistent. Real book/market marks still win when present.

Surfaced by the `auramaur health` mark-integrity gate (WARN). After deploy, the next reconciler cycle re-marks the stranded rows and the gate clears.

## Test
`tests/test_sync_mark_floor.py` — a zero-mark position floors to avg_cost with unrealized zeroed; a healthy mark passes through intact.

Assisted-by: Claude (Anthropic)