### PR TITLE
feat(econ): data-driven pricing core for Kalshi econ-indicator bins (Phase B core)

### DIFF
--- a/auramaur/data_sources/fred.py
+++ b/auramaur/data_sources/fred.py
@@ -92,6 +92,30 @@ class FREDSource:
         logger.info("fred_fetched", count=len(items[:limit]))
         return items[:limit]
 
+    async def get_observations(self, series_id: str, n: int = 60) -> list[tuple[datetime, float]]:
+        """Latest ``n`` (date, value) observations for a series, oldest-first.
+
+        Pricing-oriented accessor (distinct from the news ``fetch``): the
+        econ-indicator pricer estimates a distribution from the recent history.
+        Returns [] on failure — callers must handle the empty case (don't
+        price a bin off no data).
+        """
+        loop = asyncio.get_running_loop()
+
+        def _run() -> list[tuple[datetime, float]]:
+            series = self._fred.get_series(series_id).dropna().tail(n)
+            out: list[tuple[datetime, float]] = []
+            for date, value in series.items():
+                ts = date.to_pydatetime() if hasattr(date, "to_pydatetime") else date
+                out.append((ts, float(value)))
+            return out
+
+        try:
+            return await loop.run_in_executor(None, _run)
+        except Exception:
+            logger.exception("fred_observations_failed", series_id=series_id)
+            return []
+
     async def fetch(self, query: str, limit: int = 20) -> list[NewsItem]:
         """Run the blocking FRED API call in a thread-pool executor."""
         loop = asyncio.get_running_loop()

