### PR TITLE
[codex] Fix multi-venue arb routing

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2965,6 +2965,8 @@ class AuramaurBot:
             pnl_tracker=self._components["pnl_tracker"],
             calibration=self._components["calibration"],
             analyzer=self._components.get("analyzer"),
+            # Phase 3: evidence-grounded comprehension taps the shared aggregator.
+            aggregator=self._components.get("aggregator"),
         )
         interval = max(60, self.settings.resolution_lens.interval_seconds)
         while self._running:

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2839,13 +2839,14 @@ class AuramaurBot:
             db=self._components["db"],
             settings=self.settings,
             discovery=self._components["discovery"],
-            exchange=self._components["exchange"],
+            exchange=(self._components.get("exchanges") or {}).get("polymarket"),
             risk_manager=self._components["risk_manager"],
             pnl_tracker=self._components["pnl_tracker"],
             analyzer=self._components.get("analyzer"),
             # Kalshi econ-bin ladder arb fetches its own series; pass the Kalshi
             # discovery if present (no-op when Kalshi isn't configured).
             kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
+            exchanges=self._components.get("exchanges") or {},
         )
         interval = max(60, self.settings.entailment_arb.interval_seconds)
         while self._running:
@@ -2865,12 +2866,13 @@ class AuramaurBot:
         pillar = CrossVenueArbPillar(
             db=self._components["db"],
             settings=self.settings,
-            discovery=self._components["discovery"],
-            exchange=self._components["exchange"],
+            discovery=(self._components.get("discoveries") or {}).get("polymarket"),
+            exchange=(self._components.get("exchanges") or {}).get("polymarket"),
             risk_manager=self._components["risk_manager"],
             pnl_tracker=self._components["pnl_tracker"],
             analyzer=self._components.get("analyzer"),
             kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
+            exchanges=self._components.get("exchanges") or {},
         )
         interval = max(60, self.settings.cross_venue_arb.interval_seconds)
         while self._running:

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2857,6 +2857,31 @@ class AuramaurBot:
                 log.error("entailment.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_cross_venue_arb(self) -> None:
+        """Periodic cross-venue (Poly×Kalshi) semantic-equivalence arb scan.
+        Paper-forced by config; no-op unless Kalshi discovery is wired."""
+        from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
+
+        pillar = CrossVenueArbPillar(
+            db=self._components["db"],
+            settings=self.settings,
+            discovery=self._components["discovery"],
+            exchange=self._components["exchange"],
+            risk_manager=self._components["risk_manager"],
+            pnl_tracker=self._components["pnl_tracker"],
+            analyzer=self._components.get("analyzer"),
+            kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
+        )
+        interval = max(60, self.settings.cross_venue_arb.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("cross_venue.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_econ_indicator(self) -> None:
         """Periodic data-driven Kalshi econ-indicator bin pricing (paper-forced)."""
         from auramaur.data_sources.fred import FREDSource
@@ -3629,6 +3654,8 @@ class AuramaurBot:
         # Entailment arbitrage (paper-forced until proven)
         if self.settings.entailment_arb.enabled:
             tasks.append(asyncio.create_task(self._task_entailment_arb(), name="entailment_arb"))
+        if self.settings.cross_venue_arb.enabled:
+            tasks.append(asyncio.create_task(self._task_cross_venue_arb(), name="cross_venue_arb"))
 
         # Data-driven Kalshi econ-indicator pricing (paper-forced until proven)
         if self.settings.econ_indicator.enabled:

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.exchange.models import (
     Confidence,
     Fill,
@@ -124,14 +124,14 @@ class BiasHarvestPillar:
             return False
         # Classify before the block: discovery often hands us an empty/mislabeled
         # category, which slips through a raw `category in blocked` test and only
-        # gets corrected after entry — that bypass let sports/politics_us markets
-        # (both already blocked) into the paper book. Resolve the category the
-        # same way persistence does, then reject it against the global block AND
-        # the bias-harvest no-edge list (weather/sports/politics_us).
-        cat = ensure_category(market.question, market.description, market.category)
+        # gets corrected after entry. blocked_category_hit checks the stored label
+        # OR a fresh classification (mislabel-safe, like the gateway), against the
+        # global block AND the bias-harvest no-edge list (weather/sports/politics_us).
         excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
-        if cat in excluded:
-            log.debug("bias_harvest.skip_category", market_id=market.id, category=cat)
+        hit = blocked_category_hit(excluded, market.question, market.description,
+                                   market.category)
+        if hit:
+            log.debug("bias_harvest.skip_category", market_id=market.id, category=hit)
             return False
         if market.end_date is None:
             return False

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -122,7 +122,16 @@ class BiasHarvestPillar:
             return False
         if market.liquidity < cfg.min_liquidity:
             return False
-        if (market.category or "") in set(self._settings.risk.blocked_categories):
+        # Classify before the block: discovery often hands us an empty/mislabeled
+        # category, which slips through a raw `category in blocked` test and only
+        # gets corrected after entry — that bypass let sports/politics_us markets
+        # (both already blocked) into the paper book. Resolve the category the
+        # same way persistence does, then reject it against the global block AND
+        # the bias-harvest no-edge list (weather/sports/politics_us).
+        cat = ensure_category(market.question, market.description, market.category)
+        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        if cat in excluded:
+            log.debug("bias_harvest.skip_category", market_id=market.id, category=cat)
             return False
         if market.end_date is None:
             return False

--- a/auramaur/strategy/classifier.py
+++ b/auramaur/strategy/classifier.py
@@ -125,6 +125,13 @@ POLITICS_INTL_KEYWORDS: list[str] = [
     "netherlands", "dutch", "denmark", "danish", "greenland",
     "norway", "norwegian", "sweden", "swedish", "hungary", "hungarian",
     "austria", "austrian", "kenya", "kenyan", "congo",
+    # Sub-national/Commonwealth markers seen mislabeled politics_us: governance
+    # terms ("vote"/"election") with no country marker default to US, so foreign
+    # separatist/by-election markets ("Alberta vote for independence", "Andy
+    # Burnham ... by-election") landed in politics_us. "by-election" is a
+    # distinctly Commonwealth/parliamentary term (the US says "special election").
+    "by-election", "alberta", "quebec", "ontario",
+    "scotland", "scottish", "wales", "welsh", "catalonia", "catalan",
 ]
 # "primary" is intentionally absent: description boilerplate ("primary
 # listing", "primary market") filed SpaceX-IPO and tennis markets as
@@ -331,3 +338,29 @@ def ensure_category(question: str, description: str = "",
     routes through this instead of writing ``market.category`` raw.
     """
     return category or classify_market(question or "", description or "")
+
+
+def blocked_category_hit(
+    blocked, question: str, description: str = "",
+    stored_category: str | None = "",
+) -> str | None:
+    """Return the offending category if this market is blocked, else None.
+
+    Mirrors the single gateway (risk.checks.check_blocked_category): a market is
+    blocked when its STORED label OR a fresh ``classify_market`` is in
+    ``blocked``. ``ensure_category`` only fills an EMPTY label, so it closes the
+    empty-label bypass but not the stale/mislabeled case (a market stored 'other'
+    that is really sports); this checks both. Use it for strategy-level
+    efficiency pre-filters so they agree with the gateway instead of trusting the
+    raw stored label.
+    """
+    blocked_set = set(blocked or [])
+    if not blocked_set:
+        return None
+    stored = stored_category or ""
+    if stored in blocked_set:
+        return stored
+    fresh = classify_market(question or "", description or "")
+    if fresh in blocked_set:
+        return fresh
+    return None

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -1,0 +1,305 @@
+"""Cross-venue semantic-equivalence arbitrage — Polymarket × Kalshi.
+
+The arb scanner already pairs IDENTICAL questions across venues. This pillar
+targets the harder, untapped case: markets that are *logically equivalent but
+worded differently* across Poly and Kalshi (e.g. "Fed cuts rates in July?" vs
+"Fed funds target below X after the July meeting?"). When two such markets price
+the same real claim differently, the gap is a structural arb — no forecast.
+
+The KILLER risk is resolution-criteria mismatch: two markets that look equivalent
+but resolve on different sources / dates / edge-cases turn a "free" arb into a
+paired loss. So equivalence is verified ADVERSARIALLY (default: not equivalent)
+with the same skeptical machinery the resolution lens uses, and only a
+high-confidence verdict trades. PAPER-FORCED and NOT graduation-exempt (unlike
+same-question arb, a mismatch here is a real directional loss): the cell must
+earn live like any other.
+
+Orientation:
+  * "same"     — A_YES resolves iff B_YES. Arb when the YES prices differ: buy
+                 YES on the cheaper-YES venue + NO on the dearer; payout is always
+                 $1, cost 1-|pA-pB|, profit |pA-pB|.
+  * "inverted" — A_YES resolves iff B_NO. A and B are complementary, so fair
+                 pA+pB == 1; arb when pA+pB < 1 (buy both YES) — profit 1-pA-pB.
+
+Rides the standard rails as strategy_source='cross_venue_arb'.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.strategy.arbitrage_scanner import _word_overlap_score
+
+log = structlog.get_logger()
+
+
+EQUIVALENCE_PROMPT = """You are auditing whether two prediction markets on DIFFERENT venues resolve the SAME underlying claim. Be adversarial: the default answer is "none". A false match turns a "risk-free" arbitrage into a paired loss, so only assert equivalence you are sure of.
+
+Polymarket market: "{question_a}"
+Polymarket resolution details: {description_a}
+
+Kalshi market: "{question_b}"
+Kalshi resolution details: {description_b}
+
+Two markets are EQUIVALENT only if, in EVERY possible world, they resolve to a determined relationship under their OWN written criteria — accounting for thresholds, timing/settlement windows, qualifying language, the exact resolution source, and edge cases. Decide the orientation:
+- "same": Polymarket-YES resolves YES if and only if Kalshi-YES resolves YES.
+- "inverted": Polymarket-YES resolves YES if and only if Kalshi-YES resolves NO (they are complementary).
+If you can construct ANY plausible scenario where the claimed relationship breaks (different dates, sources, thresholds, rounding, "official" vs actual, partial events), answer "none".
+
+Respond with ONLY this JSON:
+{{"orientation": "same" | "inverted" | "none", "confidence": 0.0-1.0, "counterexample": "<the scenario that best breaks equivalence, or 'none found'>"}}"""
+
+
+class CrossVenueArbPillar:
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, analyzer=None, kalshi_discovery=None) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery            # Polymarket discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._analyzer = analyzer
+        self._kalshi_discovery = kalshi_discovery
+
+    # -- schema ----------------------------------------------------------
+
+    async def _ensure_schema(self) -> None:
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS cross_venue_verdicts (
+                   poly_id TEXT NOT NULL,
+                   kalshi_id TEXT NOT NULL,
+                   orientation TEXT NOT NULL,
+                   confidence REAL NOT NULL DEFAULT 0,
+                   reasoning TEXT NOT NULL DEFAULT '',
+                   traded_at TEXT,
+                   checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+                   PRIMARY KEY (poly_id, kalshi_id))""")
+        await self._db.commit()
+
+    # -- market quality --------------------------------------------------
+
+    def _real_book(self, m: Market) -> bool:
+        """Reject dead/placeholder books before believing any price."""
+        cfg = self._settings.cross_venue_arb
+        if not m.active or not (0.0 < m.outcome_yes_price < 1.0):
+            return False
+        venue = m.exchange or "polymarket"
+        min_liq = cfg.kalshi_min_liquidity if venue == "kalshi" else cfg.min_liquidity
+        if m.liquidity < min_liq:
+            return False
+        if m.spread and m.spread * 100.0 > cfg.max_spread_pct:
+            return False
+        if m.end_date is None:
+            return False
+        end = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+        hours = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+        return hours >= cfg.min_hours_to_resolution
+
+    # -- candidate pairing -----------------------------------------------
+
+    async def _candidate_pairs(self) -> list[tuple[Market, Market]]:
+        """Poly × Kalshi pairs above a word-overlap floor (cheap pre-filter
+        before the LLM equivalence check). Both legs must be real books."""
+        cfg = self._settings.cross_venue_arb
+        if self._kalshi_discovery is None:
+            return []
+        try:
+            poly = await self._discovery.get_markets(limit=cfg.scan_limit)
+            kalshi = await self._kalshi_discovery.get_markets(limit=cfg.scan_limit)
+        except Exception as e:
+            log.debug("cross_venue.scan_error", error=str(e))
+            return []
+        poly = [m for m in poly if self._real_book(m)]
+        kalshi = [m for m in kalshi if self._real_book(m)]
+        pairs: list[tuple[Market, Market, float]] = []
+        for a in poly:
+            for b in kalshi:
+                score = _word_overlap_score(a.question, b.question)
+                if score >= cfg.min_word_overlap:
+                    pairs.append((a, b, score))
+        # Strongest lexical matches first; cap the LLM fan-out per cycle.
+        pairs.sort(key=lambda t: t[2], reverse=True)
+        return [(a, b) for a, b, _ in pairs[:cfg.max_llm_calls_per_cycle]]
+
+    async def _verify_equivalence(self, a: Market, b: Market):
+        """Cached adversarial equivalence verdict -> (orientation, confidence)."""
+        row = await self._db.fetchone(
+            "SELECT orientation, confidence FROM cross_venue_verdicts "
+            "WHERE poly_id = ? AND kalshi_id = ?", (a.id, b.id))
+        if row is not None:
+            return row["orientation"], float(row["confidence"])
+        if self._analyzer is None:
+            return "none", 0.0
+        orientation, confidence, reasoning = "none", 0.0, ""
+        try:
+            raw = await self._analyzer._call_llm(EQUIVALENCE_PROMPT.format(
+                question_a=a.question, description_a=(a.description or "")[:600],
+                question_b=b.question, description_b=(b.description or "")[:600]))
+            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            orientation = str(parsed.get("orientation", "none"))
+            confidence = float(parsed.get("confidence", 0.0))
+            reasoning = str(parsed.get("counterexample", ""))[:400]
+            if orientation not in ("same", "inverted"):
+                orientation = "none"
+        except Exception as e:
+            log.warning("cross_venue.llm_parse_error", a=a.id, b=b.id, error=str(e))
+        await self._db.execute(
+            """INSERT OR REPLACE INTO cross_venue_verdicts
+               (poly_id, kalshi_id, orientation, confidence, reasoning)
+               VALUES (?, ?, ?, ?, ?)""",
+            (a.id, b.id, orientation, confidence, reasoning))
+        await self._db.commit()
+        return orientation, confidence
+
+    # -- arb math --------------------------------------------------------
+
+    def _required_gap(self, a: Market, b: Market) -> float:
+        """Min edge to clear BOTH legs' taker fees + a buffer (Poly maker ~0,
+        Kalshi charges per leg) — a gap that doesn't clear fees is a loss."""
+        from auramaur.strategy.signals import taker_fee_rate
+        cfg = self._settings.cross_venue_arb
+        fees = self._settings.arbitrage.exchange_fees
+        pa, pb = a.outcome_yes_price, b.outcome_yes_price
+        fee_a = taker_fee_rate(a.exchange or "polymarket", a.category or "", fees) * pa * (1.0 - pa)
+        fee_b = taker_fee_rate(b.exchange or "kalshi", b.category or "", fees) * pb * (1.0 - pb)
+        return fee_a + fee_b + cfg.gap_buffer
+
+    def _arb(self, a: Market, b: Market, orientation: str):
+        """Return (edge, side_a, side_b) for an executable arb, else None.
+
+        'same': buy YES where YES is cheaper, NO where dearer (payout always $1).
+        'inverted': A,B complementary — if pA+pB<1 buy both YES; if >1 buy both NO.
+        """
+        pa, pb = a.outcome_yes_price, b.outcome_yes_price
+        if orientation == "same":
+            edge = abs(pa - pb)
+            if pa < pb:   # A_YES cheap -> buy A_YES, buy B_NO (sell dear B_YES)
+                return edge, OrderSide.BUY, OrderSide.SELL
+            return edge, OrderSide.SELL, OrderSide.BUY
+        if orientation == "inverted":
+            s = pa + pb
+            if s < 1.0:   # both underpriced -> buy both YES
+                return 1.0 - s, OrderSide.BUY, OrderSide.BUY
+            return s - 1.0, OrderSide.SELL, OrderSide.SELL  # both overpriced -> both NO
+        return None
+
+    # -- execution -------------------------------------------------------
+
+    def _leg_signal(self, m: Market, side: OrderSide, fair: float,
+                    edge: float, why: str) -> Signal:
+        return Signal(
+            market_id=m.id, market_question=m.question,
+            claude_prob=max(0.01, min(0.99, fair)),
+            claude_confidence=Confidence.HIGH,   # verified structural arb, not a forecast
+            market_prob=m.outcome_yes_price,
+            edge=edge * 100.0,
+            evidence_summary=f"Cross-venue arb ({why}).",
+            recommended_side=side,
+            strategy_source="cross_venue_arb",
+        )
+
+    async def _already_traded(self, a_id: str, b_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT traded_at FROM cross_venue_verdicts WHERE poly_id = ? AND kalshi_id = ?",
+            (a_id, b_id))
+        return bool(row and row["traded_at"])
+
+    async def _enter_pair(self, a: Market, b: Market, edge: float,
+                          side_a: OrderSide, side_b: OrderSide,
+                          orientation: str, conf: float) -> bool:
+        cfg = self._settings.cross_venue_arb
+        why = f"{orientation}; gap {edge:.3f}"
+        sig_a = self._leg_signal(a, side_a, fair=b.outcome_yes_price, edge=edge, why=why)
+        sig_b = self._leg_signal(b, side_b, fair=a.outcome_yes_price, edge=edge, why=why)
+
+        dec_a = await self._risk.evaluate(sig_a, a)
+        dec_b = await self._risk.evaluate(sig_b, b)
+        if not (dec_a.approved and dec_b.approved):
+            log.info("cross_venue.risk_rejected", a=a.id, b=b.id,
+                     reason_a=dec_a.reason, reason_b=dec_b.reason)
+            return False
+        size = min(dec_a.position_size, dec_b.position_size, cfg.stake_usd)
+        if size <= 0:
+            return False
+        force_paper = (getattr(dec_a, "force_paper", False)
+                       or getattr(dec_b, "force_paper", False))
+        is_live = self._settings.is_live and not cfg.paper and not force_paper
+
+        order_a = self._exchange.prepare_order(sig_a, a, size, is_live)
+        order_b = self._exchange.prepare_order(sig_b, b, size, is_live)
+        if order_a is None or order_b is None:
+            return False
+        result_a = await self._exchange.place_order(order_a)
+        if result_a.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("cross_venue.leg_a_rejected", a=a.id, status=result_a.status)
+            return False
+        result_b = await self._exchange.place_order(order_b)
+        if result_b.status not in ("filled", "paper", "partial", "pending"):
+            log.error("cross_venue.leg_b_failed_single_leg", a=a.id, b=b.id,
+                      status=result_b.status)
+        for market, order, result in ((a, order_a, result_a), (b, order_b, result_b)):
+            if result.status in ("filled", "paper", "partial", "pending"):
+                await self._record_leg(market, order, result, why)
+        await self._db.execute(
+            "UPDATE cross_venue_verdicts SET traded_at = datetime('now') "
+            "WHERE poly_id = ? AND kalshi_id = ?", (a.id, b.id))
+        await self._db.commit()
+        log.info("cross_venue.entered", a=a.id, b=b.id, orientation=orientation,
+                 edge=round(edge, 3), confidence=conf, paper=result_a.is_paper)
+        return True
+
+    async def _record_leg(self, market: Market, order, result, why: str) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        if result.status in ("filled", "paper", "partial") and fill_size > 0:
+            await self._pnl.record_fill(Fill(
+                order_id=result.order_id, market_id=order.market_id,
+                token_id=order.token_id, side=order.side, token=order.token,
+                size=fill_size, price=fill_price, is_paper=bool(result.is_paper)))
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'cross_venue_arb')""",
+            (market.id, market.outcome_yes_price, "HIGH", market.outcome_yes_price,
+             0.0, f"Cross-venue arb leg ({why})",
+             "BUY" if order.side == OrderSide.BUY else "SELL"))
+        await self._db.commit()
+
+    # -- main cycle ------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.cross_venue_arb
+        if not cfg.enabled:
+            return 0
+        await self._ensure_schema()
+        pairs = await self._candidate_pairs()
+        if not pairs:
+            return 0
+        entered = 0
+        for a, b in pairs:
+            if entered >= cfg.max_pairs_per_cycle:
+                break
+            if await self._already_traded(a.id, b.id):
+                continue
+            orientation, conf = await self._verify_equivalence(a, b)
+            if orientation == "none" or conf < cfg.llm_min_confidence:
+                continue
+            res = self._arb(a, b, orientation)
+            if res is None:
+                continue
+            edge, side_a, side_b = res
+            if edge < self._required_gap(a, b):
+                continue
+            try:
+                if await self._enter_pair(a, b, edge, side_a, side_b, orientation, conf):
+                    entered += 1
+            except Exception as e:
+                log.error("cross_venue.entry_error", a=a.id, b=b.id, error=str(e))
+        if entered:
+            log.info("cross_venue.cycle_done", entered=entered)
+        return entered

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -56,11 +56,15 @@ Respond with ONLY this JSON:
 
 class CrossVenueArbPillar:
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, analyzer=None, kalshi_discovery=None) -> None:
+                 pnl_tracker, analyzer=None, kalshi_discovery=None,
+                 exchanges=None) -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery            # Polymarket discovery
         self._exchange = exchange
+        self._exchanges = dict(exchanges or {})
+        if exchange is not None:
+            self._exchanges.setdefault("polymarket", exchange)
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._analyzer = analyzer
@@ -77,8 +81,19 @@ class CrossVenueArbPillar:
                    confidence REAL NOT NULL DEFAULT 0,
                    reasoning TEXT NOT NULL DEFAULT '',
                    traded_at TEXT,
+                   partial_at TEXT,
+                   last_error TEXT,
                    checked_at TEXT NOT NULL DEFAULT (datetime('now')),
                    PRIMARY KEY (poly_id, kalshi_id))""")
+        for ddl in (
+            "ALTER TABLE cross_venue_verdicts ADD COLUMN partial_at TEXT",
+            "ALTER TABLE cross_venue_verdicts ADD COLUMN last_error TEXT",
+        ):
+            try:
+                await self._db.execute(ddl)
+                await self._db.commit()
+            except Exception:
+                pass
         await self._db.commit()
 
     # -- market quality --------------------------------------------------
@@ -106,7 +121,7 @@ class CrossVenueArbPillar:
         """Poly × Kalshi pairs above a word-overlap floor (cheap pre-filter
         before the LLM equivalence check). Both legs must be real books."""
         cfg = self._settings.cross_venue_arb
-        if self._kalshi_discovery is None:
+        if self._discovery is None or self._kalshi_discovery is None:
             return []
         try:
             poly = await self._discovery.get_markets(limit=cfg.scan_limit)
@@ -205,14 +220,38 @@ class CrossVenueArbPillar:
 
     async def _already_traded(self, a_id: str, b_id: str) -> bool:
         row = await self._db.fetchone(
-            "SELECT traded_at FROM cross_venue_verdicts WHERE poly_id = ? AND kalshi_id = ?",
+            "SELECT traded_at, partial_at FROM cross_venue_verdicts "
+            "WHERE poly_id = ? AND kalshi_id = ?",
             (a_id, b_id))
-        return bool(row and row["traded_at"])
+        return bool(row and (row["traded_at"] or row["partial_at"]))
+
+    def _exchange_for(self, market: Market):
+        return self._exchanges.get(market.exchange or "polymarket")
+
+    async def _mark_partial(self, a_id: str, b_id: str, error: str) -> None:
+        await self._db.execute(
+            """UPDATE cross_venue_verdicts
+               SET partial_at = datetime('now'), last_error = ?
+               WHERE poly_id = ? AND kalshi_id = ?""",
+            (error[:400], a_id, b_id))
+        await self._db.commit()
 
     async def _enter_pair(self, a: Market, b: Market, edge: float,
                           side_a: OrderSide, side_b: OrderSide,
                           orientation: str, conf: float) -> bool:
         cfg = self._settings.cross_venue_arb
+        exchange_a = self._exchange_for(a)
+        exchange_b = self._exchange_for(b)
+        if exchange_a is None or exchange_b is None:
+            log.info(
+                "cross_venue.missing_exchange",
+                a=a.id,
+                b=b.id,
+                exchange_a=a.exchange,
+                exchange_b=b.exchange,
+            )
+            return False
+
         why = f"{orientation}; gap {edge:.3f}"
         sig_a = self._leg_signal(a, side_a, fair=b.outcome_yes_price, edge=edge, why=why)
         sig_b = self._leg_signal(b, side_b, fair=a.outcome_yes_price, edge=edge, why=why)
@@ -230,21 +269,33 @@ class CrossVenueArbPillar:
                        or getattr(dec_b, "force_paper", False))
         is_live = self._settings.is_live and not cfg.paper and not force_paper
 
