### PR TITLE
fix(econ): cap implausible model-vs-market divergence (naive-nowcast guard)

### DIFF
--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -152,6 +152,13 @@ class EconIndicatorPillar:
         edge = model_p - market_p
         if abs(edge) < self._required_edge(market):
             return False
+        # Implausible-disagreement guard: a random-walk nowcast that disagrees
+        # with the market by a huge margin is naive (the crowd prices forward
+        # info the model lacks), not an edge — trust the market and skip.
+        if abs(edge) > cfg.max_divergence:
+            log.info("econ_indicator.implausible_divergence", market_id=market.id,
+                     model_p=round(model_p, 3), market_p=round(market_p, 3))
+            return False
         if await self._already_entered_or_held(market.id):
             return False
         side = OrderSide.BUY if edge > 0 else OrderSide.SELL  # SELL -> Kalshi buys NO

--- a/config/settings.py
+++ b/config/settings.py
@@ -340,6 +340,12 @@ class EconIndicatorConfig(BaseModel):
     series: list[str] = Field(default_factory=list)
     stake_usd: float = 10.0
     min_edge: float = 0.07
+    # Upper sanity bound on |model - market|. A random-walk nowcast disagreeing
+    # with the market by more than this isn't edge — it's the model being naive
+    # against a forward-looking crowd (e.g. CPI YoY: the model anchors to the
+    # last stale print while the market prices expected disinflation). Beyond
+    # this gap, trust the market and skip — the econ analog of name-the-gap.
+    max_divergence: float = 0.30
     max_open: int = 30
     max_entries_per_cycle: int = 5
     history_n: int = 60

--- a/tests/test_econ_indicator.py
+++ b/tests/test_econ_indicator.py
@@ -90,7 +90,9 @@ def test_enters_mispriced_bin_and_skips_fair():
         db = Database(":memory:"); await db.connect()
         try:
             vals = [4.0, 4.1, 3.9, 4.0, 4.1, 3.9, 4.0, 4.0]   # ~4.0, low vol
-            bins = [_bin(4.5, 0.70), _bin(4.6, 0.31)]          # one rich, one fair
+            # model P(above 4.5)~0.31: priced 0.50 is a plausible ~19pt edge
+            # (within max_divergence); the 4.6 bin priced ~0.27 is fair.
+            bins = [_bin(4.5, 0.50), _bin(4.6, 0.27)]
             pillar = _pillar(db, _settings(), bins, vals)
             entered = await pillar.run_once()
             assert entered == 1
@@ -99,6 +101,22 @@ def test_enters_mispriced_bin_and_skips_fair():
             assert len(rows) == 1
             assert rows[0]["market_id"] == "KXU3-26NOV-T4.5"
             assert rows[0]["action"] == "SELL"               # market too high -> buy NO
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_skips_implausible_divergence():
+    """A model that disagrees with the market by more than max_divergence is
+    naive (forward-priced crowd), not edge -> skip rather than bet hard."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            vals = [4.0, 4.1, 3.9, 4.0, 4.1, 3.9, 4.0, 4.0]   # model mean ~4.0
+            # market prices "above 4.0" at 0.03 -> model ~0.5 vs 0.03 = ~0.47 gap
+            bins = [_bin(4.0, 0.03), _bin(4.1, 0.03)]
+            pillar = _pillar(db, _settings(max_divergence=0.30), bins, vals)
+            assert await pillar.run_once() == 0
         finally:
             await db.close()
     asyncio.run(run())


### PR DESCRIPTION
## What
The Phase B paper run immediately surfaced the random-walk nowcast betting hard against a forward-looking market — model `P(CPI YoY > 4.0%) ≈ 0.60` vs the market's `≈ 0.075` (a ~50pt gap), firing on every bin. That's not edge; the nowcast anchors to the last stale print (~4.2%) while the crowd prices expected June disinflation.

Adds `econ_indicator.max_divergence` (default 0.30): beyond that gap, trust the market and skip — the econ analog of the name-the-gap gate. Keeps the paper ledger + calibration meaningful instead of dominated by naive extreme bets. Paper-forced throughout.

## Test
A market-vs-model gap beyond `max_divergence` is skipped; a plausible in-range mispricing still enters. Full suite green.

Assisted-by: Claude (Anthropic)