### PR TITLE
fix(resolution): settle each mode explicitly so a live leg isn't booked as paper

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -111,8 +111,14 @@ class ResolutionTracker:
                 # Feed into calibration — triggers online Platt update
                 await self._calibration.record_resolution(market_id, outcome)
 
-                # Compute realized PnL from the portfolio position and clean up
-                await self._settle_position(market_id, outcome)
+                # Compute realized PnL from the position and clean up. Settle
+                # each mode explicitly: a market can be held in BOTH paper and
+                # live (the paper track mirrors live markets), and a mode-blind
+                # settle would book just one — picking the wrong one when the
+                # portfolio row is absent and it falls back to cost_basis (which
+                # carries both modes). Each call is a no-op if that mode isn't held.
+                await self._settle_position(market_id, outcome, is_paper_scope=0)
+                await self._settle_position(market_id, outcome, is_paper_scope=1)
 
                 # Mark the market as inactive in our DB so other queries
                 # (e.g. depth research, correlation) stop considering it.

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -428,6 +428,39 @@ class TestSettlePosition:
 
         asyncio.run(run())
 
+    def test_cost_basis_fallback_respects_is_paper_scope(self):
+        """When a market is held in BOTH modes and the portfolio row is absent,
+        a mode-scoped settle must book only the targeted mode off cost_basis —
+        not pick the wrong leg (the bug that booked a live loss as paper)."""
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                for paper in (0, 1):
+                    await db.execute(
+                        """INSERT INTO cost_basis (market_id, token, token_id, size,
+                                                   avg_cost, total_cost, realized_pnl, is_paper)
+                           VALUES ('mkt-z', 'Yes', 'tok', 10.0, 0.20, 2.0, 0, ?)""",
+                        (paper,),
+                    )
+                await db.commit()
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                await tracker._settle_position("mkt-z", outcome=False, is_paper_scope=0)  # live only
+
+                live = await db.fetchone("SELECT size FROM cost_basis WHERE market_id='mkt-z' AND is_paper=0")
+                paper = await db.fetchone("SELECT size FROM cost_basis WHERE market_id='mkt-z' AND is_paper=1")
+                assert live["size"] == 0, "live leg must settle"
+                assert paper["size"] == 10.0, "paper leg must be untouched"
+                refs = [r["source_ref"] for r in await db.fetchall(
+                    "SELECT source_ref FROM pnl_ledger WHERE market_id='mkt-z'")]
+                assert refs == ["settle:mkt-z:YES:0"], refs
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
 
 # ---------------------------------------------------------------------------
 # Venue-truth sweep (Polymarket data-api) — settles positions the Gamma loop


### PR DESCRIPTION
## Problem
A market can be held in **both** paper and live (the paper track mirrors live markets), so `cost_basis` carries one row per mode. The mode-blind per-market settle — after falling back to `cost_basis` when the portfolio row was absent — picked a row arbitrarily (`ORDER BY size DESC`). It booked a **live** loss under the **paper** `source_ref` (`settle:…:1`) and left the live leg unsettled, so the live position kept resurrecting at a `$0` mark and tripping the `position_marks` gate.

## Fix
Settle each mode explicitly in `check_resolutions` (`is_paper_scope=0` then `=1`). Each call is a no-op when that mode isn't held, and `_settle_position`'s cost_basis fallback already scopes to `is_paper`.

## Test
A both-modes holding with no portfolio row settles only the targeted mode (live row zeroed, paper untouched, single `settle:…:0` ledger row).

Assisted-by: Claude (Anthropic)