### PR TITLE
chore(lint): clear the ruff backlog (214 -> 0)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
@@ -25,27 +24,24 @@ from auramaur.data_sources.websearch import WebSearchSource
 from auramaur.db.database import Database
 from auramaur.exchange.client import PolymarketClient
 from auramaur.exchange.gamma import GammaClient
-from auramaur.exchange.models import Fill, Order, OrderSide, OrderType, TokenType
+from auramaur.exchange.models import OrderSide, TokenType
 
 if TYPE_CHECKING:
-    from auramaur.exchange.models import Market, Signal
+    pass
 from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
 from auramaur.exchange.paper import PaperTrader
 from auramaur.monitoring.alerts import AlertManager
 from auramaur.monitoring.display import (
-    console, show_banner, show_error, show_portfolio, show_source_error, show_startup,
+    console, show_banner, show_error, show_portfolio, show_startup,
 )
 from auramaur.monitoring.logger import setup_logging
 from auramaur.nlp.analyzer import ClaudeAnalyzer
 from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
-from auramaur.nlp.errors import BudgetExhausted
 from auramaur.risk.manager import RiskManager
 from auramaur.risk.portfolio import PortfolioTracker
 from auramaur.strategy.arbitrage_scanner import (
-    ArbOpportunity,
     ArbitrageScanner,
-    NegRiskArbOpportunity,
 )
 from auramaur.strategy.engine import TradingEngine
 from auramaur.strategy.market_maker import MarketMaker
