### PR TITLE
feat(entailment_arb): wire Kalshi econ-bin ladder arb (series-fetch + fee-clearing)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2768,6 +2768,9 @@ class AuramaurBot:
             risk_manager=self._components["risk_manager"],
             pnl_tracker=self._components["pnl_tracker"],
             analyzer=self._components.get("analyzer"),
+            # Kalshi econ-bin ladder arb fetches its own series; pass the Kalshi
+            # discovery if present (no-op when Kalshi isn't configured).
+            kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
         )
         interval = max(60, self.settings.entailment_arb.interval_seconds)
         while self._running:

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -143,6 +143,34 @@ class KalshiClient:
         data = json.loads(raw)
         return data.get("market")
 
+    async def get_markets_by_series(self, series_ticker: str,
+                                    limit: int = 200) -> list[Market]:
+        """Fetch open markets for ONE series — i.e. all bins of a threshold
+        ladder (e.g. every KXCPIYOY-26NOV-T* strike).
+
+        The generic get_markets() scans events by recency/volume and misses
+        niche econ ladders; the series filter pulls the whole bin set so the
+        ladder-arb scanner sees a complete, orderable family.
+        """
+        self._init_api()
+        try:
+            import json
+            raw = await self._call_raw(
+                self._markets_api.get_markets_without_preload_content,
+                series_ticker=series_ticker, status="open", limit=min(limit, 200),
+            )
+            rows = json.loads(raw).get("markets", [])
+            out: list[Market] = []
+            for m in rows:
+                parsed = self._parse_market(m)
+                if parsed is not None:
+                    out.append(parsed)
+            return out
+        except Exception as e:
+            log.error("kalshi.series_fetch_error", series=series_ticker,
+                      error=str(e))
+            return []
+
     async def get_markets(self, active: bool = True, limit: int = 100) -> list[Market]:
         """Fetch markets from Kalshi API."""
         self._init_api()

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -94,6 +94,11 @@ def ladder_pairs(markets: list[Market]) -> list[tuple[Market, Market, str]]:
     thr_families: dict[tuple, list[tuple[float, Market]]] = {}
     top_families: dict[tuple, list[tuple[int, Market]]] = {}
     for m in markets:
+        # Question-text ladders are Polymarket's; Kalshi ladders are matched
+        # separately by ticker (kalshi_ladder_pairs). Never cross venues — the
+        # legs must execute and settle on the same exchange.
+        if (m.exchange or "polymarket") != "polymarket":
+            continue
         t = parse_threshold(m.question)
         if t:
             key, _direction, value = t
@@ -217,7 +222,7 @@ Respond with ONLY this JSON:
 
 class EntailmentArbPillar:
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, analyzer=None) -> None:
+                 pnl_tracker, analyzer=None, kalshi_discovery=None) -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
@@ -225,6 +230,8 @@ class EntailmentArbPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._analyzer = analyzer
+        # Optional Kalshi discovery for the econ-bin ladder arb (series-fetched).
+        self._kalshi_discovery = kalshi_discovery
 
     # -- market quality -------------------------------------------------
 
@@ -233,7 +240,19 @@ class EntailmentArbPillar:
         cfg = self._settings.entailment_arb
         if not m.active or not (0.0 < m.outcome_yes_price < 1.0):
             return False
-        if (m.exchange or "polymarket") != "polymarket":
+        venue = m.exchange or "polymarket"
+        if venue == "kalshi":
+            # Kalshi ladder legs: same dead-book guards, venue-scaled liquidity.
+            if m.liquidity < cfg.kalshi_min_liquidity:
+                return False
+            if m.spread and m.spread * 100.0 > cfg.max_spread_pct:
+                return False
+            if m.end_date is None:
+                return False
+            end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+            hours = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+            return hours >= cfg.min_hours_to_resolution
+        if venue != "polymarket":
             return False
         if m.liquidity < cfg.min_liquidity:
             return False
@@ -319,6 +338,44 @@ class EntailmentArbPillar:
         await self._db.commit()
         return direction, confidence
 
