### PR TITLE
fix(resolution): settle resolved-but-unpinned VOID markets at the refund price

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -106,6 +106,21 @@ class ResolutionTracker:
 
                 outcome = self._detect_resolution(market, exchange)
                 if outcome is None:
+                    # Resolved-but-unpinned VOID (50/50 refund): the binary
+                    # detector waits forever, but the venue has finalized it, so
+                    # settle each mode at the refund price to free the capital.
+                    if self._detect_void(market, exchange):
+                        refund = market.outcome_yes_price  # ~0.5 for both sides
+                        await self._settle_position(market_id, False, is_paper_scope=0,
+                                                    override_exit_price=refund)
+                        await self._settle_position(market_id, False, is_paper_scope=1,
+                                                    override_exit_price=refund)
+                        await self._db.execute(
+                            "UPDATE markets SET active = 0 WHERE id = ?", (market_id,))
+                        await self._db.commit()
+                        log.info("resolution.void_settled", market_id=market_id,
+                                 refund=round(refund, 3))
+                        resolved_count += 1
                     continue
 
                 # Feed into calibration — triggers online Platt update
@@ -322,13 +337,33 @@ class ResolutionTracker:
         # Eligible but price ambiguous (e.g. closed awaiting oracle) — wait.
         return None
 
+    @staticmethod
+    def _detect_void(market: Market, exchange: str) -> bool:
+        """A VOID is a market that resolved to ~50/50 (both sides refunded at
+        ~0.5) — e.g. a cancelled event. The binary detector returns None for
+        such an unpinned price and waits forever, even though the venue has
+        FINALIZED it (closed=True + uma resolved). Detect that terminal state
+        so it can settle at the refund price instead of stranding capital.
+
+        Requires the venue's explicit closure + resolution signals (never just
+        a mid-range price on a still-open market) and a near-midpoint price.
+        """
+        if exchange != "polymarket":
+            return False
+        if not (getattr(market, "closed", False)
+                and (getattr(market, "uma_status", "") or "").lower() == "resolved"):
+            return False
+        yes = market.outcome_yes_price
+        return 0.4 <= yes <= 0.6  # symmetric refund, not a pinned winner
+
     # ------------------------------------------------------------------
     # Position settlement
     # ------------------------------------------------------------------
 
     async def _settle_position(self, market_id: str, outcome: bool,
                                token_scope: str | None = None,
-                               is_paper_scope: int | None = None) -> None:
+                               is_paper_scope: int | None = None,
+                               override_exit_price: float | None = None) -> None:
         """Clean up the portfolio entry and log realized PnL for a resolved market.
 
         Computes the realized profit/loss from the position, records it in
@@ -336,6 +371,11 @@ class ResolutionTracker:
         ``token_scope`` / ``is_paper_scope`` are given the settlement is
         scoped to that exact row (the venue sweep settles per held token);
         without them the legacy market-wide behavior is preserved.
+
+        ``override_exit_price`` settles the held token at that exact price
+        instead of the binary 0/1 — used for VOID resolutions (a market that
+        resolved 50/50, refunding both sides at ~0.5), where the binary outcome
+        doesn't apply.
         """
         # Token comparisons are case-insensitive throughout settlement: the
         # cost_basis table stores the venue's mixed-case label ("Yes"/"No")
@@ -399,8 +439,11 @@ class ResolutionTracker:
         # consistent regardless of the venue's mixed-case cost_basis label.
         token = (token or "YES").upper()
 
-        # Settlement price: YES resolves to $1, NO resolves to $0
-        if token == "NO":
+        # Settlement price: a VOID refunds the held token at override_exit_price
+        # (~0.5); otherwise YES resolves to $1, NO to $0 by the binary outcome.
+        if override_exit_price is not None:
+            exit_price = max(0.0, min(1.0, override_exit_price))
+        elif token == "NO":
             # Holding NO tokens: worth $1 if outcome is NO, $0 if YES
             exit_price = 0.0 if outcome else 1.0
         else:

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -447,6 +447,55 @@ class TestSettlePosition:
 
         asyncio.run(run())
 
