### PR TITLE
refactor(arb): record arb-scanner fills through the gateway (consolidate money paths)

### DIFF
--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -137,6 +137,10 @@ class ArbExecutionMixin:
                 buy_client.place_order(buy_order),
                 sell_client.place_order(sell_order),
             )
+            for _o, _r in ((buy_order, buy_result), (sell_order, sell_result)):
+                await self._exit_gateway.record_external_fill(
+                    _o, _r, strategy_source="conditional_arb",
+                    exchange_name=_o.exchange or "polymarket")
             buy_ok = buy_result.status not in ("rejected", "error")
             sell_ok = sell_result.status not in ("rejected", "error")
             mode = "PAPER" if not is_live else "LIVE"
@@ -491,6 +495,10 @@ class ArbExecutionMixin:
             results = await asyncio.gather(
                 *[exchange_client.place_order(o) for o in orders]
             )
+            for _o, _r in zip(orders, results):
+                await self._exit_gateway.record_external_fill(
+                    _o, _r, strategy_source="negrisk_arb",
+                    exchange_name=_o.exchange or "polymarket")
             n_ok = sum(1 for r in results if r.status not in ("rejected", "error"))
             mode = "PAPER" if not is_live else "LIVE"
             if n_ok == len(orders):
@@ -642,6 +650,10 @@ class ArbExecutionMixin:
         try:
             yes_result = await exchange_client.place_order(yes_order)
             no_result = await exchange_client.place_order(no_order)
+            for _o, _r in ((yes_order, yes_result), (no_order, no_result)):
+                await self._exit_gateway.record_external_fill(
+                    _o, _r, strategy_source="internal_arb",
+                    exchange_name=_o.exchange or "polymarket")
 
             log.info(
                 "arb_scanner.internal_executed",
@@ -815,6 +827,16 @@ class ArbExecutionMixin:
                 cheap_client.place_order(yes_order),
                 expensive_client.place_order(no_order),
             )
+
+            # Record both legs through the gateway so they get the same invariant
+            # as every other money path (fills + cost_basis + pnl_ledger + the
+            # pending trades-mirror the order monitor finalizes). The legs were
+            # placed concurrently above to minimize the leg-risk window, so they
+            # use record_external_fill rather than submit_*.
+            for _o, _r, _exn in ((yes_order, yes_result, cheap_exchange),
+                                 (no_order, no_result, expensive_exchange)):
+                await self._exit_gateway.record_external_fill(
+                    _o, _r, strategy_source="cross_exchange_arb", exchange_name=_exn)
 
             yes_ok = yes_result.status not in ("rejected", "error")
             no_ok = no_result.status not in ("rejected", "error")
@@ -1023,6 +1045,8 @@ class ArbExecutionMixin:
                     error_message=result.error_message,
                     market_id=pos["mid"],
                 )
