### PR TITLE
refactor(exec): ExecutionGateway — one execution tail for every strategy

### DIFF
--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -1,17 +1,22 @@
 """ExecutionGateway — the single mechanical path from an approved trade to a
 recorded fill.
 
-Phase 0 of the execution refactor (see the platform-refactor roadmap): the
-canonical entry tail historically lived in ``TradingEngine._build_and_place_order``
-and was reimplemented, divergently, inside every standalone strategy. This
-module extracts that tail VERBATIM into one reusable component so later phases
-can route the strategies (and exits) through it and delete the duplication.
+The canonical entry tail historically lived in
+``TradingEngine._build_and_place_order`` and was reimplemented, divergently,
+inside every standalone strategy. This component extracts that tail so the
+strategies (and exits) route through one place and the duplication — the source
+of token/accounting bugs — is deleted.
 
 The gateway changes *who* calls the money path, never the path itself: routing,
 the ``place_order`` triple-gate (kill-switch / geoblock / live-enabled), the
 paper fork, and ``record_fill`` all keep their existing behavior. Risk
-evaluation stays with the caller in Phase 0 — the caller passes the already
-risk-approved ``size_dollars`` and ``force_paper`` on the intent.
+evaluation stays with the caller — the caller passes the already risk-approved
+``size_dollars`` and ``force_paper`` on the intent.
+
+``submit`` runs the single-leg path. ``submit_paired`` runs a both-or-nothing
+pair (the arb pillars): it builds BOTH orders before placing EITHER, places A
+then B, and unwinds a live-pending A if B fails — preserving the atomicity a
+per-leg ``submit`` could not.
 """
 
 from __future__ import annotations
@@ -23,22 +28,25 @@ import structlog
 
 from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
 from auramaur.db.database import Database
-from auramaur.exchange.models import Fill, Market, OrderResult, OrderSide, Signal
+from auramaur.exchange.models import Fill, Market, Order, OrderResult, OrderSide, Signal
 from auramaur.exchange.protocols import ExchangeClient
 from auramaur.monitoring.display import show_order, show_order_dropped
 from config.settings import Settings
 
 log = structlog.get_logger()
 
+# Statuses that count as "the order left the building" (recorded / tracked).
+_OK_STATUSES = ("filled", "paper", "partial", "pending")
+_FILLED_STATUSES = ("filled", "paper", "partial")
+
 
 @dataclass
 class TradeIntent:
     """A risk-approved decision to trade, handed to the gateway to execute.
 
-    Phase 0 covers the entry path only; ``size_dollars`` is the caller's
-    risk-approved position size and ``force_paper`` carries the graduation
-    ladder's downgrade. Later phases extend this with an exit ``kind`` and a
-    ``prebuilt_order`` for paths that skip routing.
+    ``size_dollars`` is the caller's risk-approved position size and
+    ``force_paper`` carries the graduation ladder's (and the strategy's own
+    ``cfg.paper``) downgrade to dry-run.
     """
 
     signal: Signal
@@ -59,7 +67,7 @@ class ExecutionResult:
     """
 
     status: Literal["filled", "paper", "partial", "pending", "rejected", "skipped"]
-    order: object | None = None
+    order: Order | None = None
     result: OrderResult | None = None
     fill: Fill | None = None
     reason: str = ""
@@ -85,23 +93,96 @@ class ExecutionGateway:
         self.db = db
         self.pnl_tracker = pnl_tracker
 
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     async def submit(self, intent: TradeIntent) -> ExecutionResult:
         """Build an order (via router or direct) and place it, recording the
         fill. Behavior-identical to the former
         ``TradingEngine._build_and_place_order``.
         """
-        signal = intent.signal
-        market = intent.market
-        size_dollars = intent.size_dollars
-
-        # ``force_paper`` (graduation ladder) downgrades this ENTRY to dry-run
-        # regardless of global live mode — it can only restrict, never arm.
         is_live = self.settings.is_live and not intent.force_paper
+        order = await self._build_order(
+            intent.signal, intent.market, intent.size_dollars, is_live,
+            exchange=self.exchange, router=self.router,
+        )
+        if order is None:
+            return ExecutionResult(status="skipped", reason="not submitted")
+        return await self._place_and_record(
+            order, intent.signal, self.exchange, self.exchange_name)
+
+    async def submit_paired(
+        self,
+        a: TradeIntent,
+        b: TradeIntent,
+        *,
+        exchange_a: ExchangeClient,
+        exchange_name_a: str,
+        exchange_b: ExchangeClient,
+        exchange_name_b: str,
+    ) -> tuple[ExecutionResult, ExecutionResult]:
+        """Both-or-nothing paired execution for the arb pillars.
+
+        Builds BOTH orders before placing EITHER (a leg that can't be built
+        never leaves the other naked), places A then B, and cancels a
+        live-pending A if B fails. ``record_fill`` + the trades-mirror are owned
+        here; the caller keeps its signals / portfolio / verdict writes and any
+        partial-fill bookkeeping. Legs may live on different exchanges
+        (cross-venue), so each carries its own exchange + name. Both intents
+        should share the same ``force_paper`` (the pillars paper-force the pair
+        together).
+        """
+        is_live_a = self.settings.is_live and not a.force_paper
+        is_live_b = self.settings.is_live and not b.force_paper
+        order_a = await self._build_order(
+            a.signal, a.market, a.size_dollars, is_live_a,
+            exchange=exchange_a, router=None)
+        order_b = await self._build_order(
+            b.signal, b.market, b.size_dollars, is_live_b,
+            exchange=exchange_b, router=None)
+        if order_a is None or order_b is None:
+            skip = ExecutionResult(status="skipped", reason="leg build failed")
+            return skip, ExecutionResult(status="skipped", reason="leg build failed")
+
+        res_a = await self._place_and_record(
+            order_a, a.signal, exchange_a, exchange_name_a)
+        if res_a.status not in _OK_STATUSES:
+            # Leg A rejected — B is never placed, nothing to unwind.
+            return res_a, ExecutionResult(status="skipped", reason="leg_a_not_ok")
+
+        res_b = await self._place_and_record(
+            order_b, b.signal, exchange_b, exchange_name_b)
+        if res_b.status not in _OK_STATUSES:
+            # Leg risk: A is in, B failed. Cancel a live-pending A so we don't
+            # sit on a naked directional leg (paper / already-filled A can't be
+            # cancelled — that's the genuine single-leg the caller logs).
+            if (res_a.result is not None and res_a.result.status == "pending"
+                    and not res_a.result.is_paper):
+                try:
+                    await exchange_a.cancel_order(res_a.result.order_id)
+                except Exception as e:  # noqa: BLE001 — best-effort unwind
+                    log.warning("gateway.paired_leg_a_cancel_failed",
+                                order_id=res_a.result.order_id, error=str(e))
+        return res_a, res_b
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _build_order(
+        self, signal: Signal, market: Market, size_dollars: float, is_live: bool,
+        *, exchange: ExchangeClient, router: SmartOrderRouter | None,
+    ) -> Order | None:
+        """Route (or prepare) an order. Returns ``None`` — having recorded the
+        appropriate ``order_build_drops`` cooldown — when the signal is
+        unmarketable at the book or the order can't be built.
+        """
         try:
-            if self.router:
-                order = await self.router.route(signal, market, size_dollars, is_live)
+            if router:
+                order = await router.route(signal, market, size_dollars, is_live)
             else:
-                order = self.exchange.prepare_order(signal, market, size_dollars, is_live)
+                order = exchange.prepare_order(signal, market, size_dollars, is_live)
         except UnmarketableSignal as skip:
             # No realizable edge at the book. This gate runs before the
             # paper/live split on purpose: paper fills simulate at the
@@ -125,7 +206,7 @@ class ExecutionGateway:
                 await self.db.commit()
             except Exception:
                 pass
-            return ExecutionResult(status="skipped", reason=f"unmarketable: {skip}")
+            return None
 
         if order is None:
             show_order_dropped(market.id, f"order build failed (${size_dollars:.2f} — could not build a valid order)")
@@ -148,12 +229,21 @@ class ExecutionGateway:
                 await self.db.commit()
             except Exception:
                 pass  # Table may not exist yet
-            return ExecutionResult(status="skipped", reason="order build failed")
+            return None
 
         if not order.source:
             order.source = signal.strategy_source or "llm"
-        result = await self.exchange.place_order(order)
-        show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=self.exchange_name, error_message=result.error_message, market_id=order.market_id)
+        return order
+
+    async def _place_and_record(
+        self, order: Order, signal: Signal,
+        exchange: ExchangeClient, exchange_name: str,
+    ) -> ExecutionResult:
+        """Place a built order, then log slippage, record the fill, and mirror
+        to ``trades``. Shared by the single-leg and paired paths.
+        """
+        result = await exchange.place_order(order)
+        show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=exchange_name, error_message=result.error_message, market_id=order.market_id)
 
         # Cooldown on API errors — retry in 30 min, not every cycle
         if result.status == "rejected" and result.order_id == "ERROR":
@@ -170,7 +260,7 @@ class ExecutionGateway:
 
         # Log slippage only for actual executions.  Live pending orders echo
         # the limit price but have not filled yet.
-        if result.status in ("filled", "paper", "partial") and result.filled_price > 0:
+        if result.status in _FILLED_STATUSES and result.filled_price > 0:
             slippage_bps = (result.filled_price - order.price) / order.price * 10000
             if order.side == OrderSide.SELL:
                 slippage_bps = -slippage_bps  # For sells, lower fill = worse
@@ -178,7 +268,7 @@ class ExecutionGateway:
                 await self.db.execute(
                     """INSERT INTO slippage_log (market_id, exchange, side, expected_price, filled_price, slippage_bps, size, order_type)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (order.market_id, order.exchange or self.exchange_name, order.side.value,
+                    (order.market_id, order.exchange or exchange_name, order.side.value,
                      order.price, result.filled_price, round(slippage_bps, 2), order.size,
                      order.order_type.value if hasattr(order, 'order_type') else 'limit'),
                 )