-        order_a = self._exchange.prepare_order(sig_a, a, size, is_live)
-        order_b = self._exchange.prepare_order(sig_b, b, size, is_live)
+        order_a = exchange_a.prepare_order(sig_a, a, size, is_live)
+        order_b = exchange_b.prepare_order(sig_b, b, size, is_live)
         if order_a is None or order_b is None:
             return False
-        result_a = await self._exchange.place_order(order_a)
-        if result_a.status not in ("filled", "paper", "partial", "pending"):
+        ok_statuses = ("filled", "paper", "partial", "pending")
+        result_a = await exchange_a.place_order(order_a)
+        if result_a.status not in ok_statuses:
             log.warning("cross_venue.leg_a_rejected", a=a.id, status=result_a.status)
             return False
-        result_b = await self._exchange.place_order(order_b)
-        if result_b.status not in ("filled", "paper", "partial", "pending"):
+
+        result_b = await exchange_b.place_order(order_b)
+        if result_b.status not in ok_statuses:
             log.error("cross_venue.leg_b_failed_single_leg", a=a.id, b=b.id,
                       status=result_b.status)
+            await self._record_leg(a, order_a, result_a, why)
+            if result_a.status == "pending" and not result_a.is_paper:
+                try:
+                    await exchange_a.cancel_order(result_a.order_id)
+                except Exception as e:
+                    log.warning("cross_venue.leg_a_cancel_failed",
+                                a=a.id, order_id=result_a.order_id, error=str(e))
+            await self._mark_partial(
+                a.id, b.id, result_b.error_message or f"leg_b_{result_b.status}")
+            return False
+
         for market, order, result in ((a, order_a, result_a), (b, order_b, result_b)):
