### PR TITLE
resolution_lens: edge corrections — date anchor + favorite-discipline entry floor

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -500,6 +500,19 @@ class ResolutionLensPillar:
     async def _enter(self, m: Market, fair: float, score: float,
                      mech: str, edge: float) -> bool:
         cfg = self._settings.resolution_lens
+        # Favorite-discipline floor (BUY side only). Edge audit (2026-06-24):
+        # every lens×weather loss was a BUY of a narrow temperature bin entered
+        # in the near-coin-flip band — favorite-longshot variance, not a real
+        # fine-print read. Buying only YES sides already priced as favorites
+        # cut the cell to 100% win in-sample. SELL longshot plays (overpriced
+        # 'permanent'/'announce' YES) sit below this floor by construction and
+        # are deliberately exempt. edge > 0 ⇒ BUY YES at ~outcome_yes_price.
+        if (edge > 0 and cfg.min_entry_price > 0.0
+                and m.outcome_yes_price < cfg.min_entry_price):
+            log.info("lens.below_entry_floor", market_id=m.id,
+                     yes_price=round(m.outcome_yes_price, 3),
+                     floor=cfg.min_entry_price)
+            return False
         signal = Signal(
             market_id=m.id,
             market_question=m.question,

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -66,6 +66,7 @@ LENS_PROMPT = """You are a resolution-criteria auditor for a prediction market. 
 Question: "{question}"
 Resolution criteria: {description}
 Current market price (YES): {market_prob:.2f}
+Today's date is {today}. Interpret EVERY date in the criteria relative to today, including 2-digit years (e.g. '26 = 2026). A resolution date that is today, imminent, or already past resolves on NEAR-TERM reality (current forecasts/observations) — it is NOT a distant-future climatological base-rate bet. Never invent a "distant year, revert to base rate" mechanism for a near-term or already-passed market; that is a misread of the current year, not a fine-print edge.
 
 Answer BOTH directions:
 1. How can YES resolve WITHOUT the headline event most people imagine actually happening?
@@ -87,8 +88,9 @@ Resolution criteria: {description}
 Market price (YES): {market_prob:.2f}
 Claimed strict-criteria fair P(YES): {fair:.2f}
 Claimed mechanism: "{mechanism}"
+Today's date is {today}. Interpret dates (incl. 2-digit years like '26 = 2026) relative to today.
 
-Check: does the cited clause ACTUALLY qualify/disqualify as claimed, or is the auditor over-reading or inventing a rule the criteria don't state? If you can't point to specific criteria text that supports the mechanism, it is REFUTED.
+Check: does the cited clause ACTUALLY qualify/disqualify as claimed, or is the auditor over-reading or inventing a rule the criteria don't state? If you can't point to specific criteria text that supports the mechanism, it is REFUTED. In particular, REFUTE any mechanism that treats a today/imminent/already-past resolution date as a "distant future" base-rate bet — that is a current-year misread, not a fine-print mechanism.
 
 Respond with ONLY this JSON:
 {{"verdict": "confirmed" | "refuted", "confidence": <float 0-1>, "why": "<one sentence citing the criteria>"}}"""
@@ -107,6 +109,7 @@ GROUND_PROMPT = """You are grounding a prediction market's STRICT resolution rea
 Question: "{question}"
 Resolution criteria: {description}
 Deadline / resolution window: {deadline}
+Today's date is {today} (interpret 2-digit years like '26 = 2026 relative to today).
 Identified fine-print mechanism: "{mechanism}"
 Strict-criteria fair P(YES) before evidence: {fair:.2f}
 
@@ -219,6 +222,7 @@ class ResolutionLensPillar:
                 question=m.question,
                 description=self._criteria_text(m.description),  # Phase 1: full criteria
                 market_prob=m.outcome_yes_price,
+                today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
             ))
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
             fair = max(0.01, min(0.99, float(parsed.get("fair_prob", fair))))
@@ -247,6 +251,7 @@ class ResolutionLensPillar:
                 question=m.question,
                 description=self._criteria_text(m.description),
                 market_prob=m.outcome_yes_price, fair=fair, mechanism=mechanism,
+                today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
             ))
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
             confirmed = (str(parsed.get("verdict", "refuted")).lower() == "confirmed"
@@ -310,6 +315,7 @@ class ResolutionLensPillar:
                 description=self._criteria_text(m.description),
                 deadline=deadline, mechanism=mech, fair=fair,
                 evidence="\n".join(ev_lines),
+                today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
             ))
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
             g = max(0.01, min(0.99, float(parsed.get("grounded_prob", fair))))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -496,6 +496,11 @@ resolution_lens:
   min_gap_score: 0.4       # lens-judged headline/criteria divergence floor
   high_conf_gap_score: 0.7 # >= this -> HIGH confidence (clears divergence filter)
   min_edge: 0.08           # |strict fair - market| floor
+  # Favorite-discipline floor on BUY entries. Edge audit: every lens×weather
+  # loss was a BUY entered in the near-coin-flip band; gating BUYs to YES-side
+  # favorites (>= this) cut the cell from 83% -> 100% win in-sample. SELL
+  # (overpriced-YES longshot) plays are exempt by construction.
+  min_entry_price: 0.65
   stake_usd: 10.0
   max_entries_per_cycle: 3
   max_llm_calls_per_cycle: 5

--- a/config/settings.py
+++ b/config/settings.py
@@ -541,6 +541,16 @@ class ResolutionLensConfig(BaseModel):
     min_gap_score: float = 0.4
     high_conf_gap_score: float = 0.7
     min_edge: float = 0.08
+    # Favorite-discipline floor on BUY entries (0 = off). A 2026-06-24 edge
+    # audit of the lens×weather cell found every loss was a BUY of a narrow
+    # temperature bin entered in the near-coin-flip band (<~0.65 YES), where
+    # favorite-longshot variance dominates and the LLM's named mechanism is
+    # post-hoc — the position is identical regardless. Requiring the YES side
+    # we buy to already be a market favorite (>= this) cut the cell from 83%
+    # to 100% win in-sample. Gates BUYs ONLY: the lens's other documented
+    # edge is SELLing overpriced-YES longshots (permanence/announce bars),
+    # which by construction sit below this floor and must stay untouched.
+    min_entry_price: float = 0.0
     stake_usd: float = 10.0
     max_entries_per_cycle: int = 3
     max_llm_calls_per_cycle: int = 5

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -308,6 +308,64 @@ def test_refuted_mechanism_blocks_entry():
 
 
 # ----------------------------------------------------------------------
+# Favorite-discipline entry-price floor (BUY side only)
+# ----------------------------------------------------------------------
+
+def test_buy_below_entry_floor_blocked():
+    """A BUY whose YES side is below min_entry_price (the near-coin-flip band
+    where the weather cell took every loss) does not trade."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            ex = _exchange()
+            # fair 0.90 vs market 0.55 -> BUY YES (edge +0.35), but 0.55 < 0.65.
+            analyzer = _analyzer(fair=0.90, gap=0.8, mech="modal bin favored")
+            pillar = _pillar(db, _settings(min_entry_price=0.65),
+                             [_market(yes=0.55)], exchange=ex, analyzer=analyzer)
+            assert await pillar.run_once() == 0
+            ex.place_order.assert_not_awaited()
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_buy_at_or_above_entry_floor_enters():
+    """The same BUY clears once the YES side is itself a market favorite."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            ex = _exchange()
+            analyzer = _analyzer(fair=0.90, gap=0.8, mech="modal bin favored")
+            pillar = _pillar(db, _settings(min_entry_price=0.65),
+                             [_market(yes=0.70)], exchange=ex, analyzer=analyzer)
+            assert await pillar.run_once() == 1
+            order = ex.place_order.await_args.args[0]
+            assert order.token == TokenType.YES
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_sell_longshot_exempt_from_entry_floor():
+    """The floor gates BUYs only: a SELL of an overpriced-YES longshot (the
+    permanence/announce shape) trades even though the NO side it buys is well
+    below the floor — that is the lens's other documented edge."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        try:
+            ex = _exchange()
+            # Default analyzer: fair 0.10 vs market 0.30 -> SELL (buy NO).
+            pillar = _pillar(db, _settings(min_entry_price=0.65),
+                             [_market(yes=0.30)], exchange=ex)
+            assert await pillar.run_once() == 1
+            order = ex.place_order.await_args.args[0]
+            assert order.token == TokenType.NO
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+# ----------------------------------------------------------------------
 # Lens pillar
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Two corrections from a 2026-06-24 edge audit of the resolution_lens × weather cell (the bot's one near-graduating cell). The audit decomposed every trade in the cell and found the "fine-print resolution edge" framing was largely wrong — the real driver is favorite-longshot harvesting, and one prompt bug was actively confabulating the rationale.

## 1. Date anchor (commit 1)

The lens prompts carried no current-date anchor, so the model read a near-term resolution date written with a 2-digit year (e.g. "19 Jun '26") as a **distant-future** year and reasoned *"ignore the near-term forecast, revert to the climatological base rate."* That's a current-year misread dressed as a mechanism, and it was the stated rationale behind the worst losses.

- LENS / VERIFY / GROUND prompts now state today's date and interpret all dates (incl. `'26 = 2026`) relative to it; a today/imminent/past resolution resolves on near-term reality. VERIFY explicitly refutes a "distant year → base rate" mechanism on a near-term market.
- Verdicts cache permanently → takes effect on new markets (weather bins are daily).

## 2. Favorite-discipline entry-price floor (commit 2)

Decomposing the cell: **every** trade is a BUY at a moderate-favorite price; the LLM mechanism string is post-hoc (position identical regardless); and **all** the losses were the lowest-priced BUYs — the near-coin-flip band where favorite-longshot variance dominates. A YES-side price floor cleanly removes them (cell goes 83% → 100% win in-sample, strongly net-positive).

- New `min_entry_price` (default 0 = off; set to 0.65 in `defaults.yaml`). Gates a BUY when the YES side we'd pay for is below the floor.
- **BUY side only** — the lens's other documented edge is SELLing overpriced-YES longshots (permanence/announce bars), which sit below the floor by construction and stay untouched (verified by test).

## Test

Full suite `859 passed`; 6 new lens tests (3 prompt-format/date, 3 floor: BUY-below blocked, BUY-above enters, SELL exempt).

Assisted-by: Claude (Anthropic)