@@ -878,7 +874,7 @@ class AuramaurBot(
                         # Gates closed — fall back to the manual-action banner.
                         console.print()
                         console.print(
-                            f"[bold green]╔══ REDEMPTION AVAILABLE ══╗[/]"
+                            "[bold green]╔══ REDEMPTION AVAILABLE ══╗[/]"
                         )
                         console.print(
                             f"[bold green]║[/] [green]${payout:.2f} USDC[/] ready to "
@@ -887,11 +883,11 @@ class AuramaurBot(
                             f"(net [green]${summary['net_pnl_now']:+.2f}[/])"
                         )
                         console.print(
-                            f"[bold green]║[/] [dim]→ https://polymarket.com/portfolio  "
-                            f"or run:[/] [cyan]auramaur redeem --submit[/]"
+                            "[bold green]║[/] [dim]→ https://polymarket.com/portfolio  "
+                            "or run:[/] [cyan]auramaur redeem --submit[/]"
                         )
                         console.print(
-                            f"[bold green]╚══════════════════════════╝[/]"
+                            "[bold green]╚══════════════════════════╝[/]"
                         )
                         console.print()
                         last_notified_payout = payout
@@ -1361,12 +1357,10 @@ class AuramaurBot(
     async def _task_position_sync(self) -> None:
         """Periodically sync positions from CLOB trade history (ground truth)."""
         from auramaur.broker.reconciler import PositionReconciler
-        from auramaur.broker.pnl import PnLTracker
         from auramaur.broker.sync import PositionSyncer
 
         reconciler: PositionReconciler = self._components["reconciler"]
         syncer: PositionSyncer = self._components["syncer"]
-        pnl: PnLTracker = self._components["pnl_tracker"]
         interval = self.settings.broker.sync_interval_seconds
 
         while self._running:

--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from auramaur.exchange.models import (
-    Confidence, Market, Order, OrderSide, OrderType, Signal, TokenType,
+    Confidence, Market, Order, OrderSide, Signal, TokenType,
 )
 from auramaur.monitoring.display import console
 from auramaur.nlp.errors import BudgetExhausted
@@ -176,7 +176,7 @@ class ArbExecutionMixin:
         on markets where the strategic batch found potential edge but
         confidence was low or the market is high-value.
         """
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from auramaur.strategy.agent_analyzer import AgentAnalyzer
 
@@ -274,7 +274,6 @@ class ArbExecutionMixin:
                     candidate = await depth_agent.deep_research(market)
                     if candidate:
                         # Run through risk checks and execution
-                        from auramaur.strategy.protocols import TradeCandidate
                         results = await engine._execute_candidates([candidate])
                         trades = [r for r in results if r.get("order")]
                         if trades:
@@ -394,7 +393,7 @@ class ArbExecutionMixin:
         with the COMPLETE set, so if any leg fails risk checks the whole package
         is skipped, and a partial fill raises a critical alert for manual review.
         """
-        from auramaur.exchange.models import Confidence, Signal
+        from auramaur.exchange.models import Signal
 
         engine = engines.get(opp.exchange)
         if engine is None:
@@ -535,7 +534,7 @@ class ArbExecutionMixin:
 
         Both legs must pass risk checks independently before execution.
         """
-        from auramaur.exchange.models import Confidence, Signal
+        from auramaur.exchange.models import Signal
 
         market = opp.market_a  # Same market for both sides
         exchange_name = opp.exchange_a
@@ -698,7 +697,7 @@ class ArbExecutionMixin:
         concurrent; half-fills trigger a cancel with a critical alert if
         cancel can't confirm.
         """
-        from auramaur.exchange.models import Confidence, Signal
+        from auramaur.exchange.models import Signal
 
         # Identify which side is cheap (lower YES price)
         if opp.price_a <= opp.price_b:
@@ -914,7 +913,7 @@ class ArbExecutionMixin:
         sell contracts to bring it down to TARGET_EVENT_PCT.  This prevents
         concentration risk from locking up all capital in one bet.
         """
-        from auramaur.exchange.models import Confidence, Signal, TokenType as TT
+        from auramaur.exchange.models import Signal, TokenType as TT
 
         MAX_EVENT_PCT = 0.30   # trigger rebalance above 30%
         TARGET_EVENT_PCT = 0.20  # trim down to 20%
@@ -975,7 +974,7 @@ class ArbExecutionMixin:
                 target=round(target_exposure, 2),
                 excess=round(excess, 2),
             )
-            from datetime import datetime, timezone
+            from datetime import datetime
             ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
             console.print(
                 f"[dim]{ts}[/] [bold yellow]REBALANCE[/] {event_key} "

--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -294,7 +294,7 @@ class ExitExecutionMixin:
         SELL signal with ``exit_token`` set and let the exchange's
         ``prepare_order`` do the rest.
         """
-        from auramaur.exchange.models import Confidence, Market, Signal
+        from auramaur.exchange.models import Confidence, Signal
 
         market = await discovery.get_market(pos.market_id)
         if market is None:

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -13,11 +13,10 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from auramaur.exchange.models import Fill, Order, OrderResult, OrderSide, TokenType
+from auramaur.exchange.models import Fill
 from auramaur.monitoring.display import console
 
 if TYPE_CHECKING:
-    from auramaur.db.database import Database
     from auramaur.exchange.client import PolymarketClient
     from auramaur.exchange.paper import PaperTrader
     from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
@@ -388,7 +387,6 @@ class OrderMonitorMixin:
                     # Also feed into attribution if available
                     attributor = self._components.get("attributor")
                     if attributor is not None:
-                        db: Database = self._components["db"]
                         # Attribution is handled inside _settle_position via
                         # daily_stats; log for visibility only.
                         log.info("resolution.attribution_notified", count=resolved)

--- a/auramaur/broker/allocator.py
+++ b/auramaur/broker/allocator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import structlog
 

--- a/auramaur/broker/onchain.py
+++ b/auramaur/broker/onchain.py
@@ -27,10 +27,8 @@ Safety:
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 from typing import Any
 

--- a/auramaur/cli.py
+++ b/auramaur/cli.py
@@ -582,7 +582,7 @@ def health():
             console.print(f"  [{colour[r.severity]}]{r.severity:<5}[/] {r.name}: {r.detail}")
         if report.live_allowed:
             warns = len(report.warnings)
-            console.print(f"\n[bold green]LIVE ALLOWED[/]"
+            console.print("\n[bold green]LIVE ALLOWED[/]"
                           + (f" ([yellow]{warns} warning(s)[/])" if warns else ""))
             return 0
         console.print("\n[bold red]LIVE BLOCKED[/] — "

--- a/auramaur/data_sources/espn.py
+++ b/auramaur/data_sources/espn.py
@@ -57,7 +57,8 @@ class ESPNSource:
                         teams = comp.get("competitors") or []
                         score_line = ""
                         if len(teams) == 2 and teams[0].get("score") is not None:
-                            a = teams[0]; b = teams[1]
+                            a = teams[0]
+                            b = teams[1]
                             score_line = f"{a.get('team', {}).get('displayName', '?')} {a.get('score', '?')} - {b.get('team', {}).get('displayName', '?')} {b.get('score', '?')}"
                         items.append(NewsItem(
                             id=hashlib.md5(f"espn:{event.get('id')}".encode()).hexdigest(),

--- a/auramaur/data_sources/fred.py
+++ b/auramaur/data_sources/fred.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 import structlog
 from fredapi import Fred  # type: ignore[import-untyped]
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/data_sources/google_trends.py
+++ b/auramaur/data_sources/google_trends.py
@@ -14,7 +14,6 @@ The RSS feed has been stable for years and is the safest choice.
 from __future__ import annotations
 
 import hashlib
-import re
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 

--- a/auramaur/data_sources/metaculus.py
+++ b/auramaur/data_sources/metaculus.py
@@ -122,7 +122,6 @@ class MetaculusSource:
                 question_id = question.get("id", 0)
                 forecaster_count = question.get("number_of_forecasters", 0)
                 resolution_date = question.get("resolve_time", "")
-                created = question.get("created_time", "")
 
                 content = (
                     f"METACULUS COMMUNITY FORECAST: {title_text}\n"

--- a/auramaur/data_sources/newsapi.py
+++ b/auramaur/data_sources/newsapi.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/data_sources/reddit.py
+++ b/auramaur/data_sources/reddit.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import asyncpraw  # type: ignore[import-untyped]
 import structlog
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/data_sources/rss.py
+++ b/auramaur/data_sources/rss.py
@@ -10,7 +10,7 @@ import aiohttp
 import feedparser  # type: ignore[import-untyped]
 import structlog
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/data_sources/twitter.py
+++ b/auramaur/data_sources/twitter.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import structlog
 import tweepy  # type: ignore[import-untyped]
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/data_sources/websearch.py
+++ b/auramaur/data_sources/websearch.py
@@ -9,6 +9,9 @@ from datetime import datetime, timezone
 
 import logging
 import structlog
+
+from auramaur.data_sources.base import NewsItem
+
 try:
     from ddgs import DDGS  # type: ignore[import-untyped]
 except ImportError:
@@ -16,8 +19,6 @@ except ImportError:
 
 # Suppress noisy Yahoo News parser warnings from ddgs
 logging.getLogger("ddgs.engines.yahoo_news").setLevel(logging.ERROR)
-
-from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
 

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import math
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import structlog
@@ -748,7 +747,7 @@ class PolymarketClient:
 
     async def get_order_book(self, token_id: str) -> OrderBook:
         """Get order book for a token (public, no auth needed)."""
-        from auramaur.exchange.models import OrderBook, OrderBookLevel
+        from auramaur.exchange.models import OrderBook
         try:
             await self.clob_call(self._init_clob_client)
             raw = await self.clob_call(self._clob_client.get_order_book, token_id)

--- a/auramaur/exchange/cryptodotcom.py
+++ b/auramaur/exchange/cryptodotcom.py
@@ -26,10 +26,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
-import json
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import aiohttp

--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -187,7 +187,6 @@ class GammaClient:
             # Extract prices from outcomes/tokens
             yes_price = 0.5
             no_price = 0.5
-            tokens = data.get("tokens", []) or data.get("clobTokenIds", [])
 
             if isinstance(data.get("outcomePrices"), str):
                 import json

--- a/auramaur/exchange/ibkr.py
+++ b/auramaur/exchange/ibkr.py
@@ -14,9 +14,7 @@ Safety: Same three-gate model as other exchanges.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import structlog
@@ -388,7 +386,6 @@ class IBKRClient:
             # Parse contract info from token_id
             parts = order.token_id.split(":")
             con_id = int(parts[0])
-            action_str = parts[1]
             right = parts[2]
             strike = float(parts[3])
             expiry = parts[4]

--- a/auramaur/exchange/ibkr_equity.py
+++ b/auramaur/exchange/ibkr_equity.py
@@ -13,7 +13,6 @@ backtested net-negative in every variant — pre-failed, never activated.
 from __future__ import annotations
 
 import time
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import structlog

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import datetime
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import structlog

--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -26,7 +26,6 @@ import hashlib
 import hmac
 import time
 import urllib.parse
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import aiohttp

--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import random
 import uuid
-from datetime import datetime
 
 import structlog
 
 from auramaur.db.database import Database
-from auramaur.exchange.models import Order, OrderResult, OrderSide, OrderType, Position, TokenType
+from auramaur.exchange.models import Order, OrderResult, OrderSide, Position, TokenType
 
 log = structlog.get_logger()
 

--- a/auramaur/monitoring/live_gate.py
+++ b/auramaur/monitoring/live_gate.py
@@ -14,7 +14,6 @@ state are untrustworthy.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 from typing import Literal
 

--- a/auramaur/nlp/ensemble_analyzer.py
+++ b/auramaur/nlp/ensemble_analyzer.py
@@ -7,9 +7,6 @@ then blends their probability estimates weighted by per-model calibration accura
 from __future__ import annotations
 
 import asyncio
-import json
-import re
-from datetime import date, datetime, timezone
 
 import structlog
 from pydantic import BaseModel, Field

--- a/auramaur/nlp/evidence_compressor.py
+++ b/auramaur/nlp/evidence_compressor.py
@@ -15,8 +15,6 @@ into the principal components that carry the most predictive signal.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import re
 
 import structlog
@@ -235,7 +233,6 @@ def _extract_temporal(evidence: list[NewsItem]) -> str:
         return ""
 
     newest = min(ages)
-    oldest = max(ages)
 
     if newest < 1:
         freshness = "Breaking — evidence from last hour"

--- a/auramaur/nlp/evidence_ranker.py
+++ b/auramaur/nlp/evidence_ranker.py
@@ -12,7 +12,6 @@ so we feed the model the best N items, not the first N.
 
 from __future__ import annotations
 
-import math
 from datetime import datetime, timezone
 
 import structlog

--- a/auramaur/risk/checks.py
+++ b/auramaur/risk/checks.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 from typing import Any
 

--- a/auramaur/risk/kelly.py
+++ b/auramaur/risk/kelly.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import statistics
 
 from auramaur.exchange.models import Confidence

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 import structlog
 

--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from datetime import date
 from pathlib import Path
 
 import structlog

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -14,27 +14,26 @@ import time
 
 from auramaur.data_sources.aggregator import Aggregator
 from auramaur.db.database import Database
-from auramaur.exchange.models import Market, OrderResult, OrderSide, Signal
+from auramaur.exchange.models import Market, OrderResult, Signal
 from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
 
 # Shared directory for cross-instance market claim locks
 _CLAIM_DIR = os.path.join(tempfile.gettempdir(), "auramaur_claims")
 os.makedirs(_CLAIM_DIR, exist_ok=True)
 from auramaur.monitoring.display import (
-    show_analysis, show_analyzing, show_cycle_summary,
-    show_evidence, show_order, show_order_dropped, show_risk_decision, show_scan_results,
+    show_analysis, show_analyzing, show_evidence, show_risk_decision,
 )
 from auramaur.nlp.analyzer import ClaudeAnalyzer
 from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
-from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
+from auramaur.broker.allocator import CapitalAllocator
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
-from auramaur.broker.router import SmartOrderRouter, UnmarketableSignal
+from auramaur.broker.router import SmartOrderRouter
 from auramaur.risk.manager import RiskManager
-from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.order_flow import OrderFlowTracker
-from auramaur.strategy.protocols import MarketAnalyzer, TradeCandidate
-from auramaur.strategy.signals import detect_edge, taker_fee_rate
+from auramaur.strategy.protocols import MarketAnalyzer
+from auramaur.strategy.signals import detect_edge
 from auramaur.strategy.engine_cycle import CycleOrchestrationMixin
 
 log = structlog.get_logger()

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -10,14 +10,13 @@ execution gateway, the allocator). Method-local imports moved with the methods.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import structlog
 
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
 from auramaur.killswitch import kill_switch_present
-from auramaur.exchange.models import Market, OrderResult, OrderSide, Signal
+from auramaur.exchange.models import Market, OrderSide, Signal
 from auramaur.monitoring.display import (
     show_cycle_summary,
     show_risk_decision,
@@ -485,7 +484,6 @@ class CycleOrchestrationMixin:
         markets = [m for m, _score in ranked_markets[:_MAX_STRATEGIC_BATCH]]
 
         # Gather evidence for all markets first
-        from auramaur.nlp.query_decomposer import extract_search_queries
 
         # Evidence gathering is the dominant cycle cost — each market fans out
         # to ~15 data sources. Running markets concurrently (instead of one at a

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 
 import structlog

--- a/auramaur/strategy/pipeline_analyzer.py
+++ b/auramaur/strategy/pipeline_analyzer.py
@@ -161,7 +161,6 @@ class PipelineAnalyzer:
         price_history: dict[str, list[float]] | None = None,
     ) -> list[TradeCandidate]:
         """Analyze markets one at a time (legacy path)."""
-        from auramaur.nlp.query_decomposer import extract_search_queries
 
         candidates: list[TradeCandidate] = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,17 @@ auramaur = "auramaur.cli:main"
 target-version = "py311"
 line-length = 100
 
+[tool.ruff.lint.per-file-ignores]
+# The orchestrators use intentional late/in-function module imports to break
+# import cycles; E402 (import-not-at-top) there is by design, not a defect.
+"auramaur/bot.py" = ["E402"]
+"auramaur/strategy/engine.py" = ["E402"]
+"auramaur/cli.py" = ["E402"]
+# Tests and research scripts: inline semicolons (E702), local setup imports
+# (E402), and throwaway locals (F841) are idiomatic here and not worth churn.
+"tests/**" = ["E402", "E702", "F841"]
+"scripts/**" = ["E402", "E702", "F841"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/scripts/research/edge_audit.py
+++ b/scripts/research/edge_audit.py
@@ -14,7 +14,6 @@ Brier: mean((pred-actual)^2). 0 = perfect, 0.25 = coin flip. <0.25 = real edge.
 from __future__ import annotations
 
 import sqlite3
-import sys
 
 DB = "auramaur.db"
 

--- a/tests/test_attribution_strategy.py
+++ b/tests/test_attribution_strategy.py
@@ -1,7 +1,6 @@
 """Strategy attribution now sums cost_basis.realized_pnl (not trades.pnl)."""
 
 import asyncio
-from types import SimpleNamespace
 
 from auramaur.db.database import Database
 from auramaur.monitoring.attribution import PerformanceAttributor

--- a/tests/test_clob_call.py
+++ b/tests/test_clob_call.py
@@ -15,7 +15,6 @@ import time
 import pytest
 
 from auramaur.exchange.client import PolymarketClient
-from auramaur.exchange.paper import PaperTrader
 from unittest.mock import MagicMock
 
 

--- a/tests/test_econ_pricing.py
+++ b/tests/test_econ_pricing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 
 from auramaur.strategy.econ_pricing import (
     ECON_SERIES,

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -7,7 +7,7 @@ import asyncio
 import pytest
 
 from auramaur.db.database import Database
-from auramaur.nlp.ensemble import EnsembleEstimator, ProbabilitySource
+from auramaur.nlp.ensemble import EnsembleEstimator
 
 
 class MockSource:

--- a/tests/test_execution_strategy.py
+++ b/tests/test_execution_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from auramaur.exchange.models import OrderBook, OrderBookLevel, OrderSide, OrderType
 from auramaur.strategy.execution import ExecutionStrategy

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -8,9 +8,6 @@ from auramaur.exchange.ibkr import IBKRClient
 from auramaur.exchange.models import Confidence, Market, Order, OrderSide, Signal, TokenType
 from auramaur.nlp.reframer import (
     OptionContract,
-    ReframedMarket,
-    TradeMapping,
-    ReframeType,
     reframe_option_as_binary,
 )
 

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -469,7 +469,7 @@ class TestKalshiV2BookSideMapping:
 
 class TestKalshiCancelV2:
     def _client(self):
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import MagicMock
         import asyncio as _asyncio
         c = KalshiClient.__new__(KalshiClient)
         c._init_api = MagicMock()

--- a/tests/test_multi_exchange_risk.py
+++ b/tests/test_multi_exchange_risk.py
@@ -1,6 +1,5 @@
 """Tests for multi-exchange risk enforcement."""
 
-import pytest
 
 from auramaur.exchange.models import Market, Order, OrderSide
 

--- a/tests/test_onchain_redeemer.py
+++ b/tests/test_onchain_redeemer.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from eth_account import Account

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -273,7 +273,6 @@ async def test_poll_timeout_cancels(client):
     client.cancel_order = mock_cancel
     client._live_pending["order123"] = original_order
 
-    import time
     with patch("asyncio.sleep", new_callable=AsyncMock), \
          patch("time.monotonic", side_effect=[0, 0, 0.5, 1.0, 1.5, 999]):
         result = await client.poll_until_terminal("order123", timeout=1, poll_interval=0.1)

--- a/tests/test_paper_trader.py
+++ b/tests/test_paper_trader.py
@@ -1,7 +1,7 @@
 """Tests for paper trading simulator."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from auramaur.exchange.models import Order, OrderSide
 from auramaur.exchange.paper import PaperTrader

--- a/tests/test_reframer.py
+++ b/tests/test_reframer.py
@@ -6,8 +6,6 @@ from datetime import datetime, timezone
 from auramaur.nlp.reframer import (
     OptionContract,
     ReframeType,
-    ReframedMarket,
-    TradeMapping,
     reframe_option_as_binary,
     reframe_earnings_binary,
     select_interesting_strikes,

--- a/tests/test_rejection_cooldown.py
+++ b/tests/test_rejection_cooldown.py
@@ -10,10 +10,8 @@ bench until the cooldown expires, the market reprices, or news flags it.
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
 
 from auramaur.db.database import Database
 from auramaur.exchange.models import Market

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -623,7 +623,6 @@ class TestSettlePosition:
     def test_detect_void(self):
         """closed + uma resolved + ~0.5 price = VOID (refund); pinned or
         still-open or non-poly is not a void."""
-        from auramaur.exchange.models import Market
 
         def mk(**kw):
             d = dict(active=True, closed=True, yes_price=0.5)

--- a/tests/test_risk_checks.py
+++ b/tests/test_risk_checks.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 from auramaur.risk.checks import (
-    CheckResult,
     check_kill_switch,
     check_max_drawdown,
     check_drawdown_heat,

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,7 +1,7 @@
 """Tests for signal/edge detection."""
 
 import pytest
-from auramaur.exchange.models import Market, Confidence
+from auramaur.exchange.models import Market
 from auramaur.nlp.analyzer import AnalysisResult
 from auramaur.strategy.signals import detect_edge
 


### PR DESCRIPTION
Pays down the lint debt the rescue review flagged, so the new advisory CI lint job (#191) is a meaningful signal rather than noise.

## What

- **Auto-fixed safe rules** across the tree: ~80 unused imports (F401), 8 redefinitions (F811), 5 placeholder-less f-strings (F541). No `__init__.py` re-exports touched.
- **Removed 6 dead local assignments** in production (F841) — unused component lookups / parsed fields in `bot`, `bot_order_monitor`, `metaculus`, `gamma`, `ibkr`, `evidence_compressor` (all pure, no side effects).
- **Fixed the last 2 production nits by hand**: a semicolon-joined pair in `espn`, and an import-after-statement in `websearch` (moved `NewsItem` up; the ddgs log-suppression stays in place).
- **per-file-ignores** for intentional patterns so they don't re-noise: E402 in the orchestrators (`bot`/`engine`/`cli` use late imports to break cycles), and E402/E702/F841 in tests + research scripts.

## Result

`ruff check .` → **All checks passed** (was 214). Full suite passes; production modules touched were import-smoke-tested. No behavior change.

Assisted-by: Claude (Anthropic)