### PR TITLE
refactor(exec): route exits through gateway.submit_exit (phase 3)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -75,6 +75,7 @@ class AuramaurBot:
         self._rebalance_cooldowns: dict[str, float] = {}  # kept for reference, allocator handles concentration
         self._exit_failures: set[str] = set()  # Track failed exit sells to avoid spam
         self._exit_pending: set[str] = set()  # Track exits with resting orders
+        self.__exit_gateway = None  # Lazily built; see _exit_gateway property
         # Track attempted cross-exchange arbs so the scanner doesn't re-execute
         # the same opportunity every 5-minute cycle. Maps arb-key -> expiry ts.
         self._arb_attempts: dict[str, float] = {}
@@ -831,6 +832,27 @@ class AuramaurBot:
         self._exit_failures.discard(exit_key)
         log.debug("exit.suppression_cleared", exit_key=exit_key, status=status)
 
+    @property
+    def _exit_gateway(self):
+        """Lazily build the ExecutionGateway used for exits.
+
+        Exits price the SELL themselves and skip risk, so this is only used via
+        ``submit_exit`` (prebuilt order, per-call exchange). The gateway's own
+        exchange/router are unused for that path; db + pnl_tracker come from the
+        wired components. Rebuilt if the pnl_tracker reference changes.
+        """
+        db = self._components.get("db")
+        pnl = self._components.get("pnl_tracker")
+        gw = self.__exit_gateway
+        if gw is None or gw.db is not db or gw.pnl_tracker is not pnl:
+            from auramaur.broker.execution_gateway import ExecutionGateway
+            gw = ExecutionGateway(
+                router=None, exchange=None, exchange_name="",
+                settings=self.settings, db=db, pnl_tracker=pnl,
+            )
+            self.__exit_gateway = gw
+        return gw
+
     async def _execute_poly_exit(
         self,
         pos,
@@ -1007,8 +1029,9 @@ class AuramaurBot:
             dry_run=not self.settings.is_live,
             source="exit",
         )
-        result = await exchange.place_order(sell_order)
-        if result.status == "rejected":
+        res = await self._exit_gateway.submit_exit(
+            sell_order, exchange=exchange, exchange_name="polymarket")
+        if res.status == "rejected":
             log.warning("exit.sell_failed", market_id=pos.market_id)
             return False
 
@@ -1090,14 +1113,9 @@ class AuramaurBot:
             return False
 
         order.source = "exit"
-        result = await exchange.place_order(order)
-        from auramaur.monitoring.display import show_order
-        show_order(
-            result.status, result.order_id, "SELL", order.size, order.price,
-            result.is_paper, exchange="kalshi", error_message=result.error_message,
-            market_id=pos.market_id,
-        )
-        if result.status == "rejected":
+        res = await self._exit_gateway.submit_exit(
+            order, exchange=exchange, exchange_name="kalshi")
+        if res.status == "rejected":
             return False
 
         await alerts.send(

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -110,7 +110,33 @@ class ExecutionGateway:
         if order is None:
             return ExecutionResult(status="skipped", reason="not submitted")
         return await self._place_and_record(
-            order, intent.signal, self.exchange, self.exchange_name)
+            order, strategy_source=intent.signal.strategy_source,
+            signal_id=getattr(intent.signal, "id", None),
+            exchange=self.exchange, exchange_name=self.exchange_name)
+
+    async def submit_exit(
+        self,
+        order: Order,
+        *,
+        exchange: ExchangeClient,
+        exchange_name: str,
+        strategy_source: str = "exit",
+    ) -> ExecutionResult:
+        """Place a PREBUILT exit order and record it.
+
+        Exits skip risk (the portfolio monitor already decided) and skip routing
+        (the caller prices the SELL against the live bid). The gateway places it
+        and writes the pending trades-mirror — so the order monitor, which
+        finalizes a live exit's fill asynchronously, UPDATEs that row instead of
+        inserting an 'order_monitor'-attributed one (and an immediate paper-mode
+        fill is recorded here). No double-write: a live exit is pending at
+        placement (filled_size 0), so the fill is recorded once, by the monitor.
+        """
+        if not order.source:
+            order.source = strategy_source
+        return await self._place_and_record(
+            order, strategy_source=strategy_source, signal_id=None,
+            exchange=exchange, exchange_name=exchange_name)
 
     async def submit_paired(
         self,
@@ -146,13 +172,17 @@ class ExecutionGateway:
             return skip, ExecutionResult(status="skipped", reason="leg build failed")
 
         res_a = await self._place_and_record(
-            order_a, a.signal, exchange_a, exchange_name_a)
+            order_a, strategy_source=a.signal.strategy_source,
+            signal_id=getattr(a.signal, "id", None),
+            exchange=exchange_a, exchange_name=exchange_name_a)
         if res_a.status not in _OK_STATUSES:
             # Leg A rejected — B is never placed, nothing to unwind.
             return res_a, ExecutionResult(status="skipped", reason="leg_a_not_ok")
 
         res_b = await self._place_and_record(
-            order_b, b.signal, exchange_b, exchange_name_b)
+            order_b, strategy_source=b.signal.strategy_source,
+            signal_id=getattr(b.signal, "id", None),
+            exchange=exchange_b, exchange_name=exchange_name_b)
         if res_b.status not in _OK_STATUSES:
             # Leg risk: A is in, B failed. Cancel a live-pending A so we don't
             # sit on a naked directional leg (paper / already-filled A can't be
