### PR TITLE
fix(kalshi): send client_order_id so live orders use the v2 create-order flow

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -388,8 +389,16 @@ class KalshiClient:
             else:
                 yes_price_cents = max(1, min(99, int(order.price * 100)))
 
+            # Kalshi's v2 create-order requires a client-generated idempotency
+            # key (client_order_id). Omitting it routes to the now-removed v1
+            # flow, which returns a 2xx "deprecated_v1_order_endpoint" body with
+            # no order object — so EVERY live order (entries and exits) silently
+            # failed. A fresh UUID per attempt satisfies v2 and is safe: orders
+            # are limit GTC and deduped upstream (the resting-order guard above),
+            # so per-attempt uniqueness won't double-place.
             req = CreateOrderRequest(
                 ticker=order.token_id,
+                client_order_id=str(uuid.uuid4()),
                 side=kalshi_side,
                 action=action,
                 count=int(order.size),

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -353,6 +353,39 @@ class TestKalshiNoOrderIdSoftReject:
         # No ghost order tracked.
         assert client._live_pending == {}
 
+    @pytest.mark.asyncio
+    async def test_live_order_includes_client_order_id(self):
+        """Kalshi v2 create-order requires a client_order_id idempotency key;
+        omitting it routes to the removed v1 flow ('deprecated_v1_order_endpoint')
+        and silently fails every live order. The request must carry a UUID."""
+        import uuid as _uuid
+        from unittest.mock import AsyncMock, MagicMock
+
+        client = KalshiClient.__new__(KalshiClient)
+        client._init_api = MagicMock()
+        client._portfolio_api = MagicMock()
+        client._settings = MagicMock()
+        client._settings.is_live = True
+        client._live_pending = {}
+        client._call_raw = AsyncMock(side_effect=[
+            json.dumps({"orders": []}),                      # dup-check
+            json.dumps({"order": {"order_id": "ord-1", "status": "resting"}}),
+        ])
+
+        order = Order(
+            market_id="KXTEST", exchange="kalshi", side=OrderSide.SELL,
+            token=TokenType.NO, token_id="KXTEST", size=24, price=0.97,
+            dry_run=False,
+        )
+        result = await client.place_order(order)
+
+        assert result.status == "pending"
+        # The create_order call carried a valid UUID client_order_id.
+        create_call = client._call_raw.await_args_list[1]
+        req = create_call.kwargs["create_order_request"]
+        assert req.client_order_id
+        _uuid.UUID(req.client_order_id)  # raises if not a valid UUID
+
 
 class TestKalshiPrepareOrderDirectSell:
     def test_sell_signal_becomes_buy_no(self):


### PR DESCRIPTION
## Root cause (surfaced by #185's diagnostic)

Once #185 deployed, the next exit retry logged Kalshi's actual response:

```
{"error":{"code":"deprecated_v1_order_endpoint","message":"Please switch to the V2 endpoints","details":"https://docs.kalshi.com/api-reference/orders/create-order-v2"}}
```

returned as a **2xx with no order object** (which is why it never raised). The endpoint URL is already v2 (`/trade-api/v2/portfolio/orders`, and 2.1.4 is the latest SDK), so the deprecation is about the **request shape**: Kalshi's v2 create-order requires a client-generated **`client_order_id`** idempotency key. The bot omitted it, so the request routed to the removed v1 flow.

## Impact

This broke **all live Kalshi order placement — entries and exits**, not just the two stuck positions. Those exits were simply the only live Kalshi orders being attempted, so they're what surfaced it.

## Fix

Generate a per-attempt UUID `client_order_id` on every `CreateOrderRequest`. Safe re: idempotency — orders are limit GTC and deduped by the existing resting-order guard, so per-attempt uniqueness won't double-place.

## Test

A live order's `create_order` request carries a valid UUID `client_order_id`. Full suite **862 passed**.

## Validation plan

After merge + restart, the next Kalshi exit retry should no longer return `deprecated_v1_order_endpoint` — it should place (or return a real, actionable Kalshi reason). I'll confirm from the log.

Assisted-by: Claude (Anthropic)