-            if result.status in ("filled", "paper", "partial", "pending"):
-                await self._record_leg(market, order, result, why)
+            await self._record_leg(market, order, result, why)
         await self._db.execute(
             "UPDATE cross_venue_verdicts SET traded_at = datetime('now') "
             "WHERE poly_id = ? AND kalshi_id = ?", (a.id, b.id))

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -30,7 +30,7 @@ from auramaur.nlp.calibration import CalibrationTracker
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
 from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
 from auramaur.risk.manager import RiskManager
-from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.strategy.order_flow import OrderFlowTracker
 from auramaur.strategy.protocols import MarketAnalyzer, TradeCandidate
 from auramaur.strategy.signals import detect_edge, taker_fee_rate
@@ -976,7 +976,10 @@ class TradingEngine:
                         if self.settings.is_live else None)
 
         for m in candidates:
-            if m.category in blocked:
+            # Classify-before-block like the gateway: a market stored 'other'
+            # that is really sports slips past a raw `category in blocked` test,
+            # so check the stored label OR a fresh classification (mislabel-safe).
+            if blocked_category_hit(blocked, m.question, m.description, m.category):
                 filtered_count += 1
                 continue
             if allowed_live is not None and m.category not in allowed_live:

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -222,11 +222,15 @@ Respond with ONLY this JSON:
 
 class EntailmentArbPillar:
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, analyzer=None, kalshi_discovery=None) -> None:
+                 pnl_tracker, analyzer=None, kalshi_discovery=None,
+                 exchanges=None) -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
         self._exchange = exchange
+        self._exchanges = dict(exchanges or {})
+        if exchange is not None:
+            self._exchanges.setdefault("polymarket", exchange)
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._analyzer = analyzer
@@ -383,6 +387,9 @@ class EntailmentArbPillar:
         )
         return row is not None
 
+    def _exchange_for(self, market: Market):
+        return self._exchanges.get(market.exchange or "polymarket")
+
     # -- main cycle -------------------------------------------------------
 
     async def run_once(self) -> int:
@@ -462,6 +469,18 @@ class EntailmentArbPillar:
     async def _enter_pair(self, implier: Market, implied: Market,
                           gap: float, why: str, conf: float) -> bool:
         cfg = self._settings.entailment_arb
+        exchange_a = self._exchange_for(implier)
+        exchange_b = self._exchange_for(implied)
+        if exchange_a is None or exchange_b is None:
+            log.info(
+                "entailment.missing_exchange",
+                a=implier.id,
+                b=implied.id,
+                exchange_a=implier.exchange,
+                exchange_b=implied.exchange,
+            )
+            return False
+
         # Leg 1: NO on the implier (its YES is overpriced vs the bound).
         sig_a = self._leg_signal(implier, OrderSide.SELL,
                                  fair=implied.outcome_yes_price, gap=gap, why=why)
@@ -484,28 +503,37 @@ class EntailmentArbPillar:
                        or getattr(dec_b, "force_paper", False))
         is_live = self._settings.is_live and not cfg.paper and not force_paper
 
-        order_a = self._exchange.prepare_order(sig_a, implier, size, is_live)
-        order_b = self._exchange.prepare_order(sig_b, implied, size, is_live)
+        order_a = exchange_a.prepare_order(sig_a, implier, size, is_live)
+        order_b = exchange_b.prepare_order(sig_b, implied, size, is_live)
         if order_a is None or order_b is None:
             return False
 
-        result_a = await self._exchange.place_order(order_a)
-        if result_a.status not in ("filled", "paper", "partial", "pending"):
+        ok_statuses = ("filled", "paper", "partial", "pending")
+        result_a = await exchange_a.place_order(order_a)
+        if result_a.status not in ok_statuses:
             log.warning("entailment.leg_a_rejected", a=implier.id,
                         status=result_a.status)
             return False
-        result_b = await self._exchange.place_order(order_b)
-        if result_b.status not in ("filled", "paper", "partial", "pending"):
+        result_b = await exchange_b.place_order(order_b)
+        if result_b.status not in ok_statuses:
             # Leg risk: A is in, B failed. Flag loudly — the position is
             # directional until B fills or A is exited.
             log.error("entailment.leg_b_failed_single_leg", a=implier.id,
                       b=implied.id, status=result_b.status,
                       error=result_b.error_message)
+            await self._record_leg(implier, order_a, result_a, why, gap)
+            if result_a.status == "pending" and not result_a.is_paper:
+                try:
+                    await exchange_a.cancel_order(result_a.order_id)
+                except Exception as e:
+                    log.warning("entailment.leg_a_cancel_failed",
+                                a=implier.id, order_id=result_a.order_id,
+                                error=str(e))
+            return False
 
         for market, order, result in ((implier, order_a, result_a),
                                       (implied, order_b, result_b)):
-            if result.status in ("filled", "paper", "partial", "pending"):
-                await self._record_leg(market, order, result, why, gap)
+            await self._record_leg(market, order, result, why, gap)
 
         await self._db.execute(
             "UPDATE entailment_verdicts SET traded_at = datetime('now') "
@@ -523,6 +551,7 @@ class EntailmentArbPillar:
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
+        exchange_name = market.exchange or order.exchange or "polymarket"
         if result.status in ("filled", "paper", "partial") and fill_size > 0:
             await self._pnl.record_fill(Fill(
                 order_id=result.order_id, market_id=order.market_id,
@@ -533,8 +562,8 @@ class EntailmentArbPillar:
             """INSERT OR IGNORE INTO markets (id, exchange, question, category,
                active, outcome_yes_price, outcome_no_price, volume, liquidity,
                last_updated)
-               VALUES (?, 'polymarket', ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
-            (market.id, market.question,
+               VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, exchange_name, market.question,
              ensure_category(market.question, market.description, market.category),
              market.outcome_yes_price, market.outcome_no_price,
              market.volume, market.liquidity),
@@ -551,21 +580,23 @@ class EntailmentArbPillar:
             """INSERT INTO trades (market_id, timestamp, side, size, price,
                is_paper, order_id, status, strategy_source, exchange)
                VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'entailment_arb',
-                       'polymarket')""",
+                       ?)""",
             (order.market_id, order.side.value, fill_size, fill_price,
              1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status),
+             "filled" if result.status in ("filled", "paper") else result.status,
+             exchange_name),
         )
         await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id,
                is_paper, updated_at)
-               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               VALUES (?, ?, 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   exchange = excluded.exchange,
                    size = excluded.size, avg_price = excluded.avg_price,
                    current_price = excluded.current_price,
                    updated_at = excluded.updated_at""",
-            (order.market_id, fill_size, fill_price, fill_price,
+            (order.market_id, exchange_name, fill_size, fill_price, fill_price,
              market.category or "", order.token.value, order.token_id,
              1 if is_paper else 0),
         )

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -94,9 +94,34 @@ Respond with ONLY this JSON:
 {{"verdict": "confirmed" | "refuted", "confidence": <float 0-1>, "why": "<one sentence citing the criteria>"}}"""
 
 
+# Phase 3: evidence-grounded comprehension — the synergy stage. The model reads
+# CURRENT evidence AGAINST the strict criteria. This is deliberately NOT a
+# forecast ("will the event happen?", where the crowd beats the LLM); it is a
+# reading task ("do the literal criteria resolve YES given THIS evidence by the
+# deadline?", where reading-a-rule-against-facts is the LLM's edge). Catches the
+# case where a fine-print mechanism is real but current reality has already moved
+# the true probability — so the lens doesn't trade a stale mechanic against a
+# market that is correctly priced for the present.
+GROUND_PROMPT = """You are grounding a prediction market's STRICT resolution reading in CURRENT EVIDENCE. Do NOT forecast whether the headline event will happen — assess whether the LITERAL written criteria resolve YES given the evidence and the deadline.
+
+Question: "{question}"
+Resolution criteria: {description}
+Deadline / resolution window: {deadline}
+Identified fine-print mechanism: "{mechanism}"
+Strict-criteria fair P(YES) before evidence: {fair:.2f}
+
+Current evidence (most recent / relevant first):
+{evidence}
+
+Read the evidence against the CRITERIA, not the headline. Where does current reality stand relative to the specific written bar (officiality, permanence, exact source, deadline, compound conditions)? Has the bar already been met, is it clearly on track, or is it unmet/blocked? If the evidence shows the strict bar is unlikely to be met as written, P(YES) should be LOW even if the headline event seems likely — and vice versa.
+
+Respond with ONLY this JSON:
+{{"grounded_prob": <float 0-1, P(YES) under the strict criteria given the evidence>, "confidence": <float 0-1, how much the evidence actually informs this>, "why": "<one sentence on what the evidence shows about the strict bar>"}}"""
+
+
 class ResolutionLensPillar:
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, calibration, analyzer) -> None:
+                 pnl_tracker, calibration, analyzer, aggregator=None) -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
@@ -105,6 +130,10 @@ class ResolutionLensPillar:
         self._pnl = pnl_tracker
         self._calibration = calibration
         self._analyzer = analyzer
