### PR TITLE
feat(weather): paper-forced city-temperature pillar (ensemble vs market)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2812,6 +2812,31 @@ class AuramaurBot:
                 log.error("econ_indicator.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_weather_temp(self) -> None:
+        """Open-Meteo ensemble pricing of Polymarket city-temperature bins (paper)."""
+        from auramaur.data_sources.openmeteo import OpenMeteoSource
+        from auramaur.strategy.weather_temp import WeatherTempPillar
+
+        pillar = WeatherTempPillar(
+            db=self._components["db"],
+            settings=self.settings,
+            discovery=self._components["discovery"],
+            exchange=self._components["exchange"],
+            risk_manager=self._components["risk_manager"],
+            pnl_tracker=self._components["pnl_tracker"],
+            calibration=self._components["calibration"],
+            weather=OpenMeteoSource(),
+        )
+        interval = max(60, self.settings.weather_temp.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("weather_temp.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_resolution_lens(self) -> None:
         """Periodic resolution-language lens scan (paper-forced by config)."""
         from auramaur.strategy.resolution_lens import ResolutionLensPillar
@@ -3484,6 +3509,10 @@ class AuramaurBot:
         # Data-driven Kalshi econ-indicator pricing (paper-forced until proven)
         if self.settings.econ_indicator.enabled:
             tasks.append(asyncio.create_task(self._task_econ_indicator(), name="econ_indicator"))
+
+        # Open-Meteo ensemble city-temperature pricing (paper-forced spike)
+        if self.settings.weather_temp.enabled:
+            tasks.append(asyncio.create_task(self._task_weather_temp(), name="weather_temp"))
 
         # Resolution-language lens (paper-forced until proven)
         if self.settings.resolution_lens.enabled:

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -1,0 +1,184 @@
+"""Weather-temperature pillar (#weather spike) — price Polymarket daily
+city-temperature bins from an Open-Meteo ensemble, trade the mispricings.
+
+Measurement-first: every priced bin is logged (model vs market) so we can score
+against realized highs before trusting it. PAPER-FORCED by default; a divergence
+cap blocks implausibly large gaps (likely a bin-rounding or station-match
+artifact, not edge) until the paper record validates the model.
+"""
+
+from __future__ import annotations
+
+from datetime import timezone
+
+import structlog
+
+from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.weather_pricing import (
+    bin_probability,
+    parse_temp_market,
+)
+
+log = structlog.get_logger()
+
+
+class WeatherTempPillar:
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, calibration, weather) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._weather = weather
+
+    async def run_once(self) -> int:
+        cfg = self._settings.weather_temp
+        if not cfg.enabled or self._weather is None:
+            return 0
+        markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        entered = 0
+        for m in markets:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            if (m.exchange or "polymarket") != "polymarket":
+                continue
+            if m.end_date is None:
+                continue
+            end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+            spec = parse_temp_market(m.question, end.date())
+            if spec is None:
+                continue
+            try:
+                if await self._price_and_enter(m, spec):
+                    entered += 1
+            except Exception as e:
+                log.error("weather_temp.error", market_id=m.id, error=str(e))
+        if entered:
+            log.info("weather_temp.cycle_done", entered=entered)
+        return entered
+
+    def _required_edge(self, market: Market) -> float:
+        from auramaur.strategy.signals import taker_fee_rate
+        cfg = self._settings.weather_temp
+        p = market.outcome_yes_price
+        fee = taker_fee_rate("polymarket", market.category or "",
+                             self._settings.arbitrage.exchange_fees) * p * (1.0 - p)
+        return cfg.min_edge + fee
+
+    async def _price_and_enter(self, market: Market, spec) -> bool:
+        cfg = self._settings.weather_temp
+        members = await self._weather.daily_ensemble(
+            spec.lat, spec.lon, spec.target, spec.kind, spec.unit)
+        model_p = bin_probability(members, spec.lo, spec.hi)
+        if model_p is None:
+            return False
+        market_p = market.outcome_yes_price
+        edge = model_p - market_p
+        # Always log model vs market — this is the measurement record.
+        log.info("weather_temp.priced", market_id=market.id, city=spec.city,
+                 kind=spec.kind, model_p=round(model_p, 3), market_p=round(market_p, 3),
+                 members=len(members))
+        if abs(edge) < self._required_edge(market):
+            return False
+        if abs(edge) > cfg.max_divergence:
+            log.info("weather_temp.implausible_divergence", market_id=market.id,
+                     model_p=round(model_p, 3), market_p=round(market_p, 3))
+            return False
+        if await self._already_entered_or_held(market.id):
+            return False
+        side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+        signal = Signal(
+            market_id=market.id, market_question=market.question,
+            claude_prob=max(0.01, min(0.99, model_p)),
+            claude_confidence=Confidence.MEDIUM, market_prob=market_p,
+            edge=abs(edge) * 100.0,
+            evidence_summary=(f"GEFS ensemble P(bin)={model_p:.2f} ({len(members)} members) "
+                              f"vs market {market_p:.2f} for {spec.city} {spec.kind} temp."),
+            recommended_side=side, strategy_source="weather_temp",
+        )
+        await self._persist_signal(signal, market)
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("weather_temp.risk_rejected", market_id=market.id, reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+        is_live_order = (self._settings.is_live and not cfg.paper
+                         and not getattr(decision, "force_paper", False))
+        order = self._exchange.prepare_order(signal, market, size, is_live_order)
+        if order is None:
+            return False
+        result = await self._exchange.place_order(order)
+        if result.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("weather_temp.order_rejected", market_id=market.id, status=result.status)
+            return False
+        await self._record_entry(signal, market, order, result)
+        log.info("weather_temp.entered", market_id=market.id, side=side.value,
+                 model_p=round(model_p, 3), market_p=round(market_p, 3), paper=result.is_paper)
+        return True
+
+    async def _already_entered_or_held(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'weather_temp' LIMIT 1",
+            (market_id,))
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,))
+        return row is not None
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, 'polymarket', ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.condition_id, market.question,
+             (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity))
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'weather_temp')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value))
+        await self._db.commit()
+
+    async def _record_entry(self, signal: Signal, market: Market, order, result) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        if result.status in ("filled", "paper", "partial") and fill_size > 0:
+            await self._pnl.record_fill(Fill(
+                order_id=result.order_id, market_id=order.market_id,
+                token_id=order.token_id, side=order.side, token=order.token,
+                size=fill_size, price=fill_price, is_paper=is_paper))
+        await self._db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, strategy_source, exchange)
+               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'weather_temp', 'polymarket')""",
+            (order.market_id, order.side.value, fill_size, fill_price,
+             1 if is_paper else 0, result.order_id,
+             "filled" if result.status in ("filled", "paper") else result.status))
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id, is_paper, updated_at)
+               VALUES (?, 'polymarket', ?, ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size, avg_price = excluded.avg_price,
+                   current_price = excluded.current_price, updated_at = excluded.updated_at""",
+            (order.market_id, order.side.value, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0))
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("weather_temp.calibration_error", error=str(e))

