### PR TITLE
fix(kalshi): reject + log a create_order response with no order id

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -413,7 +413,38 @@ class KalshiClient:
             )
             data = json.loads(raw)
             order_data = data.get("order", {})
-            order_id = str(order_data.get("order_id", "unknown"))
+            order_id = str(order_data.get("order_id", "")) if order_data else ""
+
+            # A 2xx response with NO order object is a soft rejection Kalshi
+            # returns without raising (so it never hit the except below): the
+            # SDK only raises on 4xx/5xx. The old code defaulted order_id to
+            # 'unknown' and returned status='pending', which (a) discarded the
+            # response body that names the actual reason, and (b) wrote a phantom
+            # pending trade the monitor later flipped to 'error' — so a failing
+            # exit retried every cycle forever with the cause invisible. Surface
+            # the raw body and reject so the caller stops (and doesn't mirror a
+            # ghost fill).
+            if not order_id:
+                err = ""
+                if isinstance(data, dict):
+                    err = str(data.get("error") or data.get("message") or "")
+                log.error(
+                    "order.live_no_order_id",
+                    exchange="kalshi",
+                    ticker=order.token_id,
+                    side=kalshi_side,
+                    action=action,
+                    yes_price=yes_price_cents,
+                    error=err[:300] or "no 'order' in response",
+                    raw=str(raw)[:500],
+                )
+                return OrderResult(
+                    order_id="KALSHI_NO_ORDER",
+                    market_id=order.market_id,
+                    status="rejected",
+                    is_paper=False,
+                    error_message=(err[:200] or "kalshi returned no order id"),
+                )
 
             log.info(
                 "order.live_placed",
@@ -425,8 +456,7 @@ class KalshiClient:
             # Track the live order so the order monitor can poll it for fills,
             # reconcile trades.status, and TTL-cancel it if it rests unfilled.
             # Without this the row inserted at placement stays 'pending' forever.
-            if order_id and order_id != "unknown":
-                self._live_pending[order_id] = order
+            self._live_pending[order_id] = order
 
             return OrderResult(
                 order_id=order_id,

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -318,6 +318,42 @@ class TestKalshiPaperGate:
         paper.execute.assert_called_once()
 
 
+class TestKalshiNoOrderIdSoftReject:
+    @pytest.mark.asyncio
+    async def test_live_order_without_order_id_rejects_not_pending(self):
+        """A 2xx create_order response with no `order` object (Kalshi's soft
+        rejection — no exception raised) must REJECT, not return a phantom
+        'pending' with order_id='unknown' that the monitor flips to 'error' and
+        the exit retries forever. The raw body is surfaced for diagnosis."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        client = KalshiClient.__new__(KalshiClient)
+        client._init_api = MagicMock()
+        client._portfolio_api = MagicMock()
+        client._settings = MagicMock()
+        client._settings.is_live = True
+        client._live_pending = {}
+        # dup-check call returns no resting orders; the create_order call returns
+        # a body with an error and NO 'order' object (the observed shape).
+        client._call_raw = AsyncMock(side_effect=[
+            json.dumps({"orders": []}),
+            json.dumps({"error": "too_few_contracts"}),
+        ])
+
+        order = Order(
+            market_id="KXTEST", exchange="kalshi", side=OrderSide.SELL,
+            token=TokenType.YES, token_id="KXTEST", size=16, price=0.04,
+            dry_run=False,
+        )
+        result = await client.place_order(order)
+
+        assert result.status == "rejected"
+        assert result.order_id == "KALSHI_NO_ORDER"
+        assert "too_few_contracts" in result.error_message
+        # No ghost order tracked.
+        assert client._live_pending == {}
+
+
 class TestKalshiPrepareOrderDirectSell:
     def test_sell_signal_becomes_buy_no(self):
         """Kalshi SELL signal should become BUY NO (can't sell what you don't own)."""


### PR DESCRIPTION
## What was erroring

Live Kalshi exits on two held positions (a YES dust loser and a NO winner) retried every cycle and piled up `status='error'` trades rows with `order_id='unknown'` (8 today, 14 yesterday) — inflating the daily trade count with non-trades.

## Root cause of the *invisible*-ness

The Kalshi `create_order` SDK only raises on 4xx/5xx. A **soft rejection** comes back as a **2xx body with no `order` object** — so it never hit the `except` path. `place_order` then:
1. defaulted `order_id` to `'unknown'`,
2. returned `status='pending'`, and
3. **discarded the raw response body** — which is exactly where Kalshi names the reason.

The phantom `pending` row was then flipped to `error` by the monitor's sentinel reaper, and since the position stays held, the exit re-attempted forever. The actual rejection reason was never logged.

## Fix

When the response carries no order id: log the raw body + any `error`/`message` field (`order.live_no_order_id`) and return `status='rejected'` with a descriptive `error_message`. `rejected` is not an `_OK_STATUS`, so the gateway writes **no trades-mirror at all** — the phantom-pending→error churn stops cleanly, and `_execute_kalshi_exit` returns False instead of looping.

## What this does and doesn't do

- **Does**: stop the error-row churn, and surface Kalshi's real reason on the next retry.
- **Doesn't (yet)**: fix the underlying rejection. The markets are open and far-dated (end_date 2030/2035), so it's an order-validation issue — not settlement. Once deployed, the `order.live_no_order_id` log line will name the exact cause, and we can address it (likely a position/size or extreme-price validation).

## Test

A no-`order` response rejects with `order_id='KALSHI_NO_ORDER'`, echoes the error, and tracks no ghost order. Full suite **861 passed**.

Assisted-by: Claude (Anthropic)