+        # Phase 3: the evidence aggregator (same one the ensemble uses). Optional
+        # so the pillar still constructs without it (grounding then no-ops and the
+        # lens falls back to the criteria-strict fair).
+        self._aggregator = aggregator
 
     # -- candidate filtering ---------------------------------------------
 
@@ -152,13 +181,19 @@ class ResolutionLensPillar:
         return desc[:head] + "\n…[criteria trimmed]…\n" + desc[-(cap - head):]
 
     async def _ensure_schema(self) -> None:
-        """Idempotent: add the `verified` column on pre-existing DBs."""
-        try:
-            await self._db.execute(
-                "ALTER TABLE lens_verdicts ADD COLUMN verified INTEGER NOT NULL DEFAULT -1")
-            await self._db.commit()
-        except Exception:
-            pass  # already exists
+        """Idempotent: add columns on pre-existing DBs (verified for Phase 2;
+        grounded_fair/grounded_at for Phase 3 — the latter is TTL'd, not a
+        permanent cache, since evidence is fresh while criteria are static)."""
+        for ddl in (
+            "ALTER TABLE lens_verdicts ADD COLUMN verified INTEGER NOT NULL DEFAULT -1",
+            "ALTER TABLE lens_verdicts ADD COLUMN grounded_fair REAL",
+            "ALTER TABLE lens_verdicts ADD COLUMN grounded_at TEXT",
+        ):
+            try:
+                await self._db.execute(ddl)
+                await self._db.commit()
+            except Exception:
+                pass  # column already exists
 
     async def _verdict(self, m: Market):
         """Cached lens verdict -> (fair, gap_score, mechanism, verified). The
@@ -218,6 +253,84 @@ class ResolutionLensPillar:
             (1 if confirmed else 0, m.id))
         await self._db.commit()
         return confirmed
+
+    async def _gather_evidence(self, m: Market) -> list:
+        """Fetch + rank current evidence for one market via the shared aggregator
+        (the same pipeline the ensemble uses). Returns [] on any failure so
+        grounding degrades gracefully to the criteria-strict fair."""
+        if self._aggregator is None:
+            return []
+        cfg = self._settings.resolution_lens
+        try:
+            from auramaur.nlp.query_decomposer import extract_search_queries
+            from auramaur.nlp.evidence_ranker import rank_evidence
+            queries = extract_search_queries(
+                m.question, m.description or "", m.category or "")
+            seen: set[str] = set()
+            items: list = []
+            per_q = max(1, self._settings.nlp.evidence_per_source)
+            for q in (queries or [m.question])[:3]:
+                for it in await self._aggregator.gather(
+                        q, limit_per_source=per_q, category=m.category or None):
+                    if it.id not in seen:
+                        seen.add(it.id)
+                        items.append(it)
+            nlp = self._settings.nlp
+            ranked = rank_evidence(
+                m.question, items, top_n=cfg.phase3_max_evidence,
+                backend=nlp.relevance_backend, model_name=nlp.embedding_model)
+            return ranked or items[:cfg.phase3_max_evidence]
+        except Exception as e:
+            log.warning("lens.evidence_error", market_id=m.id, error=str(e))
+            return []
+
+    async def _ground(self, m: Market, fair: float, mech: str) -> tuple[float, float] | None:
+        """Phase 3: read CURRENT evidence against the strict criteria → a grounded
+        fair P(YES) + confidence. Persists (grounded_fair, grounded_at) with a TTL
+        re-check. Returns (grounded_fair, confidence), or None when evidence/LLM
+        is unavailable (caller falls back to the criteria-strict fair)."""
+        cfg = self._settings.resolution_lens
+        evidence = await self._gather_evidence(m)
+        if not evidence:
+            return None
+        ev_lines = []
+        for it in evidence[:cfg.phase3_max_evidence]:
+            when = it.published_at.strftime("%Y-%m-%d") if it.published_at else "?"
+            snippet = (it.content or it.title or "")[:200]
+            ev_lines.append(f"- [{when}] {it.source}: {it.title} — {snippet}")
+        deadline = (m.end_date.strftime("%Y-%m-%d") if m.end_date else "unspecified")
+        try:
+            raw = await self._analyzer._call_llm(GROUND_PROMPT.format(
+                question=m.question,
+                description=self._criteria_text(m.description),
+                deadline=deadline, mechanism=mech, fair=fair,
+                evidence="\n".join(ev_lines),
+            ))
+            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            g = max(0.01, min(0.99, float(parsed.get("grounded_prob", fair))))
+            conf = max(0.0, min(1.0, float(parsed.get("confidence", 0.0))))
+        except Exception as e:
+            log.warning("lens.ground_parse_error", market_id=m.id, error=str(e))
+            return None
+        await self._db.execute(
+            "UPDATE lens_verdicts SET grounded_fair = ?, grounded_at = datetime('now') WHERE market_id = ?",
+            (g, m.id))
+        await self._db.commit()
+        log.info("lens.grounded", market_id=m.id, criteria_fair=round(fair, 3),
+                 grounded_fair=round(g, 3), confidence=round(conf, 2),
+                 evidence_n=len(evidence))
+        return g, conf
+
+    async def _grounding_fresh(self, market_id: str) -> float | None:
+        """Return a still-fresh grounded_fair (within the TTL), else None."""
+        cfg = self._settings.resolution_lens
+        row = await self._db.fetchone(
+            """SELECT grounded_fair FROM lens_verdicts
+               WHERE market_id = ? AND grounded_fair IS NOT NULL
+                 AND grounded_at IS NOT NULL
+                 AND (julianday('now') - julianday(grounded_at)) * 24.0 < ?""",
+            (market_id, cfg.phase3_ttl_hours))
+        return float(row["grounded_fair"]) if row else None
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
         row = await self._db.fetchone(
@@ -340,8 +453,30 @@ class ResolutionLensPillar:
             if cfg.verify_enabled and verified != 1:
                 log.info("lens.mechanism_refuted", market_id=m.id, mechanism=mech[:80])
                 continue
+            # Phase 3: evidence-grounded comprehension on a VERIFIED gap. Read
+            # current evidence against the strict criteria (not a re-forecast). If
+            # grounding has edge, trade the grounded fair; if it shows the gap is
+            # already priced for current reality, the recomputed edge falls below
+            # the floor and we skip — the synergy gate. Falls back to the
+            # criteria-strict fair when evidence/LLM is unavailable or low-
+            # confidence, so a fetch miss never blocks accrual.
+            trade_fair = fair
+            if cfg.phase3_grounding_enabled and self._aggregator is not None:
+                g = await self._grounding_fresh(m.id)
+                if g is None and calls < cfg.max_llm_calls_per_cycle:
+                    calls += 1
+                    res = await self._ground(m, fair, mech)
+                    if res is not None and res[1] >= cfg.phase3_min_confidence:
+                        g = res[0]
+                if g is not None:
+                    trade_fair = g
+            edge = trade_fair - m.outcome_yes_price
+            if abs(edge) < cfg.min_edge:
+                log.info("lens.grounded_no_edge", market_id=m.id,
+                         grounded_fair=round(trade_fair, 3), market=m.outcome_yes_price)
+                continue
             try:
-                if await self._enter(m, fair, score, mech, edge):
+                if await self._enter(m, trade_fair, score, mech, edge):
                     entered += 1
             except Exception as e:
                 log.error("lens.entry_error", market_id=m.id, error=str(e))

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -255,6 +255,13 @@ class ResolutionLensPillar:
                       clob_token_yes, clob_token_no
                FROM markets
                WHERE active = 1 AND exchange = 'polymarket'
+                 -- Only future-dated markets: the table is ~87% stale rows
+                 -- (resolved markets keep active=1 with a past end_date), and the
+                 -- lens can't trade a resolved market. Without this the scan loads
+                 -- tens of thousands of dead rows every cycle just to drop them in
+                 -- _eligible. NULL end_date is kept (undated markets still eligible).
+                 AND (end_date IS NULL
+                      OR end_date >= strftime('%Y-%m-%dT%H:%M:%SZ','now'))
                  AND (question LIKE '%announce%' OR question LIKE '%official%'
                       OR question LIKE '%confirm%' OR question LIKE '%permanent%'
                       OR question LIKE '%exactly%' OR question LIKE '%ceasefire%'

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.exchange.models import (
     Confidence,
     Fill,
@@ -126,7 +126,11 @@ class ResolutionLensPillar:
             return False
         if m.spread and m.spread * 100.0 > cfg.max_spread_pct:
             return False
-        if (m.category or "") in set(self._settings.risk.blocked_categories):
+        # Classify-before-block like the gateway: trust the stored label OR a
+        # fresh classification, so a mislabeled blocked market is filtered here
+        # instead of only at the gateway (saves an LLM read).
+        if blocked_category_hit(self._settings.risk.blocked_categories,
+                                m.question, m.description, m.category):
             return False
         if len(m.description or "") < cfg.min_description_chars:
             return False  # no fine print to read

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -221,7 +221,11 @@ class ResolutionTracker:
             # Only the ledger insert is idempotent — re-running settlement
             # would re-add the P&L to daily_stats and cost_basis.
             held_token = row["token"] or "YES"
-            ref = f"settle:{row['market_id']}:{held_token}:0"
+            # Match the canonical (side-keyed) source_ref used by _settle_position
+            # so a side already booked under a different label ("YES" vs the
+            # literal outcome) is recognised and not re-settled.
+            canon = "NO" if held_token.upper() == "NO" else "YES"
+            ref = f"settle:{row['market_id']}:{canon}:0"
             if await self._db.fetchone(
                     "SELECT 1 FROM pnl_ledger WHERE source_ref = ?", (ref,)):
                 continue
@@ -461,7 +465,16 @@ class ResolutionTracker:
         # already in the ledger; an already-booked leg still falls through to the
         # cleanup below (zero its residual cost_basis size, drop the portfolio
         # row) so it stops resurrecting.
-        source_ref = f"settle:{market_id}:{token}:{is_paper_flag}"
+        # Canonicalize the source_ref to the binary YES/NO SIDE the exit-price
+        # branch above already uses (every non-"NO" token is the YES side). A
+        # non-binary market's held side carries a varying label across cycles —
+        # "YES" one pass, the literal outcome ("ARKANSAS RAZORBACKS") the next —
+        # which produced distinct source_refs and DOUBLE-BOOKED the settlement.
+        # Keying the ref on the side (not the label) makes the dedup hold; the
+        # ledger row, cost_basis match and portfolio delete still use the real
+        # label so the right rows are zeroed/removed.
+        canon_token = "NO" if token == "NO" else "YES"
+        source_ref = f"settle:{market_id}:{canon_token}:{is_paper_flag}"
         already_booked = await self._db.fetchone(
             "SELECT 1 FROM pnl_ledger WHERE source_ref = ?", (source_ref,)
         )

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -223,45 +223,83 @@ class ResolutionTracker:
             held_token = row["token"] or "YES"
             # Match the canonical (side-keyed) source_ref used by _settle_position
             # so a side already booked under a different label ("YES" vs the
-            # literal outcome) is recognised and not re-settled.
+            # literal outcome) is recognised.
             canon = "NO" if held_token.upper() == "NO" else "YES"
             ref = f"settle:{row['market_id']}:{canon}:0"
-            if await self._db.fetchone(
-                    "SELECT 1 FROM pnl_ledger WHERE source_ref = ?", (ref,)):
-                continue
-            # cur_price/is_winner are relative to OUR held side; map back to
-            # the market-level YES outcome the settlement path expects.
-            held_yes = (row["token"] or "YES") == "YES"
-            outcome_yes = vp.is_winner if held_yes else (not vp.is_winner)
+
+            # The data-api reports OUR held token's payout directly: is_winner
+            # means this token redeems for $1, else $0. That's authoritative and
+            # label-agnostic, so settle the held token at that exact exit price
+            # (override) rather than re-deriving it from a YES/NO outcome — the
+            # YES/NO round-trip mis-mapped non-binary labels (a team name was
+            # treated as the NO side). outcome_yes is kept only for the report.
             exit_price = 1.0 if vp.is_winner else 0.0
+            venue_pnl = (exit_price - row["avg_price"]) * row["size"]
+            outcome_yes = vp.is_winner if canon == "YES" else (not vp.is_winner)
+
+            # An already-settled side whose booked value MATCHES the venue is
+            # done — skip (the syncer resurrects the row until redemption).
+            prior = await self._db.fetchone(
+                "SELECT pnl FROM pnl_ledger WHERE source_ref = ?", (ref,))
+            if prior is not None and abs(prior["pnl"] - venue_pnl) <= 0.01:
+                continue
+
             settlements.append({
                 "market_id": row["market_id"],
                 "title": vp.title,
-                "token": row["token"] or "YES",
+                "token": held_token,
                 "size": row["size"],
                 "avg_price": row["avg_price"],
-                "pnl": (exit_price - row["avg_price"]) * row["size"],
+                "pnl": venue_pnl,
                 "status": vp.status,
                 "outcome_yes": outcome_yes,
+                "correction": prior is not None,
             })
             if dry_run:
                 continue
+
+            if prior is not None:
+                # A STALE prior settlement disagrees with the authoritative venue
+                # outcome (e.g. it booked the winning side at $0). The venue wins:
+                # correct the booked value in place — one row per side with the
+                # right value (a delta row would distort event/win counts) — and
+                # adjust daily_stats by the delta. _settle_position below then
+                # cleans up the resurrected row (cleanup-only, ref already booked).
+                delta = venue_pnl - prior["pnl"]
+                await self._db.execute(
+                    "UPDATE pnl_ledger SET pnl = ?, qty = ? WHERE source_ref = ?",
+                    (venue_pnl, row["size"], ref))
+                today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+                await self._db.execute(
+                    """INSERT INTO daily_stats (date, total_pnl, trades_count, wins, losses)
+                       VALUES (?, ?, 0, 0, 0)
+                       ON CONFLICT(date) DO UPDATE SET
+                           total_pnl = total_pnl + excluded.total_pnl""",
+                    (today, delta))
+                log.info(
+                    "resolution.venue_correction",
+                    market_id=row["market_id"], token=held_token,
+                    prior_pnl=round(prior["pnl"], 2),
+                    venue_pnl=round(venue_pnl, 2), title=vp.title[:60])
+
             await self._settle_position(
-                row["market_id"], outcome_yes,
-                token_scope=row["token"] or "YES", is_paper_scope=0,
+                row["market_id"], bool(vp.is_winner),
+                token_scope=held_token, is_paper_scope=0,
+                override_exit_price=exit_price,
             )
             await self._db.execute(
                 "UPDATE markets SET active = 0 WHERE id = ?",
                 (row["market_id"],),
             )
             await self._db.commit()
-            log.info(
-                "resolution.venue_settled",
-                market_id=row["market_id"],
-                token=row["token"],
-                status=vp.status,
-                title=vp.title[:60],
-            )
+            if prior is None:
+                log.info(
+                    "resolution.venue_settled",
+                    market_id=row["market_id"],
+                    token=held_token,
+                    status=vp.status,
+                    title=vp.title[:60],
+                )
         return settlements
 
     # ------------------------------------------------------------------

--- a/config/settings.py
+++ b/config/settings.py
@@ -452,6 +452,33 @@ class EntailmentArbConfig(BaseModel):
     kalshi_gap_buffer: float = 0.01
 
 
+class CrossVenueArbConfig(BaseModel):
+    """Cross-venue semantic-equivalence arbitrage (strategy/cross_venue_arb.py).
+
+    Trades price gaps between Polymarket and Kalshi markets that are logically
+    equivalent but worded differently. Candidate pairs are pre-filtered by word
+    overlap, then verified ADVERSARIALLY by an LLM (default: not equivalent) at a
+    high confidence floor — a false match is a paired loss, not a free arb. The
+    gap must clear both legs' taker fees + a buffer. PAPER-FORCED by default and
+    NOT graduation-exempt (resolution-mismatch risk = a real directional loss).
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    min_word_overlap: float = 0.5
+    gap_buffer: float = 0.02
+    stake_usd: float = 10.0
+    max_pairs_per_cycle: int = 2
+    max_llm_calls_per_cycle: int = 8
+    scan_limit: int = 200
+    min_liquidity: float = 1000.0
+    kalshi_min_liquidity: float = 50.0
+    max_spread_pct: float = 5.0
+    min_hours_to_resolution: float = 6.0
+    llm_min_confidence: float = 0.9
+    interval_seconds: int = 1200
+
+
 class OddLotTenderConfig(BaseModel):
     """Odd-lot tender harvester (strategy/oddlot_tender.py).
 
@@ -914,6 +941,7 @@ class Settings(BaseSettings):
     bias_harvest: BiasHarvestConfig = Field(default_factory=lambda: BiasHarvestConfig(**_DEFAULTS.get("bias_harvest", {})))
     graduation: GraduationConfig = Field(default_factory=lambda: GraduationConfig(**_DEFAULTS.get("graduation", {})))
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
+    cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))

--- a/config/settings.py
+++ b/config/settings.py
@@ -331,6 +331,16 @@ class BiasHarvestConfig(BaseModel):
     # and can reverse. Fails open (only an ACTIVE dispute is skipped), so a
     # market with no UMA data still enters as before. See [[uma-dispute-gate]].
     skip_disputed: bool = True
+    # Categories where the favorite-longshot harvest has NO edge and bleeds —
+    # the "longshot" carries genuine directional signal, not mispricing, so the
+    # band sells correctly-priced outcomes and pays the asymmetric tail. The
+    # paper track localised the loss to weather (summer heat genuinely hits temp
+    # thresholds) and sports/politics_us (already in risk.blocked_categories,
+    # but those are bias-harvest-specific no-edge zones too — weather can't be a
+    # global block because weather_temp trades it profitably). Checked on top of
+    # risk.blocked_categories, against the CLASSIFIED category (not the raw label
+    # that an unclassified market would slip through). See [[bias-harvest-strategy]].
+    exclude_categories: list[str] = ["weather", "sports", "politics_us"]
 
 
 class EconIndicatorConfig(BaseModel):

--- a/config/settings.py
+++ b/config/settings.py
@@ -502,6 +502,22 @@ class ResolutionLensConfig(BaseModel):
     # fine-print. Only trade when confirmed at >= verify_min_confidence.
     verify_enabled: bool = True
     verify_min_confidence: float = 0.7
+    # Phase 3: evidence-grounded comprehension. The lens reads CURRENT evidence
+    # (the same aggregator pipeline the ensemble uses) AGAINST the strict
+    # criteria — "do the literal criteria resolve YES given this evidence and the
+    # deadline?" — not a re-forecast. This fuses the two things that individually
+    # work (LLM comprehension + live evidence) on the task where the LLM has edge
+    # (reading a rule against facts), instead of forecasting (where it loses).
+    # Runs ONLY on candidates that already cleared gap_score + adversarial verify,
+    # so evidence/LLM spend lands only on real fine-print gaps. The grounded
+    # estimate is NOT permanently cached (evidence is fresh): re-grounds when
+    # older than phase3_ttl_hours. Falls back to the criteria-strict fair (already
+    # Phase 1+2 validated) if evidence/grounding is unavailable — never blocks
+    # accrual on a fetch miss.
+    phase3_grounding_enabled: bool = True
+    phase3_ttl_hours: float = 12.0
+    phase3_min_confidence: float = 0.5
+    phase3_max_evidence: int = 6
     interval_seconds: int = 1800
     # Paper-phase eligibility: while the cell is hard paper-forced (paper=True)
     # it can never reach the venue, so the live-trading guards (hold horizon,

--- a/tests/test_bias_harvest.py
+++ b/tests/test_bias_harvest.py
@@ -207,6 +207,40 @@ def test_skips_out_of_band_and_ineligible():
     asyncio.run(run())
 
 
+def test_excludes_no_edge_categories_even_when_unclassified():
+    """The favorite-longshot harvest has no edge in weather/sports/politics_us —
+    the 'longshot' carries real signal. These must be skipped both when labelled
+    AND when discovery hands an EMPTY category (the bypass that let blocked
+    sports/politics_us markets into the paper book): the check classifies first.
+    A genuinely in-band 'other'/'tech' favorite still enters."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        pillar, _ = _pillar(db, _settings(), [])
+
+        # labelled no-edge category -> skipped
+        labelled = _market("w1", yes=0.90, category="weather")
+        assert pillar._eligible(labelled) is False
+
+        # EMPTY category but a temperature question -> classified weather -> skipped
+        unlabelled_temp = _market("w2", yes=0.90, category="")
+        unlabelled_temp.question = "Will the highest temperature in Moscow exceed 35C?"
+        assert pillar._eligible(unlabelled_temp) is False
+
+        # EMPTY category but a sports question -> classified sports -> skipped
+        unlabelled_sport = _market("s1", yes=0.90, category="")
+        unlabelled_sport.question = "United States vs. Paraguay: United States to win?"
+        assert pillar._eligible(unlabelled_sport) is False
+
+        # an in-band tech favorite is unaffected
+        ok = _market("t1", yes=0.90, category="tech")
+        ok.question = "Will OpenAI release GPT-6 this year?"
+        assert pillar._eligible(ok) is True
+        await db.close()
+
+    asyncio.run(run())
+
+
 def test_skips_actively_disputed_favorite():
     """A perfectly in-band favorite is skipped when its UMA resolution is
     actively disputed (the fat-tail flip filter). A non-disputed twin enters."""

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,6 +1,29 @@
 """Tests for market category classification."""
 