@@ -192,7 +282,7 @@ class ExecutionGateway:
         # Record P&L only for actual executions.  Pending live orders are
         # mirrored to trades below, then finalized by the order monitor.
         recorded_fill: Fill | None = None
-        if result.status in ("filled", "paper", "partial") and result.filled_size > 0:
+        if result.status in _FILLED_STATUSES and result.filled_size > 0:
             fill = Fill(
                 order_id=result.order_id,
                 market_id=order.market_id,
@@ -207,7 +297,7 @@ class ExecutionGateway:
                 await self.pnl_tracker.record_fill(fill)
                 recorded_fill = fill
 
-        if result.status in ("filled", "paper", "partial", "pending"):
+        if result.status in _OK_STATUSES:
             # Mirror into legacy `trades` table so the CLI stats view,
             # order monitor, and holding-period lookups stay in sync.
             # PnLTracker writes authoritative execution rows to `fills`.
@@ -228,7 +318,7 @@ class ExecutionGateway:
                         result.order_id,
                         trade_status,
                         None,
-                        order.exchange or self.exchange_name,
+                        order.exchange or exchange_name,
                         signal.strategy_source,
                     ),
                 )

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -1,0 +1,242 @@
+"""ExecutionGateway — the single mechanical path from an approved trade to a
+recorded fill.
+
+Phase 0 of the execution refactor (see the platform-refactor roadmap): the
+canonical entry tail historically lived in ``TradingEngine._build_and_place_order``
+and was reimplemented, divergently, inside every standalone strategy. This
+module extracts that tail VERBATIM into one reusable component so later phases
+can route the strategies (and exits) through it and delete the duplication.
+
+The gateway changes *who* calls the money path, never the path itself: routing,
+the ``place_order`` triple-gate (kill-switch / geoblock / live-enabled), the
+paper fork, and ``record_fill`` all keep their existing behavior. Risk
+evaluation stays with the caller in Phase 0 — the caller passes the already
+risk-approved ``size_dollars`` and ``force_paper`` on the intent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import structlog
+
+from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
+from auramaur.db.database import Database
+from auramaur.exchange.models import Fill, Market, OrderResult, OrderSide, Signal
+from auramaur.exchange.protocols import ExchangeClient
+from auramaur.monitoring.display import show_order, show_order_dropped
+from config.settings import Settings
+
+log = structlog.get_logger()
+
+
+@dataclass
+class TradeIntent:
+    """A risk-approved decision to trade, handed to the gateway to execute.
+
+    Phase 0 covers the entry path only; ``size_dollars`` is the caller's
+    risk-approved position size and ``force_paper`` carries the graduation
+    ladder's downgrade. Later phases extend this with an exit ``kind`` and a
+    ``prebuilt_order`` for paths that skip routing.
+    """
+
+    signal: Signal
+    market: Market
+    size_dollars: float
+    force_paper: bool = False
+    kind: Literal["entry"] = "entry"
+
+
+@dataclass
+class ExecutionResult:
+    """The outcome of a gateway submission, exposing every decision point.
+
+    ``result`` is the underlying :class:`OrderResult` for any submitted order
+    (including a rejected one) and ``None`` when the trade was skipped before
+    submission (unmarketable / build failure) — preserving the legacy
+    ``_build_and_place_order`` return contract (``None`` == not submitted).
+    """
+
+    status: Literal["filled", "paper", "partial", "pending", "rejected", "skipped"]
+    order: object | None = None
+    result: OrderResult | None = None
+    fill: Fill | None = None
+    reason: str = ""
+
+
+class ExecutionGateway:
+    """Routes an approved :class:`TradeIntent` through route → place → record."""
+
+    def __init__(
+        self,
+        *,
+        router: SmartOrderRouter | None,
+        exchange: ExchangeClient,
+        exchange_name: str,
+        settings: Settings,
+        db: Database,
+        pnl_tracker,
+    ) -> None:
+        self.router = router
+        self.exchange = exchange
+        self.exchange_name = exchange_name
+        self.settings = settings
+        self.db = db
+        self.pnl_tracker = pnl_tracker
+
+    async def submit(self, intent: TradeIntent) -> ExecutionResult:
+        """Build an order (via router or direct) and place it, recording the
+        fill. Behavior-identical to the former
+        ``TradingEngine._build_and_place_order``.
+        """
+        signal = intent.signal
+        market = intent.market
+        size_dollars = intent.size_dollars
+
+        # ``force_paper`` (graduation ladder) downgrades this ENTRY to dry-run
+        # regardless of global live mode — it can only restrict, never arm.
+        is_live = self.settings.is_live and not intent.force_paper
+        try:
+            if self.router:
+                order = await self.router.route(signal, market, size_dollars, is_live)
+            else:
+                order = self.exchange.prepare_order(signal, market, size_dollars, is_live)
+        except UnmarketableSignal as skip:
+            # No realizable edge at the book. This gate runs before the
+            # paper/live split on purpose: paper fills simulate at the
+            # reference price, so letting paper books keep these trades
+            # would graduate strategies on fills live could never get.
+            show_order_dropped(market.id, f"unmarketable: {skip}")
+            log.info(
+                "engine.entry_unmarketable",
+                market_id=market.id,
+                strategy=signal.strategy_source,
+                reason=str(skip),
+            )
+            try:
+                # Shorter block than build failures: the book can move.
+                await self.db.execute(
+                    """INSERT OR REPLACE INTO order_build_drops
+                       (market_id, blocked_until, reason)
+                       VALUES (?, datetime('now', '+30 minutes'), ?)""",
+                    (market.id, f"unmarketable: {skip}"),
+                )
+                await self.db.commit()
+            except Exception:
+                pass
+            return ExecutionResult(status="skipped", reason=f"unmarketable: {skip}")
+
+        if order is None:
+            show_order_dropped(market.id, f"order build failed (${size_dollars:.2f} — could not build a valid order)")
+            log.warning(
+                "engine.order_dropped",
+                market_id=market.id,
+                size_dollars=size_dollars,
+                reason="prepare_order returned None (bad price/token or router rejection)",
+            )
+            # Sub-minimum sizing is now bumped up in prepare_order, so a None
+            # order here is a genuine build failure (bad price/token). Block
+            # only briefly so a transient issue can retry next cycle.
+            try:
+                await self.db.execute(
+                    """INSERT OR REPLACE INTO order_build_drops
+                       (market_id, blocked_until, reason)
+                       VALUES (?, datetime('now', '+2 hours'), ?)""",
+                    (market.id, f"order build failed at ${size_dollars:.2f}"),
+                )
+                await self.db.commit()
+            except Exception:
+                pass  # Table may not exist yet
+            return ExecutionResult(status="skipped", reason="order build failed")
+
+        if not order.source:
+            order.source = signal.strategy_source or "llm"
+        result = await self.exchange.place_order(order)
+        show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=self.exchange_name, error_message=result.error_message, market_id=order.market_id)
+
+        # Cooldown on API errors — retry in 30 min, not every cycle
+        if result.status == "rejected" and result.order_id == "ERROR":
+            try:
+                await self.db.execute(
+                    """INSERT OR REPLACE INTO order_build_drops
+                       (market_id, blocked_until, reason)
+                       VALUES (?, datetime('now', '+30 minutes'), ?)""",
+                    (order.market_id, "place_order API error"),
+                )
+                await self.db.commit()
+            except Exception:
+                pass
+
+        # Log slippage only for actual executions.  Live pending orders echo
+        # the limit price but have not filled yet.
+        if result.status in ("filled", "paper", "partial") and result.filled_price > 0:
+            slippage_bps = (result.filled_price - order.price) / order.price * 10000
+            if order.side == OrderSide.SELL:
+                slippage_bps = -slippage_bps  # For sells, lower fill = worse
+            try:
+                await self.db.execute(
+                    """INSERT INTO slippage_log (market_id, exchange, side, expected_price, filled_price, slippage_bps, size, order_type)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (order.market_id, order.exchange or self.exchange_name, order.side.value,
+                     order.price, result.filled_price, round(slippage_bps, 2), order.size,
+                     order.order_type.value if hasattr(order, 'order_type') else 'limit'),
+                )
+                await self.db.commit()
+            except Exception:
+                pass
+
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+
+        # Record P&L only for actual executions.  Pending live orders are
+        # mirrored to trades below, then finalized by the order monitor.
+        recorded_fill: Fill | None = None
+        if result.status in ("filled", "paper", "partial") and result.filled_size > 0:
+            fill = Fill(
+                order_id=result.order_id,
+                market_id=order.market_id,
+                token_id=order.token_id,
+                side=order.side,
+                token=order.token,
+                size=result.filled_size,
+                price=fill_price,
+                is_paper=result.is_paper,
+            )
+            if self.pnl_tracker:
+                await self.pnl_tracker.record_fill(fill)
+                recorded_fill = fill
+
+        if result.status in ("filled", "paper", "partial", "pending"):
+            # Mirror into legacy `trades` table so the CLI stats view,
+            # order monitor, and holding-period lookups stay in sync.
+            # PnLTracker writes authoritative execution rows to `fills`.
+            try:
+                trade_status = "filled" if result.status == "paper" else result.status
+                await self.db.execute(
+                    """INSERT INTO trades
+                       (market_id, signal_id, side, size, price, is_paper,
+                        order_id, status, kelly_fraction, exchange, strategy_source)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        order.market_id,
+                        getattr(signal, "id", None),
+                        order.side.value,
+                        fill_size,
+                        fill_price,
+                        1 if result.is_paper else 0,
+                        result.order_id,
+                        trade_status,
+                        None,
+                        order.exchange or self.exchange_name,
+                        signal.strategy_source,
+                    ),
+                )
+                await self.db.commit()
+            except Exception as e:
+                log.debug("engine.trade_mirror_error", error=str(e))
+
+        return ExecutionResult(
+            status=result.status, order=order, result=result, fill=recorded_fill,
+            reason=result.error_message or "",
+        )

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -36,10 +36,10 @@ from datetime import datetime, timezone
 
 import structlog
 
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.exchange.models import (
     Confidence,
-    Fill,
     Market,
     OrderSide,
     Signal,
@@ -60,6 +60,13 @@ class BiasHarvestPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # Shared execution tail (route -> place -> record_fill -> trades-mirror).
+        # No router: bias_harvest enters passively at the observed price, so the
+        # gateway falls back to prepare_order exactly as before.
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
 
     # ------------------------------------------------------------------
     # Scan cycle
@@ -211,27 +218,25 @@ class BiasHarvestPillar:
             return False
         size = min(decision.position_size, cfg.stake_usd)
 
-        # Passive limit at the observed price (prepare_order uses the seen
-        # token price, tick-rounded — no improvement, no crossing). Paper-
-        # forced entries pass is_live=False so the order carries dry_run=True
-        # regardless of the global live gates. The graduation ladder
-        # (decision.force_paper) can also paper-force, never un-paper.
-        is_live_order = (self._settings.is_live and not cfg.paper
-                         and not getattr(decision, "force_paper", False))
-        order = self._exchange.prepare_order(signal, market, size, is_live_order)
-        if order is None:
-            log.warning("bias_harvest.order_build_failed", market_id=market.id)
-            return False
-        result = await self._exchange.place_order(order)
-        if result.status not in ("filled", "paper", "partial", "pending"):
+        # Passive limit at the observed price (prepare_order uses the seen token
+        # price, tick-rounded — no improvement, no crossing). Paper-forced
+        # entries pass force_paper so the order carries dry_run=True regardless
+        # of the global live gates; the graduation ladder (decision.force_paper)
+        # can also paper-force, never un-paper. The gateway owns route -> place
+        # -> record_fill -> trades-mirror; the pillar keeps its own
+        # portfolio + calibration writes below.
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
             log.warning("bias_harvest.order_rejected", market_id=market.id,
-                        status=result.status, error=result.error_message)
+                        status=res.status, error=res.reason)
             return False
 
-        await self._record_entry(signal, market, order, result)
+        await self._record_position(signal, market, res.order, res.result)
         log.info("bias_harvest.entered", market_id=market.id,
-                 token=order.token.value, price=order.price,
-                 size=order.size, paper=result.is_paper)
+                 token=res.order.token.value, price=res.order.price,
+                 size=res.order.size, paper=res.result.is_paper)
         return True
 
     # ------------------------------------------------------------------
@@ -260,35 +265,18 @@ class BiasHarvestPillar:
         )
         await self._db.commit()
 
-    async def _record_entry(self, signal: Signal, market: Market,
-                            order, result) -> None:
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        """Write the portfolio row + calibration prediction for a filled entry.
+
+        The fill (-> cost_basis -> pnl_ledger) and the trades-mirror are owned
+        by :class:`ExecutionGateway`; this keeps only the two writes the gateway
+        does not (yet) own: the portfolio row the resolution tracker settles
+        against, and the calibration prediction for resolution scoring.
+        """
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
-
-        # Fills -> cost_basis (+ pnl_ledger at realization)
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id,
-                market_id=order.market_id,
-                token_id=order.token_id,
-                side=order.side,
-                token=order.token,
-                size=fill_size,
-                price=fill_price,
-                is_paper=is_paper,
-            ))
-
-        # trades mirror (entry-strategy attribution + dedup belt)
-        await self._db.execute(
-            """INSERT INTO trades (market_id, timestamp, side, size, price,
-               is_paper, order_id, status, strategy_source, exchange)
-               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'bias_harvest',
-                       'polymarket')""",
-            (order.market_id, order.side.value, fill_size, fill_price,
-             1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status),
-        )
 
         # Portfolio row so the resolution tracker settles the position. The
         # mode-scoped position sync won't maintain paper rows in a live bot,

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -31,7 +31,8 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.arbitrage_scanner import _word_overlap_score
 
 log = structlog.get_logger()
@@ -69,6 +70,12 @@ class CrossVenueArbPillar:
         self._pnl = pnl_tracker
         self._analyzer = analyzer
         self._kalshi_discovery = kalshi_discovery
+        # Shared execution tail; submit_paired takes the per-leg exchange, so the
+        # gateway's own exchange is only a default (legs are cross-venue).
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
 
     # -- schema ----------------------------------------------------------
 
@@ -265,53 +272,45 @@ class CrossVenueArbPillar:
         size = min(dec_a.position_size, dec_b.position_size, cfg.stake_usd)
         if size <= 0:
             return False
-        force_paper = (getattr(dec_a, "force_paper", False)
+        # Paper-force the pair together (cfg.paper or either leg's graduation
+        # downgrade). The gateway owns both-or-nothing placement, fills, the
+        # trades-mirror, and the live-pending leg-A unwind; the pillar keeps its
+        # signals-per-leg + verdict bookkeeping below.
+        force_paper = (cfg.paper or getattr(dec_a, "force_paper", False)
                        or getattr(dec_b, "force_paper", False))
-        is_live = self._settings.is_live and not cfg.paper and not force_paper
+        res_a, res_b = await self._gateway.submit_paired(
+            TradeIntent(signal=sig_a, market=a, size_dollars=size, force_paper=force_paper),
+            TradeIntent(signal=sig_b, market=b, size_dollars=size, force_paper=force_paper),
+            exchange_a=exchange_a, exchange_name_a=(a.exchange or "polymarket"),
+            exchange_b=exchange_b, exchange_name_b=(b.exchange or "kalshi"))
 
-        order_a = exchange_a.prepare_order(sig_a, a, size, is_live)
-        order_b = exchange_b.prepare_order(sig_b, b, size, is_live)
-        if order_a is None or order_b is None:
-            return False
         ok_statuses = ("filled", "paper", "partial", "pending")
-        result_a = await exchange_a.place_order(order_a)
-        if result_a.status not in ok_statuses:
-            log.warning("cross_venue.leg_a_rejected", a=a.id, status=result_a.status)
+        if res_a.status not in ok_statuses:
+            log.warning("cross_venue.leg_a_rejected", a=a.id, status=res_a.status)
             return False
-
-        result_b = await exchange_b.place_order(order_b)
-        if result_b.status not in ok_statuses:
+        if res_b.status not in ok_statuses:
             log.error("cross_venue.leg_b_failed_single_leg", a=a.id, b=b.id,
-                      status=result_b.status)
-            await self._record_leg(a, order_a, result_a, why)
-            if result_a.status == "pending" and not result_a.is_paper:
-                try:
-                    await exchange_a.cancel_order(result_a.order_id)
-                except Exception as e:
-                    log.warning("cross_venue.leg_a_cancel_failed",
-                                a=a.id, order_id=result_a.order_id, error=str(e))
+                      status=res_b.status)
+            await self._record_leg(a, res_a.order, res_a.result, why)
             await self._mark_partial(
-                a.id, b.id, result_b.error_message or f"leg_b_{result_b.status}")
+                a.id, b.id, res_b.reason or f"leg_b_{res_b.status}")
             return False
 
-        for market, order, result in ((a, order_a, result_a), (b, order_b, result_b)):
-            await self._record_leg(market, order, result, why)
+        for market, res in ((a, res_a), (b, res_b)):
+            await self._record_leg(market, res.order, res.result, why)
         await self._db.execute(
             "UPDATE cross_venue_verdicts SET traded_at = datetime('now') "
             "WHERE poly_id = ? AND kalshi_id = ?", (a.id, b.id))
         await self._db.commit()
         log.info("cross_venue.entered", a=a.id, b=b.id, orientation=orientation,
-                 edge=round(edge, 3), confidence=conf, paper=result_a.is_paper)
+                 edge=round(edge, 3), confidence=conf, paper=res_a.result.is_paper)
         return True
 
     async def _record_leg(self, market: Market, order, result, why: str) -> None:
-        fill_size = result.filled_size if result.filled_size > 0 else order.size
-        fill_price = result.filled_price if result.filled_price > 0 else order.price
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id, market_id=order.market_id,
-                token_id=order.token_id, side=order.side, token=order.token,
-                size=fill_size, price=fill_price, is_paper=bool(result.is_paper)))
+        # The fill (-> cost_basis -> pnl_ledger) and the trades-mirror are owned
+        # by the ExecutionGateway; the pillar keeps the per-leg signals row (the
+        # arb-leg convention stores the market price as claude_prob — there is no
+        # LLM estimate for an arb leg).
         await self._db.execute(
             """INSERT INTO signals (market_id, claude_prob, claude_confidence,
                market_prob, edge, evidence_summary, action, strategy_source)

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -21,7 +21,8 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.econ_pricing import (
     estimate_distribution,
@@ -47,6 +48,11 @@ class EconIndicatorPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # Shared execution tail; no router (Kalshi taker entry via prepare_order).
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="kalshi",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
 
     async def run_once(self) -> int:
         cfg = self._settings.econ_indicator
@@ -183,20 +189,17 @@ class EconIndicatorPillar:
                      reason=decision.reason)
             return False
         size = min(decision.position_size, cfg.stake_usd)
