### PR TITLE
fix(monitor): attribute monitor-finalized fills to the order's source, not 'order_monitor'

### DIFF
--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -155,7 +155,12 @@ class OrderMonitorMixin:
                                                     order_id,
                                                     result.status,
                                                     order.exchange or exchange_name,
-                                                    "order_monitor",
+                                                    # Attribute to the order's own source (market_maker,
+                                                    # exit, ...) when known — only orders placed OUTSIDE
+                                                    # the gateway reach this fallback INSERT (gateway
+                                                    # paths pre-write a row the UPDATE above hits), so
+                                                    # 'order_monitor' was masking the real strategy.
+                                                    getattr(order, "source", None) or "order_monitor",
                                                 ),
                                             )
                                         await db.commit()


### PR DESCRIPTION
Completes the direct-order-path consolidation for the paths that **legitimately stay outside the gateway**. `market_maker` (maker-only, graduation-exempt), the IBKR exit (equity track), and `momentum_coupling` place orders directly; their live fills are finalized by the order monitor, which **hardcoded `strategy_source='order_monitor'`** on the fallback `trades` INSERT — masking the real strategy.

Only orders placed *outside* the gateway reach that fallback (gateway paths pre-write a pending row the UPDATE hits and keeps attributed), so using `order.source` here attributes MM fills to `'market_maker'`, IBKR to `'exit'`, etc.

**Why not give MM placement-side recording (like the arb scanner in #177):** MM's `post_only` quotes mostly cancel unfilled, so a pending `trades` row per quote would bloat the table. The monitor's record-on-fill is the *correct* mechanism for maker orders — it just needed the right attribution.

Reporting-only (`trades.strategy_source` feeds attribution/holding-period views, not any trading gate). Full suite: **841 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)