-from auramaur.strategy.classifier import classify_market, classify_tags
+from auramaur.strategy.classifier import (
+    blocked_category_hit,
+    classify_market,
+    classify_tags,
+)
+
+
+def test_blocked_category_hit_stored_empty_and_mislabeled():
+    """The pre-filter helper mirrors the gateway: block on the stored label OR a
+    fresh classification, so it catches an empty label (the bypass) AND a
+    stale/mislabeled one (stored 'other' that is really sports)."""
+    blocked = {"sports", "politics_us"}
+    # stored label is blocked
+    assert blocked_category_hit(blocked, "Team A vs Team B", "", "sports") == "sports"
+    # empty label, but the question classifies into a blocked category
+    assert blocked_category_hit(
+        blocked, "Will Republicans win the Senate?", "", "") == "politics_us"
+    # mislabeled 'other' that is really sports -> caught via fresh classify
+    assert blocked_category_hit(
+        blocked, "United States vs. Paraguay: USA O/U 2.5", "", "other") == "sports"
+    # a genuinely allowed market returns None
+    assert blocked_category_hit(blocked, "Will OpenAI release GPT-6?", "", "tech") is None
+    # empty blocked set never blocks
+    assert blocked_category_hit(set(), "Team A vs Team B", "", "sports") is None
 
 
 def test_politics_us():