+                await self._exit_gateway.record_external_fill(
+                    order, result, strategy_source="rebalance", exchange_name="kalshi")
 
                 if result.status not in ("rejected",):
                     sell_value = order.size * order.price

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -274,7 +274,35 @@ class ExecutionGateway:
         """
         result = await exchange.place_order(order)
         show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=exchange_name, error_message=result.error_message, market_id=order.market_id)
+        return await self._record_result(
+            order, result, strategy_source=strategy_source,
+            signal_id=signal_id, exchange_name=exchange_name)
 
+    async def record_external_fill(
+        self, order: Order, result: OrderResult, *,
+        strategy_source: str, exchange_name: str,
+    ) -> ExecutionResult:
+        """Record a fill for an order placed OUTSIDE the gateway.
+
+        The arb scanner places its legs CONCURRENTLY (asyncio.gather) to minimize
+        the leg-risk window, so it can't go through submit_*; this gives those
+        already-placed legs the same recording invariant — slippage, record_fill
+        (paper/filled), and the pending trades-mirror the order monitor later
+        UPDATEs for live fills. No double-record: a live leg is pending at
+        placement (filled_size 0), so its fill is recorded once, by the monitor.
+        """
+        return await self._record_result(
+            order, result, strategy_source=strategy_source,
+            signal_id=None, exchange_name=exchange_name)
+
+    async def _record_result(
+        self, order: Order, result: OrderResult, *,
+        strategy_source: str, signal_id, exchange_name: str,
+    ) -> ExecutionResult:
+        """Post-placement recording shared by _place_and_record (single-leg /
+        paired / exit) and record_external_fill (the concurrently-placed arb
+        legs): API-error cooldown, slippage, record_fill, and the trades-mirror.
+        """
         # Cooldown on API errors — retry in 30 min, not every cycle
         if result.status == "rejected" and result.order_id == "ERROR":
             try:

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -236,6 +236,47 @@ def test_submit_paired_leg_b_fail_unwinds_pending_a():
     asyncio.run(run())
 
 
+def test_record_external_fill_paper_records_fill_and_trade():
+    """The arb scanner places legs concurrently, then records each via
+    record_external_fill — a paper fill must land in fills + trades, attributed
+    to the arb strategy (not 'order_monitor')."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        order = Order(market_id="arb1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.40)
+        result = OrderResult(order_id="ax", market_id="arb1", status="paper",
+                             filled_size=20.0, filled_price=0.40, is_paper=True)
+        gw = _gateway(db, MagicMock())  # exchange unused — order already placed
+        res = await gw.record_external_fill(
+            order, result, strategy_source="cross_exchange_arb", exchange_name="polymarket")
+        assert res.status == "paper" and res.fill is not None
+        assert len(await db.fetchall("SELECT 1 FROM fills WHERE market_id='arb1'")) == 1
+        t = await db.fetchall("SELECT strategy_source FROM trades WHERE market_id='arb1'")
+        assert len(t) == 1 and dict(t[0])["strategy_source"] == "cross_exchange_arb"
+
+    asyncio.run(run())
+
+
+def test_record_external_fill_live_pending_defers_to_monitor():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        order = Order(market_id="arb2", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.40)
+        result = OrderResult(order_id="live-ax", market_id="arb2", status="pending",
+                             filled_size=0.0, is_paper=False)
+        gw = _gateway(db, MagicMock())
+        res = await gw.record_external_fill(
+            order, result, strategy_source="cross_exchange_arb", exchange_name="polymarket")
+        assert res.status == "pending"
+        assert await db.fetchall("SELECT 1 FROM fills") == []  # monitor records it
+        t = await db.fetchall("SELECT status FROM trades WHERE order_id='live-ax'")
+        assert len(t) == 1 and dict(t[0])["status"] == "pending"
+
+    asyncio.run(run())
+
+
 def test_submit_exit_paper_records_fill_and_trade():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
Closes the **"direct order paths remain"** point from the re-review. The bot's arbitrage scanner (conditional / cross-exchange / internal / neg-risk arb + rebalance) placed legs directly and **recorded nothing itself** — live fills were finalized by the order monitor (mis-attributed `'order_monitor'`) and **paper-arb fills went unrecorded**. So these money paths sidestepped the gateway invariant we built.

The arb legs are placed **concurrently** (`asyncio.gather`) to minimize the leg-risk window, so they can't use `submit_*`. Instead the gateway grows **`record_external_fill`**: the post-placement recording (slippage, `record_fill`, pending trades-mirror) extracted into a shared `_record_result` helper. Every arb leg now calls it after placement → the same invariant as every other money path: fills + cost_basis + pnl_ledger + a trades-mirror **attributed to the arb strategy**, which the monitor finalizes for live fills.

- **No double-record:** a live leg is pending at placement (`filled_size 0`), recorded once by the monitor; paper-arb fills are now recorded too. Same coordination as `submit_exit`.
- `_place_and_record` split into place+show + `_record_result`; `submit` / `submit_paired` / `submit_exit` behavior unchanged.
- All 5 arb placement sites wired; concurrent placement + arb-specific rollback preserved.
- Tests cover `record_external_fill` (paper records w/ arb attribution; live-pending defers to the monitor).

`market_maker` (maker-only, graduation-exempt) and the IBKR exit (equity track) remain intentionally outside the gateway. The arb scanner is currently dormant, so this is low immediate impact — it makes the path correct for when it fires. Full suite: **841 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)