### PR TITLE
fix(portfolio): scope the exit re-mark write to the held token

### DIFF
--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -334,14 +334,25 @@ class PortfolioTracker:
                         pass
                     else:
                         pos.current_price = new_mark
+                        # Scope the write to THIS token. The portfolio key is
+                        # (market_id, is_paper, token); without the token clause
+                        # a market we hold on both sides (NO and YES rows) has
+                        # BOTH rows overwritten with whichever leg was marked —
+                        # so the NO row gets stamped the YES price (and vice
+                        # versa), inverting a winner into a phantom loser in the
+                        # persisted mark (corrupting display, drawdown, Kelly,
+                        # and category exposure, which read the stored value).
                         update_sql = (
                             """UPDATE portfolio
                                SET current_price = ?,
                                    unrealized_pnl = (? - avg_price) * size,
                                    updated_at = datetime('now')
-                               WHERE market_id = ?"""
+                               WHERE market_id = ? AND token = ?"""
                         )
-                        update_params: list[object] = [pos.current_price, pos.current_price, pos.market_id]
+                        update_params: list[object] = [
+                            pos.current_price, pos.current_price,
+                            pos.market_id, pos.token.value,
+                        ]
                         if exchange:
                             update_sql += " AND exchange = ?"
                             update_params.append(exchange)

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -338,6 +338,54 @@ async def test_unresolved_token_keeps_stored_mark(settings):
 
 
 @pytest.mark.asyncio
+async def test_remark_does_not_clobber_sibling_token(settings):
+    """A market held on BOTH sides has a NO row and a YES row. Re-marking one
+    leg must update ONLY that leg — the per-token write must not stamp the NO
+    row with the YES price (and vice versa), which would invert a winner into a
+    phantom loser in the persisted mark."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings.is_live = True
+        # Hold NO (cost 0.66, the real winner) and a small YES leg, same market.
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('mkt', 'polymarket', 'BUY', 60, 0.66, 0.66,
+                       'tech', 'NO', 'tok_no', 0)"""
+        )
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('mkt', 'polymarket', 'BUY', 2, 0.19, 0.19,
+                       'tech', 'YES', 'tok_yes', 0)"""
+        )
+        await db.commit()
+
+        # Live: NO=0.805 (the held winner), YES=0.195.
+        gamma = AsyncMock()
+        gamma.get_market = AsyncMock(return_value=_make_market(
+            "mkt", 0.195, no_price=0.805,
+            clob_yes="tok_yes", clob_no="tok_no",
+        ))
+
+        tracker = PortfolioTracker(db=db, settings=settings)
+        await tracker.check_exits(settings, gamma, exchange="polymarket")
+
+        no_row = await db.fetchone(
+            "SELECT current_price FROM portfolio WHERE market_id='mkt' AND token='NO'")
+        yes_row = await db.fetchone(
+            "SELECT current_price FROM portfolio WHERE market_id='mkt' AND token='YES'")
+        # Each leg marked at its OWN side's live price — no cross-clobber.
+        assert no_row["current_price"] == pytest.approx(0.805)
+        assert yes_row["current_price"] == pytest.approx(0.195)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_label_used_when_market_tokens_unknown(settings):
     """No CLOB token ids on the market (e.g. Kalshi) — the YES/NO label keeps
     driving the mark, as before."""


### PR DESCRIPTION
## Symptom

A live position held on both sides (a NO leg and a small YES leg of the same market) showed its **winning NO leg marked at the YES price** — a real +22% winner displayed as a ~−70% loser in the bot's stored mark.

## Root cause

`check_exits` refreshes each live position's mark from the live Gamma API and writes it back to `portfolio`. The write filtered on `market_id` (+ `exchange`/`is_paper`) but **not `token`**. The portfolio key is `(market_id, is_paper, token)`, so for a market held on both sides the single `UPDATE` stamped **both** the NO and YES rows with whichever leg was marked last — the NO row got the YES price, inverting the persisted mark.

## Severity

- **Exit decisions were NOT affected.** The stop-loss / profit-target logic uses the correctly-resolved *per-token in-memory* mark (re-fetched live each cycle via `_resolve_mark_price`, which resolves side authoritatively by `token_id`). No wrongful stop-loss fired.
- The corrupted **persisted** value feeds everything that reads the portfolio table: P&L/value display (and the hourly health report), the drawdown gate, Kelly sizing, and category exposure. Intermittent — other writers (sync/reconcile) restore complementary values between cycles, so it ping-pongs.
- Blast radius: live markets held on both sides (≈13 at time of discovery).

## Fix

Add `AND token = ?` to the re-mark `UPDATE` so it touches only the row it resolved. New test: a both-sides position marks each leg at its own live price with no cross-clobber.

Full suite: **860 passed**.

Assisted-by: Claude (Anthropic)