@@ -89,6 +112,17 @@ def test_foreign_election_is_politics_intl():
     ) == "politics_intl"
     assert classify_market("Rodrigo Paz out as President of Bolivia?") == "politics_intl"
     assert classify_market("Will Germany hold a snap election in 2026?") == "politics_intl"
+
+
+def test_subnational_and_byelection_are_politics_intl():
+    """Sub-national/Commonwealth markers without a country word used to default
+    to politics_us (governance term + no intl marker). Alberta/Quebec/Scotland
+    separatist votes and UK by-elections must route to politics_intl."""
+    assert classify_market("Will Alberta vote for independence in 2026?") == "politics_intl"
+    assert classify_market(
+        "Will Andy Burnham win the 2026 Makerfield by-election?") == "politics_intl"
+    assert classify_market("Will Scotland vote for independence?") == "politics_intl"
+    assert classify_market("Will Quebec hold an independence referendum?") == "politics_intl"
 
 
 def test_us_election_stays_politics_us():

--- a/tests/test_cross_venue_arb.py
+++ b/tests/test_cross_venue_arb.py
@@ -1,0 +1,177 @@
+"""Cross-venue semantic-equivalence arb: arb math + adversarial gate + entry."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market, Order, OrderResult, OrderSide, OrderType, TokenType,
+)
+from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
+from config.settings import Settings
+
+
+def _market(mid, exchange, yes, q="Will the Fed cut rates at the July meeting?",
+            liquidity=5000.0, days_out=20.0) -> Market:
+    return Market(
+        id=mid, exchange=exchange, question=q, active=True,
+        outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=liquidity, volume=liquidity, spread=0.01, category="economics",
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_out),
+        clob_token_yes="ty", clob_token_no="tn",
+    )
+
+
+def _settings(**kw):
+    s = Settings()
+    s.cross_venue_arb.enabled = True
+    s.cross_venue_arb.paper = True
+    for k, v in kw.items():
+        setattr(s.cross_venue_arb, k, v)
+    return s
+
+
+def _exchange():
+    ex = MagicMock()
+
+    def prepare_order(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(market_id=market.id, token_id="tok", side=OrderSide.BUY,
+                     token=token, size=round(size / max(price, 0.01), 2),
+                     price=round(price, 2), order_type=OrderType.LIMIT,
+                     dry_run=not is_live)
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(side_effect=lambda o: OrderResult(
+        order_id=f"ord-{o.market_id}", market_id=o.market_id,
+        status="paper" if o.dry_run else "filled",
+        filled_size=o.size, filled_price=o.price, is_paper=o.dry_run))
+    return ex
+
+
+def _risk(approved=True, size=8.0):
+    rm = MagicMock()
+    d = MagicMock()
+    d.approved = approved
+    d.position_size = size if approved else 0.0
+    d.reason = "" if approved else "blk"
+    d.force_paper = False
+    rm.evaluate = AsyncMock(return_value=d)
+    return rm
+
+
+def _analyzer(orientation="same", conf=0.95):
+    a = MagicMock()
+    a._call_llm = AsyncMock(return_value=(
+        f'{{"orientation": "{orientation}", "confidence": {conf}, "counterexample": "none found"}}'))
+    return a
+
+
+def _pillar(db, settings, poly, kalshi, exchange=None, risk=None, analyzer=None):
+    disc = MagicMock(); disc.get_markets = AsyncMock(return_value=poly)
+    kdisc = MagicMock(); kdisc.get_markets = AsyncMock(return_value=kalshi)
+    return CrossVenueArbPillar(
+        db=db, settings=settings, discovery=disc,
+        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        pnl_tracker=PnLTracker(db, settings),
+        analyzer=analyzer if analyzer is not None else _analyzer(),
+        kalshi_discovery=kdisc)
+
+
+# -- arb math (pure) ---------------------------------------------------
+
+def test_arb_math_same_orientation():
+    s = _settings()
+    p = _pillar(MagicMock(), s, [], [])
+    a = _market("p", "polymarket", 0.40)
+    b = _market("k", "kalshi", 0.55)
+    edge, side_a, side_b = p._arb(a, b, "same")
+    assert abs(edge - 0.15) < 1e-9
+    # A_YES cheaper -> buy A_YES, sell (NO) the dearer B
+    assert side_a == OrderSide.BUY and side_b == OrderSide.SELL
+
+
+def test_arb_math_inverted_orientation():
+    s = _settings()
+    p = _pillar(MagicMock(), s, [], [])
+    a = _market("p", "polymarket", 0.40)
+    b = _market("k", "kalshi", 0.45)   # complementary, sum 0.85 < 1 -> both YES
+    edge, side_a, side_b = p._arb(a, b, "inverted")
+    assert abs(edge - 0.15) < 1e-9
+    assert side_a == OrderSide.BUY and side_b == OrderSide.BUY
+
+
+# -- full cycle --------------------------------------------------------
+
+def test_equivalent_mispriced_pair_enters_both_legs():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            a = _market("p1", "polymarket", 0.40)
+            b = _market("k1", "kalshi", 0.55)
+            ex = _exchange()
+            pillar = _pillar(db, _settings(), [a], [b], exchange=ex,
+                             analyzer=_analyzer("same", 0.95))
+            entered = await pillar.run_once()
+            assert entered == 1
+            # both legs placed
+            assert ex.place_order.await_count == 2
+            row = await db.fetchone(
+                "SELECT traded_at FROM cross_venue_verdicts WHERE poly_id='p1' AND kalshi_id='k1'")
+            assert row["traded_at"] is not None
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_non_equivalent_pair_does_not_trade():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            a = _market("p1", "polymarket", 0.40)
+            b = _market("k1", "kalshi", 0.55)
+            ex = _exchange()
+            pillar = _pillar(db, _settings(), [a], [b], exchange=ex,
+                             analyzer=_analyzer("none", 0.2))
+            assert await pillar.run_once() == 0
+            assert ex.place_order.await_count == 0
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_subfee_gap_does_not_trade():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            # equivalent + confident, but YES prices nearly equal -> gap < fees+buffer
+            a = _market("p1", "polymarket", 0.50)
+            b = _market("k1", "kalshi", 0.505)
+            ex = _exchange()
+            pillar = _pillar(db, _settings(), [a], [b], exchange=ex,
+                             analyzer=_analyzer("same", 0.95))
+            assert await pillar.run_once() == 0
+            assert ex.place_order.await_count == 0
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_no_kalshi_discovery_is_noop():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            disc = MagicMock(); disc.get_markets = AsyncMock(return_value=[])
+            pillar = CrossVenueArbPillar(
+                db=db, settings=_settings(), discovery=disc, exchange=_exchange(),
+                risk_manager=_risk(), pnl_tracker=PnLTracker(db, _settings()),
+                analyzer=_analyzer(), kalshi_discovery=None)
+            assert await pillar.run_once() == 0
+        finally:
+            await db.close()
+    asyncio.run(run())

--- a/tests/test_cross_venue_arb.py
+++ b/tests/test_cross_venue_arb.py
@@ -35,22 +35,36 @@ def _settings(**kw):
     return s
 
 
-def _exchange():
+def _exchange(reject: bool = False):
     ex = MagicMock()
 
     def prepare_order(signal, market, size, is_live):
         token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
         price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
-        return Order(market_id=market.id, token_id="tok", side=OrderSide.BUY,
-                     token=token, size=round(size / max(price, 0.01), 2),
-                     price=round(price, 2), order_type=OrderType.LIMIT,
-                     dry_run=not is_live)
+        return Order(
+            market_id=market.id, exchange=market.exchange, token_id="tok",
+            side=OrderSide.BUY, token=token,
+            size=round(size / max(price, 0.01), 2),
+            price=round(price, 2), order_type=OrderType.LIMIT,
+            dry_run=not is_live,
+        )
+
+    def place_order(o):
+        if reject:
+            return OrderResult(
+                order_id=f"err-{o.market_id}", market_id=o.market_id,
+                status="rejected", is_paper=o.dry_run,
+                error_message="venue rejected",
+            )
+        return OrderResult(
+            order_id=f"ord-{o.market_id}", market_id=o.market_id,
+            status="paper" if o.dry_run else "filled",
+            filled_size=o.size, filled_price=o.price, is_paper=o.dry_run,
+        )
 
     ex.prepare_order = MagicMock(side_effect=prepare_order)
-    ex.place_order = AsyncMock(side_effect=lambda o: OrderResult(
-        order_id=f"ord-{o.market_id}", market_id=o.market_id,
-        status="paper" if o.dry_run else "filled",
-        filled_size=o.size, filled_price=o.price, is_paper=o.dry_run))
+    ex.place_order = AsyncMock(side_effect=place_order)
+    ex.cancel_order = AsyncMock(return_value=True)
     return ex
 
 
@@ -72,15 +86,21 @@ def _analyzer(orientation="same", conf=0.95):
     return a
 
 
-def _pillar(db, settings, poly, kalshi, exchange=None, risk=None, analyzer=None):
+def _pillar(db, settings, poly, kalshi, exchange=None, risk=None, analyzer=None,
+            exchanges=None):
     disc = MagicMock(); disc.get_markets = AsyncMock(return_value=poly)
     kdisc = MagicMock(); kdisc.get_markets = AsyncMock(return_value=kalshi)
+    exchanges = exchanges or {
+        "polymarket": exchange or _exchange(),
+        "kalshi": _exchange(),
+    }
     return CrossVenueArbPillar(
         db=db, settings=settings, discovery=disc,
-        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        exchange=exchanges.get("polymarket"), risk_manager=risk or _risk(),
         pnl_tracker=PnLTracker(db, settings),
         analyzer=analyzer if analyzer is not None else _analyzer(),
-        kalshi_discovery=kdisc)
+        kalshi_discovery=kdisc,
+        exchanges=exchanges)
 
 
 # -- arb math (pure) ---------------------------------------------------
@@ -115,12 +135,15 @@ def test_equivalent_mispriced_pair_enters_both_legs():
             a = _market("p1", "polymarket", 0.40)
             b = _market("k1", "kalshi", 0.55)
             ex = _exchange()
+            kex = _exchange()
             pillar = _pillar(db, _settings(), [a], [b], exchange=ex,
-                             analyzer=_analyzer("same", 0.95))
+                             analyzer=_analyzer("same", 0.95),
+                             exchanges={"polymarket": ex, "kalshi": kex})
             entered = await pillar.run_once()
             assert entered == 1
             # both legs placed
-            assert ex.place_order.await_count == 2
+            assert ex.place_order.await_count == 1
+            assert kex.place_order.await_count == 1
             row = await db.fetchone(
                 "SELECT traded_at FROM cross_venue_verdicts WHERE poly_id='p1' AND kalshi_id='k1'")
             assert row["traded_at"] is not None
@@ -172,6 +195,60 @@ def test_no_kalshi_discovery_is_noop():
                 risk_manager=_risk(), pnl_tracker=PnLTracker(db, _settings()),
                 analyzer=_analyzer(), kalshi_discovery=None)
             assert await pillar.run_once() == 0
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_uses_venue_specific_exchange_clients():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            a = _market("p1", "polymarket", 0.40)
+            b = _market("k1", "kalshi", 0.55)
+            poly_ex = _exchange()
+            kalshi_ex = _exchange()
+            pillar = _pillar(
+                db, _settings(), [a], [b],
+                exchanges={"polymarket": poly_ex, "kalshi": kalshi_ex},
+                analyzer=_analyzer("same", 0.95),
+            )
+
+            assert await pillar.run_once() == 1
+            poly_order = poly_ex.place_order.await_args.args[0]
+            kalshi_order = kalshi_ex.place_order.await_args.args[0]
+            assert poly_order.exchange == "polymarket"
+            assert kalshi_order.exchange == "kalshi"
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_second_leg_rejection_marks_partial_not_traded_and_does_not_retry():
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            a = _market("p1", "polymarket", 0.40)
+            b = _market("k1", "kalshi", 0.55)
+            poly_ex = _exchange()
+            kalshi_ex = _exchange(reject=True)
+            pillar = _pillar(
+                db, _settings(), [a], [b],
+                exchanges={"polymarket": poly_ex, "kalshi": kalshi_ex},
+                analyzer=_analyzer("same", 0.95),
+            )
+
+            assert await pillar.run_once() == 0
+            row = await db.fetchone(
+                "SELECT traded_at, partial_at, last_error FROM cross_venue_verdicts "
+                "WHERE poly_id='p1' AND kalshi_id='k1'")
+            assert row["traded_at"] is None
+            assert row["partial_at"] is not None
+            assert row["last_error"] == "venue rejected"
+
+            assert await pillar.run_once() == 0
+            assert poly_ex.place_order.await_count == 1
+            assert kalshi_ex.place_order.await_count == 1
         finally:
             await db.close()
     asyncio.run(run())

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -133,26 +133,40 @@ def _settings(**overrides) -> Settings:
     return s
 
 
-def _exchange():
+def _exchange(reject: bool = False, reject_on_call: int | None = None):
     ex = MagicMock()
 
     def prepare_order(signal, market, size, is_live):
         token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
         price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
         return Order(
-            market_id=market.id, token_id="tok", side=OrderSide.BUY,
+            market_id=market.id, exchange=market.exchange, token_id=market.ticker or "tok",
+            side=OrderSide.BUY,
             token=token, size=round(size / max(price, 0.01), 2),
             price=round(price, 2), order_type=OrderType.LIMIT,
             dry_run=not is_live,
         )
 
     ex.prepare_order = MagicMock(side_effect=prepare_order)
-    ex.place_order = AsyncMock(side_effect=lambda order: OrderResult(
-        order_id=f"ord-{order.market_id}", market_id=order.market_id,
-        status="paper" if order.dry_run else "filled",
-        filled_size=order.size, filled_price=order.price,
-        is_paper=order.dry_run,
-    ))
+    calls = 0
+
+    def place_order(order):
+        nonlocal calls
+        calls += 1
+        if reject or calls == reject_on_call:
+            return OrderResult(
+                order_id=f"err-{order.market_id}", market_id=order.market_id,
+                status="rejected", is_paper=order.dry_run, error_message="venue rejected",
+            )
+        return OrderResult(
+            order_id=f"ord-{order.market_id}", market_id=order.market_id,
+            status="paper" if order.dry_run else "filled",
+            filled_size=order.size, filled_price=order.price,
+            is_paper=order.dry_run,
+        )
+
+    ex.place_order = AsyncMock(side_effect=place_order)
+    ex.cancel_order = AsyncMock(return_value=True)
     return ex
 
 
@@ -167,13 +181,17 @@ def _risk(approved=True, size=8.0, force_paper=False):
     return rm
 
 
-def _pillar(db, settings, markets, exchange=None, risk=None, analyzer=None):
+def _pillar(db, settings, markets, exchange=None, risk=None, analyzer=None,
+            kalshi_discovery=None, exchanges=None):
     discovery = MagicMock()
     discovery.get_markets = AsyncMock(return_value=markets)
+    exchanges = exchanges or {"polymarket": exchange or _exchange()}
     return EntailmentArbPillar(
         db=db, settings=settings, discovery=discovery,
-        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        exchange=exchanges.get("polymarket"), risk_manager=risk or _risk(),
         pnl_tracker=PnLTracker(db, settings), analyzer=analyzer,
+        kalshi_discovery=kalshi_discovery,
+        exchanges=exchanges,
     )
 
 
@@ -255,6 +273,58 @@ def test_enters_violating_pair_both_legs_paper():
 
         # One shot per pair: second scan does nothing.
         assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_kalshi_ladder_uses_kalshi_exchange_and_records_kalshi_rows():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = _settings(kalshi_series=["KXCPIYOY"])
+        kalshi_discovery = MagicMock()
+        kalshi_discovery.get_markets_by_series = AsyncMock(return_value=[
+            _kx("KXCPIYOY-26NOV-T4.4", 0.40),
+            _kx("KXCPIYOY-26NOV-T4.6", 0.60),
+        ])
+        poly_ex = _exchange()
+        kalshi_ex = _exchange()
+        pillar = _pillar(
+            db, settings, [],
+            kalshi_discovery=kalshi_discovery,
+            exchanges={"polymarket": poly_ex, "kalshi": kalshi_ex},
+        )
+
+        assert await pillar.run_once() == 1
+        poly_ex.place_order.assert_not_awaited()
+        assert kalshi_ex.place_order.await_count == 2
+        assert {c.args[0].exchange for c in kalshi_ex.place_order.await_args_list} == {"kalshi"}
+
+        trade_rows = await db.fetchall(
+            "SELECT DISTINCT exchange FROM trades WHERE strategy_source='entailment_arb'")
+        assert {r["exchange"] for r in trade_rows} == {"kalshi"}
+        portfolio_rows = await db.fetchall("SELECT DISTINCT exchange FROM portfolio")
+        assert {r["exchange"] for r in portfolio_rows} == {"kalshi"}
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_second_leg_rejection_is_not_counted_as_entered_or_retried():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(reject_on_call=2)
+        pillar = _pillar(db, _settings(), _violating_ladder(), exchange=ex)
+
+        assert await pillar.run_once() == 0
+        trades = await db.fetchall(
+            "SELECT market_id FROM trades WHERE strategy_source='entailment_arb'")
+        assert [t["market_id"] for t in trades] == ["hi"]
+
+        assert await pillar.run_once() == 0
+        assert ex.place_order.await_count == 2
         await db.close()
 
     asyncio.run(run())

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -397,7 +397,8 @@ def test_lexical_candidates_scan_whole_table_not_volume_top():
         db = Database(":memory:")
         await db.connect()
         try:
-            async def _ins(mid, q, exchange="polymarket", active=1, liq=5000.0):
+            async def _ins(mid, q, exchange="polymarket", active=1, liq=5000.0,
+                           end_days=20):
                 await db.execute(
                     "INSERT INTO markets (id, exchange, question, description, "
                     "category, end_date, outcome_yes_price, outcome_no_price, "
@@ -407,12 +408,15 @@ def test_lexical_candidates_scan_whole_table_not_volume_top():
                      "Long fine-print resolution criteria describing the strict "
                      "written bar that must be met for YES to resolve.",
                      "politics_intl",
-                     (datetime.now(timezone.utc) + timedelta(days=20)).isoformat(),
+                     (datetime.now(timezone.utc) + timedelta(days=end_days)).isoformat(),
                      0.30, 0.70, liq, "ty", "tn", active))
             await _ins("hit", "Will Iran officially announce a permanent ceasefire?")
             await _ins("plain", "Will Bitcoin go up tomorrow?")            # no trigger
             await _ins("inactive", "Will X officially confirm it?", active=0)
             await _ins("kalshi", "Will Y officially announce?", exchange="kalshi")
+            # resolved-but-active rows (past end_date) are ~87% of the table —
+            # the lens can't trade them, so the lexical scan must exclude them.
+            await _ins("stale", "Will Z officially announce a permanent deal?", end_days=-5)
             await db.commit()
 
             pillar = _pillar(db, _settings(), markets=[])

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -108,6 +108,117 @@ def _analyzer(fair=0.10, gap=0.8, mech="'permanent' requires explicit permanence
     return a
 
 
+def _analyzer3(fair=0.10, gap=0.8, mech="'permanent' bar", verify="confirmed",
+               verify_conf=0.9, grounded=0.10, ground_conf=0.9):
+    """Analyzer mock that also answers the Phase 3 GROUND_PROMPT."""
+    a = MagicMock()
+
+    async def _call(prompt, **kw):
+        if "grounded_prob" in prompt:
+            return f'{{"grounded_prob": {grounded}, "confidence": {ground_conf}, "why": "x"}}'
+        if "ADVERSARIALLY CHECK" in prompt or '"verdict"' in prompt:
+            return f'{{"verdict": "{verify}", "confidence": {verify_conf}, "why": "x"}}'
+        return f'{{"fair_prob": {fair}, "gap_score": {gap}, "mechanism": "{mech}"}}'
+
+    a._call_llm = AsyncMock(side_effect=_call)
+    return a
+
+
+def _aggregator_mock(n=2):
+    from auramaur.data_sources.base import NewsItem
+    agg = MagicMock()
+    items = [NewsItem(id=f"e{i}", source="news", title=f"headline {i}",
+                      content="evidence body") for i in range(n)]
+    agg.gather = AsyncMock(return_value=items)
+    return agg
+
+
+def _pillar3(db, settings, markets, exchange=None, risk=None, analyzer=None,
+                 aggregator=None):
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    calibration = MagicMock(); calibration.record_prediction = AsyncMock()
+    return ResolutionLensPillar(
+        db=db, settings=settings, discovery=discovery,
+        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        pnl_tracker=PnLTracker(db, settings), calibration=calibration,
+        analyzer=analyzer if analyzer is not None else _analyzer3(),
+        aggregator=aggregator,
+    )
+
+
+def test_phase3_grounding_confirms_gap_then_enters():
+    """Evidence-grounded comprehension on a verified gap: when grounding agrees
+    the strict bar is unmet (low grounded P(YES)), the edge holds and the lens
+    trades the grounded fair; lens_verdicts records grounded_fair."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            with patch("auramaur.nlp.query_decomposer.extract_search_queries",
+                       return_value=["q"]), \
+                 patch("auramaur.nlp.evidence_ranker.rank_evidence",
+                       side_effect=lambda q, items, **kw: items):
+                m = _market(yes=0.30)
+                pillar = _pillar3(db, _settings(), [m],
+                                      analyzer=_analyzer3(fair=0.10, grounded=0.10),
+                                      aggregator=_aggregator_mock())
+                entered = await pillar.run_once()
+                assert entered == 1
+                row = await db.fetchone(
+                    "SELECT grounded_fair FROM lens_verdicts WHERE market_id=?", (m.id,))
+                assert row["grounded_fair"] is not None
+                assert abs(row["grounded_fair"] - 0.10) < 1e-6
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_phase3_grounding_kills_edge_skips():
+    """The synergy gate: a real fine-print gap that current evidence shows is
+    ALREADY priced for reality (grounded fair ≈ market) drops the recomputed edge
+    below the floor — the lens skips instead of trading a stale mechanic."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            with patch("auramaur.nlp.query_decomposer.extract_search_queries",
+                       return_value=["q"]), \
+                 patch("auramaur.nlp.evidence_ranker.rank_evidence",
+                       side_effect=lambda q, items, **kw: items):
+                m = _market(yes=0.30)
+                # criteria fair 0.10 (edge 0.20), but grounding says 0.29 ≈ market
+                pillar = _pillar3(db, _settings(), [m],
+                                      analyzer=_analyzer3(fair=0.10, grounded=0.29),
+                                      aggregator=_aggregator_mock())
+                entered = await pillar.run_once()
+                assert entered == 0   # grounded edge 0.01 < min_edge 0.08
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_phase3_low_confidence_falls_back_to_criteria_fair():
+    """Low grounding confidence is ignored — the lens falls back to the
+    Phase 1+2-validated criteria fair rather than trusting weak evidence."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            with patch("auramaur.nlp.query_decomposer.extract_search_queries",
+                       return_value=["q"]), \
+                 patch("auramaur.nlp.evidence_ranker.rank_evidence",
+                       side_effect=lambda q, items, **kw: items):
+                m = _market(yes=0.30)
+                # grounding would kill the edge (0.29) BUT confidence is low -> ignored
+                pillar = _pillar3(db, _settings(), [m],
+                                      analyzer=_analyzer3(fair=0.10, grounded=0.29,
+                                                          ground_conf=0.2),
+                                      aggregator=_aggregator_mock())
+                entered = await pillar.run_once()
+                assert entered == 1   # criteria fair 0.10 used -> edge 0.20 holds
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
 def _pillar(db, settings, markets, exchange=None, risk=None, analyzer=None):
     discovery = MagicMock()
     discovery.get_markets = AsyncMock(return_value=markets)

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -494,6 +494,132 @@ class TestSettlePosition:
 
         asyncio.run(run())
 