-        is_live_order = (self._settings.is_live and not cfg.paper
-                         and not getattr(decision, "force_paper", False))
-        order = self._exchange.prepare_order(signal, market, size, is_live_order)
-        if order is None:
-            return False
-        result = await self._exchange.place_order(order)
-        if result.status not in ("filled", "paper", "partial", "pending"):
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
             log.warning("econ_indicator.order_rejected", market_id=market.id,
-                        status=result.status, error=result.error_message)
+                        status=res.status, error=res.reason)
             return False
-        await self._record_entry(signal, market, order, result)
+        await self._record_position(signal, market, res.order, res.result)
         log.info("econ_indicator.entered", market_id=market.id, side=side.value,
                  model_p=round(model_p, 3), market_p=round(market_p, 3),
-                 paper=result.is_paper)
+                 paper=res.result.is_paper)
         return True
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
@@ -232,24 +235,12 @@ class EconIndicatorPillar:
         )
         await self._db.commit()
 
-    async def _record_entry(self, signal: Signal, market: Market, order, result) -> None:
+    async def _record_position(self, signal: Signal, market: Market, order, result) -> None:
+        # Fill + trades-mirror owned by the ExecutionGateway; this keeps the
+        # portfolio row (resolution tracker settles it) + calibration.
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id, market_id=order.market_id,
-                token_id=order.token_id, side=order.side, token=order.token,
-                size=fill_size, price=fill_price, is_paper=is_paper,
-            ))
-        await self._db.execute(
-            """INSERT INTO trades (market_id, timestamp, side, size, price,
-               is_paper, order_id, status, strategy_source, exchange)
-               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'econ_indicator', 'kalshi')""",
-            (order.market_id, order.side.value, fill_size, fill_price,
-             1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status),
-        )
         await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id,

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -28,6 +28,7 @@ from auramaur.nlp.analyzer import ClaudeAnalyzer
 from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
 from auramaur.risk.manager import RiskManager
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
@@ -76,6 +77,7 @@ class TradingEngine:
         self._hybrid = False  # Set by bot when --hybrid flag is active
         self.strategic = None  # StrategicAnalyzer, set by bot after init
         self._components_pnl = None  # Set by bot after init
