### PR TITLE
docs(db): close out the foreign_keys=OFF review item with evidence

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -19,6 +19,13 @@ class Database:
         self._db = await aiosqlite.connect(self.db_path)
         self._db.row_factory = aiosqlite.Row
         await self._db.execute("PRAGMA journal_mode=WAL")
+        # foreign_keys stays OFF by design, NOT as repair debt. The markets
+        # table is curated/ephemeral — resolved markets age out of it — so a
+        # trade/signal/portfolio row legitimately outlives its markets row.
+        # The schema's trades->markets FK is therefore too strict: an audit
+        # (PRAGMA foreign_key_check, 2026-06-23) found ~1843 such legitimate
+        # orphans. Re-enabling FKs would reject valid inserts; the fix, if ever
+        # wanted, is to RELAX the FK declarations, not flip this PRAGMA.
         await self._db.execute("PRAGMA foreign_keys=OFF")
         # CLI commands share the file with the running bot; without a busy
         # timeout a writer collision fails instantly ("database is locked" —


### PR DESCRIPTION
Closes the last open item from the architecture review (`PRAGMA foreign_keys=OFF` flagged as "removed safety net").

Ran an FK audit (`PRAGMA foreign_key_check`): **~1843 violations, all the `trades → markets` constraint**. These are **legitimate** — the `markets` table is curated/ephemeral (resolved markets age out), so a `trades` row outlives its `markets` row by design. Re-enabling `foreign_keys` would reject valid inserts. So `foreign_keys=OFF` is **defensible, not repair debt**; the real fix, if ever wanted, is relaxing the over-strict FK *declarations*, not flipping the PRAGMA.

This PR just **documents that rationale at the PRAGMA site** so it isn't re-flagged. No behavior change.

While here, I also verified (read-only, no change needed) that `category_stats.kelly_multiplier` is **calibration-derived** (brier/accuracy/n), independent of realized P&L — so after the #174 daily-loss fix there are **no remaining behavior-critical realized-P&L reads**. The Phase 4 "single source" goal is met for everything that gates trading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)