### PR TITLE
config: deep-band bias_harvest (band_lo 0.90) + pin model to claude-opus-4-8

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -313,7 +313,12 @@ class BiasHarvestConfig(BaseModel):
 
     enabled: bool = False
     paper: bool = True
-    band_lo: float = 0.80
+    # Deep band only. The backtest's edge lived in 0.90-0.97 (won 99.3% of 151);
+    # the shallow 0.80-0.90 tier has no favorite-longshot edge in practice — paper
+    # showed it busting ~24% vs the ~12-20% its price implied (net-negative), while
+    # 0.90-0.97 ran 94% win / net-positive. Raised 0.80->0.90 so the cell harvests
+    # only where the bias is real. See [[bias-harvest-strategy]].
+    band_lo: float = 0.90
     band_hi: float = 0.97
     edge_uplift: float = 0.04
     stake_usd: float = 10.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -197,7 +197,7 @@ _INTENSITY_PRESETS: dict[str, dict] = {
 class NLPConfig(BaseModel):
     cache_ttl_breaking_seconds: int = 900
     cache_ttl_slow_seconds: int = 7200
-    model: str = "claude-sonnet-4-20250514"
+    model: str = "claude-opus-4-8"
     max_tokens: int = 4096
     api_intensity: Literal["low", "medium", "full_blast"] = "medium"
     skip_second_opinion: bool = False
@@ -222,7 +222,7 @@ class NLPConfig(BaseModel):
     tool_use_edge_threshold_pct: float = 8.0  # edge % above which tool-use fires in auto mode
     tool_use_max_budget_usd: float = 0.50  # per-market tool-use budget cap
     tool_use_max_markets_per_cycle: int = 2  # cap concurrent refinements per cycle
-    tool_use_model: str = "claude-opus-4-7"  # can differ from strategic batch model
+    tool_use_model: str = "claude-opus-4-8"  # can differ from strategic batch model
 
     # Lever 1: effort tiering. `--effort` scales thinking-token burn per call,
     # which is what eats the Max+ rate-limit window. Reserve `max` for the


### PR DESCRIPTION
Two focused config tunes from the provisional-strategy review:

- **bias_harvest band_lo 0.80 -> 0.90** — paper showed the shallow 0.80-0.90 tier busting ~24% vs the ~12-20% its price implied (net-negative); the deep 0.90-0.97 tier ran 94% win / net-positive, matching the backtest (deep band won 99.3% of 151). Harvest only where the favorite-longshot edge is real.
- **pin nlp model to claude-opus-4-8** — committed default was a stale claude-sonnet-4-20250514 (overridden to the 'opus' alias at runtime); pin explicitly so the comprehension pillars (resolution_lens read/verify/ground, cross_venue equivalence, entailment verify) use the strongest reasoning. tool_use_model 4-7 -> 4-8 to match.

config/settings.py only. Verified live (band_lo 0.90, model returns MODEL_OK); 820 tests green.

Assisted-by: Claude (Anthropic)