### PR TITLE
fix(safety): route every KILL_SWITCH check through one root-aware helper

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
 import structlog
@@ -534,7 +535,7 @@ class AuramaurBot(
         return cash < 5.0
 
     async def _check_kill_switch(self) -> bool:
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             show_error("KILL SWITCH ACTIVE — halting all trading")
             self._running = False
             alerts = self._components.get("alerts")

--- a/auramaur/broker/onchain.py
+++ b/auramaur/broker/onchain.py
@@ -31,6 +31,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 from typing import Any
 
 import structlog
@@ -184,7 +185,7 @@ class OnChainRedeemer:
         is a separate opt-in because redemption is a distinct money-moving
         operation and shouldn't ride on the trading toggle.
         """
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             return False
         if not self._settings.auramaur_live:
             return False

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -1690,8 +1690,10 @@ def _render_readiness_table(report) -> None:
 @main.command()
 def kill():
     """Activate the kill switch."""
-    from pathlib import Path
-    Path("KILL_SWITCH").touch()
+    from auramaur.killswitch import KILL_SWITCH_PATH
+    # Arm at the canonical repo-root path so every check finds it regardless of
+    # the launch directory.
+    KILL_SWITCH_PATH.touch()
     console.print("[bold red]KILL SWITCH ACTIVATED[/]")
 
 
@@ -1699,9 +1701,14 @@ def kill():
 def unkill():
     """Deactivate the kill switch."""
     from pathlib import Path
-    ks = Path("KILL_SWITCH")
-    if ks.exists():
-        ks.unlink()
+    from auramaur.killswitch import KILL_SWITCH_PATH
+    # Remove both the canonical and any CWD-relative switch so disarm is total.
+    removed = False
+    for ks in (KILL_SWITCH_PATH, Path("KILL_SWITCH")):
+        if ks.exists():
+            ks.unlink()
+            removed = True
+    if removed:
         console.print("[bold green]Kill switch deactivated[/]")
     else:
         console.print("Kill switch was not active.")

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import math
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import structlog
 
@@ -304,7 +305,7 @@ class PolymarketClient:
         3. order.dry_run=False
         """
         # Check kill switch first
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="order_blocked")
             return OrderResult(
                 order_id="BLOCKED",

--- a/auramaur/exchange/cryptodotcom.py
+++ b/auramaur/exchange/cryptodotcom.py
@@ -30,6 +30,7 @@ import json
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import aiohttp
 import structlog
@@ -313,7 +314,7 @@ class CryptoComClient:
     async def place_order(self, order: Order) -> OrderResult:
         """Place an order. Paper trades by default."""
         # Kill switch
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="order_blocked")
             return OrderResult(
                 order_id="BLOCKED",

--- a/auramaur/exchange/ibkr.py
+++ b/auramaur/exchange/ibkr.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import structlog
 
@@ -338,7 +339,7 @@ class IBKRClient:
     async def place_order(self, order: Order) -> OrderResult:
         """Place an option order via IB."""
         # Kill switch
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="order_blocked")
             return OrderResult(
                 order_id="BLOCKED",

--- a/auramaur/exchange/ibkr_equity.py
+++ b/auramaur/exchange/ibkr_equity.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import structlog
 
@@ -100,7 +101,7 @@ class IBKREquityClient:
         Gated + capped. To exit a position use close_position()."""
         side_str = (side.value if isinstance(side, OrderSide) else str(side)).upper()
 
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="ibkr_equity_order_blocked")
             return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
                                is_paper=True, error_message="kill switch")
@@ -140,7 +141,7 @@ class IBKREquityClient:
         CAVEAT: a cashQty close is only as exact as the quote, so it may leave
         sub-cent dust — verify live that positions flatten cleanly before trusting
         this for hands-off exits."""
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="ibkr_equity_close_blocked")
             return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
                                is_paper=True, error_message="kill switch")
@@ -209,7 +210,7 @@ class IBKREquityClient:
             return OrderResult(order_id="ERROR", market_id=symbol, status="rejected",
                                is_paper=True, error_message="qty must be positive")
 
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="ibkr_equity_order_blocked")
             return OrderResult(order_id="BLOCKED", market_id=symbol, status="rejected",
                                is_paper=True, error_message="kill switch")