+    def test_detect_void(self):
+        """closed + uma resolved + ~0.5 price = VOID (refund); pinned or
+        still-open or non-poly is not a void."""
+        from auramaur.exchange.models import Market
+
+        def mk(**kw):
+            d = dict(active=True, closed=True, yes_price=0.5)
+            d.update(kw)
+            m = _make_market(active=d["active"], yes_price=d["yes_price"], closed=d["closed"])
+            m.uma_status = d.get("uma_status", "resolved")
+            return m
+        assert ResolutionTracker._detect_void(mk(), "polymarket") is True
+        assert ResolutionTracker._detect_void(mk(yes_price=0.98), "polymarket") is False   # pinned winner
+        assert ResolutionTracker._detect_void(mk(uma_status="proposed"), "polymarket") is False
+        assert ResolutionTracker._detect_void(mk(closed=False), "polymarket") is False
+        assert ResolutionTracker._detect_void(mk(), "kalshi") is False
+
+    def test_void_settles_held_token_at_refund_price(self):
+        """A void settles the held token at ~0.5 (refund), not 0/1 — booking the
+        real pnl vs entry and freeing the position."""
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                # held NO @ 0.51, refunded at 0.5 -> tiny loss
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                                               avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('void-1', 'No', 'tok', 13.0, 0.51, 6.63, 0, 0)""")
+                await db.execute(
+                    """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                                              current_price, token, is_paper, updated_at)
+                       VALUES ('void-1', 'polymarket', 'BUY', 13.0, 0.51, 0.5, 'NO', 0, datetime('now'))""")
+                await db.commit()
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                await tracker._settle_position("void-1", False, is_paper_scope=0,
+                                               override_exit_price=0.5)
+                led = await db.fetchone(
+                    "SELECT pnl FROM pnl_ledger WHERE source_ref='settle:void-1:NO:0'")
+                assert led is not None
+                assert abs(led["pnl"] - (0.5 - 0.51) * 13.0) < 1e-9   # refund, not -100%
+                pf = await db.fetchone("SELECT COUNT(*) AS n FROM portfolio WHERE market_id='void-1'")
+                assert pf["n"] == 0
+            finally:
+                await db.close()
+        asyncio.run(run())
+
     def test_cost_basis_fallback_respects_is_paper_scope(self):
         """When a market is held in BOTH modes and the portfolio row is absent,
         a mode-scoped settle must book only the targeted mode off cost_basis —


### PR DESCRIPTION
## Problem
A Polymarket market can finalize as a **VOID** — `closed=True`, `umaResolutionStatus=resolved`, but `outcomePrices ≈ ["0.5","0.5"]` (both sides refunded at the midpoint, e.g. a cancelled/ambiguous event). The binary resolution detector only settles on a *pinned* price (≥0.99 / ≤0.01), so it returns `None` for 0.5/0.5 and **waits forever** — stranding the position at a stale mark.

Live example: two F1 Bahrain podium markets (1586884/1586885) resolved 50/50 on **2026-04-16** and were still unsettled ~2 months later, holding ~$9.50 of capital at a phantom 0.5 mark.

## Fix
- **`_detect_void()`** — `closed=True` + `uma resolved` + near-midpoint price (0.4–0.6) ⇒ terminal void. Requires the venue's explicit closure/resolution flags (never just a mid-range price on a still-open market).
- **`_settle_position(override_exit_price=…)`** — settle the held token at an exact price (the ~0.5 refund) instead of the binary 0/1.
- **`check_resolutions`** — when the binary detector waits, settle a detected void at the refund price (both paper+live modes) and deactivate. Books the real P&L vs entry (a small gain/loss, not a phantom −100%) and frees the capital. Idempotent via the existing `source_ref`.

## Test
`_detect_void` (void vs pinned-winner vs still-open vs non-Poly); a void settles the held NO at the 0.5 refund (real pnl vs entry, not −100%) and removes the portfolio row. Full suite: 783 passed.

Assisted-by: Claude (Anthropic)