### PR TITLE
hotfix: missing imports in extracted mixin modules (live cycle crashing)

### DIFF
--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -19,6 +19,7 @@ import structlog
 from auramaur.exchange.models import (
     Confidence, Market, Order, OrderSide, OrderType, Signal, TokenType,
 )
+from auramaur.monitoring.display import console
 from auramaur.nlp.errors import BudgetExhausted
 from auramaur.strategy.arbitrage_scanner import (
     ArbOpportunity, ArbitrageScanner, NegRiskArbOpportunity,

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from auramaur.exchange.models import Fill, Order, OrderResult, OrderSide, TokenType
+from auramaur.monitoring.display import console
 
 if TYPE_CHECKING:
     from auramaur.db.database import Database

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -17,6 +17,9 @@ import structlog
 
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
 from auramaur.exchange.models import Market, OrderResult, OrderSide, Signal
+from auramaur.monitoring.display import show_scan_results
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.strategy.signals import taker_fee_rate
 
 if TYPE_CHECKING:
     from auramaur.strategy.protocols import TradeCandidate

--- a/tests/test_no_unbound_names.py
+++ b/tests/test_no_unbound_names.py
@@ -1,0 +1,51 @@
+"""Guard against the mixin-extraction failure mode: a method moved into a new
+module that uses a module-level symbol (often a *lowercase* helper like
+blocked_category_hit / taker_fee_rate / console) which wasn't imported there.
+
+Such a bug imports fine and passes tests whose paths don't hit the symbol, then
+NameErrors at runtime on a live code path — exactly what shipped in the engine
+cycle split. This audits the extracted modules for free names with no module-,
+class-, function-, parameter-, assignment-, or except-binding.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_EXTRACTED = [
+    "auramaur/strategy/engine_cycle.py",
+    "auramaur/bot_arb.py",
+    "auramaur/bot_exits.py",
+    "auramaur/bot_strategy_tasks.py",
+    "auramaur/bot_order_monitor.py",
+]
+
+
+def _unbound_names(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    bound = set(dir(builtins)) | {"self", "cls", "__class__"}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for a in node.names:
+                bound.add((a.asname or a.name).split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            bound.add(node.id)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+    used = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+    return sorted(u for u in used if u not in bound)
+
+
+@pytest.mark.parametrize("rel", _EXTRACTED)
+def test_extracted_module_has_no_unbound_names(rel):
+    missing = _unbound_names(_ROOT / rel)
+    assert not missing, f"{rel} references unbound names (missing imports?): {missing}"


### PR DESCRIPTION
The phase-5 extractions moved methods using module-level helpers into new modules without importing those helpers. The extraction AST sweep only flagged **capitalized** names, so it missed lowercase ones — they import fine and pass tests whose paths don't hit them, then `NameError` on a live path.

**`engine_cycle.py` was crashing every trading cycle in production:** `Trading cycle failed: name 'blocked_category_hit' is not defined`.

- `engine_cycle.py`: import `blocked_category_hit` + `ensure_category` (classifier), `show_scan_results` (display), `taker_fee_rate` (signals).
- `bot_arb.py`, `bot_order_monitor.py`: import `console` (display).
- **Regression guard:** `tests/test_no_unbound_names.py` AST-audits every extracted module for unbound names (lowercase-inclusive) — current and future extractions.

Full suite: 842 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)