@@ -305,7 +306,7 @@ class IBKREquityClient:
         if dry_run is None:
             dry_run = not self._settings.is_live
 
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="ibkr_fx_convert_blocked")
             return OrderResult(order_id="BLOCKED", market_id=f"USD{source_ccy}",
                                status="rejected", is_paper=True,

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -6,6 +6,7 @@ import asyncio
 import uuid
 from datetime import datetime
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import structlog
 
@@ -324,7 +325,7 @@ class KalshiClient:
     async def place_order(self, order: Order) -> OrderResult:
         """Place an order. Paper trades by default."""
         # Kill switch
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="order_blocked")
             return OrderResult(
                 order_id="BLOCKED",

--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -27,6 +27,7 @@ import hmac
 import time
 import urllib.parse
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import aiohttp
 import structlog
@@ -226,7 +227,7 @@ class KrakenSpotClient:
         side_str = side_str.lower()
 
         # 1. Kill switch.
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("kill_switch.active", action="kraken_order_blocked")
             return OrderResult(order_id="BLOCKED", market_id=pair, status="rejected",
                                is_paper=True, error_message="kill switch")

--- a/auramaur/killswitch.py
+++ b/auramaur/killswitch.py
@@ -1,0 +1,25 @@
+"""Single source of truth for the KILL_SWITCH safety check.
+
+CLAUDE.md absolute rule #2: if the KILL_SWITCH file exists, halt ALL trading.
+Many call sites used a bare ``Path("KILL_SWITCH")``, which is resolved relative
+to the process CWD — so a launch from a directory other than the repo root would
+silently miss the switch. Anchor the check to the repo root (and still honor the
+CWD for backward-compat with tooling that touches ``./KILL_SWITCH``), and route
+every site through this one function so the behavior can't drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Repo root = one level up from this file's package dir (auramaur/ -> repo root).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The canonical kill-switch path. Arm/disarm tooling should create/remove THIS
+# file so the check below reliably finds it regardless of launch directory.
+KILL_SWITCH_PATH = _REPO_ROOT / "KILL_SWITCH"
+
+
+def kill_switch_present() -> bool:
+    """True if the KILL_SWITCH file exists at the repo root OR the current CWD."""
+    return KILL_SWITCH_PATH.exists() or Path("KILL_SWITCH").exists()

--- a/auramaur/monitoring/live_gate.py
+++ b/auramaur/monitoring/live_gate.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 from typing import Literal
 
 from auramaur.db.database import Database
@@ -55,7 +56,7 @@ async def preflight(settings, db: Database) -> PreflightReport:
         report.results.append(GateResult(name, severity, detail))
 
     # 1. Kill switch — halts ALL trading by design.
-    if Path("KILL_SWITCH").exists():
+    if kill_switch_present():
         add("kill_switch", "BLOCK", "KILL_SWITCH file present")
     else:
         add("kill_switch", "OK", "absent")

--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 from typing import Any
 
 from pydantic import BaseModel
@@ -23,7 +24,7 @@ class CheckResult(BaseModel):
 
 async def check_kill_switch() -> CheckResult:
     """Fail if KILL_SWITCH file exists on disk."""
-    active = Path("KILL_SWITCH").exists()
+    active = kill_switch_present()
     return CheckResult(
         name="kill_switch",
         passed=not active,

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
+from auramaur.killswitch import kill_switch_present
 from auramaur.exchange.models import Market, OrderResult, OrderSide, Signal
 from auramaur.monitoring.display import (
     show_cycle_summary,
@@ -469,13 +470,12 @@ class CycleOrchestrationMixin:
         price_history: dict[str, list[float]] | None = None,
     ) -> list[dict]:
         """Strategic cycle: batch analysis with persistent world model."""
-        from pathlib import Path
         from auramaur.nlp.strategic import StrategicAnalyzer
         from auramaur.exchange.models import Confidence
         exchange_fees = self.settings.arbitrage.exchange_fees
 
         # Kill switch check — halt immediately if active
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.warning("engine.kill_switch_active", method="strategic")
             return []
 

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -21,6 +21,7 @@ import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 
 import structlog
 
@@ -115,7 +116,7 @@ class MarketMaker:
         Returns list of cycle results (one per market acted on).
         """
         # Kill switch check
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.critical("market_maker.kill_switch_active")
             return []
 

--- a/auramaur/strategy/pipeline_analyzer.py
+++ b/auramaur/strategy/pipeline_analyzer.py
@@ -10,6 +10,7 @@ import time
 import structlog
 
 from auramaur.data_sources.aggregator import Aggregator
+from auramaur.killswitch import kill_switch_present
 from auramaur.db.database import Database
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.exchange.protocols import ExchangeClient
@@ -76,10 +77,9 @@ class PipelineAnalyzer:
         price_history: dict[str, list[float]] | None = None,
     ) -> list[TradeCandidate]:
         """Batch analysis with persistent world model."""
-        from pathlib import Path
         from auramaur.nlp.query_decomposer import extract_search_queries
 
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             log.warning("pipeline.kill_switch_active")
             return []
 

--- a/auramaur/treasury/transfers.py
+++ b/auramaur/treasury/transfers.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from auramaur.killswitch import kill_switch_present
 from typing import Callable
 
 import structlog
