### PR TITLE
feat(monitoring): hydrology-market watcher (arm the compHydro moat)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2812,6 +2812,26 @@ class AuramaurBot:
                 log.error("econ_indicator.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_hydro_watch(self) -> None:
+        """Alert when a tradeable hydrology market appears (compHydro moat armed)."""
+        from auramaur.monitoring.hydro_market_watch import HydroMarketWatcher
+
+        watcher = HydroMarketWatcher(
+            db=self._components["db"],
+            settings=self.settings,
+            discoveries=self._components.get("discoveries") or {},
+            alerts=self._components.get("alerts"),
+        )
+        interval = max(300, self.settings.hydro_watch.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await watcher.run_once()
+            except Exception as e:
+                log.error("hydro_watch.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_weather_temp(self) -> None:
         """Open-Meteo ensemble pricing of Polymarket city-temperature bins (paper)."""
         from auramaur.data_sources.openmeteo import OpenMeteoSource
@@ -3513,6 +3533,10 @@ class AuramaurBot:
         # Open-Meteo ensemble city-temperature pricing (paper-forced spike)
         if self.settings.weather_temp.enabled:
             tasks.append(asyncio.create_task(self._task_weather_temp(), name="weather_temp"))
+
+        # Hydrology-market watcher (alert-only; arms the compHydro moat)
+        if self.settings.hydro_watch.enabled:
+            tasks.append(asyncio.create_task(self._task_hydro_watch(), name="hydro_watch"))
 
         # Resolution-language lens (paper-forced until proven)
         if self.settings.resolution_lens.enabled:

--- a/auramaur/monitoring/hydro_market_watch.py
+++ b/auramaur/monitoring/hydro_market_watch.py
@@ -1,0 +1,93 @@
+"""Hydrology market watcher — alert when a tradeable water market appears.
+
+Kalshi/Polymarket don't currently list liquid hydrology markets (streamflow,
+drought, reservoir level, flood stage, snowpack), so the compHydro data moat
+(CSFS streamflow, COS water-obs, CAS attributes) has nothing to price. This
+watcher flips that into "armed and waiting": each cycle it scans both venues
+and ALERTS (no trading) the first time a genuine hydrology market shows up with
+liquidity, so the moat can be deployed.
+
+The matcher is deliberately precise — the naive substring scan false-positived
+on "Aust*rain*" / "*Rain*bow Six" — so it requires word-boundaried,
+hydrology-specific terms.
+"""
+
+from __future__ import annotations
+
+import re
+
+import structlog
+
+log = structlog.get_logger()
+
+# Word-boundaried, hydrology-specific terms. Bare "rain"/"snow"/"water" are
+# excluded (too many false positives: Austrian, Rainbow, snowboard); only terms
+# that unambiguously denote a water/hydrology event qualify.
+_HYDRO_RE = re.compile(
+    r"\b("
+    r"streamflow|runoff|reservoir|snowpack|snow water equivalent|swe|"
+    r"drought|flood|flooding|flood stage|"
+    r"water level|river level|lake level|river flow|"
+    r"lake mead|lake powell|colorado river|mississippi river|"
+    r"rainfall|precipitation|snowfall"
+    r")\b",
+    re.I,
+)
+
+
+def is_hydro_market(text: str) -> bool:
+    """True if the text denotes a hydrology/water market (precise, not substring)."""
+    return bool(_HYDRO_RE.search(text or ""))
+
+
+class HydroMarketWatcher:
+    def __init__(self, db, settings, discoveries: dict, alerts) -> None:
+        self._db = db
+        self._settings = settings
+        self._discoveries = discoveries or {}
+        self._alerts = alerts
+
+    async def _ensure_table(self) -> None:
+        await self._db.execute(
+            "CREATE TABLE IF NOT EXISTS hydro_watch_seen "
+            "(market_id TEXT PRIMARY KEY, venue TEXT, question TEXT, first_seen TEXT)")
+        await self._db.commit()
+
+    async def run_once(self) -> int:
+        cfg = self._settings.hydro_watch
+        if not cfg.enabled or self._alerts is None:
+            return 0
+        await self._ensure_table()
+        new = 0
+        for venue, disc in self._discoveries.items():
+            try:
+                markets = await disc.get_markets(limit=cfg.scan_limit)
+            except Exception as e:
+                log.debug("hydro_watch.scan_error", venue=venue, error=str(e))
+                continue
+            for m in markets:
+                text = f"{m.question or ''} {getattr(m, 'description', '') or ''}"
+                if not is_hydro_market(text):
+                    continue
+                liq = max(float(m.liquidity or 0), float(m.volume or 0))
+                if liq < cfg.min_liquidity:
+                    continue
+                row = await self._db.fetchone(
+                    "SELECT 1 FROM hydro_watch_seen WHERE market_id = ?", (m.id,))
+                if row is not None:
+                    continue  # already alerted
+                await self._db.execute(
+                    "INSERT OR IGNORE INTO hydro_watch_seen (market_id, venue, question, first_seen) "
+                    "VALUES (?, ?, ?, datetime('now'))",
+                    (m.id, venue, (m.question or "")[:200]))
+                await self._db.commit()
+                await self._alerts.send(
+                    f"🌊 Hydrology market listed on {venue}: "
+                    f"{(m.question or '')[:120]} (liq ~${liq:.0f}) — CSFS/COS data is ready to price it.",
+                    level="info")
+                log.info("hydro_watch.new_market", venue=venue, market_id=m.id,
+                         question=(m.question or "")[:80])
+                new += 1
+        if new:
+            log.info("hydro_watch.cycle_done", new=new)
+        return new

--- a/config/settings.py
+++ b/config/settings.py
@@ -352,6 +352,17 @@ class EconIndicatorConfig(BaseModel):
     interval_seconds: int = 1800
 
 
+class HydroWatchConfig(BaseModel):
+    """Hydrology-market watcher (monitoring/hydro_market_watch.py). Alert-only:
+    no liquid water markets exist today, so this just flags the first time one
+    appears on a venue, so the compHydro data moat can be deployed. Cheap."""
+
+    enabled: bool = False
+    scan_limit: int = 500
+    min_liquidity: float = 100.0
+    interval_seconds: int = 21600  # every 6h — new markets aren't urgent
+
+
 class WeatherTempConfig(BaseModel):
     """Open-Meteo ensemble pricing of Polymarket city-temperature bins
     (strategy/weather_temp.py). Measurement spike: PAPER-FORCED and disabled
@@ -847,6 +858,7 @@ class Settings(BaseSettings):
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
+    hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))
     resolution_lens: ResolutionLensConfig = Field(default_factory=lambda: ResolutionLensConfig(**_DEFAULTS.get("resolution_lens", {})))
     oddlot_tender: OddLotTenderConfig = Field(default_factory=lambda: OddLotTenderConfig(**_DEFAULTS.get("oddlot_tender", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))

--- a/tests/test_hydro_market_watch.py
+++ b/tests/test_hydro_market_watch.py
@@ -1,0 +1,67 @@
+"""Hydrology-market watcher: precise matcher + alert-once dedup."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.monitoring.hydro_market_watch import HydroMarketWatcher, is_hydro_market
+from config.settings import Settings
+
+
+def test_matcher_hits_real_hydro_terms():
+    for q in [
+        "Will Lake Mead drop below 1000 ft by December?",
+        "Will there be a drought emergency in California in 2026?",
+        "Will the Colorado River reach flood stage in July?",
+        "Will Sierra snowpack exceed 150% of normal?",
+        "Will streamflow at the gauge exceed 5000 cfs?",
+        "Will the reservoir level fall below capacity?",
+    ]:
+        assert is_hydro_market(q), q
+
+
+def test_matcher_rejects_false_positives():
+    # the exact substrings that broke the naive scan
+    for q in [
+        "Will Oscar Piastri get pole at the 2026 F1 Austrian Grand Prix?",
+        "Rainbow Six Siege: 100 Thieves vs Shopify Rebellion",
+        "Will it be a snowboard gold for Team USA?",   # 'snow' substring, not hydro
+        "Will Nithya Raman win the LA mayoral election?",
+    ]:
+        assert not is_hydro_market(q), q
+
+
+def _settings():
+    s = Settings()
+    s.hydro_watch.enabled = True
+    s.hydro_watch.min_liquidity = 100.0
+    return s
+
+
+def _mkt(mid, q, liq=5000.0):
+    return Market(id=mid, exchange="kalshi", question=q, liquidity=liq, volume=liq)
+
+
+def test_alerts_once_per_market():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            disc = MagicMock()
+            disc.get_markets = AsyncMock(return_value=[
+                _mkt("h1", "Will Lake Mead drop below 1000 ft?"),
+                _mkt("x1", "Will the F1 Austrian GP be wet?"),          # not hydro
+                _mkt("h2", "Drought emergency declared?", liq=10.0),    # below min_liq
+            ])
+            alerts = MagicMock(); alerts.send = AsyncMock()
+            w = HydroMarketWatcher(db, _settings(), {"kalshi": disc}, alerts)
+            assert await w.run_once() == 1            # only h1 qualifies
+            alerts.send.assert_awaited_once()
+            # second cycle: already seen -> no new alert
+            assert await w.run_once() == 0
+            assert alerts.send.await_count == 1
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## What
No liquid water market exists on Kalshi/Polymarket today (verified — every "match" was a substring false positive like *Aust**rain**n* / *Rainbow Six*), so the streamflow/water data moat (CSFS/COS/CAS) has nothing to price. This **alert-only** watcher turns "great data, no market" into "armed and waiting": each cycle it scans both venues and alerts the **first time** a genuine hydrology market appears with liquidity (Lake Mead level, drought, flood stage, snowpack, reservoir…), so the moat can be deployed the moment a product exists.

- `is_hydro_market()` — precise **word-boundary** matcher on hydrology-specific terms; bare `rain`/`snow`/`water` excluded to avoid the false positives the naive scan hit.
- `HydroMarketWatcher` — scans discoveries, filters by liquidity, **alerts once per market** (dedup table `hydro_watch_seen`). No trading, no positions.
- `HydroWatchConfig` (6h cadence) + bot task; disabled by default.

## Test
Matcher hits real hydro phrasings and rejects the known false positives (Austrian GP / Rainbow Six / snowboard); alerts exactly once per qualifying market, skips below-liquidity and non-hydro. Full suite green.

Assisted-by: Claude (Anthropic)