+        self._exec_gateway: ExecutionGateway | None = None  # Lazily built; see _gateway
         # News-flagged markets: market_id -> UTC timestamp of flag.
         # Populated by NewsReactor when a headline matches; read by run_cycle
         # to boost these markets into the strategic batch without triggering
@@ -695,156 +697,46 @@ class TradingEngine:
 
         return {"market": market, "signal": signal, "decision": decision, "order": order}
 
+    @property
+    def _gateway(self) -> ExecutionGateway:
+        """Lazily build (and keep in sync with) the ExecutionGateway.
+
+        ``exchange_name`` and ``_components_pnl`` are bound by the bot AFTER
+        engine init, so the gateway is built on first use and rebuilt if either
+        late-bound collaborator changes.
+        """
+        gw = self._exec_gateway
+        if (gw is None
+                or gw.exchange_name != self.exchange_name
+                or gw.pnl_tracker is not self._components_pnl):
+            gw = ExecutionGateway(
+                router=self.router,
+                exchange=self.exchange,
+                exchange_name=self.exchange_name,
+                settings=self.settings,
+                db=self.db,
+                pnl_tracker=self._components_pnl,
+            )
+            self._exec_gateway = gw
+        return gw
+
     async def _build_and_place_order(
         self, signal: Signal, market: Market, size_dollars: float,
         force_paper: bool = False,
     ) -> OrderResult | None:
         """Build an order (via router or direct) and place it.
 
-        ``force_paper`` (graduation ladder) downgrades this ENTRY to dry-run
-        regardless of global live mode — it can only restrict, never arm.
+        Delegates to :class:`ExecutionGateway`; returns the underlying
+        ``OrderResult`` (or ``None`` when the trade was skipped before
+        submission — unmarketable / build failure), preserving the prior
+        return contract. ``force_paper`` (graduation ladder) downgrades this
+        ENTRY to dry-run regardless of global live mode.
         """
