### PR TITLE
fix(kalshi): v2-aware dup-check (book_side) + v2 cancel with legacy fallback

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -308,6 +308,19 @@ class KalshiClient:
             dry_run=not is_live,
         )
 
+    @staticmethod
+    def _v2_book_side(token: TokenType, side: OrderSide) -> str:
+        """The v2 single-book side (bid/ask) for an order.
+
+        v2 is a single YES book: bid = buy YES, ask = sell YES. A NO order flips
+        (buy NO == sell YES == ask; sell NO == buy YES == bid). Shared by
+        place_order (what we send) and the dup-check (what we compare against
+        resting orders' ``book_side``), so the two can't drift.
+        """
+        if token == TokenType.YES:
+            return "bid" if side == OrderSide.BUY else "ask"
+        return "ask" if side == OrderSide.BUY else "bid"
+
     async def place_order(self, order: Order) -> OrderResult:
         """Place an order. Paper trades by default."""
         # Kill switch
@@ -336,28 +349,30 @@ class KalshiClient:
         # === LIVE ORDER PATH ===
         self._init_api()
 
-        # Guard: skip if we already have a resting order on the same market + side
+        # Guard: skip if we already have a resting order on the same book side.
+        # v2 is single-book — every resting order reports side='yes' with the
+        # real direction in `book_side` (bid/ask). The old yes/no + action
+        # compare never matched a v2 resting order, so the guard silently went
+        # dark (a NO order, recorded as a YES bid/ask, could stack duplicates).
+        # Compare the v2 book_side we'd post against each resting order's.
         try:
             import json as _json
             existing_raw = await self._call_raw(
                 self._portfolio_api.get_orders_without_preload_content,
             )
             existing_data = _json.loads(existing_raw)
