### PR TITLE
feat(router): depth-aware entry sizing (size vs book capacity + slippage)

### DIFF
--- a/auramaur/broker/router.py
+++ b/auramaur/broker/router.py
@@ -141,12 +141,68 @@ class SmartOrderRouter:
             crossed_to_ask = True
             order_type = OrderType.LIMIT
             limit_price = max(0.01, min(0.99, round(ask, 2)))
+
+            # Depth-aware sizing: the gate above only proved the BEST ask clears
+            # the floor. For the FULL size we walk the asks up to the slippage
+            # budget — the price at which realizable edge would fall to the
+            # min-edge floor, also bounded by the cents cap — and trim the order
+            # to the in-budget depth (a fraction of it, so we're not the whole
+            # book). If too little of the requested size fits within budget, the
+            # rest would only fill by paying through the floor, so skip.
+            try:
+                depth_aware = bool(self._settings.execution.depth_aware_routing)
+            except Exception:
+                depth_aware = False
+            if depth_aware and base_order.size > 0:
+                cap_frac = float(getattr(self._settings.execution, "book_capacity_fraction", 0.5))
+                min_fill = float(getattr(self._settings.execution, "min_fill_fraction", 0.5))
+                # Highest price that still leaves >= min_edge after slippage.
+                edge_budget_pts = max(0.0, edge_pct - min_edge_pct)
+                price_cap = base_order.price + edge_budget_pts / 100.0
+                # Honor the cents cap too (waived above 40% edge, mirroring above).
+                if edge_pct <= 40.0:
+                    price_cap = min(price_cap, base_order.price + max_cross)
+                price_cap = max(price_cap, ask)  # always at least take the best ask
+                price_cap = min(0.99, price_cap)
+
+                in_budget_depth = book.depth_within(price_cap, is_buy=True)
+                capacity = in_budget_depth * cap_frac
+                executable = min(base_order.size, capacity)
+                if executable < min_fill * base_order.size - 1e-9:
+                    raise UnmarketableSignal(
+                        f"book absorbs only {executable:.1f} of {base_order.size:.1f} "
+                        f"shares within slippage budget (cap {price_cap:.2f}, "
+                        f"min fill {min_fill:.0%}) for {market.id}"
+                    )
+                _, vwap, sweep_price = book.fill_to_size(executable, is_buy=True)
+                if executable < base_order.size - 1e-9:
+                    log.info(
+                        "router.size_trimmed_to_capacity",
+                        market_id=market.id,
+                        requested=round(base_order.size, 1),
+                        executable=round(executable, 1),
+                        in_budget_depth=round(in_budget_depth, 1),
+                        price_cap=round(price_cap, 3),
+                    )
+                    base_order = base_order.model_copy(update={"size": executable})
+                # Price the limit at the SWEEP price — the worst level the size
+                # actually needs — not the full budget cap: a size that fits in
+                # the best ask still prices at the ask, and only a multi-level
+                # sweep lifts the limit (always <= price_cap). Cheapest-first
+                # matching means the effective fill is the VWAP (<= the limit).
+                if sweep_price > 0:
+                    limit_price = max(0.01, min(0.99, round(sweep_price, 2)))
+                cross_cost_pts = (vwap - base_order.price) * 100.0 if vwap else cross_cost_pts
+                realizable_edge = edge_pct - cross_cost_pts
+
             log.info(
                 "router.crossed_to_ask",
                 market_id=market.id,
                 edge_pct=round(edge_pct, 2),
                 realizable_edge=round(realizable_edge, 2),
                 ask=ask,
+                limit_price=limit_price,
+                size=round(base_order.size, 1),
                 cross_cost_pts=round(cross_cost_pts, 2),
             )
         elif not has_book:

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -204,6 +204,50 @@ class OrderBook(BaseModel):
             return self.best_ask - self.best_bid
         return None
 
