### PR TITLE
fix(kalshi): parse v2 fixed-point fields in get_order_status

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -538,35 +538,64 @@ class KalshiClient:
             return OrderBook()
 
     async def get_order_status(self, order_id: str) -> OrderResult:
-        """Query order status from Kalshi."""
+        """Query order status from Kalshi.
+
+        Reads the RAW order JSON because v2 orders use a different field set than
+        the SDK's Order model exposes: ``fill_count_fp`` / ``remaining_count_fp``
+        (fixed-point decimal strings, e.g. "16.00") and ``yes_price_dollars`` /
+        ``no_price_dollars`` (dollar strings) instead of the legacy
+        ``count`` / ``remaining_count`` / ``yes_price`` (cents). With the old
+        getattr parse those came back 0, so a fully-filled v2 order reported
+        filled_size=0 and the monitor skipped record_fill — the realized P&L of
+        every v2 fill went unbooked. Fall back to the legacy fields for safety.
+        """
+        import json
         self._init_api()
         try:
-            response = await self._call(self._portfolio_api.get_order, order_id)
-            order_data = response.order
+            raw = await self._call_raw(
+                self._portfolio_api.get_order_without_preload_content, order_id)
+            od = (json.loads(raw) or {}).get("order", {}) or {}
 
             status_map = {
-                "resting": "pending",
-                "canceled": "cancelled",
-                "executed": "filled",
-                "pending": "pending",
+                "resting": "pending", "canceled": "cancelled",
+                "executed": "filled", "pending": "pending",
             }
-            raw_status = str(getattr(order_data, "status", "pending")).lower()
-            status = status_map.get(raw_status, "pending")
+            status = status_map.get(str(od.get("status", "pending")).lower(), "pending")
 
-            # Terminal/historical orders come back with count, remaining_count
-            # and yes_price all None — coerce to 0 so the arithmetic below
-            # doesn't raise (which previously made every status query on an old
-            # order fail).
-            count = getattr(order_data, "count", 0) or 0
-            remaining = getattr(order_data, "remaining_count", 0) or 0
-            yes_price = getattr(order_data, "yes_price", 0) or 0
+            def _num(*keys):
+                for k in keys:
+                    v = od.get(k)
+                    if v not in (None, ""):
+                        try:
+                            return float(v)
+                        except (TypeError, ValueError):
+                            pass
+                return 0.0
+
+            # Filled size: prefer the explicit v2 fill_count, else initial-minus-
+            # remaining; tolerate the legacy integer fields on old responses.
+            filled = _num("fill_count_fp", "fill_count")
+            if filled <= 0:
+                initial = _num("initial_count_fp", "count")
+                remaining = _num("remaining_count_fp", "remaining_count")
+                filled = max(0.0, initial - remaining)
+
+            # Price in terms of the outcome leg we hold (v2 prices are dollars;
+            # legacy yes_price is cents → /100).
+            outcome = str(od.get("side") or od.get("outcome_side") or "yes").lower()
+            if outcome == "no":
+                price = _num("no_price_dollars")
+            else:
+                price = _num("yes_price_dollars")
+            if price <= 0:  # legacy cents fallback
+                price = _num("yes_price") / 100.0
 
             return OrderResult(
                 order_id=order_id,
-                market_id=getattr(order_data, "ticker", "") or "",
+                market_id=str(od.get("ticker", "") or ""),
                 status=status,  # type: ignore[arg-type]
-                filled_size=float(count - remaining),
-                filled_price=float(yes_price) / 100,
+                filled_size=filled,
+                filled_price=price,
                 is_paper=False,
             )
         except Exception as e:

--- a/tests/test_kalshi_order_tracking.py
+++ b/tests/test_kalshi_order_tracking.py
@@ -136,29 +136,60 @@ def test_reconcile_leaves_transient_errors_pending():
 
 @pytest.mark.asyncio
 async def test_get_order_status_handles_none_fields():
