### PR TITLE
harden: HTTP timeouts on evidence sources + case-insensitive Confidence

### DIFF
--- a/auramaur/broker/redeemer.py
+++ b/auramaur/broker/redeemer.py
@@ -75,7 +75,7 @@ async def fetch_redeemable_positions(
 
     close_session = session is None
     if session is None:
-        session = aiohttp.ClientSession()
+        session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=20))
 
     try:
         params = {"user": proxy_address, "sizeThreshold": "0.01"}

--- a/auramaur/data_sources/bluesky.py
+++ b/auramaur/data_sources/bluesky.py
@@ -40,7 +40,7 @@ class BlueskySource:
         }
 
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
                 async with session.get(_SEARCH, params=params, timeout=aiohttp.ClientTimeout(total=10)) as resp:
                     if resp.status != 200:
                         logger.debug("bluesky.bad_status", status=resp.status)

--- a/auramaur/data_sources/coingecko.py
+++ b/auramaur/data_sources/coingecko.py
@@ -119,7 +119,7 @@ class CoinGeckoSource:
             # smaller coin we can't resolve.
             matched_ids = ["bitcoin", "ethereum"]
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
             prices = await self._fetch_prices(session, matched_ids[:5])
             trending = await self._fetch_trending(session)
 

--- a/auramaur/data_sources/espn.py
+++ b/auramaur/data_sources/espn.py
@@ -108,7 +108,7 @@ class ESPNSource:
     async def fetch(self, query: str, limit: int = 20) -> list[NewsItem]:
         q_tokens = [t for t in (query or "").lower().split() if len(t) > 2]
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
             batches = await asyncio.gather(
                 *(self._fetch_one(session, path, short) for path, short in _LEAGUES.items())
             )

--- a/auramaur/data_sources/gdelt.py
+++ b/auramaur/data_sources/gdelt.py
@@ -48,7 +48,7 @@ class GDELTSource:
         }
 
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
                 async with session.get(_URL, params=params, timeout=aiohttp.ClientTimeout(total=12)) as resp:
                     if resp.status != 200:
                         logger.debug("gdelt.bad_status", status=resp.status)

--- a/auramaur/data_sources/hackernews.py
+++ b/auramaur/data_sources/hackernews.py
@@ -53,7 +53,7 @@ class HackerNewsSource:
         q_lower = (query or "").lower()
         q_tokens = [t for t in q_lower.split() if len(t) > 2]
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
             ids = await self._fetch_ids(session)
             if not ids:
                 return []

--- a/auramaur/data_sources/newsapi.py
+++ b/auramaur/data_sources/newsapi.py
@@ -30,7 +30,7 @@ class NewsAPISource:
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15))
         return self._session
 
     async def _rate_limit(self) -> None:

--- a/auramaur/data_sources/usgs.py
+++ b/auramaur/data_sources/usgs.py
@@ -36,7 +36,7 @@ class USGSSource:
     async def fetch(self, query: str, limit: int = 20) -> list[NewsItem]:
         items: list[NewsItem] = []
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as session:
                 async with session.get(_FEED_URL, timeout=aiohttp.ClientTimeout(total=10)) as resp:
                     if resp.status != 200:
                         logger.warning("usgs.fetch_error", status=resp.status)

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -22,6 +22,19 @@ class Confidence(str, Enum):
     MEDIUM_HIGH = "MEDIUM_HIGH"
     HIGH = "HIGH"
 
+    @classmethod
+    def _missing_(cls, value):
+        """Case-insensitive lookup so an LLM returning e.g. ``'medium'`` (Gemini
+        does) resolves to ``MEDIUM`` instead of crashing the cycle with
+        ``'medium' is not a valid Confidence``. Truly-unknown values still raise.
+        """
+        if isinstance(value, str):
+            norm = value.strip().upper().replace("-", "_").replace(" ", "_")
+            for member in cls:
+                if member.value == norm:
+                    return member
+        return None
+
 
 class Market(BaseModel):
     id: str

--- a/auramaur/monitoring/alerts.py
+++ b/auramaur/monitoring/alerts.py
@@ -19,7 +19,7 @@ class AlertManager:
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15))
         return self._session
 
     async def close(self) -> None:

--- a/tests/test_confidence_normalization.py
+++ b/tests/test_confidence_normalization.py
@@ -1,0 +1,37 @@
+"""Confidence enum accepts case-/separator-insensitive strings.
+
+An LLM (Gemini, in conservation mode) returned ``'medium'`` lowercase, and
+``Confidence('medium')`` crashed a live trading cycle with
+``'medium' is not a valid Confidence``. The ``_missing_`` hook normalizes so
+every Confidence(...) call site is protected at once.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from auramaur.exchange.models import Confidence
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("medium", Confidence.MEDIUM),
+    ("MEDIUM", Confidence.MEDIUM),
+    ("high", Confidence.HIGH),
+    ("low", Confidence.LOW),
+    ("medium_high", Confidence.MEDIUM_HIGH),
+    ("Medium-Low", Confidence.MEDIUM_LOW),
+    (" High ", Confidence.HIGH),
+    ("MEDIUM HIGH", Confidence.MEDIUM_HIGH),
+])
+def test_confidence_normalizes(value, expected):
+    assert Confidence(value) is expected
+
+
+def test_canonical_values_unaffected():
+    assert Confidence("MEDIUM") is Confidence.MEDIUM
+    assert Confidence.HIGH.value == "HIGH"
+
+
+def test_truly_invalid_still_raises():
+    with pytest.raises(ValueError):
+        Confidence("definitely-not-a-level")


### PR DESCRIPTION
Two defensive fixes for the failure modes the overnight health watches surfaced.

**1) Hard hang (the 30-min outage).** An `aiohttp` request with no timeout on an evidence source stalled, and since asyncio is single-threaded it froze the whole event loop — confirmed via `faulthandler` (main loop idle in `select()`, no deadlock, awaiting a socket that never responded). The LLM calls were already protected (Claude subprocess `asyncio.wait_for` 180–480s; `llm_router` post 120s), but several data-source sessions were bare `aiohttp.ClientSession()` with no timeout. Added a **15s session timeout** to `newsapi/usgs/coingecko/hackernews/espn/gdelt/bluesky` + `alerts`, and **20s** to the redeemer. (`rss`/`google_trends` already had per-request timeouts; `cli` is manual-only.) A stalled source now fails fast and the cycle skips it.

**2) Cycle crash.** Gemini returned `'medium'` lowercase and `Confidence('medium')` raised `'medium' is not a valid Confidence`, failing a kalshi cycle. Added a `Confidence._missing_` hook that normalizes case + separators (`'medium'`→`MEDIUM`, `'Medium-Low'`→`MEDIUM_LOW`) so **every** `Confidence(...)` call site is protected at once; truly-invalid values still raise.

Tests cover Confidence normalization. Full suite: **856 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)