+    def fill_to_size(self, shares: float, is_buy: bool) -> tuple[float, float, float]:
+        """Walk the book as a taker and return ``(fillable_shares, vwap,
+        marginal_price)``.
+
+        A BUY lifts asks cheapest-first; a SELL hits bids highest-first.
+        ``fillable_shares`` is what the book can actually absorb (<= the
+        requested ``shares``); ``vwap`` is the volume-weighted price over them
+        (the *effective* price the size pays/receives, not the top-of-book
+        quote); ``marginal_price`` is the worst level touched — the minimum
+        limit price that still fills the whole size. Returns ``(0.0, 0.0, 0.0)``
+        when the relevant side is empty or ``shares`` is non-positive.
+        """
+        levels = self.asks if is_buy else self.bids
+        if not levels or shares <= 0:
+            return 0.0, 0.0, 0.0
+        # Taker lifts the best price first: asks ascending, bids descending.
+        ordered = sorted(levels, key=lambda lvl: lvl.price, reverse=not is_buy)
+        remaining = shares
+        cost = 0.0
+        filled = 0.0
+        marginal = 0.0
+        for lvl in ordered:
+            if remaining <= 1e-9:
+                break
+            take = min(remaining, lvl.size)
+            cost += take * lvl.price
+            filled += take
+            marginal = lvl.price
+            remaining -= take
+        if filled <= 0:
+            return 0.0, 0.0, 0.0
+        return filled, cost / filled, marginal
+
+    def depth_within(self, price_cap: float, is_buy: bool) -> float:
+        """Total shares available no worse than ``price_cap`` on the taker side.
+
+        For a BUY, sums ask sizes at price <= cap (the shares we could lift
+        without paying more than the cap); for a SELL, bid sizes at price >= cap.
+        """
+        levels = self.asks if is_buy else self.bids
+        if is_buy:
+            return sum(lvl.size for lvl in levels if lvl.price <= price_cap + 1e-9)
+        return sum(lvl.size for lvl in levels if lvl.price >= price_cap - 1e-9)
+
 
 class ExitReason(str, Enum):
     STOP_LOSS = "STOP_LOSS"

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,6 +49,18 @@ class ExecutionConfig(BaseModel):
     # guard), regardless of the slippage band above.
     exit_min_bid_price: float = 0.05
     spread_capture_min_bps: int = 50
+    # Depth-aware entry routing: size an entry against the ACTUAL book, not just
+    # the top-of-book ask. The router walks the asks up to the slippage budget
+    # (the price at which realizable edge would fall to min_edge, also bounded
+    # by entry_max_cross_cents), and trims the order to the depth available
+    # there. depth_aware_routing toggles the behavior; book_capacity_fraction
+    # caps how much of that in-budget depth a single order may take (don't be
+    # the whole book); min_fill_fraction skips the entry when less than this
+    # share of the requested size fits within budget (a dust fill isn't worth
+    # the entry). Set depth_aware_routing False to restore top-of-book pricing.
+    depth_aware_routing: bool = True
+    book_capacity_fraction: float = 0.5
+    min_fill_fraction: float = 0.5
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0
     edge_erosion_min_pct: float = 2.0