-    """Terminal/historical orders return None count/price — must not crash.
+    """Terminal/historical orders return no count/price fields — must not crash.
 
     This was the bug that made every reconcile query on an old order fail with
     'unsupported operand type(s) for -: NoneType and NoneType'.
     """
+    import json
     client = _client(is_live=True)
     client._init_api = MagicMock()
     client._portfolio_api = MagicMock()  # normally set by _init_api
-
-    order_data = MagicMock()
-    order_data.status = "executed"
-    order_data.ticker = "KXFOO-1"
-    order_data.count = None
-    order_data.remaining_count = None
-    order_data.yes_price = None
-    response = MagicMock()
-    response.order = order_data
-    client._call = AsyncMock(return_value=response)
+    client._call_raw = AsyncMock(return_value=json.dumps(
+        {"order": {"status": "executed", "ticker": "KXFOO-1"}}))
 
     result = await client.get_order_status("o1")
     assert result.status == "filled"
     assert result.filled_size == 0
     assert result.filled_price == 0
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_parses_v2_fixed_point_fields():
+    """v2 orders carry fill_count_fp / *_price_dollars (not the legacy
+    count / yes_price). A fully-filled v2 order must report the real filled_size
+    and dollar price — else the monitor skips record_fill and the P&L is lost."""
+    import json
+    client = _client(is_live=True)
+    client._init_api = MagicMock()
+    client._portfolio_api = MagicMock()
+    client._call_raw = AsyncMock(return_value=json.dumps({"order": {
+        "status": "executed", "ticker": "KXACT", "side": "yes",
+        "fill_count_fp": "16.00", "initial_count_fp": "16.00",
+        "remaining_count_fp": "0.00",
+        "yes_price_dollars": "0.0400", "no_price_dollars": "0.9600",
+    }}))
+    result = await client.get_order_status("o2")
+    assert result.status == "filled"
+    assert result.filled_size == 16.0
+    assert result.filled_price == 0.04
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_no_leg_uses_no_price():
+    """A NO-leg order is priced off no_price_dollars."""
+    import json
+    client = _client(is_live=True)
+    client._init_api = MagicMock()
+    client._portfolio_api = MagicMock()
+    client._call_raw = AsyncMock(return_value=json.dumps({"order": {
+        "status": "executed", "ticker": "KXNO", "side": "no",
+        "fill_count_fp": "24.00", "remaining_count_fp": "0.00",
+        "yes_price_dollars": "0.0300", "no_price_dollars": "0.9700",
+    }}))
+    result = await client.get_order_status("o3")
+    assert result.filled_size == 24.0
+    assert result.filled_price == 0.97
 
 
 def test_reconcile_pending_orders_updates_terminal_only():


### PR DESCRIPTION
## Found by auditing the Kalshi side after #187

The v2 create-order migration (#187) worked — the first live exit placed and **filled 16/16**. But the audit caught a secondary bug: `get_order_status` reported `filled_size=0` for that fully-filled order, so the order monitor (which requires `filled_size > 0`) **skipped `record_fill`** and the realized P&L went unbooked.

## Cause

v2 orders return a different field set than the SDK's `Order` model exposes. Verified against the real order:

| legacy (read by old code) | v2 actual |
|---|---|
| `count` / `remaining_count` | `fill_count_fp` / `remaining_count_fp` = `"16.00"` (decimal strings) |
| `yes_price` (cents) | `yes_price_dollars` / `no_price_dollars` = `"0.0400"` (dollar strings) |

`getattr(model, "count", 0)` returned 0 → `filled_size = 0`.

## Fix

Read the raw order JSON and parse the v2 fields: `filled_size` from `fill_count_fp` (or `initial − remaining`), price from the dollar field of the outcome leg we actually hold (`yes` vs `no`), with fallbacks to the legacy fields so old/terminal responses still parse.

## Test

v2 fixed-point parse (YES and NO legs) + the legacy/empty-field path. Full suite **868 passed**.

Assisted-by: Claude (Anthropic)