### PR TITLE
fix(pnl+config): token-scope cost_basis reads + split tracked/local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 dist/
 build/
 .env
+config/defaults.local.yaml
 *.db
 *.db-shm
 *.db-wal

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -2738,7 +2738,13 @@ class AuramaurBot:
                                    avg_cost = excluded.avg_cost,
                                    total_cost = excluded.total_cost,
                                    updated_at = excluded.updated_at""",
-                            (rp.market_id, rp.outcome, rp.token_id, rp.size,
+                            # Normalize the raw CLOB outcome ("Yes"/"No") to the
+                            # canonical TokenType value ("YES"/"NO"). Writing the raw
+                            # title-case outcome here was the one site that diverged
+                            # from the fill/Kalshi paths, splitting a single position
+                            # into duplicate (market, "No") + (market, "NO") rows.
+                            (rp.market_id, TokenType.from_str(rp.outcome).value,
+                             rp.token_id, rp.size,
                              rp.avg_cost, rp.size * rp.avg_cost),
                         )
 

--- a/auramaur/broker/pnl.py
+++ b/auramaur/broker/pnl.py
@@ -200,12 +200,18 @@ class PnLTracker:
     # ------------------------------------------------------------------
 
     async def get_cost_basis(self, market_id: str) -> tuple[float, float]:
-        """Return ``(avg_cost, size)`` for a market in the current mode.
+        """Return ``(avg_cost, size)`` for a market's dominant position in the
+        current mode.
 
-        Returns ``(0.0, 0.0)`` if no cost basis exists.
+        cost_basis is keyed by ``(market_id, token, is_paper)``, so a market
+        may have more than one row (a real two-sided position, or — pre-v20 —
+        casing-split duplicates). Pick deterministically: the largest open
+        size, then the most recently updated. Returns ``(0.0, 0.0)`` if no
+        cost basis exists.
         """
         row = await self._db.fetchone(
-            "SELECT avg_cost, size FROM cost_basis WHERE market_id = ? AND is_paper = ?",
+            "SELECT avg_cost, size FROM cost_basis WHERE market_id = ? AND is_paper = ?"
+            " ORDER BY size DESC, updated_at DESC LIMIT 1",
             (market_id, self._mode_flag()),
         )
         if row is None:
@@ -213,18 +219,21 @@ class PnLTracker:
         return float(row["avg_cost"]), float(row["size"])
 
     async def get_token_info(self, market_id: str) -> tuple[TokenType, str]:
-        """Return ``(token_type, token_id)`` for a market from cost_basis.
+        """Return ``(token_type, token_id)`` for a market's dominant position.
 