@@ -107,7 +108,7 @@ class TransferManager:
                                   amount=amount_usd, dest_key=dest_key)
 
         # 1. Kill switch.
-        if Path("KILL_SWITCH").exists():
+        if kill_switch_present():
             return blocked("kill switch active")
 
         # 2. Whitelist (config side). Kraken UI is the second, independent gate.

--- a/config/settings.py
+++ b/config/settings.py
@@ -1019,12 +1019,10 @@ class Settings(BaseSettings):
 
     @property
     def kill_switch_active(self) -> bool:
-        # Anchor the kill switch to the repo root (two levels up from this
-        # file: config/ -> repo root), not the caller's CWD. A bare
-        # Path("KILL_SWITCH") would be CWD-relative and could miss the switch
-        # when the bot is launched from the inner package directory.
-        repo_root = Path(__file__).resolve().parent.parent
-        return (repo_root / "KILL_SWITCH").exists() or Path("KILL_SWITCH").exists()
+        # Delegate to the shared root-aware helper so this and every bare call
+        # site agree on one definition (repo root OR CWD) and can't drift.
+        from auramaur.killswitch import kill_switch_present
+        return kill_switch_present()
 
     @property
     def is_live(self) -> bool:

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -1,0 +1,37 @@
+"""The shared root-aware KILL_SWITCH check.
+
+CRITICAL: these tests must NEVER create a KILL_SWITCH at the real repo root —
+that would halt the running bot. Every test monkeypatches KILL_SWITCH_PATH to a
+tmp dir and chdirs into a tmp dir, so no real switch is ever touched.
+"""
+
+from __future__ import annotations
+
+import auramaur.killswitch as ks
+
+
+def test_absent_by_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(ks, "KILL_SWITCH_PATH", tmp_path / "root" / "KILL_SWITCH")
+    monkeypatch.chdir(tmp_path)
+    assert ks.kill_switch_present() is False
+
+
+def test_root_anchor_found_even_when_cwd_lacks_it(tmp_path, monkeypatch):
+    """The bug this fixes: a switch at the repo root must be detected even when
+    the process CWD has no KILL_SWITCH (the bare CWD check would miss it)."""
+    root = tmp_path / "root"; root.mkdir()
+    cwd = tmp_path / "cwd"; cwd.mkdir()
+    monkeypatch.setattr(ks, "KILL_SWITCH_PATH", root / "KILL_SWITCH")
+    monkeypatch.chdir(cwd)  # CWD deliberately has no switch
+    assert ks.kill_switch_present() is False
+    (root / "KILL_SWITCH").touch()  # arm at the "repo root" only
+    assert ks.kill_switch_present() is True
+
+
+def test_cwd_branch_still_honored(tmp_path, monkeypatch):
+    """A CWD-relative ./KILL_SWITCH is still honored (back-compat with tooling)."""
+    monkeypatch.setattr(ks, "KILL_SWITCH_PATH", tmp_path / "root" / "KILL_SWITCH")
+    monkeypatch.chdir(tmp_path)
+    assert ks.kill_switch_present() is False
+    (tmp_path / "KILL_SWITCH").touch()
+    assert ks.kill_switch_present() is True


### PR DESCRIPTION
Verified medium finding from the rescue review.

## Problem

CLAUDE.md absolute rule #2 — *if KILL_SWITCH exists, halt all trading* — was enforced by ~16 call sites using a bare `Path("KILL_SWITCH")`, which resolves relative to the **process CWD**. A launch from any directory other than the repo root would silently miss the switch. Only `Settings.kill_switch_active` was correct (it already anchored to the repo root), so the definition had drifted.

## Fix

New `auramaur/killswitch.py` is the single source of truth:
- `kill_switch_present()` checks the **repo root OR the CWD**.
- `KILL_SWITCH_PATH` is the canonical arm location.

Every bare check now routes through it — exchange adapters (client/kalshi/kraken/ibkr/ibkr_equity/cryptodotcom), `risk/checks`, `bot`, `engine_cycle`, `market_maker`, `pipeline_analyzer`, `broker/onchain`, `treasury/transfers`, `monitoring/live_gate` — and `Settings.kill_switch_active` delegates to it so they can't drift again. The CLI `kill` arms at the repo-root path; `unkill` removes both the canonical and any CWD-relative file.

## Test

A switch at the repo root is detected even when the CWD lacks it (the exact bug), plus CWD-branch back-compat. **The tests never create a real repo-root KILL_SWITCH** (they monkeypatch the path + chdir into tmp), so they can't halt the running bot. Full suite green; the `test_no_unbound_names` lexical guard confirms no missed imports across the 16-file sweep.

Assisted-by: Claude (Anthropic)