### PR TITLE
feat(entailment_arb): Kalshi 'Above X' econ-bin ladder primitives (Phase A core)

### DIFF
--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -134,6 +134,66 @@ def ladder_pairs(markets: list[Market]) -> list[tuple[Market, Market, str]]:
 
 
 # ----------------------------------------------------------------------
+# Kalshi "Above X" econ-bin ladders (ticker-keyed, not question-keyed)
+# ----------------------------------------------------------------------
+#
+# Kalshi expresses a threshold ladder as a set of markets sharing one event
+# title ("What will CPI YoY be?") with per-bin subtitles ("Above 4.5%"); the
+# THRESHOLD and the FAMILY both live in the ticker, e.g.
+# KXCPIYOY-26NOV-T4.5 -> family "KXCPIYOY-26NOV", threshold 4.5. The
+# question-text parser can't be used here: every series uses "Above N%", so
+# grouping on the subtitle would wrongly merge CPI / unemployment / GDP bins.
+# Only the "-T<number>" strike form is a MONOTONIC ladder (above(hi) =>
+# above(lo)); categorical strikes (KXFEDDECISION -H26/-C25) are excluded.
+
+_KALSHI_LADDER_RE = re.compile(r"^(?P<family>.+)-T(?P<num>-?\d[\d,]*(?:\.\d+)?)$")
+
+
+def parse_kalshi_ladder(ticker: str):
+    """Return (family_key, value) for a Kalshi '-T<number>' threshold market,
+    else None (categorical strikes and non-ladder tickers don't match)."""
+    m = _KALSHI_LADDER_RE.match((ticker or "").strip())
+    if not m:
+        return None
+    try:
+        value = float(m.group("num").replace(",", ""))
+    except ValueError:
+        return None
+    return ("kxthr", m.group("family")), value
+
+
+def kalshi_ladder_pairs(markets: list[Market]) -> list[tuple[Market, Market, str]]:
+    """(implier, implied, why) pairs from Kalshi 'Above X' ticker ladders.
+
+    above(hi) => above(lo), so P(implier) <= P(implied) must hold — same
+    model-free bound as ladder_pairs, but families/strikes come from the
+    ticker. Kalshi-only; non-Kalshi or non-ladder tickers are ignored.
+    """
+    families: dict[tuple, list[tuple[float, Market]]] = {}
+    for m in markets:
+        if (m.exchange or "") != "kalshi":
+            continue
+        parsed = parse_kalshi_ladder(m.ticker)
+        if parsed is None:
+            continue
+        key, value = parsed
+        families.setdefault(key, []).append((value, m))
+
+    pairs: list[tuple[Market, Market, str]] = []
+    for _key, members in families.items():
+        if len(members) < 2:
+            continue
+        members.sort()
+        for i, (v_lo, m_lo) in enumerate(members):
+            for v_hi, m_hi in members[i + 1:]:
+                if v_hi == v_lo:
+                    continue
+                # "Above hi" implies "Above lo".
+                pairs.append((m_hi, m_lo, f"above {v_hi:g} => above {v_lo:g}"))
+    return pairs
+
+
+# ----------------------------------------------------------------------
 # LLM verification prompt (fuzzy pairs only)
 # ----------------------------------------------------------------------
 

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -31,11 +31,59 @@ from auramaur.exchange.models import (
 )
 from auramaur.strategy.entailment_arb import (
     EntailmentArbPillar,
+    kalshi_ladder_pairs,
     ladder_pairs,
+    parse_kalshi_ladder,
     parse_threshold,
     parse_topn,
 )
 from config.settings import Settings