--- a/auramaur/strategy/econ_pricing.py
+++ b/auramaur/strategy/econ_pricing.py
@@ -1,0 +1,129 @@
+"""Data-driven pricing for Kalshi economic-indicator bins (#2 Phase B).
+
+Kalshi runs "Above X" threshold ladders on official indicators (CPI YoY,
+unemployment, payrolls, ...). Each ladder is an implied CDF of the indicator
+at a future release. This module prices those bins from the official history
+(FRED) instead of guessing: estimate the indicator's distribution at the
+target release, then P(Above X) = 1 - CDF(X). Where the model and the market
+disagree by more than fees + a margin, there is a (forecast-based, not
+model-free) edge.
+
+EVERYTHING here is pure and deterministic — the FRED fetch and order placement
+live in the pillar. Model risk is real (a wrong transform = confident-wrong
+bets), so: transforms are explicit per series, the sigma has a floor (never
+over-concentrate), and the pillar is paper-forced until the paper ledger +
+calibration prove it.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+# ----------------------------------------------------------------------
+# Registry: Kalshi series prefix -> how to build the indicator from FRED
+# ----------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EconSpec:
+    fred_series: str
+    # how to turn the raw FRED level into the indicator the bins resolve on:
+    #   "level"      — the series value itself (e.g. unemployment rate)
+    #   "yoy"        — % change vs 12 periods ago (e.g. CPI YoY)
+    #   "mom_change" — change vs previous period, times `scale` (e.g. payrolls)
+    transform: str
+    periods_per_year: int = 12  # 12 monthly, 4 quarterly — for YoY/horizon
+    scale: float = 1.0          # mom_change unit fix (PAYEMS is in thousands)
+
+
+# Conservative starter registry — only series with an unambiguous transform.
+# (GDP annualization / Fed-decision categoricals are intentionally omitted
+# until each is validated against a real print.)
+ECON_SERIES: dict[str, EconSpec] = {
+    "KXCPIYOY": EconSpec("CPIAUCSL", "yoy", periods_per_year=12),
+    "KXU3": EconSpec("UNRATE", "level", periods_per_year=12),
+    "KXPAYROLLS": EconSpec("PAYEMS", "mom_change", periods_per_year=12, scale=1000.0),
+}
+
+
+def spec_for_series(series_ticker: str) -> EconSpec | None:
+    """Look up the EconSpec for a Kalshi series prefix (e.g. 'KXCPIYOY')."""
+    return ECON_SERIES.get((series_ticker or "").upper())
+
+
+# ----------------------------------------------------------------------
+# Distribution math (pure)
+# ----------------------------------------------------------------------
+
+def normal_cdf(x: float, mean: float = 0.0, sigma: float = 1.0) -> float:
+    """Standard normal CDF via erf — no SciPy dependency."""
+    if sigma <= 0:
+        return 1.0 if x >= mean else 0.0
+    return 0.5 * (1.0 + math.erf((x - mean) / (sigma * math.sqrt(2.0))))
+
+
+def prob_above(threshold: float, mean: float, sigma: float) -> float:
+    """P(indicator > threshold) under Normal(mean, sigma)."""
+    return 1.0 - normal_cdf(threshold, mean, sigma)
+
+
+def indicator_series(values: list[float], spec: EconSpec) -> list[float]:
+    """Transform a raw FRED level series into the indicator the bins resolve on.
+
+    Input is oldest-first raw values; output is the transformed series (also
+    oldest-first), which may be shorter (YoY drops the first `periods_per_year`).
+    """
+    if spec.transform == "level":
+        return list(values)
+    if spec.transform == "yoy":
+        p = spec.periods_per_year
+        if len(values) <= p:
+            return []
+        out = []
+        for i in range(p, len(values)):
+            base = values[i - p]
+            if base == 0:
+                continue
+            out.append((values[i] / base - 1.0) * 100.0)
+        return out
+    if spec.transform == "mom_change":
+        return [(values[i] - values[i - 1]) * spec.scale
+                for i in range(1, len(values))]
+    raise ValueError(f"unknown transform {spec.transform!r}")
+
+
+def estimate_distribution(
+    indicator: list[float],
+    horizon_periods: int = 1,
+    sigma_floor_frac: float = 0.25,
+    lookback: int = 24,
+) -> tuple[float, float] | None:
+    """Estimate (mean, sigma) for the indicator at a release `horizon_periods`
+    ahead, from its recent history.
+
+    mean  — the latest observed value (random-walk nowcast; no false precision).
+    sigma — std of recent period-over-period changes, scaled by sqrt(horizon),
+            floored at `sigma_floor_frac` of |mean| so a quiet recent window
+            can't make the model overconfident. Returns None if too little
+            history to estimate a change-vol.
+    """
+    if len(indicator) < 3:
+        return None
+    mean = indicator[-1]
+    recent = indicator[-lookback:]
+    diffs = [recent[i] - recent[i - 1] for i in range(1, len(recent))]
+    if not diffs:
+        return None
+    mu = sum(diffs) / len(diffs)
+    var = sum((d - mu) ** 2 for d in diffs) / len(diffs)
+    sigma_1 = math.sqrt(var)
+    sigma = sigma_1 * math.sqrt(max(1, horizon_periods))
+    floor = sigma_floor_frac * abs(mean)
+    sigma = max(sigma, floor, 1e-6)
+    return mean, sigma
+
+
+def bin_edge(model_p: float, market_p: float) -> float:
+    """Signed model edge for a YES position on an 'Above X' bin."""
+    return model_p - market_p

--- a/tests/test_econ_pricing.py
+++ b/tests/test_econ_pricing.py
@@ -1,0 +1,88 @@
+"""Pure pricing math for Kalshi econ-indicator bins (#2 Phase B core)."""
+
+from __future__ import annotations
+
+import math
+
+from auramaur.strategy.econ_pricing import (
+    ECON_SERIES,
+    EconSpec,
+    bin_edge,
+    estimate_distribution,
+    indicator_series,
+    normal_cdf,
+    prob_above,
+    spec_for_series,
+)
+
+
+def test_normal_cdf_basics():
+    assert abs(normal_cdf(0.0) - 0.5) < 1e-9
+    assert abs(normal_cdf(0.0, mean=0.0, sigma=1.0) - 0.5) < 1e-9
+    # ~84.13% within +1 sigma
+    assert abs(normal_cdf(1.0) - 0.8413) < 1e-3
+    # degenerate sigma -> step
+    assert normal_cdf(5.0, mean=0.0, sigma=0.0) == 1.0
+    assert normal_cdf(-5.0, mean=0.0, sigma=0.0) == 0.0
+
+
+def test_prob_above_monotone_and_symmetry():
+    mean, sigma = 4.0, 1.0
+    # higher threshold -> lower P(above) (the ladder monotonicity the bins need)
+    ps = [prob_above(t, mean, sigma) for t in (3.0, 4.0, 5.0)]
+    assert ps[0] > ps[1] > ps[2]
+    assert abs(ps[1] - 0.5) < 1e-9          # at the mean, P(above)=0.5
+    # symmetric ±1 sigma
+    assert abs(prob_above(3.0, mean, sigma) - 0.8413) < 1e-3
+    assert abs(prob_above(5.0, mean, sigma) - 0.1587) < 1e-3
+
+
+def test_indicator_level_passthrough():
+    spec = EconSpec("UNRATE", "level")
+    assert indicator_series([4.1, 4.2, 4.3], spec) == [4.1, 4.2, 4.3]
+
+
+def test_indicator_yoy():
+    spec = EconSpec("CPIAUCSL", "yoy", periods_per_year=12)
+    # 13 monthly index points; YoY of the 13th vs the 1st
+    vals = [100.0] * 12 + [104.0]
+    out = indicator_series(vals, spec)
+    assert len(out) == 1
+    assert abs(out[0] - 4.0) < 1e-9         # +4% YoY
+
+
+def test_indicator_mom_change_scaled():
+    spec = EconSpec("PAYEMS", "mom_change", scale=1000.0)
+    # PAYEMS in thousands; +90 (thousand) -> 90,000 jobs
+    out = indicator_series([100000.0, 100090.0], spec)
+    assert out == [90000.0]
+
+
+def test_estimate_distribution_floor_and_horizon():
+    # flat-ish series: tiny change-vol, but sigma floored to 25% of |mean|
+    ind = [4.0, 4.0, 4.01, 3.99, 4.0]
+    mean, sigma = estimate_distribution(ind, horizon_periods=1)
+    assert abs(mean - 4.0) < 1e-9
+    assert sigma >= 0.25 * 4.0 - 1e-9       # floor bites
+    # horizon scales sigma up by ~sqrt(h) when above the floor
+    noisy = [0.0, 1.0, -1.0, 1.5, -1.2, 0.8, -0.9, 1.1]
+    _, s1 = estimate_distribution(noisy, horizon_periods=1, sigma_floor_frac=0.0)
+    _, s4 = estimate_distribution(noisy, horizon_periods=4, sigma_floor_frac=0.0)
+    assert abs(s4 - s1 * 2.0) < 1e-6        # sqrt(4) = 2
+
+
+def test_estimate_distribution_insufficient_history():
+    assert estimate_distribution([4.0]) is None
+    assert estimate_distribution([]) is None
+
+
+def test_registry_lookup():
+    assert spec_for_series("KXCPIYOY").transform == "yoy"
+    assert spec_for_series("kxu3").transform == "level"        # case-insensitive
+    assert spec_for_series("KXFEDDECISION") is None            # not registered
+    assert "KXPAYROLLS" in ECON_SERIES
+
+
+def test_bin_edge_sign():
+    assert bin_edge(0.60, 0.45) > 0     # model richer than market -> buy YES
+    assert bin_edge(0.30, 0.45) < 0     # model cheaper -> buy NO


### PR DESCRIPTION
## What
The pure, deterministic **pricing core** for #2 Phase B (data-driven econ-indicator bin pricing). Not yet wired into trading — zero live-behavior change.

- **FRED `get_observations(series, n)`** — a pricing accessor (latest `n` `(date, value)`), distinct from the news `fetch`, to estimate the indicator's distribution.
- **`econ_pricing.py`:**
  - `ECON_SERIES` registry: Kalshi prefix → FRED series + **explicit transform** — `KXCPIYOY` (CPI YoY), `KXU3` (unemployment level), `KXPAYROLLS` (MoM change, thousands→count). Deliberately conservative: only unambiguous transforms; GDP annualization and Fed-decision categoricals are omitted until each is validated against a real print (model-risk discipline).
  - `indicator_series()` applies the transform; `estimate_distribution()` → `(mean, sigma)` with a **random-walk nowcast** + change-vol scaled by `sqrt(horizon)` and a **sigma floor** so a quiet window can't make the model overconfident.
  - `prob_above()` = `1 - NormalCDF` (via `erf`, no SciPy); `bin_edge()` signs the YES edge.

## Test
Normal CDF/`prob_above` (monotone over thresholds — the ladder property — and ±1σ symmetry); each transform (level / YoY / MoM-scaled); distribution floor + sqrt-horizon scaling + insufficient-history guard; registry lookup. Full suite green.

Next: the pillar (fetch FRED + Kalshi bins via the Phase-A series-fetch, price, emit paper-forced signals through the risk gate).

Assisted-by: Claude (Anthropic)