--- a/tests/test_orderbook_depth.py
+++ b/tests/test_orderbook_depth.py
@@ -1,0 +1,65 @@
+"""Depth-aware order-book primitives: fill_to_size (walk-the-book VWAP +
+marginal sweep price) and depth_within (in-budget capacity)."""
+
+from __future__ import annotations
+
+from auramaur.exchange.models import OrderBook, OrderBookLevel
+
+
+def _book() -> OrderBook:
+    # asks deliberately worst-first to prove ordering-agnosticism
+    return OrderBook(
+        bids=[OrderBookLevel(price=0.40, size=100.0),
+              OrderBookLevel(price=0.45, size=50.0)],
+        asks=[OrderBookLevel(price=0.60, size=100.0),
+              OrderBookLevel(price=0.50, size=30.0),
+              OrderBookLevel(price=0.55, size=20.0)],
+    )
+
+
+def test_fill_within_best_level_prices_at_best():
+    filled, vwap, marginal = _book().fill_to_size(10.0, is_buy=True)
+    assert filled == 10.0
+    assert abs(vwap - 0.50) < 1e-9
+    assert abs(marginal - 0.50) < 1e-9  # fits in the 0.50 level → limit is the ask
+
+
+def test_fill_sweeps_multiple_levels_vwap_and_marginal():
+    # 40 shares: 30@0.50 + 10@0.55 -> vwap, marginal = 0.55
+    filled, vwap, marginal = _book().fill_to_size(40.0, is_buy=True)
+    assert filled == 40.0
+    assert abs(vwap - (30 * 0.50 + 10 * 0.55) / 40) < 1e-9
+    assert abs(marginal - 0.55) < 1e-9
+
+
+def test_fill_capped_by_total_depth():
+    # only 150 shares on the asks; requesting more returns what's available
+    filled, vwap, marginal = _book().fill_to_size(1000.0, is_buy=True)
+    assert filled == 150.0
+    assert abs(marginal - 0.60) < 1e-9
+
+
+def test_fill_empty_side_returns_zeros():
+    assert OrderBook(asks=[]).fill_to_size(10.0, is_buy=True) == (0.0, 0.0, 0.0)
+    assert _book().fill_to_size(0.0, is_buy=True) == (0.0, 0.0, 0.0)
+
+
+def test_depth_within_buy_sums_asks_under_cap():
+    b = _book()
+    assert b.depth_within(0.50, is_buy=True) == 30.0          # only the 0.50 level
+    assert b.depth_within(0.55, is_buy=True) == 50.0          # 0.50 + 0.55
+    assert b.depth_within(0.60, is_buy=True) == 150.0         # all
+
+
+def test_depth_within_sell_sums_bids_over_cap():
+    b = _book()
+    assert b.depth_within(0.45, is_buy=False) == 50.0         # only the 0.45 bid
+    assert b.depth_within(0.40, is_buy=False) == 150.0        # both bids
+
+
+def test_sell_walks_bids_highest_first():
+    # selling 60: 50@0.45 + 10@0.40
+    filled, vwap, marginal = _book().fill_to_size(60.0, is_buy=False)
+    assert filled == 60.0
+    assert abs(vwap - (50 * 0.45 + 10 * 0.40) / 60) < 1e-9
+    assert abs(marginal - 0.40) < 1e-9

--- a/tests/test_router_crossing.py
+++ b/tests/test_router_crossing.py
@@ -109,6 +109,73 @@ async def test_skips_on_dead_book():
         await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 10.0, False)
 
 