+
+
+def _kx(ticker, yes, question="What will CPI YoY be?") -> Market:
+    return Market(
+        id=ticker, exchange="kalshi", ticker=ticker, question=question,
+        description="Above X%", active=True,
+        outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=5000.0, volume=5000.0, spread=0.01,
+        end_date=datetime.now(timezone.utc) + timedelta(days=5),
+    )
+
+
+def test_parse_kalshi_ladder():
+    assert parse_kalshi_ladder("KXCPIYOY-26NOV-T4.5") == (("kxthr", "KXCPIYOY-26NOV"), 4.5)
+    assert parse_kalshi_ladder("KXPAYROLLS-26NOV-T90000") == (("kxthr", "KXPAYROLLS-26NOV"), 90000.0)
+    # categorical Fed strikes are NOT monotonic ladders -> excluded
+    assert parse_kalshi_ladder("KXFEDDECISION-28JAN-H26") is None
+    assert parse_kalshi_ladder("KXFEDDECISION-28JAN-C25") is None
+    assert parse_kalshi_ladder("KXSOMETHING") is None
+
+
+def test_kalshi_ladder_pairs_direction_and_no_cross_series():
+    markets = [
+        _kx("KXCPIYOY-26NOV-T4.5", 0.30),
+        _kx("KXCPIYOY-26NOV-T4.4", 0.40),
+        _kx("KXCPIYOY-26NOV-T4.6", 0.20),
+        # different series, same "Above %" subtitle — must NOT pair with CPI
+        _kx("KXU3-26NOV-T4.5", 0.30, question="What will unemployment be?"),
+        # different PERIOD — must not pair with the NOV CPI bins
+        _kx("KXCPIYOY-26DEC-T4.5", 0.30),
+    ]
+    pairs = kalshi_ladder_pairs(markets)
+    fams = {(a.ticker, b.ticker) for a, b, _why in pairs}
+    # 3 NOV-CPI bins -> 3 ordered pairs, all implier=higher-strike => implied=lower
+    assert ("KXCPIYOY-26NOV-T4.6", "KXCPIYOY-26NOV-T4.5") in fams
+    assert ("KXCPIYOY-26NOV-T4.6", "KXCPIYOY-26NOV-T4.4") in fams
+    assert ("KXCPIYOY-26NOV-T4.5", "KXCPIYOY-26NOV-T4.4") in fams
+    assert len(pairs) == 3  # no cross-series / cross-period contamination
+    # every implier is the higher strike (so P(implier) <= P(implied) must hold)
+    for impl, imp, _ in pairs:
+        assert float(impl.ticker.split("-T")[1]) > float(imp.ticker.split("-T")[1])
+
+
+def test_kalshi_ladder_ignores_non_kalshi():
+    poly = _market("p1", "BTC above 70000 on Friday?", 0.5)
+    assert kalshi_ladder_pairs([poly]) == []
 
 
 def _market(mid, question, yes, liquidity=5000.0, spread=0.01,


### PR DESCRIPTION
## What
The deterministic, fully-tested **core** for #2 Phase A (model-free economic-indicator ladder arb on Kalshi). Pure helpers, **not yet wired into the scan loop** — zero live-behavior change.

- `parse_kalshi_ladder(ticker)` → `(family, value)` from the `-T<number>` strike (e.g. `KXCPIYOY-26NOV-T4.5` → `("kxthr","KXCPIYOY-26NOV"), 4.5`). Categorical Fed strikes (`-H26`/`-C25`) excluded — they aren't a monotonic ladder.
- `kalshi_ladder_pairs(markets)` → `(implier=above-hi, implied=above-lo, why)`, the same model-free bound `P(implier) ≤ P(implied)` as the existing Polymarket `ladder_pairs`, but keyed on the **ticker** family+period (Kalshi shares one event title across bins, so question-text grouping would wrongly merge CPI/unemployment/GDP "Above N%" bins).

## Why a separate step
`entailment_arb`'s discovery is Polymarket-gamma only, and Kalshi econ bins are niche/low-volume (they'd be missed by a generic top-N scan — the same "silent since volume-scan" trap from prior strategies). So the remaining integration needs a **Kalshi series-targeted fetch** + **per-leg fee-clearing** (Kalshi has fees; a "model-free" arb must clear both legs' ~taker fee or it isn't free), wired into the paper-forced arb loop. Landing the verified primitives first keeps that integration small and reviewable.

## Test
`parse_kalshi_ladder` (strike forms + Fed-categorical exclusion); `kalshi_ladder_pairs` (correct implier=higher-strike direction, no cross-series/cross-period contamination, non-Kalshi ignored). Full suite: 766 passed.

Assisted-by: Claude (Anthropic)