-        is_live = self.settings.is_live and not force_paper
-        try:
-            if self.router:
-                order = await self.router.route(signal, market, size_dollars, is_live)
-            else:
-                order = self.exchange.prepare_order(signal, market, size_dollars, is_live)
-        except UnmarketableSignal as skip:
-            # No realizable edge at the book. This gate runs before the
-            # paper/live split on purpose: paper fills simulate at the
-            # reference price, so letting paper books keep these trades
-            # would graduate strategies on fills live could never get.
-            show_order_dropped(market.id, f"unmarketable: {skip}")
-            log.info(
-                "engine.entry_unmarketable",
-                market_id=market.id,
-                strategy=signal.strategy_source,
-                reason=str(skip),
-            )
-            try:
-                # Shorter block than build failures: the book can move.
-                await self.db.execute(
-                    """INSERT OR REPLACE INTO order_build_drops
-                       (market_id, blocked_until, reason)
-                       VALUES (?, datetime('now', '+30 minutes'), ?)""",
-                    (market.id, f"unmarketable: {skip}"),
-                )
-                await self.db.commit()
-            except Exception:
-                pass
-            return None
-
-        if order is None:
-            show_order_dropped(market.id, f"order build failed (${size_dollars:.2f} — could not build a valid order)")
-            log.warning(
-                "engine.order_dropped",
-                market_id=market.id,
-                size_dollars=size_dollars,
-                reason="prepare_order returned None (bad price/token or router rejection)",
-            )
-            # Sub-minimum sizing is now bumped up in prepare_order, so a None
-            # order here is a genuine build failure (bad price/token). Block
-            # only briefly so a transient issue can retry next cycle.
-            try:
-                await self.db.execute(
-                    """INSERT OR REPLACE INTO order_build_drops
-                       (market_id, blocked_until, reason)
-                       VALUES (?, datetime('now', '+2 hours'), ?)""",
-                    (market.id, f"order build failed at ${size_dollars:.2f}"),
-                )
-                await self.db.commit()
-            except Exception:
-                pass  # Table may not exist yet
-            return None
-
-        if not order.source:
-            order.source = signal.strategy_source or "llm"
-        result = await self.exchange.place_order(order)
-        show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=self.exchange_name, error_message=result.error_message, market_id=order.market_id)
-
-        # Cooldown on API errors — retry in 30 min, not every cycle
-        if result.status == "rejected" and result.order_id == "ERROR":
-            try:
-                await self.db.execute(
-                    """INSERT OR REPLACE INTO order_build_drops
-                       (market_id, blocked_until, reason)
-                       VALUES (?, datetime('now', '+30 minutes'), ?)""",
-                    (order.market_id, "place_order API error"),
-                )
-                await self.db.commit()
-            except Exception:
-                pass
-
-        # Log slippage only for actual executions.  Live pending orders echo
-        # the limit price but have not filled yet.
-        if result.status in ("filled", "paper", "partial") and result.filled_price > 0:
-            slippage_bps = (result.filled_price - order.price) / order.price * 10000
-            if order.side == OrderSide.SELL:
-                slippage_bps = -slippage_bps  # For sells, lower fill = worse
-            try:
-                await self.db.execute(
-                    """INSERT INTO slippage_log (market_id, exchange, side, expected_price, filled_price, slippage_bps, size, order_type)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (order.market_id, order.exchange or self.exchange_name, order.side.value,
-                     order.price, result.filled_price, round(slippage_bps, 2), order.size,
-                     order.order_type.value if hasattr(order, 'order_type') else 'limit'),
-                )
-                await self.db.commit()
-            except Exception:
-                pass
-
-        fill_size = result.filled_size if result.filled_size > 0 else order.size
-        fill_price = result.filled_price if result.filled_price > 0 else order.price
-
-        # Record P&L only for actual executions.  Pending live orders are
-        # mirrored to trades below, then finalized by the order monitor.
-        if result.status in ("filled", "paper", "partial") and result.filled_size > 0:
-            from auramaur.exchange.models import Fill
-            fill = Fill(
-                order_id=result.order_id,
-                market_id=order.market_id,
-                token_id=order.token_id,
-                side=order.side,
-                token=order.token,
-                size=result.filled_size,
-                price=fill_price,
-                is_paper=result.is_paper,
-            )
-            pnl_tracker = self._components_pnl
-            if pnl_tracker:
-                await pnl_tracker.record_fill(fill)
-
-        if result.status in ("filled", "paper", "partial", "pending"):
-            # Mirror into legacy `trades` table so the CLI stats view,
-            # order monitor, and holding-period lookups stay in sync.
-            # PnLTracker writes authoritative execution rows to `fills`.
-            try:
-                trade_status = "filled" if result.status == "paper" else result.status
-                await self.db.execute(
-                    """INSERT INTO trades
-                       (market_id, signal_id, side, size, price, is_paper,
-                        order_id, status, kelly_fraction, exchange, strategy_source)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        order.market_id,
-                        getattr(signal, "id", None),
-                        order.side.value,
-                        fill_size,
-                        fill_price,
-                        1 if result.is_paper else 0,
-                        result.order_id,
-                        trade_status,
-                        None,
-                        order.exchange or self.exchange_name,
-                        signal.strategy_source,
-                    ),
-                )
-                await self.db.commit()
-            except Exception as e:
-                log.debug("engine.trade_mirror_error", error=str(e))
-
-        return result
+        intent = TradeIntent(
+            signal=signal, market=market, size_dollars=size_dollars,
+            force_paper=force_paper,
+        )
+        return (await self._gateway.submit(intent)).result
 
     async def _record_trade_for_attribution(self, market: Market, signal, decision) -> None:
         """Deprecated hook kept for compatibility.

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -39,9 +39,9 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.strategy.classifier import ensure_category
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.exchange.models import (
     Confidence,
-    Fill,
     Market,
     OrderSide,
     Signal,
@@ -234,6 +234,11 @@ class EntailmentArbPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._analyzer = analyzer
+        # Shared execution tail; submit_paired takes the per-leg exchange.
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
         # Optional Kalshi discovery for the econ-bin ladder arb (series-fetched).
         self._kalshi_discovery = kalshi_discovery
 
@@ -499,41 +504,32 @@ class EntailmentArbPillar:
         size = min(dec_a.position_size, dec_b.position_size, cfg.stake_usd)
         if size <= 0:
             return False
-        force_paper = (getattr(dec_a, "force_paper", False)
+        # Paper-force the pair together; the gateway owns both-or-nothing
+        # placement, fills, the trades-mirror, and the live-pending leg-A
+        # unwind. The pillar keeps its markets/signals/portfolio writes below.
+        force_paper = (cfg.paper or getattr(dec_a, "force_paper", False)
                        or getattr(dec_b, "force_paper", False))
-        is_live = self._settings.is_live and not cfg.paper and not force_paper
-
-        order_a = exchange_a.prepare_order(sig_a, implier, size, is_live)
-        order_b = exchange_b.prepare_order(sig_b, implied, size, is_live)
-        if order_a is None or order_b is None:
-            return False
+        res_a, res_b = await self._gateway.submit_paired(
+            TradeIntent(signal=sig_a, market=implier, size_dollars=size, force_paper=force_paper),
+            TradeIntent(signal=sig_b, market=implied, size_dollars=size, force_paper=force_paper),
+            exchange_a=exchange_a, exchange_name_a=(implier.exchange or "polymarket"),
+            exchange_b=exchange_b, exchange_name_b=(implied.exchange or "polymarket"))
 
         ok_statuses = ("filled", "paper", "partial", "pending")
-        result_a = await exchange_a.place_order(order_a)
-        if result_a.status not in ok_statuses:
-            log.warning("entailment.leg_a_rejected", a=implier.id,
-                        status=result_a.status)
+        if res_a.status not in ok_statuses:
+            log.warning("entailment.leg_a_rejected", a=implier.id, status=res_a.status)
             return False
-        result_b = await exchange_b.place_order(order_b)
-        if result_b.status not in ok_statuses:
+        if res_b.status not in ok_statuses:
             # Leg risk: A is in, B failed. Flag loudly — the position is
-            # directional until B fills or A is exited.
+            # directional until B fills or A is exited (the gateway already
+            # unwound a live-pending A).
             log.error("entailment.leg_b_failed_single_leg", a=implier.id,
-                      b=implied.id, status=result_b.status,
-                      error=result_b.error_message)
-            await self._record_leg(implier, order_a, result_a, why, gap)
-            if result_a.status == "pending" and not result_a.is_paper:
-                try:
-                    await exchange_a.cancel_order(result_a.order_id)
-                except Exception as e:
-                    log.warning("entailment.leg_a_cancel_failed",
-                                a=implier.id, order_id=result_a.order_id,
-                                error=str(e))
+                      b=implied.id, status=res_b.status, error=res_b.reason)
+            await self._record_leg(implier, res_a.order, res_a.result, why, gap)
             return False
 
-        for market, order, result in ((implier, order_a, result_a),
-                                      (implied, order_b, result_b)):
-            await self._record_leg(market, order, result, why, gap)
+        for market, res in ((implier, res_a), (implied, res_b)):
+            await self._record_leg(market, res.order, res.result, why, gap)
 
         await self._db.execute(
             "UPDATE entailment_verdicts SET traded_at = datetime('now') "
@@ -543,21 +539,18 @@ class EntailmentArbPillar:
         await self._db.commit()
         log.info("entailment.entered", a=implier.id, b=implied.id,
                  gap=round(gap, 3), why=why, confidence=conf,
-                 paper=result_a.is_paper)
+                 paper=res_a.result.is_paper)
         return True
 
     async def _record_leg(self, market: Market, order, result, why: str,
                           gap: float) -> None:
+        # The fill (-> cost_basis -> pnl_ledger) and the trades-mirror are owned
+        # by the ExecutionGateway; the pillar keeps the markets/signals persist
+        # and the portfolio row the resolution tracker settles against.
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
         exchange_name = market.exchange or order.exchange or "polymarket"
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id, market_id=order.market_id,
-                token_id=order.token_id, side=order.side, token=order.token,
-                size=fill_size, price=fill_price, is_paper=is_paper,
-            ))
         await self._db.execute(
             """INSERT OR IGNORE INTO markets (id, exchange, question, category,
                active, outcome_yes_price, outcome_no_price, volume, liquidity,
@@ -577,26 +570,17 @@ class EntailmentArbPillar:
              order.side.value),
         )
         await self._db.execute(
-            """INSERT INTO trades (market_id, timestamp, side, size, price,
-               is_paper, order_id, status, strategy_source, exchange)
-               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'entailment_arb',
-                       ?)""",
-            (order.market_id, order.side.value, fill_size, fill_price,
-             1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status,
-             exchange_name),
-        )
-        await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id,
                is_paper, updated_at)
