### PR TITLE
fix(resolution): match token case-insensitively when settling positions

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -311,10 +311,16 @@ class ResolutionTracker:
         scoped to that exact row (the venue sweep settles per held token);
         without them the legacy market-wide behavior is preserved.
         """
+        # Token comparisons are case-insensitive throughout settlement: the
+        # cost_basis table stores the venue's mixed-case label ("Yes"/"No")
+        # while the portfolio/ledger use the upper-cased TokenType ("YES"/"NO").
+        # A case-sensitive match left cost_basis.size un-zeroed on settlement,
+        # so _sync_live resurrected the position every cycle (only _drop_settled
+        # kept the portfolio clean), and realized_pnl never accrued.
         where = "market_id = ?"
         params: list = [market_id]
         if token_scope is not None:
-            where += " AND token = ?"
+            where += " AND UPPER(token) = UPPER(?)"
             params.append(token_scope)
         if is_paper_scope is not None:
             where += " AND is_paper = ?"
@@ -374,7 +380,7 @@ class ResolutionTracker:
             await self._db.execute(
                 """UPDATE cost_basis
                    SET realized_pnl = realized_pnl + ?, size = 0, updated_at = datetime('now')
-                   WHERE market_id = ? AND is_paper = ? AND token = ?""",
+                   WHERE market_id = ? AND is_paper = ? AND UPPER(token) = UPPER(?)""",
                 (pnl, market_id, is_paper_flag, token),
             )
         except Exception as e:
@@ -403,7 +409,7 @@ class ResolutionTracker:
         if token_scope is not None:
             await self._db.execute(
                 "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? "
-                "AND token = ?",
+                "AND UPPER(token) = UPPER(?)",
                 (market_id, is_paper_flag, token_scope),
             )
         else:

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -321,6 +321,47 @@ class TestSettlePosition:
         ]
         assert len(delete_calls) == 0
 
+    def test_settle_zeroes_cost_basis_despite_token_case(self):
+        """cost_basis stores the venue's mixed-case label ("No") while the
+        portfolio/ledger use the upper-cased TokenType ("NO"). Settlement must
+        zero cost_basis.size and accrue realized_pnl regardless of case — a
+        case-sensitive match left the row un-zeroed, resurrecting the position
+        and never booking realized P&L into cost_basis."""
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                # Held NO, mixed case in cost_basis; market resolved YES => loss.
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                                               avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('mkt-1', 'No', 'tok', 20.0, 0.50, 10.0, 0, 0)"""
+                )
+                await db.execute(
+                    """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                                              current_price, token, is_paper, updated_at)
+                       VALUES ('mkt-1', 'polymarket', 'BUY', 20.0, 0.50, 0, 'NO', 0, datetime('now'))"""
+                )
+                await db.commit()
+
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                await tracker._settle_position("mkt-1", outcome=True)  # YES wins, NO held => -10
+
+                cb = await db.fetchone(
+                    "SELECT size, realized_pnl FROM cost_basis WHERE market_id='mkt-1' AND is_paper=0")
+                assert cb["size"] == 0, "cost_basis.size must be zeroed on settlement"
+                assert abs(cb["realized_pnl"] - (-10.0)) < 1e-9, cb["realized_pnl"]
+
+                pf = await db.fetchone(
+                    "SELECT COUNT(*) AS n FROM portfolio WHERE market_id='mkt-1' AND is_paper=0")
+                assert pf["n"] == 0, "portfolio row must be removed"
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
 
 # ---------------------------------------------------------------------------
 # Venue-truth sweep (Polymarket data-api) — settles positions the Gamma loop
@@ -386,7 +427,7 @@ async def test_venue_sweep_settles_matched_token(monkeypatch):
     # The portfolio row was deleted token-scoped and the market deactivated.
     executed_sql = " ".join(str(c.args[0]) for c in db.execute.call_args_list)
     assert "DELETE FROM portfolio" in executed_sql
-    assert "AND token = ?" in executed_sql
+    assert "AND UPPER(token) = UPPER(?)" in executed_sql
     assert "UPDATE markets SET active = 0" in executed_sql
 
 


### PR DESCRIPTION
## Problem
`cost_basis` stores the venue's mixed-case outcome label (`"Yes"`/`"No"`) while the `portfolio` and `pnl_ledger` use the upper-cased `TokenType` (`"YES"`/`"NO"`). `_settle_position` reads the token off the portfolio row (upper-cased) and uses it to update `cost_basis` with a **case-sensitive** match — which hits nothing:

- `cost_basis.size` is never zeroed and `realized_pnl` never accrues.
- `_sync_live` (which selects `cost_basis WHERE size > 0`) re-adds the position to the portfolio every cycle. Only `_drop_settled` — which matches the ledger's upper-cased settled-keys — keeps the portfolio clean.
- A leg whose `_settle_position` raced an empty portfolio fetch never books at all, so it isn't in the settled-keys, isn't dropped, and resurrects at a `$0` mark indefinitely.

This affects every held leg with a mixed-case cost_basis token (a large share of live positions).

## Fix
Compare token case-insensitively (`UPPER(token) = UPPER(?)`) in the three token-scoped statements of `_settle_position`: the scoped position fetch, the `cost_basis` update, and the token-scoped portfolio delete.

## Test
- New: settling a position whose `cost_basis` token is `"No"` while the held token is `"NO"` zeroes `cost_basis.size`, accrues `realized_pnl`, and removes the portfolio row.
- Updated the venue-sweep SQL assertion to the case-insensitive form.

Assisted-by: Claude (Anthropic)