### PR TITLE
fix(resolution): settle markets the venue marks closed even while active flag lags

### DIFF
--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -266,6 +266,7 @@ class GammaClient:
                 category=category,
                 end_date=end_date,
                 active=data.get("active", True),
+                closed=bool(data.get("closed", False)),
                 outcome_yes_price=yes_price,
                 outcome_no_price=no_price,
                 volume=float(data.get("volume", 0) or 0),

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -33,6 +33,10 @@ class Market(BaseModel):
     category: str = ""
     end_date: datetime | None = None
     active: bool = True
+    # Polymarket's `active` flag lags resolution (a market stays active=True for
+    # a while after it settles), but `closed` flips at venue closure — it is the
+    # reliable "trading has ended" signal the resolution tracker keys off.
+    closed: bool = False
     outcome_yes_price: float = 0.5
     outcome_no_price: float = 0.5
     volume: float = 0

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -270,11 +270,17 @@ class ResolutionTracker:
         # 95/5 market from being settled prematurely and feeding a fake outcome
         # into calibration. (Paper positions settle ONLY through this path, so
         # the stale active flag was stranding them indefinitely.)
+        # `closed` is the venue's explicit "trading has ended" flag and flips
+        # before the lagging `active` flag does. Without it, a market that
+        # resolved while still flagged active=True with a future end_date — the
+        # exact shape of a held losing leg pinned to 0/1 — never became eligible
+        # and lingered in the portfolio at a $0 mark, its realized loss unbooked.
         end = getattr(market, "end_date", None)
         if end is not None and end.tzinfo is None:
             end = end.replace(tzinfo=timezone.utc)
         past_end_date = end is not None and datetime.now(timezone.utc) > end
-        if market.active and not past_end_date:
+        closed = bool(getattr(market, "closed", False))
+        if market.active and not past_end_date and not closed:
             return None
 
         # Eligible (inactive, or past end_date) + tightly converged price →

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -22,12 +22,14 @@ def _make_market(
     yes_price: float = 1.0,
     exchange: str = "polymarket",
     end_date=None,
+    closed: bool = False,
 ) -> Market:
     return Market(
         id=market_id,
         exchange=exchange,
         question="Will it rain tomorrow?",
         active=active,
+        closed=closed,
         outcome_yes_price=yes_price,
         outcome_no_price=1.0 - yes_price,
         end_date=end_date,
@@ -91,6 +93,22 @@ class TestDetectResolution:
         """Past end_date but price mid (closed awaiting oracle) — still wait."""
         past = datetime.now(timezone.utc) - timedelta(days=1)
         market = _make_market(active=True, yes_price=0.55, end_date=past)
+        assert ResolutionTracker._detect_resolution(market, "polymarket") is None
+
+    def test_closed_active_future_end_date_pinned_resolves(self):
+        """A resolved losing leg: venue says closed=True but the lagging active
+        flag is still True with a FUTURE end_date and price pinned to 0/1.
+        Before the fix this returned None and the position lingered at $0."""
+        future = datetime.now(timezone.utc) + timedelta(days=160)
+        won_yes = _make_market(active=True, closed=True, yes_price=1.0, end_date=future)
+        assert ResolutionTracker._detect_resolution(won_yes, "polymarket") is True
+        won_no = _make_market(active=True, closed=True, yes_price=0.0, end_date=future)
+        assert ResolutionTracker._detect_resolution(won_no, "polymarket") is False
+
+    def test_closed_but_ambiguous_price_stays_none(self):
+        """closed=True but price mid (awaiting oracle) — don't guess a winner."""
+        future = datetime.now(timezone.utc) + timedelta(days=10)
+        market = _make_market(active=True, closed=True, yes_price=0.6, end_date=future)
         assert ResolutionTracker._detect_resolution(market, "polymarket") is None
 
     def test_resolved_yes(self):


### PR DESCRIPTION
## Problem
`_detect_resolution` treated a Polymarket market as unresolved whenever its `active` flag was still `True` and its `end_date` was in the future. But the venue's `active` flag *lags* resolution — a market that has actually resolved reports `closed=True` with its price pinned to 0/1 while `active` stays `True` and `end_date` sits months out.

A held **losing** leg in that exact state never became eligible for settlement: it lingered in the portfolio at a (correct) `$0` mark with its realized loss unbooked, and the `position_marks` live-readiness gate flagged it indefinitely. These are not mismarks — `$0` is right — they're resolved losers that were never *settled*.

## Fix
Thread gamma's `closed` flag onto the `Market` model and treat it as the explicit "trading has ended" signal in `_detect_resolution`: a market is eligible for the price check when it is **inactive OR past end_date OR closed**. The tight `0.99 / 0.01` price guard still prevents settling a merely-paused market with an ambiguous price.

Once eligible and pinned, the existing settlement path books the realized P&L to the ledger (idempotent `source_ref`), updates cost basis / daily stats, and removes the portfolio row — so the gate clears truthfully rather than by falsifying a mark.

## Test
`tests/test_resolution_tracker.py`:
- `closed=True` + `active=True` + future `end_date` + price pinned → resolves (YES and NO).
- `closed=True` but ambiguous mid price → stays `None` (awaits oracle).

Assisted-by: Claude (Anthropic)