+    def _required_gap(self, implier: Market, implied: Market) -> float:
+        """Minimum violation gap to be a real arb on these legs.
+
+        Polymarket makers pay nothing → the plain min_gap (slippage/leg-risk
+        buffer). Kalshi charges a taker fee per leg, so a "model-free" gap that
+        doesn't clear BOTH legs' fees is a guaranteed loss — require
+        gap > fee(implier) + fee(implied) + buffer, fees from the live model.
+        """
+        cfg = self._settings.entailment_arb
+        if (implier.exchange or "polymarket") != "kalshi":
+            return cfg.min_gap
+        from auramaur.strategy.signals import taker_fee_rate
+        fees = self._settings.arbitrage.exchange_fees
+        pa, pb = implier.outcome_yes_price, implied.outcome_yes_price
+        fee_a = taker_fee_rate("kalshi", implier.category or "", fees) * pa * (1.0 - pa)
+        fee_b = taker_fee_rate("kalshi", implied.category or "", fees) * pb * (1.0 - pb)
+        return fee_a + fee_b + cfg.kalshi_gap_buffer
+
+    async def _kalshi_ladder_candidates(self):
+        """Fetch the configured Kalshi econ series and return model-free ladder
+        pairs (implier, implied, why, confidence=1.0). Series-fetched so the
+        whole bin set is visible; empty if Kalshi discovery isn't wired."""
+        cfg = self._settings.entailment_arb
+        if not cfg.kalshi_ladders_enabled or self._kalshi_discovery is None:
+            return []
+        markets: list[Market] = []
+        for series in cfg.kalshi_series:
+            try:
+                rows = await self._kalshi_discovery.get_markets_by_series(series)
+            except Exception as e:
+                log.debug("entailment.kalshi_series_error", series=series, error=str(e))
+                continue
+            markets.extend(m for m in rows if self._real_book(m))
+        pairs = [(impl, imp, why, 1.0) for impl, imp, why in kalshi_ladder_pairs(markets)]
+        if pairs:
+            log.info("entailment.kalshi_ladders", pairs=len(pairs), markets=len(markets))
+        return pairs
+
     async def _already_traded(self, a_id: str, b_id: str) -> bool:
         row = await self._db.fetchone(
             """SELECT 1 FROM trades WHERE strategy_source = 'entailment_arb'
@@ -337,7 +394,12 @@ class EntailmentArbPillar:
         by_id = {m.id: m for m in good}
 
         # 1. Deterministic ladders — direction known mathematically.
-        candidates: list[tuple[Market, Market, str, float]] = [
+        #    Polymarket (question-keyed) + Kalshi econ bins (ticker-keyed,
+        #    series-fetched, fee-cleared in the gate below).
+        candidates: list[tuple[Market, Market, str, float]] = (
+            await self._kalshi_ladder_candidates()
+        )
+        candidates += [
             (impl, imp, why, 1.0) for impl, imp, why in ladder_pairs(good)
         ]
 
@@ -362,7 +424,9 @@ class EntailmentArbPillar:
             if placed >= cfg.max_pairs_per_cycle:
                 break
             gap = implier.outcome_yes_price - implied.outcome_yes_price
-            if gap < cfg.min_gap:
+            # Fee-aware floor: Polymarket uses min_gap; Kalshi must clear both
+            # legs' taker fees + buffer, or the "free" arb loses to fees.
+            if gap < self._required_gap(implier, implied):
                 continue
             if await self._already_traded(implier.id, implied.id):
                 continue

--- a/config/settings.py
+++ b/config/settings.py
@@ -346,6 +346,18 @@ class EntailmentArbConfig(BaseModel):
     llm_enabled: bool = True
     llm_min_confidence: float = 0.9
     interval_seconds: int = 900
+    # Kalshi "Above X" economic-indicator ladders (model-free monotonicity arb).
+    # Fetched per-series (not via the generic scan — econ bins are niche and a
+    # top-N scan misses them). Unlike Polymarket (0% maker), Kalshi charges a
+    # taker fee per leg, so a violation must clear BOTH legs' fees + a buffer to
+    # be real — kalshi_min_gap is computed from the fee model at runtime, not
+    # this flat min_gap. Paper-forced by the graduation ladder like every cell.
+    kalshi_ladders_enabled: bool = True
+    kalshi_series: list[str] = Field(default_factory=lambda: [
+        "KXCPIYOY", "KXGDP", "KXU3", "KXPAYROLLS", "KXPCEYOY",
+    ])
+    kalshi_min_liquidity: float = 50.0
+    kalshi_gap_buffer: float = 0.01
 
 
 class OddLotTenderConfig(BaseModel):

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -86,6 +86,31 @@ def test_kalshi_ladder_ignores_non_kalshi():
     assert kalshi_ladder_pairs([poly]) == []
 
 
+def test_required_gap_clears_kalshi_fees():
+    """Polymarket legs use the flat min_gap; Kalshi legs must clear BOTH legs'
+    taker fees + buffer (so a 'model-free' arb that ignores fees is rejected)."""
+    from auramaur.strategy.signals import taker_fee_rate
+    s = _settings(kalshi_gap_buffer=0.01)
+    pillar = EntailmentArbPillar.__new__(EntailmentArbPillar)
+    pillar._settings = s
+
+    poly_a = _market("pa", "X above 5?", 0.5)
+    poly_b = _market("pb", "X above 4?", 0.4)
+    assert pillar._required_gap(poly_a, poly_b) == s.entailment_arb.min_gap
+
+    ka = _kx("KXCPIYOY-26NOV-T4.5", 0.50)
+    kb = _kx("KXCPIYOY-26NOV-T4.4", 0.40)
+    fees = s.arbitrage.exchange_fees
+    expected = (taker_fee_rate("kalshi", "", fees) * 0.50 * 0.50
+                + taker_fee_rate("kalshi", "", fees) * 0.40 * 0.60
+                + 0.01)
+    req = pillar._required_gap(ka, kb)
+    assert abs(req - expected) < 1e-9
+    # a sub-fee "violation" is rejected; a fee-clearing one is not
+    assert (0.50 - 0.49) < req          # 1c gap doesn't clear fees
+    assert (0.50 - 0.40) > req          # 10c gap does
+
+
 def _market(mid, question, yes, liquidity=5000.0, spread=0.01,
             exchange="polymarket", days_out=5.0, active=True) -> Market:
     return Market(


### PR DESCRIPTION
## What
Turns on **#2 Phase A** — the model-free monotonicity arb on Kalshi "Above X" economic-indicator ladders, building on the primitives from #152.

- **Kalshi client:** `get_markets_by_series(series)` fetches a whole bin set directly (verified the SDK exposes `get_markets_without_preload_content`). The generic event scan misses niche econ ladders — the "silent since volume-scan" trap — so we pull them by series.
- **`EntailmentArbPillar`:** optional `kalshi_discovery`; each cycle fetches the configured econ series (`KXCPIYOY/KXGDP/KXU3/KXPAYROLLS/KXPCEYOY`), real-book-filters them (venue-scaled liquidity), and adds `kalshi_ladder_pairs` to the candidate set alongside the Polymarket question-ladders.
- **Fee-clearing gate:** `_required_gap` requires a Kalshi violation to clear **both legs' taker fees + buffer** (from the live fee model). A "model-free" arb that ignores Kalshi's fee is a guaranteed loss; Polymarket keeps the flat `min_gap`.
- **No cross-venue legs:** `ladder_pairs` is now venue-scoped to Polymarket (a Kalshi market can no longer be question-paired with a Poly one).
- bot wires the Kalshi discovery in. Paper-forced by the graduation ladder.

## Test
`_required_gap` fee-clearing (Poly→min_gap; Kalshi→both-leg fees+buffer, sub-fee gap rejected, 10c gap clears); plus the prior ladder-grouping/direction tests. Full suite: 767 passed.

Assisted-by: Claude (Anthropic)