### PR TITLE
fix(risk): source the daily-loss gate from pnl_ledger, not paper-conflated daily_stats (phase 4)

### DIFF
--- a/auramaur/broker/pnl.py
+++ b/auramaur/broker/pnl.py
@@ -115,9 +115,12 @@ class PnLTracker:
                 size=fill.size,
             )
 
-            # Update daily_stats so the CLI/risk view sees realized PnL as
-            # soon as exits fire — previously only market resolution wrote
-            # this table, which made the running P&L invisible for weeks.
+            # Update daily_stats for REPORTING only (CLI / cockpit). NOTE:
+            # total_pnl here is mode-MIXED (this runs for paper + live fills),
+            # so it must NOT gate live trading — the daily-loss risk gate now
+            # sources today's LIVE realized P&L from pnl_ledger (is_paper=0) via
+            # PortfolioTracker.get_daily_pnl. peak_balance (drawdown) still uses
+            # daily_stats, which is a balance tracker, not realized P&L.
             try:
                 today = date.today().isoformat()
                 await self._db.execute(

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -195,12 +195,20 @@ class PortfolioTracker:
     # ------------------------------------------------------------------
 
     async def get_daily_pnl(self) -> float:
-        """Return today's realised PnL from the daily_stats table."""
-        today = date.today().isoformat()
+        """Return today's LIVE realised PnL from the authoritative pnl_ledger.
+
+        Sources the daily-loss risk gate (risk/manager.py check_daily_loss) from
+        the unified ledger scoped to ``is_paper = 0``, rather than
+        ``daily_stats.total_pnl`` — which conflated paper + live realized P&L,
+        so the paper-forced strategies' (by-design) losses leaked into the gate
+        that blocks LIVE trading. The day boundary is UTC to match the ledger's
+        ``realized_at`` timestamps. ``daily_stats`` remains for reporting only.
+        """
         row = await self.db.fetchone(
-            "SELECT total_pnl FROM daily_stats WHERE date = ?", (today,)
+            "SELECT COALESCE(SUM(pnl), 0) AS pnl FROM pnl_ledger "
+            "WHERE is_paper = 0 AND date(realized_at) = date('now')"
         )
-        return float(row["total_pnl"]) if row else 0.0
+        return float(row["pnl"]) if row else 0.0
 
     # ------------------------------------------------------------------
     # Drawdown

--- a/tests/test_daily_pnl_ledger.py
+++ b/tests/test_daily_pnl_ledger.py
@@ -1,0 +1,55 @@
+"""Phase 4: the daily-loss gate sources from pnl_ledger (live-only), not the
+paper+live-conflated daily_stats.total_pnl.
+
+PortfolioTracker.get_daily_pnl feeds risk/manager.py check_daily_loss, which
+blocks LIVE entries. It must count only today's LIVE realized P&L — paper-forced
+strategies lose by design and must never gate live trading.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from auramaur.db.database import Database
+from auramaur.risk.portfolio import PortfolioTracker
+
+
+async def _ledger_row(db, pnl, is_paper, ref, *, today=True):
+    realized = "datetime('now')" if today else "'2026-01-01T00:00:00+00:00'"
+    await db.execute(
+        "INSERT INTO pnl_ledger (market_id, venue, category, strategy_source, kind,"
+        " token, qty, pnl, fees, is_paper, source_ref, realized_at)"
+        f" VALUES ('m', 'polymarket', 'tech', 'llm', 'sell', 'YES', 1, ?, 0, ?, ?, {realized})",
+        (pnl, is_paper, ref),
+    )
+    await db.commit()
+
+
+def test_get_daily_pnl_is_live_only_and_today_only():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # Today, LIVE: -5 and +2  -> net -3 (the only rows that should count)
+        await _ledger_row(db, -5.0, 0, "live-a")
+        await _ledger_row(db, 2.0, 0, "live-b")
+        # Today, PAPER: -100 (the by-design paper loss that used to leak in)
+        await _ledger_row(db, -100.0, 1, "paper-today")
+        # Old day, LIVE: -50 (different day, must not count toward "today")
+        await _ledger_row(db, -50.0, 0, "live-old", today=False)
+
+        pnl = await PortfolioTracker(db).get_daily_pnl()
+        assert abs(pnl - (-3.0)) < 1e-9, f"expected -3.0 (today live only), got {pnl}"
+
+    asyncio.run(run())
+
+
+def test_get_daily_pnl_zero_when_no_live_realizations():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # Only a paper realization today — the live gate must read 0.
+        await _ledger_row(db, -250.0, 1, "paper-only")
+        pnl = await PortfolioTracker(db).get_daily_pnl()
+        assert pnl == 0.0
+
+    asyncio.run(run())


### PR DESCRIPTION
Phase 4 (making `pnl_ledger` the single realized-P&L source) surfaced a **real risk-gate bug**, not just cleanup.

`PortfolioTracker.get_daily_pnl` feeds `risk/manager.py` `check_daily_loss` — the gate that **blocks live entries**. It read `daily_stats.total_pnl`. But the `daily_stats` write in `PnLTracker.record_fill` has **no `is_paper` guard**, so `total_pnl` conflates paper + live realized P&L. The paper-forced strategies lose by design, and those losses leaked into the gate that halts **live** trading (lifetime `daily_stats` −$379 vs live `pnl_ledger` −$170; large per-day divergence).

- `get_daily_pnl` now derives today's **live** realized P&L from the authoritative `pnl_ledger` (`is_paper=0`, UTC day to match `realized_at`). The graduation ladder already sources from `pnl_ledger`; this brings the daily-loss gate onto it too.
- `daily_stats` stays for reporting (and `peak_balance` for drawdown, which is a balance tracker — not realized P&L) — commented so the dependency isn't reintroduced.
- Tests assert the gate counts today's live realizations only, excluding paper and prior days.

**Behavior note:** this is a correctness fix that *loosens* the live daily-loss gate (it now sees the smaller, correct live-only losses instead of inflated paper+live). Today it's moot (−$1 live vs −$28 conflated vs the −$200 limit), but it stops paper losses from ever halting live trading.

Scope: this is the one behavior-critical realized-P&L read that was wrong. The Kelly `category_stats` reconcile and the reporting reads (cost_basis/resolution_pnl/trades → ledger) remain follow-ups. Full suite: **839 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)