-               VALUES (?, ?, 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
                    exchange = excluded.exchange,
                    size = excluded.size, avg_price = excluded.avg_price,
                    current_price = excluded.current_price,
                    updated_at = excluded.updated_at""",
-            (order.market_id, exchange_name, fill_size, fill_price, fill_price,
+            (order.market_id, exchange_name, order.side.value, fill_size,
+             fill_price, fill_price,
              market.category or "", order.token.value, order.token_id,
              1 if is_paper else 0),
         )

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -34,9 +34,9 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.exchange.models import (
     Confidence,
-    Fill,
     Market,
     OrderSide,
     Signal,
@@ -129,6 +129,11 @@ class ResolutionLensPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # Shared execution tail; no router (passive entry at the observed price).
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
         self._analyzer = analyzer
         # Phase 3: the evidence aggregator (same one the ensemble uses). Optional
         # so the pillar still constructs without it (grounding then no-ops and the
@@ -511,31 +516,25 @@ class ResolutionLensPillar:
             log.info("lens.risk_rejected", market_id=m.id, reason=decision.reason)
             return False
         size = min(decision.position_size, cfg.stake_usd)
-        is_live = (self._settings.is_live and not cfg.paper
-                   and not getattr(decision, "force_paper", False))
-        order = self._exchange.prepare_order(signal, m, size, is_live)
-        if order is None:
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=m, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("lens.order_rejected", market_id=m.id, status=res.status)
             return False
-        result = await self._exchange.place_order(order)
-        if result.status not in ("filled", "paper", "partial", "pending"):
-            log.warning("lens.order_rejected", market_id=m.id, status=result.status)
-            return False
-        await self._record_entry(signal, m, order, result)
+        await self._record_position(signal, m, res.order, res.result)
         log.info("lens.entered", market_id=m.id, fair=fair, market=m.outcome_yes_price,
-                 gap_score=score, paper=result.is_paper)
+                 gap_score=score, paper=res.result.is_paper)
         return True
 
-    async def _record_entry(self, signal: Signal, market: Market,
-                            order, result) -> None:
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        # Fill + trades-mirror owned by the ExecutionGateway; this keeps the
+        # markets/signals persist, the portfolio row (resolution tracker settles
+        # it), and the calibration prediction.
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id, market_id=order.market_id,
-                token_id=order.token_id, side=order.side, token=order.token,
-                size=fill_size, price=fill_price, is_paper=is_paper,
-            ))
         await self._db.execute(
             """INSERT OR IGNORE INTO markets (id, exchange, question, description,
                category, active, outcome_yes_price, outcome_no_price, volume,
@@ -553,15 +552,6 @@ class ResolutionLensPillar:
             (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
              signal.market_prob, signal.edge, signal.evidence_summary,
              signal.recommended_side.value),
-        )
-        await self._db.execute(
-            """INSERT INTO trades (market_id, timestamp, side, size, price,
-               is_paper, order_id, status, strategy_source, exchange)
-               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'resolution_lens',
-                       'polymarket')""",
-            (order.market_id, order.side.value, fill_size, fill_price,
-             1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status),
         )
         await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -13,7 +13,8 @@ from datetime import timezone
 
 import structlog
 
-from auramaur.exchange.models import Confidence, Fill, Market, OrderSide, Signal
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.weather_pricing import (
     bin_probability,
@@ -33,6 +34,11 @@ class WeatherTempPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # Shared execution tail; no router (passive entry at the observed price).
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
         self._weather = weather
 
     async def run_once(self) -> int:
@@ -106,18 +112,15 @@ class WeatherTempPillar:
             log.info("weather_temp.risk_rejected", market_id=market.id, reason=decision.reason)
             return False
         size = min(decision.position_size, cfg.stake_usd)
-        is_live_order = (self._settings.is_live and not cfg.paper
-                         and not getattr(decision, "force_paper", False))
-        order = self._exchange.prepare_order(signal, market, size, is_live_order)
-        if order is None:
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("weather_temp.order_rejected", market_id=market.id, status=res.status)
             return False
-        result = await self._exchange.place_order(order)
-        if result.status not in ("filled", "paper", "partial", "pending"):
-            log.warning("weather_temp.order_rejected", market_id=market.id, status=result.status)
-            return False
-        await self._record_entry(signal, market, order, result)
+        await self._record_position(signal, market, res.order, res.result)
         log.info("weather_temp.entered", market_id=market.id, side=side.value,
-                 model_p=round(model_p, 3), market_p=round(market_p, 3), paper=result.is_paper)
+                 model_p=round(model_p, 3), market_p=round(market_p, 3), paper=res.result.is_paper)
         return True
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
@@ -150,22 +153,13 @@ class WeatherTempPillar:
              signal.recommended_side.value))
         await self._db.commit()
 
