### PR TITLE
feat(econ): data-driven Kalshi econ-indicator pillar (Phase B, paper-forced)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2782,6 +2782,36 @@ class AuramaurBot:
                 log.error("entailment.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_econ_indicator(self) -> None:
+        """Periodic data-driven Kalshi econ-indicator bin pricing (paper-forced)."""
+        from auramaur.data_sources.fred import FREDSource
+        from auramaur.strategy.econ_indicator import EconIndicatorPillar
+
+        kalshi_discovery = (self._components.get("discoveries") or {}).get("kalshi")
+        kalshi_exchange = (self._components.get("exchanges") or {}).get("kalshi")
+        if kalshi_discovery is None or kalshi_exchange is None or not self.settings.fred_api_key:
+            log.info("econ_indicator.disabled", reason="missing kalshi or FRED key")
+            return
+        pillar = EconIndicatorPillar(
+            db=self._components["db"],
+            settings=self.settings,
+            kalshi_discovery=kalshi_discovery,
+            fred_source=FREDSource(api_key=self.settings.fred_api_key),
+            exchange=kalshi_exchange,
+            risk_manager=self._components["risk_manager"],
+            pnl_tracker=self._components["pnl_tracker"],
+            calibration=self._components["calibration"],
+        )
+        interval = max(60, self.settings.econ_indicator.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("econ_indicator.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_resolution_lens(self) -> None:
         """Periodic resolution-language lens scan (paper-forced by config)."""
         from auramaur.strategy.resolution_lens import ResolutionLensPillar
@@ -3450,6 +3480,10 @@ class AuramaurBot:
         # Entailment arbitrage (paper-forced until proven)
         if self.settings.entailment_arb.enabled:
             tasks.append(asyncio.create_task(self._task_entailment_arb(), name="entailment_arb"))
+
+        # Data-driven Kalshi econ-indicator pricing (paper-forced until proven)
+        if self.settings.econ_indicator.enabled:
+            tasks.append(asyncio.create_task(self._task_econ_indicator(), name="econ_indicator"))
 
         # Resolution-language lens (paper-forced until proven)
         if self.settings.resolution_lens.enabled:

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -1,0 +1,268 @@
+"""Data-driven economic-indicator pricing pillar (#2 Phase B).
+
+Prices Kalshi "Above X" econ ladders from the official FRED history and trades
+bins the crowd misprices. Pure math lives in econ_pricing.py; this pillar wires
+it to live data + the standard rails:
+
+  FRED history -> indicator distribution -> P(Above X) per bin
+                -> edge vs the market mid -> fee-cleared signal -> risk gate
+                -> Kalshi order (paper-forced) -> fills/trades/portfolio/calibration
+
+Guardrails for model risk: only the NEAREST release with live quotes is priced
+(far bins have no book), the latest FRED print is pulled every cycle (a surprise
+relocates the mode), the distribution has a sigma floor, the edge must clear the
+Kalshi taker fee, and the pillar is PAPER-FORCED by default — the paper ledger
+and calibration prove or kill the edge before any live capital.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.econ_pricing import (
+    estimate_distribution,
+    indicator_series,
+    prob_above,
+    spec_for_series,
+)
+from auramaur.strategy.entailment_arb import parse_kalshi_ladder
+
+log = structlog.get_logger()
+
+
+class EconIndicatorPillar:
+    """Periodic data-driven scanner for Kalshi economic-indicator bins."""
+
+    def __init__(self, db, settings, kalshi_discovery, fred_source, exchange,
+                 risk_manager, pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._kalshi = kalshi_discovery
+        self._fred = fred_source
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+
+    async def run_once(self) -> int:
+        cfg = self._settings.econ_indicator
+        if not cfg.enabled or self._kalshi is None or self._fred is None:
+            return 0
+        series_list = cfg.series or list(_registered_series())
+        entered = 0
+        for prefix in series_list:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            try:
+                entered += await self._scan_series(prefix, cfg.max_entries_per_cycle - entered)
+            except Exception as e:
+                log.error("econ_indicator.series_error", series=prefix, error=str(e))
+        if entered:
+            log.info("econ_indicator.cycle_done", entered=entered)
+        return entered
+
+    async def _scan_series(self, prefix: str, budget: int) -> int:
+        cfg = self._settings.econ_indicator
+        spec = spec_for_series(prefix)
+        if spec is None:
+            return 0
+        obs = await self._fred.get_observations(spec.fred_series, n=cfg.history_n)
+        if len(obs) < 4:
+            log.debug("econ_indicator.thin_history", series=prefix, n=len(obs))
+            return 0
+        last_obs_date = obs[-1][0]
+        indicator = indicator_series([v for _, v in obs], spec)
+        if len(indicator) < 3:
+            return 0
+
+        bins = await self._kalshi.get_markets_by_series(prefix)
+        period = self._nearest_period(bins)
+        if period is None:
+            return 0
+        release, members = period
+        horizon = self._horizon_periods(last_obs_date, release, spec.periods_per_year)
+        dist = estimate_distribution(indicator, horizon_periods=horizon)
+        if dist is None:
+            return 0
+        mean, sigma = dist
+        log.info("econ_indicator.priced", series=prefix, bins=len(members),
+                 mean=round(mean, 3), sigma=round(sigma, 3), horizon=horizon)
+
+        entered = 0
+        for threshold, market in sorted(members, reverse=True):
+            if entered >= budget:
+                break
+            model_p = prob_above(threshold, mean, sigma)
+            if await self._enter_if_edge(market, model_p):
+                entered += 1
+        return entered
+
+    # -- selection helpers ---------------------------------------------------
+
+    def _nearest_period(self, bins: list[Market]):
+        """Group bins by release period (ticker family) and return the soonest
+        future release that has >= 2 live-quoted bins, as (release_dt, members)
+        where members = [(threshold, market)]."""
+        groups: dict[str, list[tuple[float, Market]]] = {}
+        ends: dict[str, datetime] = {}
+        now = datetime.now(timezone.utc)
+        for m in bins:
+            parsed = parse_kalshi_ladder(m.ticker)
+            if parsed is None or not (0.0 < m.outcome_yes_price < 1.0):
+                continue  # non-ladder or no live mid
+            if m.end_date is None:
+                continue
+            end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+            if end <= now:
+                continue
+            (_, family), value = parsed
+            groups.setdefault(family, []).append((value, m))
+            ends[family] = min(ends.get(family, end), end)
+        eligible = [(ends[f], mem) for f, mem in groups.items() if len(mem) >= 2]
+        if not eligible:
+            return None
+        eligible.sort(key=lambda x: x[0])
+        return eligible[0]
+
+    @staticmethod
+    def _horizon_periods(last_obs: datetime, release: datetime, periods_per_year: int) -> int:
+        if last_obs.tzinfo is None:
+            last_obs = last_obs.replace(tzinfo=timezone.utc)
+        days = max(0.0, (release - last_obs).total_seconds() / 86400.0)
+        days_per_period = 365.0 / max(1, periods_per_year)
+        return max(1, round(days / days_per_period))
+
+    def _required_edge(self, market: Market) -> float:
+        cfg = self._settings.econ_indicator
+        from auramaur.strategy.signals import taker_fee_rate
+        p = market.outcome_yes_price
+        fee = taker_fee_rate("kalshi", market.category or "",
+                             self._settings.arbitrage.exchange_fees) * p * (1.0 - p)
+        return cfg.min_edge + fee
+
+    # -- entry (paper-forced; same rails as bias_harvest) --------------------
+
+    async def _enter_if_edge(self, market: Market, model_p: float) -> bool:
+        cfg = self._settings.econ_indicator
+        market_p = market.outcome_yes_price
+        edge = model_p - market_p
+        if abs(edge) < self._required_edge(market):
+            return False
+        if await self._already_entered_or_held(market.id):
+            return False
+        side = OrderSide.BUY if edge > 0 else OrderSide.SELL  # SELL -> Kalshi buys NO
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=max(0.01, min(0.99, model_p)),
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market_p,
+            edge=abs(edge) * 100.0,
+            evidence_summary=(
+                f"Econ-indicator model P(above)={model_p:.2f} vs market "
+                f"{market_p:.2f} from {spec_for_series(market.ticker.split('-')[0]).fred_series} history."
+            ),
+            recommended_side=side,
+            strategy_source="econ_indicator",
+        )
+        await self._persist_signal(signal, market)
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("econ_indicator.risk_rejected", market_id=market.id,
+                     reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+        is_live_order = (self._settings.is_live and not cfg.paper
+                         and not getattr(decision, "force_paper", False))
+        order = self._exchange.prepare_order(signal, market, size, is_live_order)
+        if order is None:
+            return False
+        result = await self._exchange.place_order(order)
+        if result.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("econ_indicator.order_rejected", market_id=market.id,
+                        status=result.status, error=result.error_message)
+            return False
+        await self._record_entry(signal, market, order, result)
+        log.info("econ_indicator.entered", market_id=market.id, side=side.value,
+                 model_p=round(model_p, 3), market_p=round(market_p, 3),
+                 paper=result.is_paper)
+        return True
+
+    async def _already_entered_or_held(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'econ_indicator' LIMIT 1",
+            (market_id,),
+        )
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,))
+        return row is not None
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, 'kalshi', ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.condition_id, market.question,
+             (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'econ_indicator')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value),
+        )
+        await self._db.commit()
+
+    async def _record_entry(self, signal: Signal, market: Market, order, result) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        if result.status in ("filled", "paper", "partial") and fill_size > 0:
+            await self._pnl.record_fill(Fill(
+                order_id=result.order_id, market_id=order.market_id,
+                token_id=order.token_id, side=order.side, token=order.token,
+                size=fill_size, price=fill_price, is_paper=is_paper,
+            ))
+        await self._db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, strategy_source, exchange)
+               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'econ_indicator', 'kalshi')""",
+            (order.market_id, order.side.value, fill_size, fill_price,
+             1 if is_paper else 0, result.order_id,
+             "filled" if result.status in ("filled", "paper") else result.status),
+        )
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'kalshi', ?, ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size, avg_price = excluded.avg_price,
+                   current_price = excluded.current_price, updated_at = excluded.updated_at""",
+            (order.market_id, order.side.value, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("econ_indicator.calibration_error", error=str(e))
+
+
+def _registered_series():
+    from auramaur.strategy.econ_pricing import ECON_SERIES
+    return ECON_SERIES.keys()

--- a/config/settings.py
+++ b/config/settings.py
@@ -325,6 +325,27 @@ class BiasHarvestConfig(BaseModel):
     skip_disputed: bool = True
 
 
+class EconIndicatorConfig(BaseModel):
+    """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
+
+    PAPER-FORCED by default (and disabled until opted in). Prices "Above X"
+    ladders from FRED history; directional, so the graduation ladder keeps it
+    paper until the ledger + calibration prove it. The edge must clear the
+    Kalshi taker fee on top of min_edge (computed at runtime from the fee model).
+    series=[] means "all registered" (econ_pricing.ECON_SERIES).
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    series: list[str] = Field(default_factory=list)
+    stake_usd: float = 10.0
+    min_edge: float = 0.07
+    max_open: int = 30
+    max_entries_per_cycle: int = 5
+    history_n: int = 60
+    interval_seconds: int = 1800
+
+
 class EntailmentArbConfig(BaseModel):
     """Entailment arbitrage (strategy/entailment_arb.py).
 
@@ -798,6 +819,7 @@ class Settings(BaseSettings):
     bias_harvest: BiasHarvestConfig = Field(default_factory=lambda: BiasHarvestConfig(**_DEFAULTS.get("bias_harvest", {})))
     graduation: GraduationConfig = Field(default_factory=lambda: GraduationConfig(**_DEFAULTS.get("graduation", {})))
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
+    econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     resolution_lens: ResolutionLensConfig = Field(default_factory=lambda: ResolutionLensConfig(**_DEFAULTS.get("resolution_lens", {})))
     oddlot_tender: OddLotTenderConfig = Field(default_factory=lambda: OddLotTenderConfig(**_DEFAULTS.get("oddlot_tender", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))

--- a/tests/test_econ_indicator.py
+++ b/tests/test_econ_indicator.py
@@ -1,0 +1,137 @@
+"""Econ-indicator pillar: prices Kalshi bins from FRED, trades mispricings."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market, Order, OrderResult, OrderSide, TokenType,
+)
+from auramaur.strategy.econ_indicator import EconIndicatorPillar
+from config.settings import Settings
+
+
+def _bin(thr: float, yes: float, period="26NOV", series="KXU3") -> Market:
+    return Market(
+        id=f"{series}-{period}-T{thr}", exchange="kalshi",
+        ticker=f"{series}-{period}-T{thr}", question="What will unemployment be?",
+        description=f"Above {thr}%", active=True,
+        outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=500.0, volume=500.0, spread=0.02,
+        end_date=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+
+
+def _settings(**ov) -> Settings:
+    s = Settings()
+    s.econ_indicator.enabled = True
+    s.econ_indicator.paper = True
+    s.econ_indicator.series = ["KXU3"]
+    s.econ_indicator.min_edge = 0.07
+    s.fred_api_key = "test"
+    for k, v in ov.items():
+        setattr(s.econ_indicator, k, v)
+    return s
+
+
+def _exchange():
+    ex = MagicMock()
+
+    def prepare(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(market_id=market.id, exchange="kalshi", token_id="tok",
+                     side=OrderSide.BUY, token=token, size=round(size / max(price, 0.01), 2),
+                     price=round(price, 2), dry_run=not is_live)
+
+    ex.prepare_order = MagicMock(side_effect=prepare)
+    ex.place_order = AsyncMock(side_effect=lambda o: OrderResult(
+        order_id="o1", market_id=o.market_id, status="paper",
+        filled_size=o.size, filled_price=o.price, is_paper=o.dry_run))
+    return ex
+
+
+def _fred(values):
+    """Oldest-first monthly observations ending today."""
+    base = datetime.now(timezone.utc) - timedelta(days=30 * len(values))
+    obs = [(base + timedelta(days=30 * i), v) for i, v in enumerate(values)]
+    f = MagicMock()
+    f.get_observations = AsyncMock(return_value=obs)
+    return f
+
+
+def _risk(approved=True):
+    rm = MagicMock()
+    d = MagicMock(approved=approved, position_size=10.0 if approved else 0.0,
+                  reason="", force_paper=False)
+    rm.evaluate = AsyncMock(return_value=d)
+    return rm
+
+
+def _pillar(db, settings, bins, fred_values):
+    kalshi = MagicMock()
+    kalshi.get_markets_by_series = AsyncMock(return_value=bins)
+    cal = MagicMock(); cal.record_prediction = AsyncMock()
+    return EconIndicatorPillar(
+        db=db, settings=settings, kalshi_discovery=kalshi,
+        fred_source=_fred(fred_values), exchange=_exchange(),
+        risk_manager=_risk(), pnl_tracker=PnLTracker(db, settings),
+        calibration=cal)
+
+
+def test_enters_mispriced_bin_and_skips_fair():
+    """Unemployment ~4.0%: model P(above 4.5) ~0.31. A bin priced 0.70 is a
+    big SELL-NO edge -> enter; a bin priced ~0.31 is fair -> skip."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            vals = [4.0, 4.1, 3.9, 4.0, 4.1, 3.9, 4.0, 4.0]   # ~4.0, low vol
+            bins = [_bin(4.5, 0.70), _bin(4.6, 0.31)]          # one rich, one fair
+            pillar = _pillar(db, _settings(), bins, vals)
+            entered = await pillar.run_once()
+            assert entered == 1
+            rows = await db.fetchall(
+                "SELECT market_id, action FROM signals WHERE strategy_source='econ_indicator'")
+            assert len(rows) == 1
+            assert rows[0]["market_id"] == "KXU3-26NOV-T4.5"
+            assert rows[0]["action"] == "SELL"               # market too high -> buy NO
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_disabled_or_thin_history_noops():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            bins = [_bin(4.5, 0.70), _bin(4.6, 0.31)]
+            # too little history -> no pricing
+            pillar = _pillar(db, _settings(), bins, [4.0, 4.1])
+            assert await pillar.run_once() == 0
+            # disabled flag
+            pillar2 = _pillar(db, _settings(enabled=False), bins, [4.0]*8)
+            assert await pillar2.run_once() == 0
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_nearest_period_picks_soonest_live_with_two_bins():
+    pillar = EconIndicatorPillar.__new__(EconIndicatorPillar)
+    near = [_bin(4.5, 0.4, period="26JUL"), _bin(4.6, 0.3, period="26JUL")]
+    far = [_bin(4.5, 0.4, period="26DEC"), _bin(4.6, 0.3, period="26DEC")]
+    for m in near:
+        m.end_date = datetime.now(timezone.utc) + timedelta(days=10)
+    for m in far:
+        m.end_date = datetime.now(timezone.utc) + timedelta(days=120)
+    # a single-bin period must be ignored (need >=2 to order a ladder)
+    lonely = [_bin(4.5, 0.4, period="26AUG")]
+    lonely[0].end_date = datetime.now(timezone.utc) + timedelta(days=40)
+    picked = pillar._nearest_period(near + far + lonely)
+    assert picked is not None
+    _release, members = picked
+    assert {m.ticker for _v, m in members} == {b.ticker for b in near}


### PR DESCRIPTION
## What
Wires the Phase B pricing core (#154) into a live, **paper-forced** strategy — the data-driven alpha play. Each cycle, per registered series, it pulls the latest FRED history, builds the indicator distribution, prices the **nearest live** Kalshi "Above X" release, and trades bins the crowd misprices via the standard rails (signals / trades / fills / portfolio / calibration).

- `EconIndicatorPillar`: FRED history → indicator → distribution → `P(Above X)` per bin → edge vs market mid → fee-cleared signal → risk gate → Kalshi order. Buys **YES** when the model is richer than the market, **NO** when cheaper.
- Reuses the Phase A `get_markets_by_series` so it sees a complete bin set (not a lossy scan).

## Model-risk guardrails
- Only the **nearest** release with ≥2 live-quoted bins is priced (far bins have no book).
- The **latest FRED print is pulled every cycle** (a surprise relocates the mode).
- **Sigma floor** so a quiet window can't make the model overconfident.
- The edge must clear the **Kalshi taker fee** on top of `min_edge`.
- **PAPER-FORCED** and **disabled by default** — the graduation ladder + calibration prove or kill it before any live capital. Bot task is a no-op without a Kalshi client + FRED key.

## Test
Enters a clearly-mispriced bin (SELL→NO when the market is too high) and skips a fair one; no-ops on thin history / disabled; nearest-period selection requires ≥2 live bins and picks the soonest release. Full suite: 779 passed.

Assisted-by: Claude (Anthropic)