### PR TITLE
feat(monitoring): intraday-drift measurement spike (gate the intraday strategy)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2812,6 +2812,26 @@ class AuramaurBot:
                 log.error("econ_indicator.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_intraday_drift(self) -> None:
+        """Measurement spike: track post-signal price drift toward the LLM estimate
+        (no trading). Gates the intraday-convergence strategy on real evidence."""
+        from auramaur.monitoring.intraday_drift import IntradayDriftTracker
+
+        tracker = IntradayDriftTracker(
+            db=self._components["db"],
+            settings=self.settings,
+            discovery=self._components["discovery"],
+        )
+        interval = max(60, self.settings.intraday_drift.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await tracker.run_once()
+            except Exception as e:
+                log.error("intraday_drift.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_hydro_watch(self) -> None:
         """Alert when a tradeable hydrology market appears (compHydro moat armed)."""
         from auramaur.monitoring.hydro_market_watch import HydroMarketWatcher
@@ -3537,6 +3557,10 @@ class AuramaurBot:
         # Hydrology-market watcher (alert-only; arms the compHydro moat)
         if self.settings.hydro_watch.enabled:
             tasks.append(asyncio.create_task(self._task_hydro_watch(), name="hydro_watch"))
+
+        # Intraday-drift measurement spike (no trading; gates the intraday strat)
+        if self.settings.intraday_drift.enabled:
+            tasks.append(asyncio.create_task(self._task_intraday_drift(), name="intraday_drift"))
 
         # Resolution-language lens (paper-forced until proven)
         if self.settings.resolution_lens.enabled:

--- a/auramaur/monitoring/intraday_drift.py
+++ b/auramaur/monitoring/intraday_drift.py
@@ -1,0 +1,146 @@
+"""Intraday-drift measurement spike — does price drift toward the LLM estimate?
+
+The intraday-convergence thesis: after a catalyst the market UNDER-reacts and
+drifts toward the LLM's fresh estimate over hours (a speed/under-reaction edge),
+rather than the LLM out-forecasting the resolution (which the bot's llm/news
+paper record shows it does NOT). This measures the thesis with ZERO orders and
+zero new LLM calls: it reuses the `signals` table (claude_prob = estimate,
+market_prob = p0 at signal time) and just snapshots the market mid over a window,
+recording how far price moved TOWARD the estimate vs fees.
+
+Pure measurement. If post-signal drift-toward-estimate clears fees over 1-2
+weeks, the intraday strategy is justified; if not, we built ~no code instead of
+a trading loop + backtester.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def drift_toward(estimate: float, p0: float, mid: float) -> float:
+    """Signed price move TOWARD the estimate since the signal.
+
+    Positive = the market moved toward the LLM estimate (under-reaction edge);
+    negative = it moved away. Magnitude is in price units (dollars on 0-1).
+    """
+    direction = 1.0 if estimate >= p0 else -1.0
+    return (mid - p0) * direction
+
+
+def summarize(obs_rows: list[dict], horizons=(60, 120, 240), fee: float = 0.02) -> dict:
+    """Aggregate drift-toward-estimate by horizon bucket.
+
+    obs_rows: dicts with estimate, p0, minutes, mid (one per observation, many
+    per (market_id, signal_at)). For each horizon H, take each signal's
+    observation closest to H minutes and average drift_toward across signals;
+    report the share that beats `fee` (the bar the strategy must clear).
+    """
+    by_signal: dict[tuple, list[dict]] = {}
+    for r in obs_rows:
+        if r["minutes"] <= 0:
+            continue  # skip the t0 registration row
+        by_signal.setdefault((r["market_id"], r["signal_at"]), []).append(r)
+
+    out: dict = {"signals": len(by_signal), "horizons": {}}
+    for h in horizons:
+        drifts = []
+        for obs in by_signal.values():
+            closest = min(obs, key=lambda r: abs(r["minutes"] - h))
+            if abs(closest["minutes"] - h) > h:   # no obs near this horizon
+                continue
+            drifts.append(drift_toward(closest["estimate"], closest["p0"], closest["mid"]))
+        if not drifts:
+            out["horizons"][h] = None
+            continue
+        mean = sum(drifts) / len(drifts)
+        out["horizons"][h] = {
+            "n": len(drifts),
+            "mean_drift": round(mean, 4),
+            "share_beating_fee": round(sum(1 for d in drifts if d > fee) / len(drifts), 3),
+            "mean_beats_fee": mean > fee,
+        }
+    return out
+
+
+class IntradayDriftTracker:
+    def __init__(self, db, settings, discovery) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+
+    async def _ensure_table(self) -> None:
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS intraday_drift_obs (
+                   id INTEGER PRIMARY KEY,
+                   market_id TEXT NOT NULL, signal_at TEXT NOT NULL,
+                   strategy TEXT, estimate REAL NOT NULL, p0 REAL NOT NULL,
+                   obs_at TEXT NOT NULL, minutes REAL NOT NULL, mid REAL NOT NULL,
+                   UNIQUE(market_id, signal_at, obs_at))""")
+        await self._db.commit()
+
+    async def run_once(self) -> int:
+        cfg = self._settings.intraday_drift
+        if not cfg.enabled:
+            return 0
+        await self._ensure_table()
+        strat_filter = ",".join("'%s'" % s for s in cfg.strategies)
+
+        # 1. Register fresh signals (t0 row, mid = p0 at signal time).
+        new_rows = await self._db.fetchall(
+            f"""SELECT market_id, timestamp, strategy_source, claude_prob, market_prob
+                FROM signals
+                WHERE strategy_source IN ({strat_filter})
+                  AND timestamp >= datetime('now', '-{cfg.register_lookback_min} minutes')
+                  AND NOT EXISTS (SELECT 1 FROM intraday_drift_obs o
+                                  WHERE o.market_id = signals.market_id
+                                    AND o.signal_at = signals.timestamp)
+                LIMIT ?""", (cfg.max_tracks_per_cycle,))
+        registered = 0
+        for r in new_rows or []:
+            await self._db.execute(
+                """INSERT OR IGNORE INTO intraday_drift_obs
+                   (market_id, signal_at, strategy, estimate, p0, obs_at, minutes, mid)
+                   VALUES (?, ?, ?, ?, ?, ?, 0, ?)""",
+                (r["market_id"], r["timestamp"], r["strategy_source"],
+                 float(r["claude_prob"] or 0), float(r["market_prob"] or 0),
+                 r["timestamp"], float(r["market_prob"] or 0)))
+            registered += 1
+        await self._db.commit()
+
+        # 2. Observe still-active tracks (within the time-box) — snapshot mid.
+        active = await self._db.fetchall(
+            f"""SELECT DISTINCT market_id, signal_at, estimate, p0 FROM intraday_drift_obs
+                WHERE (julianday('now') - julianday(signal_at)) * 24.0 < {cfg.time_box_hours}
+                LIMIT ?""", (cfg.max_tracks_per_cycle,))
+        observed = 0
+        for t in active or []:
+            try:
+                m = await self._discovery.get_market(t["market_id"])
+            except Exception:
+                m = None
+            if m is None or not (0.0 < m.outcome_yes_price < 1.0):
+                continue
+            minutes = await self._db.fetchone(
+                "SELECT (julianday('now') - julianday(?)) * 1440.0 AS m", (t["signal_at"],))
+            await self._db.execute(
+                """INSERT OR IGNORE INTO intraday_drift_obs
+                   (market_id, signal_at, strategy, estimate, p0, obs_at, minutes, mid)
+                   VALUES (?, ?, '', ?, ?, datetime('now'), ?, ?)""",
+                (t["market_id"], t["signal_at"], float(t["estimate"]), float(t["p0"]),
+                 float(minutes["m"]), m.outcome_yes_price))
+            observed += 1
+        await self._db.commit()
+
+        if registered or observed:
+            log.info("intraday_drift.cycle", registered=registered, observed=observed)
+        # Periodic readout so the edge (or its absence) is visible in the log.
+        rows = await self._db.fetchall(
+            "SELECT market_id, signal_at, estimate, p0, minutes, mid FROM intraday_drift_obs")
+        rep = summarize([dict(r) for r in rows or []], fee=cfg.fee_threshold)
+        if rep["signals"] >= cfg.report_min_signals:
+            log.info("intraday_drift.report", **{"signals": rep["signals"],
+                     **{f"h{h}": v for h, v in rep["horizons"].items()}})
+        return registered + observed

--- a/config/settings.py
+++ b/config/settings.py
@@ -352,6 +352,22 @@ class EconIndicatorConfig(BaseModel):
     interval_seconds: int = 1800
 
 
+class IntradayDriftConfig(BaseModel):
+    """Intraday-drift measurement spike (monitoring/intraday_drift.py). NO
+    trading — reuses the signals table + snapshots mids to test whether price
+    drifts toward the LLM estimate intraday (the under-reaction thesis) before
+    any intraday strategy is built. Cheap; disabled by default."""
+
+    enabled: bool = False
+    strategies: list[str] = Field(default_factory=lambda: ["news_speed", "llm"])
+    interval_seconds: int = 300
+    register_lookback_min: int = 15
+    time_box_hours: float = 8.0
+    max_tracks_per_cycle: int = 60
+    fee_threshold: float = 0.02
+    report_min_signals: int = 20
+
+
 class HydroWatchConfig(BaseModel):
     """Hydrology-market watcher (monitoring/hydro_market_watch.py). Alert-only:
     no liquid water markets exist today, so this just flags the first time one
@@ -867,6 +883,7 @@ class Settings(BaseSettings):
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))
+    intraday_drift: IntradayDriftConfig = Field(default_factory=lambda: IntradayDriftConfig(**_DEFAULTS.get("intraday_drift", {})))
     resolution_lens: ResolutionLensConfig = Field(default_factory=lambda: ResolutionLensConfig(**_DEFAULTS.get("resolution_lens", {})))
     oddlot_tender: OddLotTenderConfig = Field(default_factory=lambda: OddLotTenderConfig(**_DEFAULTS.get("oddlot_tender", {})))
     arbitrage: ArbitrageConfig = Field(default_factory=lambda: ArbitrageConfig(**_DEFAULTS.get("arbitrage", {})))

--- a/tests/test_intraday_drift.py
+++ b/tests/test_intraday_drift.py
@@ -1,0 +1,73 @@
+"""Intraday-drift spike: drift math + register/observe (no trading)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.db.database import Database
+from auramaur.monitoring.intraday_drift import (
+    IntradayDriftTracker,
+    drift_toward,
+    summarize,
+)
+from config.settings import Settings
+
+
+def test_drift_toward_direction():
+    # estimate above p0: price rising toward it = positive drift
+    assert abs(drift_toward(0.70, 0.50, 0.60) - 0.10) < 1e-9
+    assert drift_toward(0.70, 0.50, 0.45) < 0          # moved away (down)
+    # estimate below p0: price falling toward it = positive drift
+    assert abs(drift_toward(0.30, 0.50, 0.40) - 0.10) < 1e-9
+    assert drift_toward(0.30, 0.50, 0.55) < 0          # moved away (up)
+
+
+def test_summarize_buckets_and_fee():
+    rows = [
+        # signal A: estimate 0.7, p0 0.5; at ~60min mid 0.62 -> drift +0.12 (>fee)
+        {"market_id": "A", "signal_at": "t", "estimate": 0.7, "p0": 0.5, "minutes": 0, "mid": 0.5},
+        {"market_id": "A", "signal_at": "t", "estimate": 0.7, "p0": 0.5, "minutes": 62, "mid": 0.62},
+        # signal B: estimate 0.3, p0 0.5; at ~60min mid 0.55 -> drift -0.05 (away)
+        {"market_id": "B", "signal_at": "t", "estimate": 0.3, "p0": 0.5, "minutes": 58, "mid": 0.55},
+    ]
+    rep = summarize(rows, horizons=(60,), fee=0.02)
+    assert rep["signals"] == 2
+    h = rep["horizons"][60]
+    assert h["n"] == 2
+    assert abs(h["mean_drift"] - ((0.12 + -0.05) / 2)) < 1e-9
+    assert h["share_beating_fee"] == 0.5   # only A beats fee
+
+
+def _settings():
+    s = Settings()
+    s.intraday_drift.enabled = True
+    s.intraday_drift.report_min_signals = 1
+    return s
+
+
+def test_tracker_registers_and_observes():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            # seed a signal ~5 min ago (within the 15-min register window, but a
+            # distinct obs_at so the registration row and the live obs don't collide)
+            await db.execute(
+                """INSERT INTO signals (market_id, timestamp, claude_prob, claude_confidence,
+                   market_prob, edge, evidence_summary, action, strategy_source)
+                   VALUES ('m1', datetime('now','-5 minutes'), 0.70, 'MEDIUM', 0.50, 20, 'x', 'BUY', 'news_speed')""")
+            await db.commit()
+            disc = MagicMock()
+            disc.get_market = AsyncMock(return_value=SimpleNamespace(outcome_yes_price=0.60))
+            tracker = IntradayDriftTracker(db, _settings(), disc)
+            await tracker.run_once()
+            # one t0 registration (mid=p0) + one live observation (mid=0.60)
+            rows = await db.fetchall("SELECT minutes, mid FROM intraday_drift_obs WHERE market_id='m1' ORDER BY minutes")
+            assert len(rows) == 2
+            assert rows[0]["minutes"] == 0 and abs(rows[0]["mid"] - 0.50) < 1e-9
+            assert rows[1]["minutes"] > 4               # ~5 min later
+            assert abs(rows[1]["mid"] - 0.60) < 1e-9      # drift toward 0.70 captured
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Why
The proposed LLM-intraday-convergence strategy rests on *"more shots/day, same reasoning edge."* But the bot's paper record shows the LLM-on-news entry signal has **no** forecasting edge (`llm` −$106 / 49ev / 33%; `news_speed` −$8). A faster exit on a no-edge entry just churns + pays more fees. The **only** viable version is an intraday **under-reaction** (speed) edge — and that's unproven and unmeasurable from the daily `price_history`.

So, gate-first: **measure the edge before building the loop + backtester.**

## What (zero orders, zero new LLM calls)
Reuses the `signals` table (`claude_prob` = estimate, `market_prob` = p0 at signal time): registers fresh `news_speed`/`llm` signals, snapshots the market mid over a time-box, and records **drift-toward-estimate** vs fees. Logs a periodic report (mean drift + share beating fee, by 60/120/240-min horizon).

If post-signal drift clears fees over 1–2 weeks → the intraday strategy is justified (and graduates like everything else). If not → we spent ~150 LOC, not a 200-LOC loop + a walk-forward backtester.

## Test
`drift_toward` direction (toward/away for estimate above/below p0); `summarize` horizon-bucketing + fee share; tracker registers a t0 row and captures a live observation. Full suite: 800 passed.

Assisted-by: Claude (Anthropic)