@@ -236,11 +266,11 @@ class ExecutionGateway:
         return order
 
     async def _place_and_record(
-        self, order: Order, signal: Signal,
+        self, order: Order, *, strategy_source: str, signal_id,
         exchange: ExchangeClient, exchange_name: str,
     ) -> ExecutionResult:
         """Place a built order, then log slippage, record the fill, and mirror
-        to ``trades``. Shared by the single-leg and paired paths.
+        to ``trades``. Shared by the single-leg, paired, and exit paths.
         """
         result = await exchange.place_order(order)
         show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=exchange_name, error_message=result.error_message, market_id=order.market_id)
@@ -310,7 +340,7 @@ class ExecutionGateway:
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         order.market_id,
-                        getattr(signal, "id", None),
+                        signal_id,
                         order.side.value,
                         fill_size,
                         fill_price,
@@ -319,7 +349,7 @@ class ExecutionGateway:
                         trade_status,
                         None,
                         order.exchange or exchange_name,
-                        signal.strategy_source,
+                        strategy_source,
                     ),
                 )
                 await self.db.commit()

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -236,6 +236,54 @@ def test_submit_paired_leg_b_fail_unwinds_pending_a():
     asyncio.run(run())
 
 
+def test_submit_exit_paper_records_fill_and_trade():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        sell = Order(market_id="x", exchange="polymarket", token_id="tok",
+                     side=OrderSide.SELL, token=TokenType.YES, size=20.0, price=0.60)
+        place = OrderResult(order_id="px", market_id="x", status="paper",
+                            filled_size=20.0, filled_price=0.60, is_paper=True)
+        ex = MagicMock(); ex.place_order = AsyncMock(return_value=place)
+        gw = ExecutionGateway(router=None, exchange=MagicMock(), exchange_name="polymarket",
+                              settings=Settings(), db=db, pnl_tracker=PnLTracker(db, Settings()))
+        res = await gw.submit_exit(sell, exchange=ex, exchange_name="polymarket")
+        assert res.status == "paper"
+        assert len(await db.fetchall("SELECT 1 FROM fills WHERE market_id='x'")) == 1
+        t = await db.fetchall("SELECT strategy_source, side FROM trades WHERE market_id='x'")
+        assert len(t) == 1
+        assert dict(t[0])["strategy_source"] == "exit" and dict(t[0])["side"] == "SELL"
+
+    asyncio.run(run())
+
+
+def test_submit_exit_live_pending_writes_trades_but_defers_fill_to_monitor():
+    """A live exit is pending at placement — submit_exit writes the pending
+    trades row (so the monitor UPDATEs it, not INSERTs 'order_monitor') but does
+    NOT record the fill; the monitor records it once when it fills."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        sell = Order(market_id="x", exchange="polymarket", token_id="tok",
+                     side=OrderSide.SELL, token=TokenType.YES, size=20.0, price=0.60)
+        place = OrderResult(order_id="live-x", market_id="x", status="pending",
+                            filled_size=0.0, is_paper=False)
+        ex = MagicMock(); ex.place_order = AsyncMock(return_value=place)
+        gw = ExecutionGateway(router=None, exchange=MagicMock(), exchange_name="polymarket",
+                              settings=Settings(), db=db, pnl_tracker=PnLTracker(db, Settings()))
+        res = await gw.submit_exit(sell, exchange=ex, exchange_name="polymarket")
+        assert res.status == "pending"
+        # No fill recorded yet (the monitor will, once).
+        assert await db.fetchall("SELECT 1 FROM fills") == []
+        # A pending trades row exists keyed by order_id, so the monitor's
+        # UPDATE ... WHERE order_id finds it (no 'order_monitor' duplicate).
+        t = await db.fetchall("SELECT status, order_id, strategy_source FROM trades WHERE order_id='live-x'")
+        assert len(t) == 1
+        assert dict(t[0])["status"] == "pending" and dict(t[0])["strategy_source"] == "exit"
+
+    asyncio.run(run())
+
+
 def test_submit_paired_build_failure_places_neither():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
Phase 3 of the execution refactor — completes the fan-in: poly + Kalshi **exits** now place through the ExecutionGateway, so every execution path (entries, arb pairs, exits) funnels through one component. Builds on #168.

## Why exits need their own method
Exits differ from entries: they skip risk (the portfolio monitor decides), price the SELL themselves, and — critically — their **live fills are recorded asynchronously by the order monitor** (`record_fill` + `UPDATE trades ... WHERE order_id`), not at placement. So this adds `submit_exit` rather than reusing `submit`.

- `submit_exit(prebuilt_order, *, exchange, exchange_name, strategy_source="exit")` places the order and writes the **pending trades-mirror**, recording an immediate paper-mode fill but **not** a live one. A live exit is pending at placement (`filled_size 0`), so the fill is recorded exactly once — later, by the monitor.
- **Monitor coordination:** the monitor's `UPDATE trades ... WHERE order_id` now finds the gateway's pending row and updates it, instead of falling back to an `INSERT` attributed to `'order_monitor'`. So live exit fills are now attributed to `'exit'` — a small accounting improvement, no double row, no double fill.
- `_place_and_record` now takes `strategy_source` + `signal_id` (was a `Signal`); `submit`/`submit_paired` pass the signal's, `submit_exit` passes `'exit'`/`None`. `submit`/`submit_paired` behavior unchanged.
- Migrated `_execute_poly_exit` and `_execute_kalshi_exit`; a lazy `_exit_gateway` on the bot supplies db + pnl_tracker. **IBKR exits left as-is** (separate equity accounting track, not the prediction-market fill/ledger path).

## Validation
- New tests: `submit_exit` paper records fill+trade as `'exit'`; live-pending writes the pending row but **defers the fill to the monitor** (no double-record).
- Parity for the exit paths proven by the existing exit + order-monitor suites. Full suite: **837 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)