### PR TITLE
feat(resolution_lens): read full criteria + adversarially verify the mechanism

### DIFF
--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -273,7 +273,9 @@ CREATE TABLE IF NOT EXISTS lens_verdicts (
     gap_score REAL NOT NULL DEFAULT 0,
     mechanism TEXT NOT NULL DEFAULT '',
     reasoning TEXT NOT NULL DEFAULT '',
-    checked_at TEXT NOT NULL DEFAULT (datetime('now'))
+    checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+    -- Adversarial mechanism check: -1 not yet verified, 0 refuted, 1 confirmed.
+    verified INTEGER NOT NULL DEFAULT -1
 );
 
 CREATE TABLE IF NOT EXISTS entailment_verdicts (

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -77,6 +77,23 @@ Respond with ONLY this JSON:
 {{"fair_prob": <float 0-1>, "gap_score": <float 0-1, how much the strict reading diverges from the headline reading>, "mechanism": "<one concrete sentence naming the specific fine-print mechanism, or 'none'>"}}"""
 
 
+# Phase 2: adversarial verification — a SECOND, skeptical pass that tries to
+# REFUTE the claimed mechanism, defaulting to refuted. Kills hallucinated /
+# over-read fine print before any (paper or live) capital is committed.
+VERIFY_PROMPT = """A resolution-criteria auditor claims a prediction market is mispriced because of a fine-print mechanism. Your job is to ADVERSARIALLY CHECK that claim — default to REFUTED unless the mechanism is clearly real and decisive under the LITERAL written criteria.
+
+Question: "{question}"
+Resolution criteria: {description}
+Market price (YES): {market_prob:.2f}
+Claimed strict-criteria fair P(YES): {fair:.2f}
+Claimed mechanism: "{mechanism}"
+
+Check: does the cited clause ACTUALLY qualify/disqualify as claimed, or is the auditor over-reading or inventing a rule the criteria don't state? If you can't point to specific criteria text that supports the mechanism, it is REFUTED.
+
+Respond with ONLY this JSON:
+{{"verdict": "confirmed" | "refuted", "confidence": <float 0-1>, "why": "<one sentence citing the criteria>"}}"""
+
+
 class ResolutionLensPillar:
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, calibration, analyzer) -> None:
@@ -119,21 +136,44 @@ class ResolutionLensPillar:
         hours = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
         return min_hours <= hours <= cfg.max_days_to_resolution * 24.0
 
+    def _criteria_text(self, desc: str) -> str:
+        """Full resolution criteria, capped — keeping the TAIL where the
+        decisive qualifier/source/edge-case clauses live (the old [:800] cut
+        them off). Head+tail when over the cap, so context survives too."""
+        cap = self._settings.resolution_lens.criteria_char_cap
+        desc = desc or ""
+        if len(desc) <= cap:
+            return desc
+        head = cap // 3
+        return desc[:head] + "\n…[criteria trimmed]…\n" + desc[-(cap - head):]
+
+    async def _ensure_schema(self) -> None:
+        """Idempotent: add the `verified` column on pre-existing DBs."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE lens_verdicts ADD COLUMN verified INTEGER NOT NULL DEFAULT -1")
+            await self._db.commit()
+        except Exception:
+            pass  # already exists
+
     async def _verdict(self, m: Market):
-        """Cached lens verdict (criteria are static — cache forever)."""
+        """Cached lens verdict -> (fair, gap_score, mechanism, verified). The
+        criteria reading is static (cache it); `verified` is -1 until the
+        adversarial check runs at trade-decision time."""
         row = await self._db.fetchone(
-            "SELECT fair_prob, gap_score, mechanism FROM lens_verdicts WHERE market_id = ?",
+            "SELECT fair_prob, gap_score, mechanism, verified FROM lens_verdicts WHERE market_id = ?",
             (m.id,),
         )
         if row is not None:
-            return float(row["fair_prob"]), float(row["gap_score"]), row["mechanism"]
+            return (float(row["fair_prob"]), float(row["gap_score"]),
+                    row["mechanism"], int(row["verified"]))
         if self._analyzer is None:
             return None
         fair, score, mech = m.outcome_yes_price, 0.0, "none"
         try:
             raw = await self._analyzer._call_llm(LENS_PROMPT.format(
                 question=m.question,
-                description=(m.description or "")[:800],
+                description=self._criteria_text(m.description),  # Phase 1: full criteria
                 market_prob=m.outcome_yes_price,
             ))
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
@@ -144,12 +184,36 @@ class ResolutionLensPillar:
             log.warning("lens.llm_parse_error", market_id=m.id, error=str(e))
         await self._db.execute(
             """INSERT OR REPLACE INTO lens_verdicts
-               (market_id, fair_prob, gap_score, mechanism)
-               VALUES (?, ?, ?, ?)""",
+               (market_id, fair_prob, gap_score, mechanism, verified)
+               VALUES (?, ?, ?, ?, -1)""",
             (m.id, fair, score, mech),
         )
         await self._db.commit()
-        return fair, score, mech
+        return fair, score, mech, -1
+
+    async def _verify_mechanism(self, m: Market, fair: float, mechanism: str) -> bool:
+        """Phase 2: adversarial check of the named mechanism. Returns True only
+        when the second pass CONFIRMS it at >= verify_min_confidence. Persists
+        the verdict (0/1) so it isn't re-checked. Fails closed (refuted) on
+        parse/LLM error — a hallucinated mechanism must not slip through."""
+        cfg = self._settings.resolution_lens
+        confirmed = False
+        try:
+            raw = await self._analyzer._call_llm(VERIFY_PROMPT.format(
+                question=m.question,
+                description=self._criteria_text(m.description),
+                market_prob=m.outcome_yes_price, fair=fair, mechanism=mechanism,
+            ))
+            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            confirmed = (str(parsed.get("verdict", "refuted")).lower() == "confirmed"
+                         and float(parsed.get("confidence", 0.0)) >= cfg.verify_min_confidence)
+        except Exception as e:
+            log.warning("lens.verify_parse_error", market_id=m.id, error=str(e))
+        await self._db.execute(
+            "UPDATE lens_verdicts SET verified = ? WHERE market_id = ?",
+            (1 if confirmed else 0, m.id))
+        await self._db.commit()
+        return confirmed
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
         row = await self._db.fetchone(
@@ -223,6 +287,7 @@ class ResolutionLensPillar:
         cfg = self._settings.resolution_lens
         if not cfg.enabled:
             return 0
+        await self._ensure_schema()
         # Lexical pre-filter over the whole universe; fall back to the volume
         # scan only if the markets table is empty (cold start).
         markets = await self._lexical_candidates()
@@ -248,10 +313,21 @@ class ResolutionLensPillar:
             v = await self._verdict(m)
             if v is None:
                 continue
-            fair, score, mech = v
+            fair, score, mech, verified = v
             edge = fair - m.outcome_yes_price
             if (score < cfg.min_gap_score or abs(edge) < cfg.min_edge
                     or mech.strip().lower() == "none"):
+                continue
+            # Phase 2: a real gap is on the table — adversarially verify the
+            # mechanism before trading (skip hallucinated fine print). Bounded
+            # by the same per-cycle LLM budget; result cached in `verified`.
+            if cfg.verify_enabled and verified == -1:
+                if calls >= cfg.max_llm_calls_per_cycle:
+                    continue  # out of budget; verify next cycle
+                calls += 1
+                verified = 1 if await self._verify_mechanism(m, fair, mech) else 0
+            if cfg.verify_enabled and verified != 1:
+                log.info("lens.mechanism_refuted", market_id=m.id, mechanism=mech[:80])
                 continue
             try:
                 if await self._enter(m, fair, score, mech, edge):

--- a/config/settings.py
+++ b/config/settings.py
@@ -460,6 +460,14 @@ class ResolutionLensConfig(BaseModel):
     min_description_chars: int = 80
     min_hours_to_resolution: float = 12.0
     max_days_to_resolution: float = 90.0
+    # Phase 1: read the FULL criteria, not the first 800 chars (the decisive
+    # qualifier usually lives at the end). Cap to bound LLM cost; head+tail kept.
+    criteria_char_cap: int = 4500
+    # Phase 2: adversarially verify the named mechanism (a 2nd skeptical LLM
+    # pass that defaults to refuted) before trading — kills hallucinated
+    # fine-print. Only trade when confirmed at >= verify_min_confidence.
+    verify_enabled: bool = True
+    verify_min_confidence: float = 0.7
     interval_seconds: int = 1800
     # Paper-phase eligibility: while the cell is hard paper-forced (paper=True)
     # it can never reach the venue, so the live-trading guards (hold horizon,

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -94,10 +94,17 @@ def _risk(approved=True, size=8.0, force_paper=False):
 
 
 def _analyzer(fair=0.10, gap=0.8, mech="'permanent' requires explicit permanence language; "
-                                       "crowd prices mere de-escalation"):
+                                       "crowd prices mere de-escalation",
+              verify="confirmed", verify_conf=0.9):
     a = MagicMock()
-    a._call_llm = AsyncMock(return_value=(
-        f'{{"fair_prob": {fair}, "gap_score": {gap}, "mechanism": "{mech}"}}'))
+
+    async def _call(prompt, **kw):
+        # The verify pass asks for a {"verdict": ...}; the lens pass for fair_prob.
+        if "ADVERSARIALLY CHECK" in prompt or '"verdict"' in prompt:
+            return f'{{"verdict": "{verify}", "confidence": {verify_conf}, "why": "x"}}'
+        return f'{{"fair_prob": {fair}, "gap_score": {gap}, "mechanism": "{mech}"}}'
+
+    a._call_llm = AsyncMock(side_effect=_call)
     return a
 
 
@@ -144,6 +151,48 @@ def test_eligible_loosens_thresholds_in_paper_mode():
         live = _pillar(db, _settings(paper=False), [m])
         assert live._eligible(m) is False
 
+    asyncio.run(run())
+
+
+# ----------------------------------------------------------------------
+# Phase 1 + 2 upgrades
+# ----------------------------------------------------------------------
+
+def test_full_criteria_not_truncated_at_800():
+    """The lens must feed the FULL criteria (tail kept) — the decisive clause
+    lives at the end and the old [:800] cut it off."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            tail = "RESOLVES NO unless an OFFICIAL signed treaty is filed."
+            desc = ("filler. " * 200) + tail        # ~1600 chars, clause at end
+            analyzer = _analyzer()
+            pillar = _pillar(db, _settings(), [_market(yes=0.30)], analyzer=analyzer)
+            m = _market(yes=0.30); m.description = desc
+            await pillar._verdict(m)
+            sent = analyzer._call_llm.await_args_list[0].args[0]
+            assert tail in sent                      # tail survived
+            assert len(desc) > 800                   # would have been cut before
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_refuted_mechanism_blocks_entry():
+    """A strong gap whose mechanism the adversarial pass REFUTES does not trade."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            ex = _exchange()
+            analyzer = _analyzer(verify="refuted", verify_conf=0.9)
+            pillar = _pillar(db, _settings(), [_market(yes=0.30)], exchange=ex, analyzer=analyzer)
+            assert await pillar.run_once() == 0
+            ex.place_order.assert_not_awaited()
+            # cached as refuted (0) so it isn't re-verified
+            row = await db.fetchone("SELECT verified FROM lens_verdicts WHERE market_id='m1'")
+            assert int(row["verified"]) == 0
+        finally:
+            await db.close()
     asyncio.run(run())
 
 


### PR DESCRIPTION
The LLM-comprehension upgrade from the audit. Two fixes, both "more reading / more skepticism," never forecasting.

## Phase 1 — stop truncating the fine print
`_verdict` fed `description[:800]`, but the markets table stores the **full** criteria (median ~980 chars, p90 1327, max 5452 — **61% exceed 800**), and the decisive clause (qualifier, required source, "resolves NO unless…") lives at the **end**. The lens was reading half its own signal. Now feeds the **full criteria** (capped at `criteria_char_cap`=4500, head+tail kept on overflow).

## Phase 2 — adversarially verify the mechanism
A single LLM call with no check let a **hallucinated / over-read** mechanism trade (the name-the-gap gate only required a mechanism *string*). Added a second, skeptical pass (`VERIFY_PROMPT`, **defaults to refuted**, must confirm at ≥ `verify_min_confidence`=0.7) before any entry — mirrors `entailment_arb`'s adversarial verify. Result cached in a new `lens_verdicts.verified` column (idempotent ALTER for existing DBs); bounded by the same per-cycle LLM budget; **fails closed**.

## Test
Full criteria reaches the LLM (tail survives, >800); a refuted mechanism blocks the entry and caches `verified=0`; existing gate/entry tests updated for the 2-pass mock. Full suite green.

Next (Phase 3, deferred): current-state grounding (deadline-passed / recent news) to unlock known-state-contradiction + news-as-fact.

Assisted-by: Claude (Anthropic)