-        Returns ``(TokenType.YES, "")`` if no cost basis exists.
+        Same deterministic disambiguation as :meth:`get_cost_basis` (largest
+        open size, then most recently updated) and case-insensitive token
+        parsing via :meth:`TokenType.from_str`, so it stays aligned with the
+        row that method returns. Returns ``(TokenType.YES, "")`` if none.
         """
         row = await self._db.fetchone(
-            "SELECT token, token_id FROM cost_basis WHERE market_id = ? AND is_paper = ?",
+            "SELECT token, token_id FROM cost_basis WHERE market_id = ? AND is_paper = ?"
+            " ORDER BY size DESC, updated_at DESC LIMIT 1",
             (market_id, self._mode_flag()),
         )
         if row is None:
             return TokenType.YES, ""
-        token = TokenType(row["token"]) if row["token"] else TokenType.YES
-        return token, row["token_id"] or ""
+        return TokenType.from_str(row["token"]), row["token_id"] or ""
 
     # ------------------------------------------------------------------
     # P&L calculations

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -86,6 +86,8 @@ class Database:
             await self._migrate_v17_to_v18()
         if from_version < 19:
             await self._migrate_v18_to_v19()
+        if from_version < 20:
+            await self._migrate_v19_to_v20()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -444,6 +446,75 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 19")
         await self._db.commit()
         log.info("database.migrated", from_version=18, to_version=19)
+
+    async def _migrate_v19_to_v20(self) -> None:
+        """Collapse casing-split cost_basis rows into canonical YES/NO tokens.
+
+        Pre-v20 the live reconciler wrote the raw CLOB outcome ("Yes"/"No")
+        while the fill and Kalshi paths wrote TokenType values ("YES"/"NO"),
+        so one position could exist as two PK-distinct rows differing only by
+        case — and the token-blind getters returned an arbitrary one. Merge
+        each (market_id, is_paper, canonical-token) group into a single row:
+        the newest ``updated_at`` wins for size/avg_cost/total_cost (the
+        reconciler's CLOB ground truth), and realized_pnl is summed so no
+        realized history is dropped. Genuine two-sided positions (distinct
+        canonical YES and NO) are preserved as two rows. A full pre-migration
+        snapshot is kept in ``cost_basis_backup_v20`` (reversible).
+        """
+        await self._db.execute("DROP TABLE IF EXISTS cost_basis_backup_v20")
+        await self._db.execute(
+            "CREATE TABLE cost_basis_backup_v20 AS SELECT * FROM cost_basis"
+        )
+
+        cursor = await self._db.execute(
+            "SELECT market_id, token, token_id, size, avg_cost, total_cost,"
+            " realized_pnl, is_paper, updated_at FROM cost_basis"
+        )
+        rows = await cursor.fetchall()
+
+        def canon(t: object) -> str:
+            return "NO" if str(t or "").strip().upper() == "NO" else "YES"
+
+        groups: dict[tuple, list] = {}
+        for r in rows:
+            groups.setdefault((r["market_id"], r["is_paper"], canon(r["token"])), []).append(r)
+
+        merged = 0
+        for (market_id, is_paper, token), grp in groups.items():
+            # Already-canonical singleton: nothing to rewrite.
+            if len(grp) == 1 and grp[0]["token"] == token:
+                continue
+            # Newest write wins for current holdings; tiebreak on larger size.
+            authoritative = max(
+                grp, key=lambda r: (str(r["updated_at"] or ""), float(r["size"] or 0))
+            )
+            realized = sum(float(r["realized_pnl"] or 0) for r in grp)
+            token_id = authoritative["token_id"] or next(
+                (r["token_id"] for r in grp if r["token_id"]), ""
+            )
+            for r in grp:
+                await self._db.execute(
+                    "DELETE FROM cost_basis WHERE market_id = ? AND is_paper = ? AND token = ?",
+                    (market_id, is_paper, r["token"]),
+                )
+            await self._db.execute(
+                "INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost,"
+                " total_cost, realized_pnl, is_paper, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    market_id, token, token_id,
+                    float(authoritative["size"] or 0),
+                    float(authoritative["avg_cost"] or 0),
+                    float(authoritative["total_cost"] or 0),
+                    realized, is_paper, authoritative["updated_at"],
+                ),
+            )
+            if len(grp) > 1:
+                merged += 1
+
+        await self._db.execute("UPDATE schema_version SET version = 20")
+        await self._db.commit()
+        log.info("database.migrated", from_version=19, to_version=20, merged_groups=merged)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -104,6 +104,17 @@ class TokenType(str, Enum):
     YES = "YES"
     NO = "NO"
 
+    @classmethod
+    def from_str(cls, value: str | None) -> "TokenType":
+        """Normalize an outcome string to a canonical TokenType.
+
+        Case-insensitive so external strings — the reconciler/CLOB raw
+        outcomes ("Yes"/"No"), Kalshi sides, legacy rows — all collapse to
+        the same canonical ``.value`` ("YES"/"NO"). Anything that isn't a
+        recognizable NO defaults to YES (the historical default).
+        """
+        return cls.NO if str(value or "").strip().upper() == "NO" else cls.YES
+
 
 class OrderType(str, Enum):
     MARKET = "MARKET"

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -16,9 +16,11 @@ execution:
   # Max cents above the reference price the router may pay to lift the ask;
   # crossing additionally requires post-cross edge >= risk.min_edge_pct.
   entry_max_cross_cents: 4
-  # Max cents below the snapshot price an exit SELL may cross down to take
-  # the real bid (otherwise exits rest at the ask and TTL-cancel forever).
-  exit_max_cross_cents: 3
+  # Slippage band for marketable exits: take the real bid when it's within
+  # this many cents of the snapshot, else skip + back off (a SELL only fills
+  # by crossing to the bid; resting inside the spread TTL-cancels forever).
+  exit_max_cross_cents: 10
+  exit_min_bid_price: 0.05   # never cross into a bid below this (junk-bid guard)
   spread_capture_min_bps: 50
   stop_loss_pct: 30.0
   profit_target_pct: 50.0
@@ -144,7 +146,7 @@ nlp:
   # or a news flag lifts the bench immediately.
   rejection_cooldown_minutes: 240
   rejection_reprice_threshold: 0.03
-  model: "opus"
+  model: "claude-opus-4-8"
   max_tokens: 4096
   # API intensity: "low", "medium", or "full_blast"
   # low:        10 markets, 3 evidence, skip second opinion, 50 calls/day
@@ -155,7 +157,7 @@ nlp:
   skip_second_opinion: false
   max_markets_per_cycle: 5
   evidence_per_source: 5
-  daily_claude_call_budget: 80
+  daily_claude_call_budget: 175
 
 calibration:
   min_samples: 30
@@ -415,6 +417,51 @@ entailment_arb:
   llm_enabled: true
   llm_min_confidence: 0.9
   interval_seconds: 900
+  # Kalshi "Above X" econ-bin ladder arb (model-free monotonicity), fetched
+  # per-series; violations must clear BOTH legs' Kalshi taker fees + buffer.
+  kalshi_ladders_enabled: true
+
+econ_indicator:
+  # Data-driven Kalshi econ-indicator bin pricing: price "Above X" ladders from
+  # FRED history (random-walk nowcast + change-vol, sigma floored), trade bins
+  # the crowd misprices. Directional -> PAPER-FORCED until the ledger +
+  # calibration prove it; edge must clear the Kalshi taker fee on top of min_edge.
+  enabled: true
+  paper: true
+  series: []             # empty = all registered (KXCPIYOY, KXU3, KXPAYROLLS)
+  stake_usd: 10.0
+  min_edge: 0.07
+  max_open: 30
+  max_entries_per_cycle: 5
+  history_n: 60
+  interval_seconds: 1800
+
+weather_temp:
+  # Open-Meteo ensemble pricing of Polymarket daily city-temperature bins.
+  # Measurement spike: PAPER-FORCED, logs model-vs-market every cycle; edge must
+  # clear the poly taker fee + min_edge, max_divergence skips artifact-scale gaps.
+  enabled: true
+  paper: true
+  min_edge: 0.10
+  max_divergence: 0.40
+  stake_usd: 10.0
+  max_entries_per_cycle: 8
+  interval_seconds: 3600
+
+intraday_drift:
+  # Measurement spike (NO trading): tracks post-signal price drift toward the LLM
+  # estimate to test the intraday under-reaction thesis before building the strat.
+  enabled: true
+  interval_seconds: 300
+  time_box_hours: 8.0
+
+hydro_watch:
+  # Alert-only: flags the first time a tradeable hydrology market (Lake Mead,
+  # drought, flood stage, snowpack, reservoir, ...) appears, so the compHydro
+  # streamflow moat can be deployed. No trading.
+  enabled: true
+  min_liquidity: 100.0
+  interval_seconds: 21600
 
 oddlot_tender:
   # Odd-lot tender harvester — first equity pillar. Issuer tender offers
@@ -470,7 +517,7 @@ bias_harvest:
   # paper: false (still behind the three live gates).
   enabled: true
   paper: true
-  band_lo: 0.80
+  band_lo: 0.90
   band_hi: 0.97
   # claude_prob = favored price + uplift (the measured band gap is +4..+6pts).
   # MUST stay < 0.05 or the divergence filter blocks entries at MEDIUM conf.
@@ -499,3 +546,20 @@ logging:
   level: "INFO"
   json_format: true
   file: "auramaur.log"
+
+cross_venue_arb:
+  # Cross-venue semantic-equivalence arb (Poly x Kalshi): logically equivalent
+  # but differently-worded markets priced apart. Candidate pairs pre-filtered by
+  # word overlap, then verified ADVERSARIALLY by the LLM (default: not equivalent)
+  # at a high confidence floor — a false match is a paired loss, not a free arb.
+  # Gap must clear both legs' taker fees + buffer. PAPER-FORCED + NOT graduation-
+  # exempt (resolution-mismatch risk = real directional loss).
+  enabled: true
+  paper: true
+  min_word_overlap: 0.5
+  llm_min_confidence: 0.9
+  gap_buffer: 0.02
+  stake_usd: 10.0
+  max_pairs_per_cycle: 2
+  max_llm_calls_per_cycle: 8
+  interval_seconds: 1200

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,12 +11,36 @@ from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
 
 
+def _deep_merge(base: dict, over: dict) -> dict:
+    """Recursively merge ``over`` onto ``base`` (override wins; dicts merge)."""
+    out = dict(base)
+    for key, value in (over or {}).items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
 def _load_defaults() -> dict:
+    """Load tracked ``defaults.yaml`` then deep-merge optional local overrides.
+
+    ``defaults.local.yaml`` (gitignored) holds operational / never-commit
+    values — the live gate, paper-book headroom, model-budget conservation
+    knobs — so the tracked file stays a paper-safe baseline. The local file is
+    absent in CI and fresh clones, so behavior there falls back to the tracked
+    defaults (and, for keys not present in either, the pydantic field defaults).
+    """
+    base: dict = {}
     defaults_path = Path(__file__).parent / "defaults.yaml"
     if defaults_path.exists():
         with open(defaults_path) as f:
-            return yaml.safe_load(f)
-    return {}
+            base = yaml.safe_load(f) or {}
+    local_path = Path(__file__).parent / "defaults.local.yaml"
+    if local_path.exists():
+        with open(local_path) as f:
+            base = _deep_merge(base, yaml.safe_load(f) or {})
+    return base
 
 
 _DEFAULTS = _load_defaults()

--- a/tests/test_config_local_override.py
+++ b/tests/test_config_local_override.py
@@ -1,0 +1,55 @@
+"""Tests for the tracked-vs-local config split.
+
+config/settings.py loads the tracked ``defaults.yaml`` and deep-merges an
+optional gitignored ``defaults.local.yaml`` on top, so operational and
+never-commit values (the live gate, paper headroom, model-budget conservation)
+live outside version control while the tracked file stays a paper-safe baseline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from config.settings import _deep_merge
+
+
+def test_deep_merge_override_wins_and_nested_dicts_merge():
+    base = {"execution": {"live": False, "paper_initial_balance": 111.0},
+            "nlp": {"model": "opus", "budget": 80}}
+    over = {"execution": {"live": True},
+            "nlp": {"budget": 175},
+            "new_section": {"x": 1}}
+    merged = _deep_merge(base, over)
+    # Override wins on the keys it sets...
+    assert merged["execution"]["live"] is True
+    assert merged["nlp"]["budget"] == 175
+    # ...while siblings in the same nested dict are preserved.
+    assert merged["execution"]["paper_initial_balance"] == 111.0
+    assert merged["nlp"]["model"] == "opus"
+    # Entirely new sections are added.
+    assert merged["new_section"] == {"x": 1}
+    # Inputs are not mutated.
+    assert base["execution"]["live"] is False
+
+
+def test_deep_merge_handles_empty_override():
+    base = {"a": {"b": 1}}
+    assert _deep_merge(base, {}) == base
+    assert _deep_merge(base, None) == base
+
+
+def test_tracked_defaults_are_paper_safe():
+    """The committed defaults.yaml alone (no local overrides) must never go
+    live — a fresh clone / CI must default to paper."""
+    tracked = yaml.safe_load(
+        (Path(__file__).resolve().parent.parent / "config" / "defaults.yaml").read_text()
+    )
+    assert tracked["execution"]["live"] is False
+    # analysis_mode is a local conservation knob — it must not be pinned in the
+    # tracked file (pydantic default "auto" applies on a fresh clone).
+    assert "analysis_mode" not in tracked.get("nlp", {})
+    # Gemini conservation mode must not leak into tracked defaults.
+    assert tracked["gemini"]["claude_budget_threshold"] == 0.8
+    assert len(tracked["gemini"]["off_hours_utc"]) == 6

--- a/tests/test_cost_basis_token_scoping.py
+++ b/tests/test_cost_basis_token_scoping.py
@@ -1,0 +1,144 @@
+"""Tests for cost_basis token scoping and the v20 casing-merge migration.
+
+Locks in the fix for the token-blind cost-basis reads:
+
+  1. ``TokenType.from_str`` normalizes any-case outcome strings to canonical
+     "YES"/"NO" (the reconciler wrote raw CLOB "Yes"/"No", everything else
+     wrote enum "YES"/"NO", which split one position into two PK rows).
+  2. ``get_cost_basis`` / ``get_token_info`` disambiguate deterministically
+     (largest open size, then most recent) instead of returning an arbitrary
+     row when a market has more than one token row.
+  3. The v19->v20 migration collapses casing-split duplicates into one
+     canonical row (newest write wins for size/avg_cost, realized_pnl summed),
+     preserves genuine two-sided positions, and keeps a reversible backup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import TokenType
+from config.settings import Settings
+
+
+def test_tokentype_from_str_normalizes_casing():
+    assert TokenType.from_str("Yes") is TokenType.YES
+    assert TokenType.from_str("yes") is TokenType.YES
+    assert TokenType.from_str("YES") is TokenType.YES
+    assert TokenType.from_str("No") is TokenType.NO
+    assert TokenType.from_str("no") is TokenType.NO
+    assert TokenType.from_str("NO") is TokenType.NO
+    assert TokenType.from_str(" no ") is TokenType.NO
+    # Unknown / empty defaults to YES (the historical default).
+    assert TokenType.from_str("") is TokenType.YES
+    assert TokenType.from_str(None) is TokenType.YES
+    assert TokenType.from_str("Something") is TokenType.YES
+    # .value is the canonical persisted form.
+    assert TokenType.from_str("No").value == "NO"
+
+
+async def _insert_cb(db, market_id, token, size, avg_cost, is_paper,
+                     realized_pnl=0.0, updated_at="2026-01-01T00:00:00+00:00"):
+    await db.execute(
+        "INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost,"
+        " total_cost, realized_pnl, is_paper, updated_at)"
+        " VALUES (?, ?, '', ?, ?, ?, ?, ?, ?)",
+        (market_id, token, size, avg_cost, size * avg_cost, realized_pnl,
+         is_paper, updated_at),
+    )
+    await db.commit()
+
+
+def test_getters_disambiguate_two_sided_position():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        tracker = PnLTracker(db, Settings())
+        mode = tracker._mode_flag()
+
+        # A genuine two-sided position: small NO + large YES in the same mode.
+        await _insert_cb(db, "m1", "NO", 5.0, 0.30, mode)
+        await _insert_cb(db, "m1", "YES", 40.0, 0.62, mode)
+
+        avg_cost, size = await tracker.get_cost_basis("m1")
+        token, _ = await tracker.get_token_info("m1")
+        # Largest open size wins, and the token returned matches it.
+        assert size == 40.0
+        assert abs(avg_cost - 0.62) < 1e-9
+        assert token is TokenType.YES
+
+    asyncio.run(run())
+
+
+def test_getters_are_case_insensitive_for_legacy_rows():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        tracker = PnLTracker(db, Settings())
+        mode = tracker._mode_flag()
+
+        # A legacy title-case row (as the reconciler used to write) must still
+        # parse to a valid TokenType rather than raising.
+        await _insert_cb(db, "m2", "No", 12.0, 0.44, mode)
+        token, _ = await tracker.get_token_info("m2")
+        assert token is TokenType.NO
+
+    asyncio.run(run())
+
+
+def test_v19_to_v20_merges_casing_splits():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+
+        # Casing-split duplicate of ONE position (live): stale "NO" from the
+        # fill path + fresh "No" from the reconciler (ground-truth price).
+        await _insert_cb(db, "split", "NO", 35.0, 0.835, 0,
+                         realized_pnl=1.5, updated_at="2026-06-01T00:00:00+00:00")
+        await _insert_cb(db, "split", "No", 35.0, 0.766, 0,
+                         realized_pnl=0.0, updated_at="2026-06-23T00:00:00+00:00")
+        # A genuine two-sided position must be preserved as two rows.
+        await _insert_cb(db, "twosided", "YES", 20.0, 0.40, 0)
+        await _insert_cb(db, "twosided", "NO", 10.0, 0.55, 0)
+        # Same market id, different mode — must stay independent.
+        await _insert_cb(db, "split", "Yes", 8.0, 0.20, 1)
+
+        await db._migrate_v19_to_v20()
+
+        # The casing split collapsed to ONE canonical NO row, newest wins.
+        rows = await db.fetchall(
+            "SELECT token, size, avg_cost, realized_pnl FROM cost_basis"
+            " WHERE market_id = 'split' AND is_paper = 0"
+        )
+        assert len(rows) == 1
+        row = dict(rows[0])
+        assert row["token"] == "NO"
+        assert abs(row["avg_cost"] - 0.766) < 1e-9          # reconciler ground truth
+        assert abs(row["realized_pnl"] - 1.5) < 1e-9        # realized history summed, not lost
+
+        # No non-canonical casing remains anywhere.
+        bad = await db.fetchall(
+            "SELECT 1 FROM cost_basis WHERE token NOT IN ('YES', 'NO')"
+        )
+        assert bad == []
+
+        # Genuine two-sided position preserved as two rows.
+        ts = await db.fetchall(
+            "SELECT token FROM cost_basis WHERE market_id = 'twosided' ORDER BY token"
+        )
+        assert [dict(r)["token"] for r in ts] == ["NO", "YES"]
+
+        # Paper-mode row for the same id is untouched (and recased).
+        paper = await db.fetchall(
+            "SELECT token, size FROM cost_basis WHERE market_id = 'split' AND is_paper = 1"
+        )
+        assert len(paper) == 1
+        assert dict(paper[0])["token"] == "YES"
+
+        # Reversible backup holds every pre-migration row.
+        backup = await db.fetchall("SELECT count(*) AS n FROM cost_basis_backup_v20")
+        assert dict(backup[0])["n"] == 5
+
+    asyncio.run(run())


### PR DESCRIPTION
Two contained correctness/hygiene fixes from an architecture review (save + freeze + extract; these are the small wins before the ExecutionGateway extraction).

## 1. Token-scope cost_basis reads + canonical token casing
`cost_basis` is keyed by `(market_id, token, is_paper)`, but `get_cost_basis()` / `get_token_info()` filtered only on `(market_id, is_paper)` with no `ORDER BY`, so a market holding more than one token row returned an arbitrary row — wrong avg_cost/token for marks and exits.

Root cause of the duplicate rows: the live reconciler wrote the raw CLOB outcome (`"Yes"`/`"No"`) into `cost_basis.token`, while the fill and Kalshi paths wrote canonical `TokenType` values (`"YES"`/`"NO"`). Same position, two PK-distinct rows differing only by case.

- `TokenType.from_str()` — case-insensitive normalization to canonical `"YES"`/`"NO"`.
- Reconciler write normalizes the outcome (the one divergent writer).
- Getters disambiguate deterministically (largest open size, then most recent) and parse case-insensitively; genuine two-sided positions are handled, not merged.
- Migration **v19→v20** collapses casing-split duplicates into one canonical row (newest write wins for size/avg_cost, realized_pnl summed); two-sided positions preserved; reversible pre-migration snapshot in `cost_basis_backup_v20`.

## 2. Split tracked defaults from local operational overrides
`settings.py` loaded only `defaults.yaml`, so the working tree mixed must-never-commit values (the go-live gate, model-budget conservation knobs) with shippable config — and five strategy-pillar config blocks existed only in the uncommitted working tree, leaving live strategy config unversioned.

- `settings.py` deep-merges an optional gitignored `config/defaults.local.yaml` on top of tracked `defaults.yaml`. Absent in CI/fresh clones → tracked file is the paper-safe baseline (`execution.live` stays false).
- Operational/never-commit values moved into the local file; previously-unversioned pillar configs + exit-slippage tuning committed.
- Verified the merged (tracked + local) config is byte-identical to the prior working tree → running behavior unchanged.

## Tests
Full suite: **827 passed**. New: `tests/test_cost_basis_token_scoping.py`, `tests/test_config_local_override.py`. Migration validated on a copy of the live DB (dup groups merged, PK-clean, two-sided positions preserved).

Note: the v20 migration runs on next bot restart (creates the reversible backup table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)