-    async def _record_entry(self, signal: Signal, market: Market, order, result) -> None:
+    async def _record_position(self, signal: Signal, market: Market, order, result) -> None:
+        # Fill (-> cost_basis -> pnl_ledger) and the trades-mirror are owned by
+        # the ExecutionGateway; this keeps the portfolio row (resolution tracker
+        # settles against it; sync is mode-scoped) + the calibration prediction.
         fill_size = result.filled_size if result.filled_size > 0 else order.size
         fill_price = result.filled_price if result.filled_price > 0 else order.price
         is_paper = bool(result.is_paper)
-        if result.status in ("filled", "paper", "partial") and fill_size > 0:
-            await self._pnl.record_fill(Fill(
-                order_id=result.order_id, market_id=order.market_id,
-                token_id=order.token_id, side=order.side, token=order.token,
-                size=fill_size, price=fill_price, is_paper=is_paper))
-        await self._db.execute(
-            """INSERT INTO trades (market_id, timestamp, side, size, price,
-               is_paper, order_id, status, strategy_source, exchange)
-               VALUES (?, datetime('now'), ?, ?, ?, ?, ?, ?, 'weather_temp', 'polymarket')""",
-            (order.market_id, order.side.value, fill_size, fill_price,
-             1 if is_paper else 0, result.order_id,
-             "filled" if result.status in ("filled", "paper") else result.status))
         await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id, is_paper, updated_at)

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -1,0 +1,157 @@
+"""Tests for ExecutionGateway (Phase 0 of the execution refactor).
+
+The gateway is the extracted, reusable form of the engine's canonical entry
+tail (route -> place -> record). These lock in that a submitted intent records
+the fill, updates cost basis, and mirrors to trades — the behavior every
+strategy will inherit when it routes through the gateway in later phases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market, Order, OrderResult, OrderSide, Signal, TokenType,
+)
+from config.settings import Settings
+
+
+def _signal(market_id="m1"):
+    return Signal(
+        market_id=market_id, claude_prob=0.62, claude_confidence="HIGH",
+        market_prob=0.50, edge=12.0, strategy_source="llm",
+    )
+
+
+def _paper_exchange(order: Order, result: OrderResult):
+    ex = MagicMock()
+    ex.prepare_order = MagicMock(return_value=order)
+    ex.place_order = AsyncMock(return_value=result)
+    return ex
+
+
+def _gateway(db, exchange):
+    return ExecutionGateway(
+        router=None, exchange=exchange, exchange_name="polymarket",
+        settings=Settings(), db=db, pnl_tracker=PnLTracker(db, Settings()),
+    )
+
+
+def test_submit_records_fill_cost_basis_and_trade():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO markets (id, exchange, question, category, active, last_updated)"
+            " VALUES ('m1', 'polymarket', 'Q?', 'tech', 1, datetime('now'))"
+        )
+        await db.commit()
+
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.50)
+        result = OrderResult(order_id="p1", market_id="m1", status="paper",
+                             filled_size=20.0, filled_price=0.50, is_paper=True)
+        gw = _gateway(db, _paper_exchange(order, result))
+
+        res = await gw.submit(TradeIntent(signal=_signal(), market=Market(id="m1", question="Q?"),
+                                          size_dollars=10.0))
+
+        # Outcome surfaced
+        assert res.status == "paper"
+        assert res.result is result
+        assert res.fill is not None and res.fill.size == 20.0
+
+        # Fill + cost basis recorded by the real PnLTracker
+        fills = await db.fetchall("SELECT * FROM fills WHERE market_id='m1'")
+        assert len(fills) == 1
+        cb = await db.fetchall("SELECT token, size FROM cost_basis WHERE market_id='m1'")
+        assert len(cb) == 1
+        assert dict(cb[0])["token"] == "YES" and dict(cb[0])["size"] == 20.0
+
+        # Mirrored to legacy trades with the strategy attribution
+        trades = await db.fetchall("SELECT side, status, strategy_source FROM trades WHERE market_id='m1'")
+        assert len(trades) == 1
+        assert dict(trades[0])["status"] == "filled"  # 'paper' maps to 'filled' in trades
+        assert dict(trades[0])["strategy_source"] == "llm"
+
+    asyncio.run(run())
+
+
+def test_submit_skips_on_build_failure_without_recording():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = MagicMock()
+        ex.prepare_order = MagicMock(return_value=None)  # build failure
+        ex.place_order = AsyncMock()
+        gw = ExecutionGateway(router=None, exchange=ex, exchange_name="polymarket",
+                              settings=Settings(), db=db, pnl_tracker=PnLTracker(db, Settings()))
+
+        res = await gw.submit(TradeIntent(signal=_signal(), market=Market(id="m1", question="Q?"),
+                                          size_dollars=10.0))
+
+        assert res.status == "skipped"
+        assert res.result is None
+        ex.place_order.assert_not_awaited()
+        # Nothing recorded, and the market is blocked from immediate retry.
+        assert await db.fetchall("SELECT * FROM fills") == []
+        drops = await db.fetchall("SELECT market_id FROM order_build_drops WHERE market_id='m1'")
+        assert len(drops) == 1
+
+    asyncio.run(run())
+
+
+def test_rejected_order_returns_result_not_none():
+    """A rejected submission still returns the OrderResult (not skipped), so
+    callers relying on the legacy 'None == not submitted' contract behave."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.50)
+        rejected = OrderResult(order_id="ERROR", market_id="m1", status="rejected")
+        gw = _gateway(db, _paper_exchange(order, rejected))
+
+        res = await gw.submit(TradeIntent(signal=_signal(), market=Market(id="m1", question="Q?"),
+                                          size_dollars=10.0))
+        assert res.status == "rejected"
+        assert res.result is rejected           # not None
+        assert res.fill is None                 # nothing filled
+        assert await db.fetchall("SELECT * FROM fills") == []
+
+    asyncio.run(run())
+
+
+def test_gateway_lazy_rebuild_tracks_late_bound_collaborators():
+    """The engine binds exchange_name / pnl after init; the lazy _gateway
+    property must rebuild when they change."""
+    async def run():
+        from auramaur.strategy.engine import TradingEngine as TE
+        # Exercise the real property against a stand-in carrying the attributes
+        # it reads (avoids spinning up a full TradingEngine).
+        holder = MagicMock()
+        holder._exec_gateway = None
+        holder.router = None
+        holder.exchange = MagicMock()
+        holder.settings = Settings()
+        holder.db = MagicMock()
+        holder.exchange_name = "polymarket"
+        holder._components_pnl = None
+        gw1 = TE._gateway.fget(holder)
+        assert gw1.exchange_name == "polymarket"
+        # Same collaborators -> same instance.
+        assert TE._gateway.fget(holder) is gw1
+        # Late-bound pnl changes -> rebuild.
+        holder._components_pnl = PnLTracker(Database(":memory:"), Settings())
+        gw2 = TE._gateway.fget(holder)
+        assert gw2 is not gw1
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pass

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -153,5 +153,105 @@ def test_gateway_lazy_rebuild_tracks_late_bound_collaborators():
     asyncio.run(run())
 
 