--- a/config/settings.py
+++ b/config/settings.py
@@ -352,6 +352,26 @@ class EconIndicatorConfig(BaseModel):
     interval_seconds: int = 1800
 
 
+class WeatherTempConfig(BaseModel):
+    """Open-Meteo ensemble pricing of Polymarket city-temperature bins
+    (strategy/weather_temp.py). Measurement spike: PAPER-FORCED and disabled
+    by default. Every bin is logged (model vs market) regardless of trading;
+    the edge must clear the Polymarket taker fee on top of min_edge, and
+    max_divergence skips implausibly large gaps (likely a bin-rounding or
+    station-match artifact, not edge) until realized highs validate the model.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    stake_usd: float = 10.0
+    min_edge: float = 0.10
+    max_divergence: float = 0.40
+    max_open: int = 40
+    max_entries_per_cycle: int = 8
+    scan_limit: int = 500
+    interval_seconds: int = 3600
+
+
 class EntailmentArbConfig(BaseModel):
     """Entailment arbitrage (strategy/entailment_arb.py).
 
@@ -826,6 +846,7 @@ class Settings(BaseSettings):
     graduation: GraduationConfig = Field(default_factory=lambda: GraduationConfig(**_DEFAULTS.get("graduation", {})))
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
+    weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     resolution_lens: ResolutionLensConfig = Field(default_factory=lambda: ResolutionLensConfig(**_DEFAULTS.get("resolution_lens", {})))
     oddlot_tender: OddLotTenderConfig = Field(default_factory=lambda: OddLotTenderConfig(**_DEFAULTS.get("oddlot_tender", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))

--- a/tests/test_weather_temp.py
+++ b/tests/test_weather_temp.py
@@ -1,0 +1,108 @@
+"""Weather-temp pillar: price Poly temp bins from the ensemble, trade mispricings."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market, Order, OrderResult, OrderSide, TokenType
+from auramaur.strategy.weather_temp import WeatherTempPillar
+from config.settings import Settings
+
+
+def _tmkt(mid, question, yes) -> Market:
+    return Market(
+        id=mid, exchange="polymarket", question=question,
+        outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=4000.0, volume=4000.0, category="weather",
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+        clob_token_yes="ty", clob_token_no="tn")
+
+
+def _settings(**ov):
+    s = Settings()
+    s.weather_temp.enabled = True
+    s.weather_temp.paper = True
+    s.weather_temp.min_edge = 0.10
+    for k, v in ov.items():
+        setattr(s.weather_temp, k, v)
+    return s
+
+
+def _exchange():
+    ex = MagicMock()
+    def prepare(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(market_id=market.id, exchange="polymarket", token_id="t",
+                     side=OrderSide.BUY, token=token, size=round(size / max(price, .01), 2),
+                     price=round(price, 2), dry_run=not is_live)
+    ex.prepare_order = MagicMock(side_effect=prepare)
+    ex.place_order = AsyncMock(side_effect=lambda o: OrderResult(
+        order_id="o1", market_id=o.market_id, status="paper",
+        filled_size=o.size, filled_price=o.price, is_paper=o.dry_run))
+    return ex
+
+
+def _risk():
+    rm = MagicMock()
+    rm.evaluate = AsyncMock(return_value=MagicMock(
+        approved=True, position_size=10.0, reason="", force_paper=False))
+    return rm
+
+
+def _pillar(db, settings, markets, members):
+    disc = MagicMock(); disc.get_markets = AsyncMock(return_value=markets)
+    weather = MagicMock(); weather.daily_ensemble = AsyncMock(return_value=members)
+    cal = MagicMock(); cal.record_prediction = AsyncMock()
+    return WeatherTempPillar(db=db, settings=settings, discovery=disc,
+                             exchange=_exchange(), risk_manager=_risk(),
+                             pnl_tracker=PnLTracker(db, settings),
+                             calibration=cal, weather=weather)
+
+
+def test_enters_when_ensemble_disagrees_and_skips_fair():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            # market says 0.27 for "Tokyo high = 23C"; ensemble puts ~3% in the bin
+            mispriced = _tmkt("w1", "Will the highest temperature in Tokyo be 23°C on June 20?", 0.27)
+            members = [26, 27, 28, 25, 29, 24, 30, 26, 27, 28]   # ~0 in [22.5,23.5)
+            pillar = _pillar(db, _settings(), [mispriced], members)
+            assert await pillar.run_once() == 1
+            row = await db.fetchone(
+                "SELECT action FROM signals WHERE strategy_source='weather_temp' AND market_id='w1'")
+            assert row["action"] == "SELL"   # model << market -> buy NO
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_skips_fair_priced_bin():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            # market 0.30; ensemble puts 3/10 in the bin -> ~fair -> skip
+            fair = _tmkt("w2", "Will the highest temperature in Tokyo be 23°C on June 20?", 0.30)
+            members = [23, 23, 23, 26, 27, 28, 25, 29, 24, 30]   # 3/10 in [22.5,23.5)
+            pillar = _pillar(db, _settings(), [fair], members)
+            assert await pillar.run_once() == 0
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_skips_implausible_divergence():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            m = _tmkt("w3", "Will the highest temperature in Atlanta be between 82-83°F on June 19?", 0.50)
+            members = [95.0] * 10   # model 0.0 vs market 0.50 -> 0.50 gap > cap
+            pillar = _pillar(db, _settings(max_divergence=0.40), [m], members)
+            assert await pillar.run_once() == 0
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## What
Wires the Open-Meteo ensemble core (#158) into a **measurement-first, paper-forced** strategy on Polymarket daily city-temperature bins — the one liquid environmental surface.

- Scans temp markets, parses the bin, prices it from the ensemble distribution, and **logs model vs market** (`weather_temp.priced`) every cycle for scoring against realized highs (the spike's point).
- Trades the mispricings paper-forced: edge must clear the Polymarket taker fee on top of `min_edge`; `max_divergence` skips implausibly large gaps (likely a bin-rounding / station-match artifact). BUY YES when the ensemble is richer than the market, NO when cheaper. Standard rails + calibration.
- `WeatherTempConfig` + bot task; disabled by default.

## Test
Enters when the ensemble disagrees (SELL→NO when market too high), skips a fair bin, skips an implausible-divergence gap. Full suite green.

Next: enable in local config (paper) to start the measurement record; revisit after ~1–2 weeks of model-vs-realized to decide if it clears the bar (and whether to graduate from Open-Meteo to the CFS/GEFS integration).

Assisted-by: Claude (Anthropic)