### PR TITLE
feat(weather): Open-Meteo ensemble pricing core for Poly city-temp bins (spike)

### DIFF
--- a/auramaur/data_sources/openmeteo.py
+++ b/auramaur/data_sources/openmeteo.py
@@ -1,0 +1,64 @@
+"""Open-Meteo ensemble weather source — free, keyless NWP forecasts.
+
+Used to price Polymarket daily city-temperature bins (#weather strategy). The
+ENSEMBLE endpoint returns ~31 GFS members of a daily max/min, i.e. a real
+forecast distribution — exactly what a bin market needs. No API key.
+
+Pure pricing math lives in strategy/weather_pricing.py; this is just the fetch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+import aiohttp
+import structlog
+
+log = structlog.get_logger()
+
+_ENSEMBLE_URL = "https://ensemble-api.open-meteo.com/v1/ensemble"
+_TIMEOUT = aiohttp.ClientTimeout(total=20)
+
+
+class OpenMeteoSource:
+    source_name = "openmeteo"
+
+    async def daily_ensemble(self, lat: float, lon: float, target: date,
+                             kind: str = "high", unit: str = "C",
+                             model: str = "gfs_seamless") -> list[float]:
+        """Return the ensemble members' daily max (kind='high') or min ('low')
+        for ``target`` at (lat, lon), in the requested unit. [] on any failure
+        or if the date isn't in the forecast horizon — callers must handle empty
+        (never price a bin off no members).
+        """
+        var = "temperature_2m_max" if kind == "high" else "temperature_2m_min"
+        params = {
+            "latitude": f"{lat:.4f}", "longitude": f"{lon:.4f}",
+            "daily": var, "models": model, "timezone": "auto",
+            "forecast_days": "16",
+            "temperature_unit": "fahrenheit" if unit.upper() == "F" else "celsius",
+        }
+        try:
+            async with aiohttp.ClientSession(timeout=_TIMEOUT) as s:
+                async with s.get(_ENSEMBLE_URL, params=params) as r:
+                    if r.status != 200:
+                        log.warning("openmeteo.http", status=r.status)
+                        return []
+                    data = await r.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            log.warning("openmeteo.fetch_error", error=str(e)[:80])
+            return []
+        daily = data.get("daily") or {}
+        times = daily.get("time") or []
+        iso = target.isoformat()
+        if iso not in times:
+            return []
+        idx = times.index(iso)
+        members: list[float] = []
+        for key, series in daily.items():
+            if not key.startswith(var):
+                continue
+            if idx < len(series) and series[idx] is not None:
+                members.append(float(series[idx]))
+        return members

--- a/auramaur/strategy/weather_pricing.py
+++ b/auramaur/strategy/weather_pricing.py
@@ -1,0 +1,92 @@
+"""Pure pricing for Polymarket daily city-temperature bins (#weather strategy).
+
+Parses "Will the highest/lowest temperature in {City} be {X}° / between {A}-{B}°
+on {date}?" into a target bin, and prices it from an Open-Meteo ensemble: the
+bin probability is just the fraction of members that land in the bin. Network
+fetch + order placement live in the pillar; everything here is deterministic.
+
+Rounding convention (a calibration risk to verify against real resolutions):
+the stated whole-degree number is the *rounded* high/low the market resolves on,
+so "be X°" => integer reading == X => [X-0.5, X+0.5); "between A-B°" => integer
+reading in [A, B] => [A-0.5, B+0.5).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+
+
+# Static geocode for the cities Polymarket runs temp markets on. Unknown city ->
+# can't price (skip) rather than guess a location.
+CITY_COORDS: dict[str, tuple[float, float]] = {
+    "atlanta": (33.749, -84.388), "miami": (25.774, -80.194),
+    "new york": (40.713, -74.006), "new york city": (40.713, -74.006),
+    "nyc": (40.713, -74.006), "los angeles": (34.052, -118.244),
+    "chicago": (41.878, -87.630), "houston": (29.760, -95.370),
+    "london": (51.507, -0.128), "paris": (48.857, 2.353),
+    "warsaw": (52.230, 21.012), "berlin": (52.520, 13.405),
+    "moscow": (55.756, 37.617), "tokyo": (35.680, 139.690),
+    "shanghai": (31.230, 121.474), "beijing": (39.904, 116.407),
+    "guangzhou": (23.129, 113.264), "seoul": (37.567, 126.978),
+    "cape town": (-33.925, 18.424), "johannesburg": (-26.205, 28.050),
+    "sydney": (-33.868, 151.209), "mumbai": (19.076, 72.878),
+    "delhi": (28.704, 77.102), "dubai": (25.205, 55.271),
+    "singapore": (1.352, 103.820), "toronto": (43.651, -79.347),
+    "mexico city": (19.433, -99.133), "são paulo": (-23.551, -46.633),
+    "sao paulo": (-23.551, -46.633),
+}
+
+_RE_KIND = re.compile(r"\b(highest|lowest)\s+temperature\b", re.I)
+_RE_CITY = re.compile(r"\btemperature in\s+(.+?)\s+be\b", re.I)
+_RE_RANGE = re.compile(r"\bbe between\s+(-?\d+)\s*-\s*(-?\d+)\s*°?\s*([CF])\b", re.I)
+_RE_EXACT = re.compile(r"\bbe\s+(-?\d+)\s*°?\s*([CF])\b", re.I)
+
+
+@dataclass(frozen=True)
+class TempSpec:
+    kind: str          # "high" | "low"
+    city: str          # normalized lower-case
+    lat: float
+    lon: float
+    unit: str          # "C" | "F"
+    lo: float          # inclusive bin lower bound (in `unit`)
+    hi: float          # exclusive bin upper bound
+    target: date
+
+
+def parse_temp_market(question: str, target: date) -> TempSpec | None:
+    """Parse a Poly temperature question into a TempSpec, or None if it isn't a
+    recognised temp-bin market / the city isn't geocoded."""
+    if not question:
+        return None
+    mk = _RE_KIND.search(question)
+    mc = _RE_CITY.search(question)
+    if not (mk and mc):
+        return None
+    kind = "high" if mk.group(1).lower() == "highest" else "low"
+    city = mc.group(1).strip().lower().rstrip("?.,")
+    coords = CITY_COORDS.get(city)
+    if coords is None:
+        return None
+
+    rng = _RE_RANGE.search(question)
+    if rng:
+        a, b, unit = float(rng.group(1)), float(rng.group(2)), rng.group(3).upper()
+        lo, hi = min(a, b) - 0.5, max(a, b) + 0.5
+    else:
+        ex = _RE_EXACT.search(question)
+        if not ex:
+            return None
+        x, unit = float(ex.group(1)), ex.group(2).upper()
+        lo, hi = x - 0.5, x + 0.5
+    return TempSpec(kind=kind, city=city, lat=coords[0], lon=coords[1],
+                   unit=unit, lo=lo, hi=hi, target=target)
+
+
+def bin_probability(members: list[float], lo: float, hi: float) -> float | None:
+    """Fraction of ensemble members landing in [lo, hi). None if no members."""
+    if not members:
+        return None
+    return sum(1 for m in members if lo <= m < hi) / len(members)

--- a/tests/test_weather_pricing.py
+++ b/tests/test_weather_pricing.py
@@ -1,0 +1,44 @@
+"""Pure parsing + bin-pricing for Polymarket city-temperature markets."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from auramaur.strategy.weather_pricing import (
+    bin_probability,
+    parse_temp_market,
+)
+
+
+def test_parse_exact_celsius():
+    s = parse_temp_market("Will the highest temperature in Tokyo be 23°C on June 20?", date(2026, 6, 20))
+    assert s is not None
+    assert s.kind == "high" and s.city == "tokyo" and s.unit == "C"
+    assert (s.lo, s.hi) == (22.5, 23.5)
+    assert abs(s.lat - 35.68) < 0.01
+
+
+def test_parse_range_fahrenheit():
+    s = parse_temp_market("Will the highest temperature in Atlanta be between 82-83°F on June 19?", date(2026, 6, 19))
+    assert s is not None
+    assert s.unit == "F" and (s.lo, s.hi) == (81.5, 83.5)
+
+
+def test_parse_lowest():
+    s = parse_temp_market("Will the lowest temperature in Miami be between 74-75°F on June 18?", date(2026, 6, 18))
+    assert s is not None and s.kind == "low" and (s.lo, s.hi) == (73.5, 75.5)
+
+
+def test_parse_unknown_city_returns_none():
+    assert parse_temp_market("Will the highest temperature in Reykjavik be 12°C on June 19?", date(2026, 6, 19)) is None
+
+
+def test_parse_non_temp_returns_none():
+    assert parse_temp_market("Will Bitcoin be above 70000 on June 19?", date(2026, 6, 19)) is None
+
+
+def test_bin_probability():
+    members = [22.0, 22.8, 23.0, 23.2, 24.0, 29.0]  # 3 of 6 in [22.5, 23.5)
+    assert abs(bin_probability(members, 22.5, 23.5) - 0.5) < 1e-9
+    assert bin_probability([], 22.5, 23.5) is None
+    assert bin_probability([30.0, 31.0], 22.5, 23.5) == 0.0


### PR DESCRIPTION
## What
The pure, tested **measurement core** for the city-temperature strategy — the one environmental market with real liquidity (Poly daily temp bins, $1.7–7.5k) priced by the one thing that fits a bin market (an NWP **ensemble** → distribution). Uses **Open-Meteo's free/keyless ensemble** (~31 GFS members) as a light stand-in for the heavy CFS/GEFS integration while we measure edge. Not wired to trading yet.

- `OpenMeteoSource.daily_ensemble(lat, lon, date, kind, unit)` → member daily highs/lows in the market's unit; `[]` outside the 16-day horizon / on failure.
- `weather_pricing`: `parse_temp_market()` → `(high/low, city, bin, unit, date)` (exact "be X°" ⇒ `[X-0.5, X+0.5)`; range "between A-B°" ⇒ `[A-0.5, B+0.5)`), `CITY_COORDS` geocode, `bin_probability()` = fraction of members in the bin.

## Live sanity check (vs real markets)
Tokyo 23°C model 0.16 vs mkt 0.27; Shanghai 28°C 0.00 vs 0.06; Atlanta 82-83°F 0.00 vs 0.26 — model runs **below** market on mid bins. Whether that's *edge* or a *bin-rounding/station-mismatch artifact* is exactly what the pillar will measure against realized highs (the spike's whole point). Station-matching + rounding convention are documented calibration risks.

## Test
Parser (exact °C / range °F / lowest / unknown-city / non-temp) + `bin_probability`. Full suite green.

Next: paper-forced pillar that logs model-vs-market per bin, with a divergence cap (don't bet hard on a likely-artifact gap until realized outcomes validate).

Assisted-by: Claude (Anthropic)