-if __name__ == "__main__":  # pragma: no cover
-    pass
+def _leg(market_id, *, order_side=OrderSide.BUY, place: OrderResult, cancel=False):
+    """A per-leg exchange: prepare_order -> a built order, place_order -> place."""
+    order = Order(market_id=market_id, exchange="polymarket", token_id="tok",
+                  side=order_side, token=TokenType.YES, size=20.0, price=0.40)
+    ex = MagicMock()
+    ex.prepare_order = MagicMock(return_value=order)
+    ex.place_order = AsyncMock(return_value=place)
+    if cancel:
+        ex.cancel_order = AsyncMock()
+    return ex
+
+
+def _paired_gateway(db):
+    return ExecutionGateway(
+        router=None, exchange=MagicMock(), exchange_name="polymarket",
+        settings=Settings(), db=db, pnl_tracker=PnLTracker(db, Settings()),
+    )
+
+
+def _intent(market_id):
+    return TradeIntent(signal=_signal(market_id), market=Market(id=market_id, question="Q?"),
+                       size_dollars=10.0)
+
+
+def test_submit_paired_records_both_legs():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex_a = _leg("a", place=OrderResult(order_id="pa", market_id="a", status="paper",
+                                           filled_size=20.0, filled_price=0.40, is_paper=True))
+        ex_b = _leg("b", place=OrderResult(order_id="pb", market_id="b", status="paper",
+                                           filled_size=20.0, filled_price=0.40, is_paper=True))
+        gw = _paired_gateway(db)
+        res_a, res_b = await gw.submit_paired(
+            _intent("a"), _intent("b"),
+            exchange_a=ex_a, exchange_name_a="polymarket",
+            exchange_b=ex_b, exchange_name_b="kalshi")
+        assert res_a.status == "paper" and res_b.status == "paper"
+        fills = await db.fetchall("SELECT market_id FROM fills")
+        assert {dict(f)["market_id"] for f in fills} == {"a", "b"}
+
+    asyncio.run(run())
+
+
+def test_submit_paired_leg_a_rejected_never_places_b():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex_a = _leg("a", place=OrderResult(order_id="ERROR", market_id="a", status="rejected"))
+        ex_b = _leg("b", place=OrderResult(order_id="pb", market_id="b", status="paper",
+                                           filled_size=20.0, filled_price=0.40, is_paper=True))
+        gw = _paired_gateway(db)
+        res_a, res_b = await gw.submit_paired(
+            _intent("a"), _intent("b"),
+            exchange_a=ex_a, exchange_name_a="polymarket",
+            exchange_b=ex_b, exchange_name_b="polymarket")
+        assert res_a.status == "rejected"
+        assert res_b.status == "skipped"
+        ex_b.place_order.assert_not_awaited()  # both-or-nothing: B never attempted
+        assert await db.fetchall("SELECT * FROM fills") == []
+
+    asyncio.run(run())
+
+
+def test_submit_paired_leg_b_fail_unwinds_pending_a():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # A is a LIVE pending order; B rejects -> A must be cancelled.
+        ex_a = _leg("a", place=OrderResult(order_id="live-a", market_id="a", status="pending",
+                                           filled_size=0.0, is_paper=False), cancel=True)
+        ex_b = _leg("b", place=OrderResult(order_id="ERROR", market_id="b", status="rejected"))
+        gw = _paired_gateway(db)
+        res_a, res_b = await gw.submit_paired(
+            _intent("a"), _intent("b"),
+            exchange_a=ex_a, exchange_name_a="polymarket",
+            exchange_b=ex_b, exchange_name_b="polymarket")
+        assert res_a.status == "pending" and res_b.status == "rejected"
+        ex_a.cancel_order.assert_awaited_once_with("live-a")
+
+    asyncio.run(run())
+
+
+def test_submit_paired_build_failure_places_neither():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex_a = _leg("a", place=OrderResult(order_id="pa", market_id="a", status="paper",
+                                           filled_size=20.0, filled_price=0.40, is_paper=True))
+        ex_a.prepare_order = MagicMock(return_value=None)  # A can't be built
+        ex_b = _leg("b", place=OrderResult(order_id="pb", market_id="b", status="paper",
+                                           filled_size=20.0, filled_price=0.40, is_paper=True))
+        gw = _paired_gateway(db)
+        res_a, res_b = await gw.submit_paired(
+            _intent("a"), _intent("b"),
+            exchange_a=ex_a, exchange_name_a="polymarket",
+            exchange_b=ex_b, exchange_name_b="polymarket")
+        assert res_a.status == "skipped" and res_b.status == "skipped"
+        ex_a.place_order.assert_not_awaited()
+        ex_b.place_order.assert_not_awaited()  # neither leg placed
+
+    asyncio.run(run())


### PR DESCRIPTION
Containment refactor from the architecture review (save + freeze + extract). The canonical entry tail (route → place → slippage_log → record_fill → trades-mirror) lived in `TradingEngine._build_and_place_order` and was reimplemented divergently inside every standalone strategy — the source of token/accounting inconsistencies. This extracts it into one component and routes every strategy through it.

## Phase 0 — extract (behavior-identical)
`auramaur/broker/execution_gateway.py`: `ExecutionGateway.submit(TradeIntent) → ExecutionResult`. The tail moved verbatim; the `place_order` triple-gate, paper fork, and `record_fill` keep their exact behavior. The engine delegates via a lazy `_gateway` property. Risk stays with the caller (the intent carries the approved size + `force_paper`).

## Phase 1 — single-leg strategies
bias_harvest, weather_temp, econ_indicator, resolution_lens now submit a `TradeIntent`; the gateway owns place → record_fill → trades-mirror. Each pillar keeps only what the gateway doesn't: signal-persist, the risk gate + stake cap, the portfolio row (sync is mode-scoped and won't maintain paper rows in a live bot), and calibration. No routers (passive/taker entry) → gateway built with `router=None`, so routing is unchanged; `cfg.paper` folds into `intent.force_paper`.

## Phase 2 — paired-leg arb
cross_venue_arb and entailment_arb need both-or-nothing atomicity a per-leg `submit()` can't give, so the gateway grows `submit_paired()`: it builds BOTH orders before placing EITHER, places A then B, and cancels a live-pending A when B fails. Legs carry their own exchange + name, so cross_venue's cross-venue (Poly + Kalshi) legs route correctly. Folds in two consistency fixes: cross_venue gains the trades-mirror it was missing, and entailment's portfolio row uses the order's real side instead of a hardcoded `'BUY'` (correct for a Poly post-swap BUY, wrong for a Kalshi SELL leg). The arb "signals carry market price" is the intentional arb-leg convention and is left as-is.

## Validation
- **Parity** for the single-leg and arb happy paths is proven by each strategy's **existing** test suite — written against the old inline path, all still green through the gateway (no test rewrites).
- New gateway tests cover `submit` (records fill+cost_basis+trade; build-failure skips; rejected returns the result; lazy rebuild) and `submit_paired` atomicity (both recorded; leg-A reject never places B; leg-B fail unwinds a live-pending A; build failure places neither).
- ~250 lines of duplicated execution code deleted across the strategies. Full suite: **835 passed**.

Not market_maker — it deliberately bypasses risk (graduation-exempt), keeps in-memory inventory, and quotes maker-only; left out by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)