+# ---------------------------------------------------------------------------
+# Depth-aware routing (phase 1): trim to in-budget capacity, sweep pricing
+# ---------------------------------------------------------------------------
+
+def _depth_settings(*, max_cross_cents=4, min_edge_pct=2.5,
+                    cap_frac=0.5, min_fill=0.5) -> MagicMock:
+    s = MagicMock()
+    s.execution.entry_max_cross_cents = max_cross_cents
+    s.execution.depth_aware_routing = True
+    s.execution.book_capacity_fraction = cap_frac
+    s.execution.min_fill_fraction = min_fill
+    s.risk.min_edge_pct = min_edge_pct
+    return s
+
+
+def _depth_router(book: OrderBook, base_price: float, order_size: float,
+                  settings: MagicMock) -> SmartOrderRouter:
+    exchange = MagicMock()
+    exchange.prepare_order = MagicMock(return_value=Order(
+        market_id="m1", exchange="polymarket", token_id="tok",
+        side=OrderSide.BUY, token=TokenType.YES, size=order_size,
+        price=base_price, dry_run=True))
+    exchange.get_order_book = AsyncMock(return_value=book)
+    return SmartOrderRouter(settings, exchange)
+
+
+@pytest.mark.asyncio
+async def test_depth_trims_size_to_capacity():
+    """Order bigger than the in-budget depth allows -> trim to capacity_fraction
+    of it, price at the (single-level) sweep price."""
+    book = OrderBook(bids=[OrderBookLevel(price=0.48, size=500.0)],
+                     asks=[OrderBookLevel(price=0.50, size=40.0)])
+    router = _depth_router(book, base_price=0.49, order_size=30.0,
+                           settings=_depth_settings(cap_frac=0.5, min_fill=0.5))
+    order = await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 30.0, False)
+    assert order is not None
+    assert order.size == 20.0          # depth 40 * 0.5 capacity
+    assert order.price == 0.50         # fits the 0.50 level -> ask
+
+
+@pytest.mark.asyncio
+async def test_depth_skips_when_below_min_fill():
+    """In-budget capacity below min_fill_fraction of the requested size -> skip."""
+    book = OrderBook(bids=[OrderBookLevel(price=0.48, size=500.0)],
+                     asks=[OrderBookLevel(price=0.50, size=40.0)])
+    router = _depth_router(book, base_price=0.49, order_size=50.0,
+                           settings=_depth_settings(cap_frac=0.5, min_fill=0.5))
+    # capacity = 40*0.5 = 20 < min_fill(0.5)*50 = 25 -> skip
+    with pytest.raises(UnmarketableSignal, match="absorbs only"):
+        await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 50.0, False)
+
+
+@pytest.mark.asyncio
+async def test_depth_sweep_prices_at_marginal_level():
+    """A size needing two levels prices the limit at the deeper (marginal)
+    level, not the best ask -- so it can actually sweep to fill."""
+    book = OrderBook(bids=[OrderBookLevel(price=0.48, size=500.0)],
+                     asks=[OrderBookLevel(price=0.50, size=10.0),
+                           OrderBookLevel(price=0.55, size=50.0)])
+    router = _depth_router(book, base_price=0.49, order_size=40.0,
+                           settings=_depth_settings(max_cross_cents=10, cap_frac=1.0, min_fill=0.5))
+    order = await router.route(_signal(edge=12.0), Market(id="m1", question="Q?"), 40.0, False)
+    assert order is not None
+    assert order.size == 40.0          # capacity ample (cap_frac 1.0)
+    assert order.price == 0.55         # marginal sweep level, not the 0.50 ask
+
+
 @pytest.mark.asyncio
 async def test_takes_price_improvement_when_ask_below_reference():
     """Ask below the reference price is free improvement -> take it; the


### PR DESCRIPTION
## Motivation
Entry routing priced the whole order at `best_ask` and sized via aggregate liquidity. An order larger than the top-of-book level implied slippage we never priced, and nothing capped the order against the book's actual capacity. (Phase 1 of the size-vs-book-capacity / slippage gating discussed off the back of issue #148.)

## Changes
- **`OrderBook.fill_to_size(shares, is_buy)`** walks the book as a taker → `(fillable, vwap, marginal_price)`; **`depth_within(price_cap, is_buy)`** gives in-budget capacity. Pure and ordering-agnostic.
- **Router (BUY / taker path):** after the existing best-ask edge + cents-cap gate, walk the asks up to the **slippage budget** — the price at which realizable edge would fall to `min_edge_pct`, also bounded by `entry_max_cross_cents` — then:
  - **trim** the order to `book_capacity_fraction` of the in-budget depth (don't be the whole book),
  - **price the limit at the marginal sweep level** (a size that fits the best ask still prices at the ask; only a real multi-level sweep lifts the limit, always ≤ the budget cap; cheapest-first matching means the effective fill is the VWAP),
  - **skip** when less than `min_fill_fraction` of the requested size fits within budget.
- **Config:** `execution.depth_aware_routing` (toggle, default on), `book_capacity_fraction` (0.5), `min_fill_fraction` (0.5). Toggle off to restore top-of-book pricing.

SELL/exit path is unchanged. Behavior is conservative by construction — the slippage budget is tied to the existing min-edge floor, so trimmed/swept fills still clear it.

## Tests
`fill_to_size` / `depth_within` primitives (VWAP, marginal price, multi-level sweep, capacity, sell side); router trims to capacity, skips below min-fill, and prices at the marginal sweep level across two levels. Full suite: 762 passed.

Assisted-by: Claude (Anthropic)