-            kalshi_side = "yes" if order.token == TokenType.YES else "no"
-            kalshi_action = "buy" if order.side == OrderSide.BUY else "sell"
+            want_book_side = self._v2_book_side(order.token, order.side)
             ticker = order.token_id
             for o in existing_data.get("orders", []):
                 if (o.get("status") == "resting"
                         and o.get("ticker") == ticker
-                        and o.get("side") == kalshi_side
-                        and o.get("action") == kalshi_action):
+                        and o.get("book_side") == want_book_side):
                     log.info(
                         "order.skip_duplicate",
                         exchange="kalshi",
                         ticker=ticker,
-                        side=kalshi_side,
-                        action=kalshi_action,
-                        reason="resting order already exists on same side",
+                        book_side=want_book_side,
+                        reason="resting order already exists on same book side",
                     )
                     return OrderResult(
                         order_id="SKIP_DUP",
@@ -392,12 +407,8 @@ class KalshiClient:
             #   YES BUY  -> bid @ price          YES SELL -> ask @ price
             #   NO  BUY  -> ask @ (1 - price)    NO  SELL -> bid @ (1 - price)
             # (a NO order carries the NO price, so 1 - price is the YES price.)
-            if order.token == TokenType.YES:
-                v2_side = "bid" if order.side == OrderSide.BUY else "ask"
-                yes_price = order.price
-            else:
-                v2_side = "ask" if order.side == OrderSide.BUY else "bid"
-                yes_price = 1.0 - order.price
+            v2_side = self._v2_book_side(order.token, order.side)
+            yes_price = order.price if order.token == TokenType.YES else 1.0 - order.price
             yes_price = max(0.01, min(0.99, yes_price))
             count = int(order.size)
             if count < 1:
@@ -603,15 +614,38 @@ class KalshiClient:
             raise
 
     async def cancel_order(self, order_id: str) -> bool:
-        """Cancel a Kalshi order."""
+        """Cancel a Kalshi order.
+
+        Prefer the v2 endpoint (DELETE /portfolio/events/orders/{id}) so we don't
+        get silently cut off the way create-order was; fall back to the legacy
+        SDK cancel (still working) if the v2 call errors, so future-proofing
+        can't break a currently-working path.
+        """
         self._init_api()
+        url = f"{self._api_base}/portfolio/events/orders/{order_id}"
+
+        def _delete():
+            return self._client.call_api(
+                "DELETE", url,
+                header_params={"Accept": "application/json"},
+                _request_timeout=_REQUEST_TIMEOUT,
+            )
+
         try:
-            await self._call(self._portfolio_api.cancel_order, order_id)
-            log.info("order.cancelled", exchange="kalshi", order_id=order_id)
+            async with self._semaphore:
+                await asyncio.to_thread(_delete)
+            log.info("order.cancelled", exchange="kalshi", order_id=order_id, via="v2")
             return True
         except Exception as e:
-            log.error("kalshi.cancel_error", order_id=order_id, error=str(e))
-            return False
+            log.warning("kalshi.cancel_v2_error", order_id=order_id, error=str(e)[:200])
+            # Fall back to the legacy SDK cancel (DELETE /portfolio/orders/{id}).
+            try:
+                await self._call(self._portfolio_api.cancel_order, order_id)
+                log.info("order.cancelled", exchange="kalshi", order_id=order_id, via="legacy")
+                return True
+            except Exception as e2:
+                log.error("kalshi.cancel_error", order_id=order_id, error=str(e2)[:200])
+                return False
 
     async def reconcile_open_orders(self) -> int:
         """Pull resting Kalshi orders into ``_live_pending`` at startup.

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -426,6 +426,78 @@ class TestKalshiV2CreateOrder:
         assert "too_few_contracts" in result.error_message
         assert client._live_pending == {}
 
+    @pytest.mark.asyncio
+    async def test_dup_check_skips_on_matching_book_side(self):
+        """A resting order on the same v2 book side (YES SELL → ask) blocks the
+        new order. The legacy yes/no compare never matched v2 resting orders."""
+        from unittest.mock import AsyncMock
+        client = self._client({"order_id": "ord"})
+        client._call_raw = AsyncMock(return_value=json.dumps({"orders": [
+            {"status": "resting", "ticker": "KXT", "side": "yes",
+             "book_side": "ask"}]}))
+        order = Order(market_id="KXT", exchange="kalshi", side=OrderSide.SELL,
+                      token=TokenType.YES, token_id="KXT", size=16, price=0.04,
+                      dry_run=False)
+        result = await client.place_order(order)
+        assert result.order_id == "SKIP_DUP" and result.status == "rejected"
+        client._client.call_api.assert_not_called()  # never reached placement
+
+    @pytest.mark.asyncio
+    async def test_dup_check_allows_different_book_side(self):
+        """A resting order on the OTHER book side does not block (bid vs ask)."""
+        from unittest.mock import AsyncMock
+        client = self._client({"order_id": "ord"})
+        client._call_raw = AsyncMock(return_value=json.dumps({"orders": [
+            {"status": "resting", "ticker": "KXT", "side": "yes",
+             "book_side": "bid"}]}))
+        order = Order(market_id="KXT", exchange="kalshi", side=OrderSide.SELL,
+                      token=TokenType.YES, token_id="KXT", size=16, price=0.04,
+                      dry_run=False)
+        result = await client.place_order(order)
+        assert result.status == "pending"  # ask != bid → proceeded
+
+
+class TestKalshiV2BookSideMapping:
+    def test_all_four_cases(self):
+        from auramaur.exchange.models import TokenType as T, OrderSide as S
+        f = KalshiClient._v2_book_side
+        assert f(T.YES, S.BUY) == "bid"
+        assert f(T.YES, S.SELL) == "ask"
+        assert f(T.NO, S.BUY) == "ask"   # buy NO == sell YES
+        assert f(T.NO, S.SELL) == "bid"  # sell NO == buy YES
+
+
+class TestKalshiCancelV2:
+    def _client(self):
+        from unittest.mock import AsyncMock, MagicMock
+        import asyncio as _asyncio
+        c = KalshiClient.__new__(KalshiClient)
+        c._init_api = MagicMock()
+        c._api_base = "https://api.elections.kalshi.com/trade-api/v2"
+        c._semaphore = _asyncio.Semaphore(1)
+        c._client = MagicMock()
+        c._portfolio_api = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_cancel_uses_v2_delete_endpoint(self):
+        c = self._client()
+        ok = await c.cancel_order("oid-1")
+        assert ok is True
+        method, url = c._client.call_api.call_args.args[0], c._client.call_api.call_args.args[1]
+        assert method == "DELETE"
+        assert url.endswith("/portfolio/events/orders/oid-1")
+        c._portfolio_api.cancel_order.assert_not_called()  # legacy not needed
+
+    @pytest.mark.asyncio
+    async def test_cancel_falls_back_to_legacy_on_v2_error(self):
+        from unittest.mock import MagicMock
+        c = self._client()
+        c._client.call_api = MagicMock(side_effect=Exception("v2 boom"))
+        ok = await c.cancel_order("oid-2")
+        assert ok is True
+        c._portfolio_api.cancel_order.assert_called_once()  # legacy fallback used
+
 
 class TestKalshiPrepareOrderDirectSell:
     def test_sell_signal_becomes_buy_no(self):


### PR DESCRIPTION
Two Kalshi-side follow-ups from the v2 order migration (#187/#188).

## 1. Dup-check went dark under v2 (single-book)

A probe of the live `get_orders` response confirmed v2 is **single-book**: every resting order reports `side='yes'` with the real direction in **`book_side`** (`bid`/`ask`). The old guard compared `yes/no` + `buy/sell`, which **never matches a v2 resting order** — so it silently stopped deduping. A NO order (booked as a YES `bid`/`ask`) could stack duplicate resting orders on the Kalshi entry-arb path.

Fix: compare the v2 `book_side` we'd post against each resting order's `book_side`. The `(token, side) → bid/ask` mapping is extracted to a shared `_v2_book_side` helper so `place_order` and the dup-check can't drift.

## 2. cancel_order future-proofing

`cancel_order` is verifiably working (**3724 cancels, 0 errors**, and resting orders genuinely clear), but it's still on the legacy `DELETE /portfolio/orders/{id}` path — the exact kind of endpoint that got cut off silently for create. Migrated to the v2 `DELETE /portfolio/events/orders/{id}` via the signed `call_api`, **with a fallback to the legacy SDK cancel** if the v2 call raises — so future-proofing can't break a currently-working path.

## Item 3 (NO→bid live validation) — not in this PR

That's a watch item, not a code change: the YES→ask mapping is live-validated (filled); NO→bid is unit-tested and symmetric but hasn't fired live yet (the remaining TAYLORSWIFT exit). I'll confirm it on the next natural fire.

## Test

Dup-check skips on matching book_side / allows the other side; all four `book_side` mappings; cancel hits the v2 DELETE path and falls back to legacy on v2 error. Full suite **873 passed**.

Assisted-by: Claude (Anthropic)