### PR TITLE
fix(monitoring): hydro watcher matches question-only, drops ambiguous terms

### DIFF
--- a/auramaur/monitoring/hydro_market_watch.py
+++ b/auramaur/monitoring/hydro_market_watch.py
@@ -20,12 +20,13 @@ import structlog
 
 log = structlog.get_logger()
 
-# Word-boundaried, hydrology-specific terms. Bare "rain"/"snow"/"water" are
-# excluded (too many false positives: Austrian, Rainbow, snowboard); only terms
-# that unambiguously denote a water/hydrology event qualify.
+# Word-boundaried, hydrology-specific terms. Excluded as ambiguous: bare
+# "rain"/"snow"/"water" (Austrian/Rainbow/snowboard), "runoff" (ELECTION
+# runoff — the first false positive in the wild), and "swe" (abbreviation).
+# Only terms that unambiguously denote a water/hydrology event qualify.
 _HYDRO_RE = re.compile(
     r"\b("
-    r"streamflow|runoff|reservoir|snowpack|snow water equivalent|swe|"
+    r"streamflow|snowmelt|reservoir|snowpack|snow water equivalent|"
     r"drought|flood|flooding|flood stage|"
     r"water level|river level|lake level|river flow|"
     r"lake mead|lake powell|colorado river|mississippi river|"
@@ -36,7 +37,11 @@ _HYDRO_RE = re.compile(
 
 
 def is_hydro_market(text: str) -> bool:
-    """True if the text denotes a hydrology/water market (precise, not substring)."""
+    """True if the text denotes a hydrology/water market (precise, not substring).
+
+    Matched against the market QUESTION only — descriptions carry verbose
+    boilerplate (e.g. "a runoff election will be held") that false-positives.
+    """
     return bool(_HYDRO_RE.search(text or ""))
 
 
@@ -66,8 +71,9 @@ class HydroMarketWatcher:
                 log.debug("hydro_watch.scan_error", venue=venue, error=str(e))
                 continue
             for m in markets:
-                text = f"{m.question or ''} {getattr(m, 'description', '') or ''}"
-                if not is_hydro_market(text):
+                # Question/title only — descriptions false-positive on boilerplate
+                # ("a runoff election will be held").
+                if not is_hydro_market(m.question or ""):
                     continue
                 liq = max(float(m.liquidity or 0), float(m.volume or 0))
                 if liq < cfg.min_liquidity:

--- a/tests/test_hydro_market_watch.py
+++ b/tests/test_hydro_market_watch.py
@@ -24,14 +24,21 @@ def test_matcher_hits_real_hydro_terms():
 
 
 def test_matcher_rejects_false_positives():
-    # the exact substrings that broke the naive scan
+    # the exact substrings that broke the naive scan + the live false positive
     for q in [
         "Will Oscar Piastri get pole at the 2026 F1 Austrian Grand Prix?",
         "Rainbow Six Siege: 100 Thieves vs Shopify Rebellion",
         "Will it be a snowboard gold for Team USA?",   # 'snow' substring, not hydro
         "Will Nithya Raman win the LA mayoral election?",
+        "Will there be a runoff election in the Georgia Senate race?",  # ELECTION runoff
     ]:
         assert not is_hydro_market(q), q
+
+
+def test_matcher_only_checks_question_not_description():
+    """Description boilerplate ('a runoff election will be held') must not match —
+    the watcher scopes to the question; the matcher is what's exercised here."""
+    assert not is_hydro_market("a majority of the vote, a runoff election will be held")
 
 
 def _settings():


### PR DESCRIPTION
First live cycle false-positived on an LA-mayoral-election market — its **description** read *"a runoff election will be held"* and `runoff` + description-scope matched. Fixes: match the **question only** (descriptions are boilerplate), and drop the ambiguous bare terms `runoff` (election runoff) / `swe` (abbreviation); added `snowmelt`. Regression tests for election-runoff phrasing + the description boilerplate. 795 tests green.

Assisted-by: Claude (Anthropic)