### PR TITLE
fix(monitor): attribute reconciled orphan orders to the market maker

### DIFF
--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -582,6 +582,15 @@ class PolymarketClient:
                     order_type=OrderType.LIMIT,
                     dry_run=False,
                     created_at=created,
+                    # The CLOB API doesn't echo our `source`, so a prior-session
+                    # orphan would otherwise reach the monitor's fallback INSERT
+                    # sourceless and get tagged 'order_monitor', masking the real
+                    # book. A live *resting GTC limit* can only come from the
+                    # market maker in the current regime — directional books are
+                    # paper-forced, arb is both-or-nothing immediate, exits cross
+                    # the spread (taker). So attribute reconciled orphans to the
+                    # MM. NOTE: revisit if any other live book ever rests limits.
+                    source="market_maker",
                 )
                 count += 1
             except (TypeError, ValueError) as e:

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -159,6 +159,11 @@ async def test_reconcile_open_orders_imports_orphans(client):
     assert buy.token_id == "tokA"
     # created_at parsed from the order's unix timestamp (not "now")
     assert buy.created_at.year == 1970
+    # Reconciled orphans are attributed to the market maker (the only live book
+    # that leaves resting GTC limits) so the monitor's fill INSERT doesn't mask
+    # them as the generic 'order_monitor' fallback.
+    assert buy.source == "market_maker"
+    assert client._live_pending["orphan-2"].source == "market_maker"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #178, closing the last attribution gap on live Polymarket fills.

## Context

#178 stopped monitor-finalized fills being masked as `order_monitor` by reading each order's own `source`. Verified working post-deploy — newly-placed MM fills now attribute correctly, with zero `order_monitor` leak.

## The residual gap

`reconcile_open_orders` rebuilds **prior-session orphan resting orders** from the CLOB open-orders API at startup. That API doesn't echo our `source` field, so a reconstructed orphan reaches the monitor's fallback INSERT sourceless and gets tagged `order_monitor` — masking the real book.

## Why stamp `market_maker` (and not persist the true source)

There's no placement-time source record to recover from: the exchange client holds no DB handle, and adding one would thread DB state through the single sensitive CLOB order path — disproportionate for a gap that only touches orphans.

But the attribution is **deducible**. A live *resting GTC limit* can only originate from the market maker in the current regime:
- directional books are paper-forced (since the 06-15 graduation-ladder flip),
- arb is both-or-nothing immediate,
- exits cross the spread as takers.

So reconciled orphans are stamped `source="market_maker"`, with a code note to revisit if any other live book ever starts resting limit orders.

## Test

The existing `test_reconcile_open_orders_imports_orphans` now asserts the orphan source; full suite **859 passed**.

Assisted-by: Claude (Anthropic)