+    def test_venue_override_corrects_stale_prior_settlement(self):
+        """settle_via_venue is authoritative (data-api is_winner). When a side
+        already settled at a STALE value (e.g. the winning side booked at $0),
+        the venue sweep corrects the booked pnl in place and adjusts daily_stats
+        — without creating a second row."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                # Stale prior settlement: the YES side booked as a LOSS at $0.
+                await db.execute(
+                    """INSERT INTO pnl_ledger (market_id, venue, category,
+                         strategy_source, kind, token, qty, pnl, fees, is_paper, source_ref)
+                       VALUES ('gm', 'polymarket', 'sports', 'llm', 'settlement',
+                               'YES', 10.0, -5.0, 0.0, 0, 'settle:gm:YES:0')""")
+                # The wallet still holds the tokens, so the syncer resurrected the
+                # row — relabelled with the literal outcome.
+                await db.execute(
+                    """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                         current_price, token, token_id, is_paper, updated_at)
+                       VALUES ('gm', 'polymarket', 'BUY', 10.0, 0.50, 1.0,
+                               'ARKANSAS RAZORBACKS', 'tok', 0, datetime('now'))""")
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                         avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('gm', 'ARKANSAS RAZORBACKS', 'tok', 10.0, 0.50, 5.0, 0, 0)""")
+                await db.commit()
+
+                vp = SimpleNamespace(asset_id="tok", is_winner=True,
+                                     status="redeemable", title="Arkansas vs Arizona")
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                with patch("auramaur.broker.redeemer.fetch_redeemable_positions",
+                           AsyncMock(return_value=[vp])):
+                    await tracker.settle_via_venue("0xproxy")
+
+                # Exactly one settlement row for the side, corrected to the win.
+                rows = await db.fetchall(
+                    "SELECT pnl FROM pnl_ledger WHERE market_id='gm' AND kind='settlement'")
+                assert len(rows) == 1
+                assert abs(rows[0]["pnl"] - (1.0 - 0.50) * 10.0) < 1e-9  # +5.0 win
+                ds = await db.fetchone("SELECT total_pnl FROM daily_stats")
+                assert abs(ds["total_pnl"] - 10.0) < 1e-9   # delta +5 - (-5)
+                pf = await db.fetchone("SELECT COUNT(*) AS n FROM portfolio WHERE market_id='gm'")
+                assert pf["n"] == 0   # resurrected row cleaned up
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
+    def test_venue_consistent_prior_is_noop(self):
+        """A prior settlement already matching the venue value is left untouched
+        (no correction, no daily_stats churn)."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                await db.execute(
+                    """INSERT INTO pnl_ledger (market_id, venue, category,
+                         strategy_source, kind, token, qty, pnl, fees, is_paper, source_ref)
+                       VALUES ('gm', 'polymarket', 'sports', 'llm', 'settlement',
+                               'YES', 10.0, 5.0, 0.0, 0, 'settle:gm:YES:0')""")
+                await db.execute(
+                    """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                         current_price, token, token_id, is_paper, updated_at)
+                       VALUES ('gm', 'polymarket', 'BUY', 10.0, 0.50, 1.0,
+                               'YES', 'tok', 0, datetime('now'))""")
+                await db.commit()
+                vp = SimpleNamespace(asset_id="tok", is_winner=True,
+                                     status="redeemable", title="t")
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                with patch("auramaur.broker.redeemer.fetch_redeemable_positions",
+                           AsyncMock(return_value=[vp])):
+                    await tracker.settle_via_venue("0xproxy")
+                row = await db.fetchone("SELECT pnl FROM pnl_ledger WHERE source_ref='settle:gm:YES:0'")
+                assert abs(row["pnl"] - 5.0) < 1e-9      # unchanged
+                ds = await db.fetchone("SELECT COUNT(*) AS n FROM daily_stats")
+                assert ds["n"] == 0                      # no daily_stats churn
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
+    def test_venue_fresh_settles_teamname_label_as_held_payout(self):
+        """A fresh venue settlement of a non-binary (team-name) held token uses
+        the data-api payout directly — a winning team-name token books a WIN,
+        not a loss from the old YES/NO round-trip that mis-mapped it to NO."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                await db.execute(
+                    """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                         current_price, token, token_id, is_paper, updated_at)
+                       VALUES ('gm', 'polymarket', 'BUY', 10.0, 0.40, 1.0,
+                               'BLAZERS', 'tok', 0, datetime('now'))""")
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                         avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('gm', 'BLAZERS', 'tok', 10.0, 0.40, 4.0, 0, 0)""")
+                await db.commit()
+                vp = SimpleNamespace(asset_id="tok", is_winner=True,
+                                     status="redeemable", title="t")
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+                with patch("auramaur.broker.redeemer.fetch_redeemable_positions",
+                           AsyncMock(return_value=[vp])):
+                    await tracker.settle_via_venue("0xproxy")
+                row = await db.fetchone("SELECT pnl FROM pnl_ledger WHERE source_ref='settle:gm:YES:0'")
+                assert row is not None
+                assert abs(row["pnl"] - (1.0 - 0.40) * 10.0) < 1e-9   # +6.0 win, not a loss
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
     def test_detect_void(self):
         """closed + uma resolved + ~0.5 price = VOID (refund); pinned or
         still-open or non-poly is not a void."""
@@ -713,7 +839,9 @@ async def test_venue_sweep_skips_already_settled_token(monkeypatch):
     async def _fetchone(sql, params=None):
         if "pnl_ledger" in sql:
             assert params == ("settle:m1:NO:0",)
-            return {"1": 1}  # settlement already recorded
+            # NO @ 0.62 won (is_winner) => (1.0-0.62)*20 = 7.6; a matching prior
+            # is consistent, so the leg is skipped (not re-settled/corrected).
+            return {"pnl": (1.0 - 0.62) * 20.0}
         return row
     db.fetchone = AsyncMock(side_effect=_fetchone)
 

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -447,6 +447,53 @@ class TestSettlePosition:
 
         asyncio.run(run())
 
+    def test_settle_same_side_under_different_labels_books_once(self):
+        """A non-binary market's held side carries a varying label across cycles
+        — "YES" one pass, the literal outcome ("ARKANSAS RAZORBACKS") the next.
+        Both settle the SAME economic side, so the source_ref must key on the
+        side (canonical YES/NO), not the label, or the settlement double-books.
+        """
+        from auramaur.db.database import Database
+
+        async def run():
+            db = Database(":memory:")
+            await db.connect()
+            try:
+                tracker = ResolutionTracker(db=db, calibration=AsyncMock(), discoveries={})
+
+                # Pass 1: row labelled "YES" (the YES side), market resolves NO => loss.
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                                               avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('game-1', 'YES', 'tok', 24.0, 0.23, 5.52, 0, 0)""")
+                await db.commit()
+                await tracker._settle_position("game-1", outcome=False, is_paper_scope=0)
+
+                # Pass 2: SAME side resurfaces relabelled with the literal outcome.
+                await db.execute(
+                    """INSERT INTO cost_basis (market_id, token, token_id, size,
+                                               avg_cost, total_cost, realized_pnl, is_paper)
+                       VALUES ('game-1', 'ARKANSAS RAZORBACKS', 'tok', 24.0, 0.23, 5.52, 0, 0)""")
+                await db.commit()
+                await tracker._settle_position(
+                    "game-1", outcome=False, token_scope="ARKANSAS RAZORBACKS",
+                    is_paper_scope=0)
+
+                # Exactly one settlement booked, under the canonical side ref.
+                n = await db.fetchone(
+                    "SELECT COUNT(*) AS n FROM pnl_ledger WHERE market_id='game-1'")
+                assert n["n"] == 1, "label variant must not create a second ledger row"
+                row = await db.fetchone(
+                    "SELECT source_ref, pnl FROM pnl_ledger WHERE market_id='game-1'")
+                assert row["source_ref"] == "settle:game-1:YES:0"
+                assert abs(row["pnl"] - (0.0 - 0.23) * 24.0) < 1e-9
+                ds = await db.fetchone("SELECT total_pnl, trades_count FROM daily_stats")
+                assert ds["trades_count"] == 1, "daily_stats must not double-count"
+            finally:
+                await db.close()
+
+        asyncio.run(run())
+
     def test_detect_void(self):
         """closed + uma resolved + ~0.5 price = VOID (refund); pinned or
         still-open or non-poly is not a void."""


### PR DESCRIPTION
## Summary

This draft PR publishes the current local strategy branch and adds a focused hardening commit for multi-venue arbitrage execution.

The new fix routes Polymarket and Kalshi legs through their own exchange clients instead of sending both legs through the primary exchange. It also stops failed two-leg entries from being marked as completed arbs, records partial cross-venue attempts, and keeps venue metadata correct in the trades/portfolio mirrors.

## Root Cause

The cross-venue and Kalshi ladder entailment paths discovered markets from multiple venues, but execution still used a single primary exchange object. In practice that could paper-fill or submit a Kalshi leg with Polymarket semantics. A second-leg rejection could also leave single-leg exposure while the pair was treated as done.

## Validation

- `.venv/bin/python -m pytest` -> `820 passed`
- `.venv/bin/ruff check auramaur/strategy/cross_venue_arb.py auramaur/strategy/entailment_arb.py tests/test_cross_venue_arb.py tests/test_entailment_arb.py --select F821,F822,F823,F841` -> passed

## Notes

Local-only operational changes in `config/defaults.yaml`, `config/settings.py`, `logs/`, and untracked venue scripts were intentionally left out of the fix commit. The branch still includes the prior unpublished commits already ahead of `origin/main`, because the fix builds on that local work.