### PR TITLE
feat(bias_harvest): skip favorites whose UMA resolution is actively disputed

### DIFF
--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -113,6 +113,13 @@ class BiasHarvestPillar:
             return False
         if (market.exchange or "polymarket") != "polymarket":
             return False  # backtest validated Polymarket only (0% fees)
+        # Tail-filter: don't harvest a favorite whose resolution is actively
+        # disputed — the pinned price can flip when the dispute clears, which is
+        # exactly the fat-tail loss the paper track surfaced. Fails open (only a
+        # confirmed DO_NOT_ACT is skipped; markets with no UMA data still enter).
+        if cfg.skip_disputed and market.dispute_risk == "DO_NOT_ACT":
+            log.debug("bias_harvest.skip_disputed", market_id=market.id)
+            return False
         if market.liquidity < cfg.min_liquidity:
             return False
         if (market.category or "") in set(self._settings.risk.blocked_categories):

--- a/config/settings.py
+++ b/config/settings.py
@@ -316,6 +316,13 @@ class BiasHarvestConfig(BaseModel):
     min_hours_to_resolution: float = 6.0
     max_days_to_resolution: float = 45.0
     interval_seconds: int = 600
+    # Tail-filter: skip a favorite whose UMA resolution is actively disputed.
+    # The deep-band backtest won 99.3%, but the rare flips that produced the
+    # paper track's fat-tail losses are disproportionately contested
+    # resolutions — a disputed market is price-pinned to the *proposed* outcome
+    # and can reverse. Fails open (only an ACTIVE dispute is skipped), so a
+    # market with no UMA data still enters as before. See [[uma-dispute-gate]].
+    skip_disputed: bool = True
 
 
 class EntailmentArbConfig(BaseModel):

--- a/tests/test_bias_harvest.py
+++ b/tests/test_bias_harvest.py
@@ -207,6 +207,30 @@ def test_skips_out_of_band_and_ineligible():
     asyncio.run(run())
 
 
+def test_skips_actively_disputed_favorite():
+    """A perfectly in-band favorite is skipped when its UMA resolution is
+    actively disputed (the fat-tail flip filter). A non-disputed twin enters."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        disputed = _market("disp", yes=0.90)
+        disputed.uma_status = "disputed"            # -> dispute_risk DO_NOT_ACT
+        pillar, _ = _pillar(db, _settings(), [disputed])
+        assert pillar._eligible(disputed) is False
+        assert await pillar.run_once() == 0
+
+        clean = _market("clean", yes=0.90)          # resolved-after-dispute/none -> READY
+        clean.uma_status = "resolved"
+        assert pillar._eligible(clean) is True
+
+        # toggle off -> dispute no longer filters
+        pillar2, _ = _pillar(db, _settings(skip_disputed=False), [disputed])
+        assert pillar2._eligible(disputed) is True
+        await db.close()
+
+    asyncio.run(run())
+
+
 def test_one_entry_per_market_and_skips_held():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
## What
Adds a tail-filter to the favorite-longshot harvest: skip a candidate whose UMA resolution is **actively disputed** (`Market.dispute_risk == DO_NOT_ACT`).

## Why
The deep-band harvest wins ~99% by backtest, but the paper track showed a fat-tail loss shape (uniform full-stake losses on the few flips). Contested resolutions are over-represented in those flips — a disputed market is price-pinned to the *proposed* outcome and can reverse when the dispute clears. This filters exactly that tail, reusing the UMA dispute signal from #149.

- **Fails open:** only a confirmed active dispute is skipped; a market with no UMA data enters as before, and a market resolved *after* a past dispute reads READY and enters. So it strictly removes risk without changing the measured entry band.
- Gated by `bias_harvest.skip_disputed` (default on).

This is #1 "Option A" from the strategy scoping — a subtractive risk filter on the existing measured edge (no backtest needed); the entry-selection-narrowing refinement (imminent-resolution restriction) is deferred pending a backtest.

## Test
In-band favorite with `uma_status="disputed"` is skipped (`run_once`==0); a `resolved` twin enters; toggling `skip_disputed=False` disables the filter.

Assisted-by: Claude (Anthropic)