### PR TITLE
refactor(bot): typed Components registry replacing the untyped dict

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -14,6 +14,7 @@ import structlog
 logging.getLogger("py_clob_client_v2.http_helpers.helpers").setLevel(logging.CRITICAL)
 
 from config.settings import Settings
+from auramaur.components import Components
 from auramaur.data_sources.aggregator import Aggregator
 from auramaur.data_sources.newsapi import NewsAPISource
 from auramaur.data_sources.reddit import RedditSource
@@ -71,7 +72,7 @@ class AuramaurBot(
         self.settings = settings or Settings()
         self._hybrid = hybrid
         self._running = False
-        self._components: dict = {}
+        self._components: Components = Components()
         self._db_path = db_path
         self._exchange_filter = exchange_filter  # If set, only run this exchange
         self._lock_file = None  # File handle kept open for duration
@@ -452,7 +453,7 @@ class AuramaurBot(
             (engines[k].exchange for k in engines if getattr(engines[k], 'exchange', None) is not None), None
         )
 
-        self._components = {
+        self._components = Components({
             "db": db, "aggregator": aggregator, "discovery": primary_discovery,
             "discoveries": discoveries,
             "paper": paper, "exchange": primary_exchange, "analyzer": analyzer,
@@ -473,7 +474,7 @@ class AuramaurBot(
             "websocket": ws, "ensemble": ensemble,
             "source_names": source_names,
             "exchange_filter": self._exchange_filter,
-        }
+        })
 
         # Name-the-gap gate: wire the post-hoc mispricing auditor into the
         # risk manager now that db + analyzer exist. Without this, the gate
@@ -534,7 +535,7 @@ class AuramaurBot(
         if kill_switch_present():
             show_error("KILL SWITCH ACTIVE — halting all trading")
             self._running = False
-            alerts = self._components.get("alerts")
+            alerts = self._components.alerts
             if alerts:
                 await alerts.send("KILL SWITCH ACTIVATED — bot halted", level="critical")
             return True
@@ -668,11 +669,11 @@ class AuramaurBot(
         from auramaur.broker.pnl import PnLTracker
 
         syncers: list = self._components.get("syncers", [])
-        pnl_tracker: PnLTracker = self._components["pnl_tracker"]
-        discoveries: dict[str, MarketDiscovery] = self._components["discoveries"]
+        pnl_tracker: PnLTracker = self._components.pnl_tracker
+        discoveries: dict[str, MarketDiscovery] = self._components.discoveries
         exchanges: dict[str, ExchangeClient] = self._components.get("exchanges", {})
-        alerts: AlertManager = self._components["alerts"]
-        portfolio_tracker: PortfolioTracker = self._components["risk_manager"].portfolio
+        alerts: AlertManager = self._components.alerts
+        portfolio_tracker: PortfolioTracker = self._components.risk_manager.portfolio
         interval = self.settings.intervals.portfolio_check_seconds
         first_tick = True
 
@@ -694,7 +695,7 @@ class AuramaurBot(
 
                     # Polymarket-only: enrich with reconciler-discovered manual buys
                     if name == "polymarket":
-                        reconciler_comp = self._components.get("reconciler")
+                        reconciler_comp = self._components.reconciler
                         if self.settings.is_live and reconciler_comp:
                             try:
                                 reconciled = await reconciler_comp.reconcile()
@@ -736,7 +737,7 @@ class AuramaurBot(
                         accuracy_map: dict[str, float | None] = {}
                         kelly_map: dict[str, float] = {}
                         category_lookup: dict[str, str] = {}
-                        attributor = self._components.get("attributor")
+                        attributor = self._components.attributor
                         if attributor:
                             accuracy_map, kelly_map = await attributor.get_accuracy_and_kelly_maps()
                             category_lookup = await attributor.get_category_lookup()
@@ -750,7 +751,7 @@ class AuramaurBot(
                         from auramaur.monitoring.books import (
                             gather_books, render_books_table,
                         )
-                        books = await gather_books(self._components["db"])
+                        books = await gather_books(self._components.db)
                         if books:
                             console.print(render_books_table(books))
                     except Exception as e:
@@ -818,7 +819,7 @@ class AuramaurBot(
 
     async def _task_cache_cleanup(self) -> None:
         """Periodically clean expired NLP cache entries."""
-        cache: NLPCache = self._components["cache"]
+        cache: NLPCache = self._components.cache
 
         while self._running:
             try:
@@ -844,8 +845,8 @@ class AuramaurBot(
         if not proxy:
             return  # no proxy configured, can't check
 
-        db: Database = self._components["db"]
-        alerts: AlertManager = self._components["alerts"]
+        db: Database = self._components.db
+        alerts: AlertManager = self._components.alerts
         redeemer = OnChainRedeemer(self.settings, db)
         # Only auto-redeem winners worth claiming; the replay guard in the
         # redemptions table prevents re-submitting an already-sent condition.
@@ -1033,7 +1034,7 @@ class AuramaurBot(
 
     async def _task_recalibrate(self) -> None:
         """Periodically refit Platt scaling calibration parameters."""
-        calibration: CalibrationTracker = self._components["calibration"]
+        calibration: CalibrationTracker = self._components.calibration
         interval = self.settings.calibration.refit_interval_hours * 3600
 
         while self._running:
@@ -1045,7 +1046,7 @@ class AuramaurBot(
 
     async def _task_attribution_update(self) -> None:
         """Periodically update performance attribution and Kelly multipliers."""
-        attributor = self._components.get("attributor")
+        attributor = self._components.attributor
         if attributor is None:
             return
 
@@ -1062,7 +1063,7 @@ class AuramaurBot(
 
     async def _task_strategy_report(self) -> None:
         """Hourly per-pillar P&L report for hybrid mode."""
-        attributor = self._components.get("attributor")
+        attributor = self._components.attributor
         if attributor is None:
             return
 
@@ -1091,7 +1092,7 @@ class AuramaurBot(
 
     async def _task_performance_feedback(self) -> None:
         """Periodically update per-category calibration stats and Kelly multipliers."""
-        feedback = self._components.get("feedback")
+        feedback = self._components.feedback
         if feedback is None:
             return
 
@@ -1152,15 +1153,15 @@ class AuramaurBot(
         are acted on before they decay (previously the whole loop ran every 4h,
         by which point conditional violations had usually closed).
         """
-        correlator = self._components.get("correlator")
-        arb_executor = self._components.get("arb_executor")
+        correlator = self._components.correlator
+        arb_executor = self._components.arb_executor
         if correlator is None or arb_executor is None:
             return
-        discovery: MarketDiscovery = self._components["discovery"]
-        risk_manager: RiskManager = self._components["risk_manager"]
-        engines: dict[str, TradingEngine] = self._components["engines"]
+        discovery: MarketDiscovery = self._components.discovery
+        risk_manager: RiskManager = self._components.risk_manager
+        engines: dict[str, TradingEngine] = self._components.engines
 
-        db: Database = self._components["db"]
+        db: Database = self._components.db
         scan_interval = 120              # act on arbs every 2 minutes
         relationship_refresh_cycles = 15  # refresh LLM relationships ~every 30 min
         cycle = 0
@@ -1238,12 +1239,12 @@ class AuramaurBot(
         Uses the Gamma client to find liquid markets, then posts bid/ask
         quotes via the exchange client. Runs every refresh_seconds.
         """
-        mm: MarketMaker | None = self._components.get("market_maker")
+        mm: MarketMaker | None = self._components.market_maker
         if mm is None:
             return
 
-        discovery: MarketDiscovery = self._components["discovery"]
-        alerts: AlertManager = self._components["alerts"]
+        discovery: MarketDiscovery = self._components.discovery
+        alerts: AlertManager = self._components.alerts
         interval = self.settings.market_maker.refresh_seconds
 
         while self._running:
@@ -1283,14 +1284,14 @@ class AuramaurBot(
 
     async def _task_price_monitor(self) -> None:
         """Monitor real-time price changes via WebSocket."""
-        ws = self._components.get("websocket")
+        ws = self._components.websocket
         if ws is None:
             return
 
-        engines: dict[str, TradingEngine] = self._components["engines"]
+        engines: dict[str, TradingEngine] = self._components.engines
         # Use primary (polymarket) engine for price-triggered re-analysis
         engine: TradingEngine = engines.get("polymarket", list(engines.values())[0])
-        discovery: MarketDiscovery = self._components["discovery"]
+        discovery: MarketDiscovery = self._components.discovery
         threshold = self.settings.ensemble.price_move_threshold_pct / 100.0
 
         # Track last-known prices for change detection
@@ -1320,7 +1321,7 @@ class AuramaurBot(
 
         ws._on_price_update = on_price_update
 
-        flow_tracker = self._components.get("flow_tracker")
+        flow_tracker = self._components.flow_tracker
 
         if flow_tracker is not None:
             async def on_trade(market_id: str, side: str, size: float) -> None:
@@ -1342,7 +1343,7 @@ class AuramaurBot(
 
     async def _task_source_weights_update(self) -> None:
         """Periodically update ensemble source weights."""
-        ensemble = self._components.get("ensemble")
+        ensemble = self._components.ensemble
         if ensemble is None:
             return
 
@@ -1359,8 +1360,8 @@ class AuramaurBot(
         from auramaur.broker.reconciler import PositionReconciler
         from auramaur.broker.sync import PositionSyncer
 
-        reconciler: PositionReconciler = self._components["reconciler"]
-        syncer: PositionSyncer = self._components["syncer"]
+        reconciler: PositionReconciler = self._components.reconciler
+        syncer: PositionSyncer = self._components.syncer
         interval = self.settings.broker.sync_interval_seconds
 
         while self._running:
@@ -1374,7 +1375,7 @@ class AuramaurBot(
                     # This loop only runs in live mode, so we explicitly
                     # write is_paper=0 and conflict on (market_id, is_paper).
                     for rp in reconciled:
-                        await self._components["db"].execute(
+                        await self._components.db.execute(
                             """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost, total_cost, is_paper, updated_at)
                                VALUES (?, ?, ?, ?, ?, ?, 0, datetime('now'))
                                ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
@@ -1405,11 +1406,11 @@ class AuramaurBot(
                         placeholders = ",".join("?" * len(live_ids))
                         # Live-mode reconciliation must only delete live rows;
                         # paper rows (is_paper=1) live in their own namespace.
-                        cb_cur = await self._components["db"].execute(
+                        cb_cur = await self._components.db.execute(
                             f"DELETE FROM cost_basis WHERE size > 0 AND is_paper = 0 AND market_id NOT IN ({placeholders})",
                             live_ids,
                         )
-                        pf_cur = await self._components["db"].execute(
+                        pf_cur = await self._components.db.execute(
                             f"DELETE FROM portfolio WHERE exchange = 'polymarket' AND is_paper = 0 AND market_id NOT IN ({placeholders})",
                             live_ids,
                         )
@@ -1419,7 +1420,7 @@ class AuramaurBot(
                             portfolio=pf_cur.rowcount if hasattr(pf_cur, "rowcount") else 0,
                         )
 
-                    await self._components["db"].commit()
+                    await self._components.db.commit()
                 else:
                     positions = await syncer.sync()
 
@@ -1440,7 +1441,7 @@ class AuramaurBot(
 
     async def _task_news_reactor(self) -> None:
         """Poll RSS feeds for breaking news and trigger fast analysis on matching markets."""
-        reactor: NewsReactor = self._components["news_reactor"]
+        reactor: NewsReactor = self._components.news_reactor
 
         while self._running:
             if await self._check_kill_switch():
@@ -1450,7 +1451,7 @@ class AuramaurBot(
                 if results:
                     trades = [r for r in results if r.get("order")]
                     if trades:
-                        alerts: AlertManager = self._components["alerts"]
+                        alerts: AlertManager = self._components.alerts
                         await alerts.send(
                             f"News reactor triggered {len(trades)} trade(s) from {len(results)} analysis(es)",
                             level="info",
@@ -1502,7 +1503,7 @@ class AuramaurBot(
         await self._init_components()
         self._running = True
 
-        db_path = self._components["db"].db_path
+        db_path = self._components.db.db_path
         if db_path != "auramaur.db":
             console.print(f"  [yellow]Instance: {db_path}[/]")
         # Persistent Claude-budget counter lives in the same sqlite file —
@@ -1514,7 +1515,7 @@ class AuramaurBot(
         # Show real balance — use reconciler for live, paper for paper mode.
         # In live mode we never fall back to paper.balance — that would show
         # paper PnL in a live banner if the reconciler fails to respond.
-        startup_balance = 0.0 if self.settings.is_live else self._components["paper"].balance
+        startup_balance = 0.0 if self.settings.is_live else self._components.paper.balance
         if self.settings.is_live:
             try:
                 total_cash = 0.0
@@ -1523,11 +1524,11 @@ class AuramaurBot(
 
                 # Polymarket balance
                 if self._exchange_filter is None or self._exchange_filter == "polymarket":
-                    reconciler_comp = self._components.get("reconciler")
+                    reconciler_comp = self._components.reconciler
                     if reconciler_comp:
                         reconciled = await reconciler_comp.reconcile()
                         position_value = sum(p.size * p.current_price for p in reconciled)
-                        syncer_comp = self._components.get("syncer")
+                        syncer_comp = self._components.syncer
                         poly_cash = await syncer_comp.get_cash_balance() if syncer_comp else 0
                         total_cash += poly_cash
                         total_position_value += position_value
@@ -1583,7 +1584,7 @@ class AuramaurBot(
             console.print(f"  IBKR: enabled ({self.settings.ibkr.environment}) | {opt}")
 
         show_startup(
-            self._components["source_names"],
+            self._components.source_names,
             startup_balance,
         )
 
@@ -1591,14 +1592,14 @@ class AuramaurBot(
         # graduation mode, and the ledger lifetime number.
         try:
             from auramaur.monitoring.books import render_books_panel
-            row = await self._components["db"].fetchone(
+            row = await self._components.db.fetchone(
                 "SELECT COALESCE(SUM(pnl), 0) AS v FROM pnl_ledger WHERE is_paper = 0")
             console.print(render_books_panel(
                 self.settings, float(row["v"]) if row else None))
         except Exception as e:
             log.debug("startup.books_panel_error", error=str(e))
 
-        exchange_filter = self._components.get("exchange_filter")
+        exchange_filter = self._components.exchange_filter
         if exchange_filter:
             console.print(f"  [cyan]Exchange filter: {exchange_filter} only[/]")
 
@@ -1609,9 +1610,9 @@ class AuramaurBot(
         if self.settings.is_live:
             try:
                 from auramaur.monitoring.live_gate import preflight
-                report = await preflight(self.settings, self._components["db"])
+                report = await preflight(self.settings, self._components.db)
                 if not report.live_allowed:
-                    rm = self._components.get("risk_manager")
+                    rm = self._components.risk_manager
                     if rm is not None:
                         rm.live_entries_blocked = True
                     blocked = ", ".join(b.name for b in report.blocks)
@@ -1619,7 +1620,7 @@ class AuramaurBot(
                               blocks=[f"{b.name}: {b.detail}" for b in report.blocks])
                     console.print(f"  [bold red]LIVE ENTRIES BLOCKED by preflight:[/] "
                                   f"{blocked} — exits stay live")
-                    alerts = self._components.get("alerts")
+                    alerts = self._components.alerts
                     if alerts is not None:
                         await alerts.send(
                             f"LIVE ENTRIES BLOCKED by preflight: {blocked}", level="critical")
@@ -1639,9 +1640,9 @@ class AuramaurBot(
         # Portfolio monitor runs whenever any exchange syncer is present so
         # Kalshi-only runs still populate `_last_known_cash` and exits fire.
         # Position sync (CLOB reconciler) remains Polymarket-specific.
-        if self._components.get("syncers"):
+        if self._components.syncers:
             tasks.append(asyncio.create_task(self._task_portfolio_monitor(), name="portfolio"))
-        if self._components.get("syncer"):
+        if self._components.syncer:
             tasks.append(asyncio.create_task(self._task_position_sync(), name="position_sync"))
 
         # Resolution checker and order monitor work with any exchange
@@ -1668,11 +1669,11 @@ class AuramaurBot(
             tasks.append(asyncio.create_task(self._task_redemption_check(), name="redemption_check"))
 
         # News reactor (if available)
-        if self._components.get("news_reactor"):
+        if self._components.news_reactor:
             tasks.append(asyncio.create_task(self._task_news_reactor(), name="news_reactor"))
 
         # Per-exchange scan + trade tasks
-        engines: dict[str, TradingEngine] = self._components["engines"]
+        engines: dict[str, TradingEngine] = self._components.engines
         for ex_name, engine in engines.items():
             tasks.append(asyncio.create_task(
                 self._task_market_scan(engine, ex_name), name=f"scan_{ex_name}",
@@ -1688,17 +1689,17 @@ class AuramaurBot(
                     name=f"orderbook_{ex_name}",
                 ))
 
-        if self._components.get("attributor"):
+        if self._components.attributor:
             tasks.append(asyncio.create_task(self._task_attribution_update(), name="attribution"))
         # Correlation-arb executes through the exempt 'arbitrage' source and
         # had no off switch at all; it shares the arbitrage book's flag.
-        if self._components.get("correlator") and self.settings.arbitrage.enabled:
+        if self._components.correlator and self.settings.arbitrage.enabled:
             tasks.append(asyncio.create_task(self._task_correlation_scan(), name="correlation"))
-        if self._components.get("websocket"):
+        if self._components.websocket:
             tasks.append(asyncio.create_task(self._task_price_monitor(), name="price_monitor"))
-        if self._components.get("ensemble"):
+        if self._components.ensemble:
             tasks.append(asyncio.create_task(self._task_source_weights_update(), name="source_weights"))
-        if self._components.get("feedback"):
+        if self._components.feedback:
             tasks.append(asyncio.create_task(self._task_performance_feedback(), name="performance_feedback"))
 
         # Arb scanner — arbitrage.enabled was a dead flag (the task ran
@@ -1751,11 +1752,11 @@ class AuramaurBot(
             tasks.append(asyncio.create_task(self._task_momentum_coupling(), name="momentum_coupling"))
 
         # Market maker (if enabled)
-        if self._components.get("market_maker"):
+        if self._components.market_maker:
             tasks.append(asyncio.create_task(self._task_market_maker(), name="market_maker"))
 
         # Hybrid strategy report (hourly per-pillar P&L)
-        if self._hybrid and self._components.get("attributor"):
+        if self._hybrid and self._components.attributor:
             tasks.append(asyncio.create_task(self._task_strategy_report(), name="strategy_report"))
 
         try:
@@ -1812,14 +1813,14 @@ class AuramaurBot(
         session's reconciler problem, exactly as before.
         """
         clients: dict[int, tuple[str, object]] = {}
-        primary = self._components.get("exchange")
+        primary = self._components.exchange
         if primary is not None and hasattr(primary, "_live_pending"):
             clients[id(primary)] = ("polymarket", primary)
-        for name, client in (self._components.get("exchanges") or {}).items():
+        for name, client in (self._components.exchanges or {}).items():
             if client is not None and hasattr(client, "_live_pending"):
                 clients.setdefault(id(client), (name, client))
 
-        db = self._components.get("db")
+        db = self._components.db
         cancelled = 0
         for exchange_name, client in clients.values():
             for order_id in list(getattr(client, "_live_pending", {}).keys()):

--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -66,7 +66,7 @@ class ArbExecutionMixin:
             log.debug("arbitrage.no_engine", buy=buy_exchange, sell=sell_exchange)
             return
 
-        alerts: AlertManager = self._components["alerts"]
+        alerts: AlertManager = self._components.alerts
 
         # Risk checks on both legs using exchange-local cash for sizing.
         buy_cash = await buy_engine._get_available_cash()
@@ -180,9 +180,9 @@ class ArbExecutionMixin:
 
         from auramaur.strategy.agent_analyzer import AgentAnalyzer
 
-        depth_agent: AgentAnalyzer = self._components["depth_agent"]
-        db: Database = self._components["db"]
-        engines: dict[str, TradingEngine] = self._components["engines"]
+        depth_agent: AgentAnalyzer = self._components.depth_agent
+        db: Database = self._components.db
+        engines: dict[str, TradingEngine] = self._components.engines
         engine = engines.get("polymarket")
         if engine is None:
             return
@@ -253,7 +253,7 @@ class ArbExecutionMixin:
                         pass
                     # Enrich with Gamma data for CLOB tokens
                     try:
-                        discovery = self._components["discovery"]
+                        discovery = self._components.discovery
                         full_market = await discovery.get_market(market.id)
                         if full_market:
                             market.clob_token_yes = full_market.clob_token_yes
@@ -282,7 +282,7 @@ class ArbExecutionMixin:
                                 market_id=market.id,
                                 edge=round(candidate.signal.edge, 1),
                             )
-                            alerts: AlertManager = self._components["alerts"]
+                            alerts: AlertManager = self._components.alerts
                             await alerts.send(
                                 f"Depth research trade: {market.question[:40]} "
                                 f"edge={candidate.signal.edge:.1f}%",
@@ -298,10 +298,10 @@ class ArbExecutionMixin:
 
     async def _task_arb_scanner(self) -> None:
         """Periodically scan all exchanges for arbitrage opportunities."""
-        scanner: ArbitrageScanner = self._components["arb_scanner"]
-        alerts: AlertManager = self._components["alerts"]
-        risk_manager: RiskManager = self._components["risk_manager"]
-        engines: dict[str, TradingEngine] = self._components["engines"]
+        scanner: ArbitrageScanner = self._components.arb_scanner
+        alerts: AlertManager = self._components.alerts
+        risk_manager: RiskManager = self._components.risk_manager
+        engines: dict[str, TradingEngine] = self._components.engines
 
         while self._running:
             if await self._check_kill_switch():
@@ -406,7 +406,7 @@ class ArbExecutionMixin:
             log.debug("arb_scanner.negrisk_unpriced_or_no_token", group=opp.neg_risk_market_id)
             return
 
-        alerts: AlertManager = self._components["alerts"]
+        alerts: AlertManager = self._components.alerts
 
         # Dedup: 1-hour cooldown per NegRisk event, set before placement.
         import time as _time
@@ -549,7 +549,7 @@ class ArbExecutionMixin:
         # against a $1.00 payout. If we already hold either token of this
         # market, skip: the one-sided leg is the exit machinery's problem,
         # not a fresh "arb".
-        db: Database = self._components["db"]
+        db: Database = self._components.db
         is_paper_flag = 0 if self.settings.is_live else 1
         held = await db.fetchone(
             "SELECT 1 FROM portfolio WHERE market_id = ? AND is_paper = ? "
@@ -560,7 +560,7 @@ class ArbExecutionMixin:
             log.info("arb_scanner.skip_partial_inventory", market_id=market.id)
             return
 
-        alerts: AlertManager = self._components["alerts"]
+        alerts: AlertManager = self._components.alerts
 
         # Build synthetic signals for risk checks.  expected_profit_pct is the
         # net package return; halving it per leg makes valid package arbs fail
@@ -717,7 +717,7 @@ class ArbExecutionMixin:
             )
             return
 
-        alerts: AlertManager = self._components["alerts"]
+        alerts: AlertManager = self._components.alerts
         max_size = self.settings.arbitrage.max_arb_size
 
         # Synthetic signals for risk checks and prepare_order.  The scanner's
@@ -1067,7 +1067,7 @@ class ArbExecutionMixin:
                         f"[dim](blocked 24h)[/]"
                     )
 
-                    alerts = self._components.get("alerts")
+                    alerts = self._components.alerts
                     if alerts:
                         await alerts.send(
                             f"Rebalance: trimmed {pos['mid']} "

--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -53,8 +53,8 @@ class ExitExecutionMixin:
         exchange/router are unused for that path; db + pnl_tracker come from the
         wired components. Rebuilt if the pnl_tracker reference changes.
         """
-        db = self._components.get("db")
-        pnl = self._components.get("pnl_tracker")
+        db = self._components.db
+        pnl = self._components.pnl_tracker
         gw = self._exit_gateway_obj
         if gw is None or gw.db is not db or gw.pnl_tracker is not pnl:
             from auramaur.broker.execution_gateway import ExecutionGateway
@@ -80,7 +80,7 @@ class ExitExecutionMixin:
         """
         # Resolve the real token_id: reconciler → cost_basis → Gamma
         token_id = ""
-        reconciler_comp = self._components.get("reconciler")
+        reconciler_comp = self._components.reconciler
         if reconciler_comp and self.settings.is_live:
             try:
                 for rp in await reconciler_comp.reconcile():
@@ -96,7 +96,7 @@ class ExitExecutionMixin:
             try:
                 # _execute_poly_exit only fires for live positions; scope to
                 # is_paper=0 so we can't pick up a stale paper-mode token_id.
-                row = await self._components["db"].fetchone(
+                row = await self._components.db.fetchone(
                     "SELECT token_id FROM cost_basis WHERE market_id = ? AND size > 0 AND is_paper = 0",
                     (pos.market_id,),
                 )
@@ -256,7 +256,7 @@ class ExitExecutionMixin:
 
     async def _prune_zero_onchain_poly_position(self, market_id: str) -> None:
         """Remove stale live Polymarket rows after an on-chain zero balance check."""
-        db = self._components.get("db")
+        db = self._components.db
         if db is None:
             return
         try:

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -32,10 +32,10 @@ class OrderMonitorMixin:
         """Monitor pending limit orders for fills and expiry."""
         from datetime import datetime, timezone
 
-        paper: PaperTrader = self._components["paper"]
-        primary_exchange: PolymarketClient = self._components["exchange"]
+        paper: PaperTrader = self._components.paper
+        primary_exchange: PolymarketClient = self._components.exchange
         exchanges: dict[str, ExchangeClient] = self._components.get("exchanges", {})
-        discovery: MarketDiscovery = self._components["discovery"]
+        discovery: MarketDiscovery = self._components.discovery
         ttl = self.settings.execution.limit_order_ttl_seconds
 
         # Reconcile orphaned live orders into _live_pending so the TTL-cancel
@@ -119,7 +119,7 @@ class OrderMonitorMixin:
                                             price=result.filled_price if result.filled_price > 0 else order.price,
                                             is_paper=False,
                                         )
-                                        pnl_tracker = self._components.get("pnl_tracker")
+                                        pnl_tracker = self._components.pnl_tracker
                                         if pnl_tracker:
                                             await pnl_tracker.record_fill(fill)
                                     except Exception as e:
@@ -130,7 +130,7 @@ class OrderMonitorMixin:
                                             error=str(e),
                                         )
 
-                                db = self._components.get("db")
+                                db = self._components.db
                                 if db and order is not None:
                                     try:
                                         price = result.filled_price if result.filled_price > 0 else order.price
@@ -209,7 +209,7 @@ class OrderMonitorMixin:
                                     # Without this status write the trades row
                                     # stays 'pending' forever even though the
                                     # collateral was released (#94).
-                                    db = self._components.get("db")
+                                    db = self._components.db
                                     if db is not None:
                                         try:
                                             await db.execute(
@@ -289,7 +289,7 @@ class OrderMonitorMixin:
         ``get_order_status`` maps unknown/aged-out orders to 'cancelled', so
         rows whose orders the CLOB no longer indexes resolve too.
         """
-        db = self._components.get("db")
+        db = self._components.db
         if db is None or not live_clients:
             return
 
@@ -348,7 +348,7 @@ class OrderMonitorMixin:
         Delegates to ResolutionTracker which handles multi-exchange
         resolution detection, calibration updates, and position settlement.
         """
-        tracker: ResolutionTracker = self._components["resolution_tracker"]
+        tracker: ResolutionTracker = self._components.resolution_tracker
 
         while self._running:
             if await self._check_kill_switch():
@@ -361,14 +361,14 @@ class OrderMonitorMixin:
                 # settled positions from `portfolio` before the Gamma-style
                 # detection path can see them, which is how Kalshi realized
                 # P&L went entirely unrecorded until 2026-06-12.
-                kalshi = (self._components.get("exchanges") or {}).get("kalshi")
+                kalshi = (self._components.exchanges or {}).get("kalshi")
                 if kalshi is not None:
                     try:
                         from auramaur.broker.kalshi_settlements import (
                             sweep_kalshi_settlements,
                         )
                         booked = await sweep_kalshi_settlements(
-                            self._components["db"], kalshi)
+                            self._components.db, kalshi)
                         booked_ok = [b for b in booked if b.get("booked")]
                         if booked_ok:
                             resolved += len(booked_ok)
@@ -385,7 +385,7 @@ class OrderMonitorMixin:
                         f"  [dim]{now_str}[/] [bold green]RESOLVED[/] {resolved} market(s) — calibration updated"
                     )
                     # Also feed into attribution if available
-                    attributor = self._components.get("attributor")
+                    attributor = self._components.attributor
                     if attributor is not None:
                         # Attribution is handled inside _settle_position via
                         # daily_stats; log for visibility only.

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -25,13 +25,13 @@ class StrategyTaskMixin:
         from auramaur.strategy.bias_harvest import BiasHarvestPillar
 
         pillar = BiasHarvestPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=self._components["discovery"],
-            exchange=self._components["exchange"],
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            calibration=self._components["calibration"],
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
         )
         interval = max(60, self.settings.bias_harvest.interval_seconds)
         while self._running:
@@ -48,17 +48,17 @@ class StrategyTaskMixin:
         from auramaur.strategy.entailment_arb import EntailmentArbPillar
 
         pillar = EntailmentArbPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=self._components["discovery"],
-            exchange=(self._components.get("exchanges") or {}).get("polymarket"),
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            analyzer=self._components.get("analyzer"),
+            discovery=self._components.discovery,
+            exchange=(self._components.exchanges or {}).get("polymarket"),
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            analyzer=self._components.analyzer,
             # Kalshi econ-bin ladder arb fetches its own series; pass the Kalshi
             # discovery if present (no-op when Kalshi isn't configured).
-            kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
-            exchanges=self._components.get("exchanges") or {},
+            kalshi_discovery=(self._components.discoveries or {}).get("kalshi"),
+            exchanges=self._components.exchanges or {},
         )
         interval = max(60, self.settings.entailment_arb.interval_seconds)
         while self._running:
@@ -76,15 +76,15 @@ class StrategyTaskMixin:
         from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
 
         pillar = CrossVenueArbPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=(self._components.get("discoveries") or {}).get("polymarket"),
-            exchange=(self._components.get("exchanges") or {}).get("polymarket"),
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            analyzer=self._components.get("analyzer"),
-            kalshi_discovery=(self._components.get("discoveries") or {}).get("kalshi"),
-            exchanges=self._components.get("exchanges") or {},
+            discovery=(self._components.discoveries or {}).get("polymarket"),
+            exchange=(self._components.exchanges or {}).get("polymarket"),
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            analyzer=self._components.analyzer,
+            kalshi_discovery=(self._components.discoveries or {}).get("kalshi"),
+            exchanges=self._components.exchanges or {},
         )
         interval = max(60, self.settings.cross_venue_arb.interval_seconds)
         while self._running:
@@ -101,20 +101,20 @@ class StrategyTaskMixin:
         from auramaur.data_sources.fred import FREDSource
         from auramaur.strategy.econ_indicator import EconIndicatorPillar
 
-        kalshi_discovery = (self._components.get("discoveries") or {}).get("kalshi")
-        kalshi_exchange = (self._components.get("exchanges") or {}).get("kalshi")
+        kalshi_discovery = (self._components.discoveries or {}).get("kalshi")
+        kalshi_exchange = (self._components.exchanges or {}).get("kalshi")
         if kalshi_discovery is None or kalshi_exchange is None or not self.settings.fred_api_key:
             log.info("econ_indicator.disabled", reason="missing kalshi or FRED key")
             return
         pillar = EconIndicatorPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
             kalshi_discovery=kalshi_discovery,
             fred_source=FREDSource(api_key=self.settings.fred_api_key),
             exchange=kalshi_exchange,
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            calibration=self._components["calibration"],
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
         )
         interval = max(60, self.settings.econ_indicator.interval_seconds)
         while self._running:
@@ -132,9 +132,9 @@ class StrategyTaskMixin:
         from auramaur.monitoring.intraday_drift import IntradayDriftTracker
 
         tracker = IntradayDriftTracker(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=self._components["discovery"],
+            discovery=self._components.discovery,
         )
         interval = max(60, self.settings.intraday_drift.interval_seconds)
         while self._running:
@@ -151,10 +151,10 @@ class StrategyTaskMixin:
         from auramaur.monitoring.hydro_market_watch import HydroMarketWatcher
 
         watcher = HydroMarketWatcher(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discoveries=self._components.get("discoveries") or {},
-            alerts=self._components.get("alerts"),
+            discoveries=self._components.discoveries or {},
+            alerts=self._components.alerts,
         )
         interval = max(300, self.settings.hydro_watch.interval_seconds)
         while self._running:
@@ -172,13 +172,13 @@ class StrategyTaskMixin:
         from auramaur.strategy.weather_temp import WeatherTempPillar
 
         pillar = WeatherTempPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=self._components["discovery"],
-            exchange=self._components["exchange"],
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            calibration=self._components["calibration"],
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
             weather=OpenMeteoSource(),
         )
         interval = max(60, self.settings.weather_temp.interval_seconds)
@@ -196,16 +196,16 @@ class StrategyTaskMixin:
         from auramaur.strategy.resolution_lens import ResolutionLensPillar
 
         pillar = ResolutionLensPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
-            discovery=self._components["discovery"],
-            exchange=self._components["exchange"],
-            risk_manager=self._components["risk_manager"],
-            pnl_tracker=self._components["pnl_tracker"],
-            calibration=self._components["calibration"],
-            analyzer=self._components.get("analyzer"),
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+            analyzer=self._components.analyzer,
             # Phase 3: evidence-grounded comprehension taps the shared aggregator.
-            aggregator=self._components.get("aggregator"),
+            aggregator=self._components.aggregator,
         )
         interval = max(60, self.settings.resolution_lens.interval_seconds)
         while self._running:
@@ -228,13 +228,13 @@ class StrategyTaskMixin:
             from auramaur.exchange.ibkr_equity import IBKREquityClient
             equity = IBKREquityClient(self.settings)
         pillar = OddLotTenderPillar(
-            db=self._components["db"],
+            db=self._components.db,
             settings=self.settings,
             edgar=edgar,
-            analyzer=self._components.get("analyzer"),
-            alerts=self._components.get("alerts"),
+            analyzer=self._components.analyzer,
+            alerts=self._components.alerts,
             equity_client=equity,
-            pnl_tracker=self._components["pnl_tracker"],
+            pnl_tracker=self._components.pnl_tracker,
         )
         interval = max(600, self.settings.oddlot_tender.interval_seconds)
         try:

--- a/auramaur/components.py
+++ b/auramaur/components.py
@@ -1,0 +1,163 @@
+"""Typed runtime component registry for AuramaurBot.
+
+``AuramaurBot`` wires ~30 long-lived services (db, risk manager, pnl ledger,
+syncers, engines, …) into a single registry that the bot and its mixins read
+from. That registry used to be a bare ``dict[str, object]`` accessed by string
+key — 85 untyped ``self._components["…"]`` lookups with no autocomplete, no
+type-checking, and a KeyError-on-a-live-path failure mode for a typo.
+
+``Components`` keeps that dict (it literally IS a ``dict``, so every existing
+subscript, ``.get()``, ``.items()`` teardown, and external consumer keeps
+working unchanged) while adding typed attribute accessors that read straight
+from it. Call sites migrate ``["db"]`` → ``.db`` incrementally; nothing is ever
+half-broken. The component-type imports live under ``TYPE_CHECKING`` (with
+``from __future__ import annotations`` the property return types are strings),
+so this module imports nothing at runtime and cannot introduce an import cycle.
+
+Always-present services use a subscript accessor (raises ``KeyError`` if truly
+absent — identical to the old ``self._components["db"]``); optional services use
+``.get()`` and return ``T | None``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from auramaur.broker.allocator import CapitalAllocator
+    from auramaur.broker.feedback import PerformanceFeedback
+    from auramaur.broker.pnl import PnLTracker
+    from auramaur.broker.reconciler import PositionReconciler
+    from auramaur.broker.router import SmartOrderRouter
+    from auramaur.broker.sync import PositionSyncer
+    from auramaur.data_sources.aggregator import Aggregator
+    from auramaur.db.database import Database
+    from auramaur.exchange.paper import PaperTrader
+    from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
+    from auramaur.exchange.websocket import PolymarketWebSocket
+    from auramaur.monitoring.alerts import AlertManager
+    from auramaur.monitoring.attribution import PerformanceAttributor
+    from auramaur.nlp.analyzer import ClaudeAnalyzer
+    from auramaur.nlp.cache import NLPCache
+    from auramaur.nlp.calibration import CalibrationTracker
+    from auramaur.nlp.ensemble import EnsembleEstimator
+    from auramaur.risk.manager import RiskManager
+    from auramaur.strategy.agent_analyzer import AgentAnalyzer
+    from auramaur.strategy.arbitrage import ArbitrageExecutor
+    from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
+    from auramaur.strategy.correlation import CorrelationDetector
+    from auramaur.strategy.engine import TradingEngine
+    from auramaur.strategy.market_maker import MarketMaker
+    from auramaur.strategy.news_reactor import NewsReactor
+    from auramaur.strategy.order_flow import OrderFlowTracker
+    from auramaur.strategy.resolution_tracker import ResolutionTracker
+
+
+class Components(dict):
+    """Typed view over the runtime component registry (see module docstring).
+
+    IS a ``dict`` so all existing subscript / ``.get()`` / ``.items()`` usage and
+    external consumers (cli, kraken pillar) keep working; the typed properties
+    below just read from it.
+    """
+
+    # -- always present (subscript; KeyError if truly missing) -------------
+    @property
+    def db(self) -> Database: return self["db"]
+
+    @property
+    def aggregator(self) -> Aggregator: return self["aggregator"]
+
+    @property
+    def paper(self) -> PaperTrader: return self["paper"]
+
+    @property
+    def analyzer(self) -> ClaudeAnalyzer: return self["analyzer"]
+
+    @property
+    def cache(self) -> NLPCache: return self["cache"]
+
+    @property
+    def calibration(self) -> CalibrationTracker: return self["calibration"]
+
+    @property
+    def risk_manager(self) -> RiskManager: return self["risk_manager"]
+
+    @property
+    def engines(self) -> dict[str, TradingEngine]: return self["engines"]
+
+    @property
+    def discoveries(self) -> dict[str, MarketDiscovery]: return self["discoveries"]
+
+    @property
+    def exchanges(self) -> dict[str, ExchangeClient]: return self["exchanges"]
+
+    @property
+    def pnl_tracker(self) -> PnLTracker: return self["pnl_tracker"]
+
+    @property
+    def syncers(self) -> list: return self["syncers"]
+
+    @property
+    def allocator(self) -> CapitalAllocator: return self["allocator"]
+
+    @property
+    def arb_scanner(self) -> ArbitrageScanner: return self["arb_scanner"]
+
+    @property
+    def resolution_tracker(self) -> ResolutionTracker: return self["resolution_tracker"]
+
+    @property
+    def depth_agent(self) -> AgentAnalyzer: return self["depth_agent"]
+
+    @property
+    def alerts(self) -> AlertManager: return self["alerts"]
+
+    @property
+    def source_names(self) -> list[str]: return self["source_names"]
+
+    # -- optional (.get(); may be None) ------------------------------------
+    @property
+    def discovery(self) -> MarketDiscovery | None: return self.get("discovery")
+
+    @property
+    def exchange(self) -> ExchangeClient | None: return self.get("exchange")
+
+    @property
+    def flow_tracker(self) -> OrderFlowTracker | None: return self.get("flow_tracker")
+
+    @property
+    def news_reactor(self) -> NewsReactor | None: return self.get("news_reactor")
+
+    @property
+    def syncer(self) -> PositionSyncer | None: return self.get("syncer")
+
+    @property
+    def reconciler(self) -> PositionReconciler | None: return self.get("reconciler")
+
+    @property
+    def router(self) -> SmartOrderRouter | None: return self.get("router")
+
+    @property
+    def attributor(self) -> PerformanceAttributor | None: return self.get("attributor")
+
+    @property
+    def feedback(self) -> PerformanceFeedback | None: return self.get("feedback")
+
+    @property
+    def correlator(self) -> CorrelationDetector | None: return self.get("correlator")
+
+    @property
+    def arb_executor(self) -> ArbitrageExecutor | None: return self.get("arb_executor")
+
+    @property
+    def market_maker(self) -> MarketMaker | None: return self.get("market_maker")
+
+    @property
+    def websocket(self) -> PolymarketWebSocket | None: return self.get("websocket")
+
+    @property
+    def ensemble(self) -> EnsembleEstimator | None: return self.get("ensemble")
+
+    @property
+    def exchange_filter(self) -> str | None: return self.get("exchange_filter")

--- a/logs/run_live_20260624_175219.out
+++ b/logs/run_live_20260624_175219.out
@@ -1,0 +1,183 @@
+HYBRID MODE — LIVE TRADING
+  Pillars: arb + news speed + LLM + market making + bias_harvest + 
+entailment_arb + resolution_lens
+Starting Auramaur bot...
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ AURAMAUR v0.1.0  |  Mode: LIVE  |  2026-06-24 17:52 UTC                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+  Build: 0b85ad795b05
+  Kalshi balance: $97.47
+  Cash: $120.12 | Positions: $1399.60 (180 markets)
+  Kraken: $1.00 USDC + $0 CAD + AVAX,POL,TON,XXRP | spec WIND-DOWN (exits only)
+  Data sources: NewsAPI, FRED, Web, RSS, Markets, PolyCtx, Metaculus, Manifold, 
+USGS, CoinGecko, HN, ESPN, GDELT, Trends, Bluesky
+  Balance: $1,519.72
+
+╭─────────────────────────────── strategy books ───────────────────────────────╮
+│ llm               LIVE        gates: divergence + name-the-gap               │
+│ bias_harvest      PAPER       band 0.90-0.97, $10/mkt                        │
+│ entailment_arb    PAPER       min gap 4c, both-or-nothing legs               │
+│ resolution_lens   PAPER       gap>=0.4, edge>=8c                             │
+│ market_maker      LIVE        graduation-exempt                              │
+│ oddlot_tender     PAPER       EDGAR scan, 99-sh entries, manual tender       │
+│ arbitrage         LIVE        graduation-exempt                              │
+│ kraken spec       WIND-DOWN   exits only, no re-entry                        │
+│ graduation        enforce     >= 20 events / 90d to earn live                │
+│ ledger            $-169.46    lifetime live realized (auramaur pnl)          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+  preflight OK, 1 warning(s)
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+         ORDER FAILED PAPER polymarket BUY $10.00 (14.5 tokens @ $0.690)
+                             Portfolio Allocation                              
+┏━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━┓
+┃ Category       ┃ Pos ┃  Exposure ┃ Alloc           ┃     PnL ┃  Acc ┃ Kelly ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━┩
+│ politics_intl  │  54 │   $674.00 │ ████        41% │ $+51.22 │  69% │ 0.20x │
+│ other          │  76 │   $406.89 │ ██▍         25% │  $+7.83 │  64% │ 0.29x │
+│ crypto         │  22 │   $180.97 │ █           11% │  $-1.39 │  77% │ 0.46x │
+│ tech           │  19 │   $142.30 │ ▊            9% │  $+9.12 │  88% │ 0.59x │
+│ science        │  10 │    $67.66 │ ▍            4% │  $+0.33 │ 100% │ 1.00x │
+│ sports         │  17 │    $63.62 │ ▍            4% │  $+8.11 │  12% │ 0.20x │
+│ entertainment  │   9 │    $40.65 │ ▏            2% │  $+3.26 │    — │ 0.75x │
+│ politics_us    │   6 │    $30.30 │ ▏            2% │  $+0.08 │  72% │ 0.77x │
+│ esports        │   4 │    $27.66 │ ▏            2% │  $+0.72 │   0% │ 1.00x │
+│ economics      │   5 │    $17.28 │              1% │  $+1.25 │  71% │ 1.00x │
+│ legal          │   2 │     $3.93 │              0% │  $-0.10 │ 100% │ 1.00x │
+├────────────────┼─────┼───────────┼─────────────────┼─────────┼──────┼───────┤
+│ Total          │ 224 │ $1,655.26 │                 │ $+80.42 │      │       │
+└────────────────┴─────┴───────────┴─────────────────┴─────────┴──────┴───────┘
+                     Strategy Books (realized = pnl_ledger)                     
+┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┓
+┃             ┃              ┃        open ┃         live ┃       paper ┃      ┃
+┃ book        ┃  open (live) ┃     (paper) ┃     realized ┃    realized ┃ win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━┩
+│ (none)      │            — │           — │         19 / │         2 / │  48% │
+│             │              │             │      $+15.55 │      $-5.60 │      │
+│ bias_harve… │            — │          31 │            — │        82 / │  88% │
+│             │              │             │              │     $-10.04 │      │
+│ exit        │            — │           — │   1 / $-1.00 │           — │   0% │
+│ kraken_dir… │            — │           — │         26 / │           — │   0% │
+│             │              │             │      $-36.53 │             │      │
+│ llm         │ 154 / $1,256 │           5 │        110 / │        56 / │  25% │
+│             │              │             │     $-151.17 │    $-121.81 │      │
+│ news_speed  │    10 / $130 │           2 │  32 / $-1.41 │        11 / │   9% │
+│             │              │             │              │    $-121.86 │      │
+│ order_moni… │            — │           — │   4 / $+8.11 │           — │  50% │
+│ resolution… │            — │          10 │            — │        20 / │  75% │
+│             │              │             │              │     $+12.92 │      │
+│ technical_… │            — │           — │   6 / $-3.00 │         1 / │   0% │
+│             │              │             │              │      $-2.79 │      │
+│ technical_… │            — │           — │            — │         1 / │   0% │
+│             │              │             │              │      $-5.90 │      │
+│ weather_te… │            — │           9 │            — │        48 / │  58% │
+│             │              │             │              │     $-57.31 │      │
+└─────────────┴──────────────┴─────────────┴──────────────┴─────────────┴──────┘
+17:53:41 | cash $15.35 free (+$19.80 in orders) | P&L -93.53 | 224 pos | PEAK
+17:54:20 >>> Strait of Hormuz traffic returns to normal by December 31?
+17:55:47 | cash $22.65 free (+$9.90 in orders) | P&L -107.48 | 224 pos | PEAK
+17:56:46 polymarket Scanned 100 markets, 1 candidates, 17 filtered
+  17:57:16 RESOLVED 67 market(s) — calibration updated
+17:57:40 | cash $32.55 | P&L -93.48 | 224 pos | PEAK
+17:57:47 >>> Will Daryl Parks win the Tallahassee mayoral election?
+         >> Claude: 13% vs Market: 23%  Edge: +8.6%  LOW
+         REJECTED (17/18) news_speed 2420481 grad:unproven category 
+'politics_us' is blocked
+18:01:34 polymarket Scanned 100 markets, 1 candidates, 18 filtered
+18:05:46 polymarket Scanned 100 markets, 1 candidates, 18 filtered
+18:09:58 polymarket Scanned 100 markets, 1 candidates, 18 filtered
+18:11:16 >>> US-Iran Final Nuclear Deal by August 31, 2026?
+18:12:09 kalshi Scanned 300 markets, 2 candidates, 47 filtered
+         > Claude: 22% vs Market: 24%  Edge: +1.0%  MEDIUM
+         REJECTED (17/18) news_speed 2633430 grad:unproven Edge 0.97% below 
+minimum 2.33%
+18:13:16 | cash $22.65 free (+$9.90 in orders) | P&L -93.59 | 224 pos | PEAK
+18:14:09 polymarket Scanned 100 markets, 1 candidates, 18 filtered
+18:16:24 kalshi Scanned 300 markets, 2 candidates, 47 filtered
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:18:20 polymarket Scanned 100 markets, 1 candidates, 19 filtered
+18:20:39 kalshi Scanned 300 markets, 2 candidates, 47 filtered
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:23:40 >>> Strait of Hormuz traffic returns to normal by July 31?
+18:24:53 kalshi Scanned 300 markets, 2 candidates, 47 filtered
+         >> Claude: 55% vs Market: 46%  Edge: +8.5%  MEDIUM
+         APPROVED (18/18) $5.37 news_speed 2176262 grad:unproven
+         ORDER FAILED PAPER polymarket BUY $5.49 (11.7 tokens @ $0.470)
+18:26:15 >>> Zcash's Orchard pool confirmed exploited?
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+  18:28:47 RESOLVED 68 market(s) — calibration updated
+18:28:51 >>> Will the Democratic Party control the Senate after the 2026 Midterm
+el...
+18:29:07 kalshi Scanned 300 markets, 2 candidates, 47 filtered
+18:29:21 | cash $32.55 | P&L -93.73 | 224 pos | PEAK
+         > Claude: 10% vs Market: 9%  Edge: +0.6%  HIGH
+         REJECTED (17/18) llm KXGDPYEAR-30-B0. grad:unproven Edge 0.63% below 
+minimum 2.32%
+         > Claude: 12% vs Market: 15%  Edge: +1.7%  HIGH
+         REJECTED (17/18) llm KXGDPYEAR-30-B2. grad:unproven Edge 1.75% below 
+minimum 2.32%
+18:30:34 kalshi Cycle: 2 signals, 0 trades (87s)
+
+18:31:09 >>> ICC T20 World Cup, Women: England vs West Indies
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:34:04 >>> Will the Edmonton Oilers be named the 2026-27 NHL Stanley Cup 
+Champion...
+         > Claude: 6% vs Market: 6%  Edge: +0.7%  MEDIUM
+         REJECTED (16/18) news_speed 2520291 grad:unproven Edge 0.69% below 
+minimum 2.33%
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:41:45 >>> Zohran Mamdani out as mayor of NYC before 2027?
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:43:55 polymarket Scanned 100 markets, 1 candidates, 14 filtered
+18:45:01 | cash $22.75 free (+$9.80 in orders) | P&L -93.70 | 224 pos | PEAK
+18:48:05 polymarket Scanned 100 markets, 2 candidates, 13 filtered
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:52:31 polymarket Scanned 100 markets, 1 candidates, 13 filtered
+18:52:41 ─ last hour: 28 claude calls | 9 evidence pulls | 35 scans | 8 mm 
+expiries
+                             Portfolio Allocation                              
+┏━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━┓
+┃ Category       ┃ Pos ┃  Exposure ┃ Alloc           ┃     PnL ┃  Acc ┃ Kelly ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━┩
+│ politics_intl  │  76 │   $964.32 │ ███▉        39% │ $+59.12 │  69% │ 1.23x │
+│ other          │ 123 │   $803.08 │ ███▏        32% │ $-20.05 │  64% │ 0.95x │
+│ tech           │  28 │   $293.38 │ █▏          12% │ $+56.13 │  88% │ 0.50x │
+│ crypto         │  26 │   $200.81 │ ▊            8% │  $-7.85 │  77% │ 1.17x │
+│ science        │   9 │    $86.07 │ ▎            3% │  $+2.17 │ 100% │ 1.00x │
+│ politics_us    │  12 │    $64.67 │ ▎            3% │  $-1.20 │  72% │ 0.85x │
+│ esports        │   7 │    $25.52 │              1% │  $+0.47 │   0% │ 1.00x │
+│ economics      │   6 │    $20.68 │              1% │  $+1.24 │  71% │ 1.00x │
+│ entertainment  │   2 │    $17.71 │              1% │  $-0.72 │    — │ 0.75x │
+│ legal          │   6 │    $12.23 │              0% │ $-11.10 │ 100% │ 1.00x │
+│ sports         │   0 │     $0.00 │              0% │  $+0.00 │  12% │ 0.38x │
+├────────────────┼─────┼───────────┼─────────────────┼─────────┼──────┼───────┤
+│ Total          │ 295 │ $2,488.46 │                 │ $+78.20 │      │       │
+└────────────────┴─────┴───────────┴─────────────────┴─────────┴──────┴───────┘
+
+--- Hybrid Strategy Report ---
+  news_speed      trades= 19  P&L=$-38.23  win=32%
+  technical_mean_reversion trades=  6  P&L=$-3.48  win=17%
+  exit            trades=  1  P&L=$-1.00  win=0%
+  order_monitor   trades=  2  P&L=$+5.53  win=50%
+  llm             trades=110  P&L=$+110.78  win=31%
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+18:56:42 polymarket Scanned 100 markets, 2 candidates, 14 filtered
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+19:00:57 polymarket Scanned 100 markets, 2 candidates, 15 filtered
+  19:01:18 RESOLVED 68 market(s) — calibration updated
+19:01:24 | cash $22.65 free (+$9.90 in orders) | P&L -93.20 | 224 pos | PEAK
+         > Claude: 7% vs Market: 5%  Edge: +1.6%  LOW
+         REJECTED (17/18) llm 2431245 grad:unproven Edge 1.65% below minimum 
+2.33%
+         < Claude: 8% vs Market: 8%  Edge: -0.3%  MEDIUM
+         REJECTED (17/18) llm 2468461 grad:unproven Edge -0.29% below minimum 
+2.33%
+19:02:30 polymarket Cycle: 2 signals, 0 trades (93s)
+
+19:02:45 | cash $22.65 free (+$9.90 in orders) | P&L -88.40 | 224 pos | PEAK
+         ORDER FAILED PAPER polymarket BUY $10.00 (10.5 tokens @ $0.950)
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+19:04:14 | cash $22.65 free (+$9.90 in orders) | P&L -93.20 | 224 pos | PEAK
+⚠ STALE BUILD: running build 0b85ad795b05 but the checkout is now at 
+ff4af05bce17 — restart the bot to pick up merged fixes
+/Users/darri.eythorsson/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
+  warnings.warn('resource_tracker: There appear to be %d '

--- a/logs/run_live_20260624_190845.out
+++ b/logs/run_live_20260624_190845.out
@@ -1,0 +1,82 @@
+HYBRID MODE — LIVE TRADING
+  Pillars: arb + news speed + LLM + market making + bias_harvest + 
+entailment_arb + resolution_lens
+Starting Auramaur bot...
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ AURAMAUR v0.1.0  |  Mode: LIVE  |  2026-06-24 19:08 UTC                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+  Build: 48e2b9e24081
+  Kalshi balance: $97.47
+  Cash: $130.02 | Positions: $1391.51 (180 markets)
+  Kraken: $1.00 USDC + $0 CAD + AVAX,POL,TON,XXRP | spec WIND-DOWN (exits only)
+  Data sources: NewsAPI, FRED, Web, RSS, Markets, PolyCtx, Metaculus, Manifold, 
+USGS, CoinGecko, HN, ESPN, GDELT, Trends, Bluesky
+  Balance: $1,521.53
+
+╭─────────────────────────────── strategy books ───────────────────────────────╮
+│ llm               LIVE        gates: divergence + name-the-gap               │
+│ bias_harvest      PAPER       band 0.90-0.97, $10/mkt                        │
+│ entailment_arb    PAPER       min gap 4c, both-or-nothing legs               │
+│ resolution_lens   PAPER       gap>=0.4, edge>=8c                             │
+│ market_maker      LIVE        graduation-exempt                              │
+│ oddlot_tender     PAPER       EDGAR scan, 99-sh entries, manual tender       │
+│ arbitrage         LIVE        graduation-exempt                              │
+│ kraken spec       WIND-DOWN   exits only, no re-entry                        │
+│ graduation        enforce     >= 20 events / 90d to earn live                │
+│ ledger            $-169.46    lifetime live realized (auramaur pnl)          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+  preflight OK, 1 warning(s)
+kraken $1.00 USDC + 0 CAD | spec: AVAX,POL,TON,XXRP
+                             Portfolio Allocation                              
+┏━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━┓
+┃ Category       ┃ Pos ┃  Exposure ┃ Alloc           ┃     PnL ┃  Acc ┃ Kelly ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━┩
+│ politics_intl  │  54 │   $673.99 │ ████        41% │ $+51.74 │  69% │ 0.20x │
+│ other          │  76 │   $406.89 │ ██▍         25% │  $+7.63 │  64% │ 0.29x │
+│ crypto         │  22 │   $180.97 │ █           11% │  $-1.39 │  77% │ 0.46x │
+│ tech           │  19 │   $142.30 │ ▊            9% │  $+9.12 │  88% │ 0.59x │
+│ science        │  10 │    $67.66 │ ▍            4% │  $+0.36 │ 100% │ 1.00x │
+│ sports         │  17 │    $63.62 │ ▍            4% │  $+8.11 │  12% │ 0.20x │
+│ entertainment  │   9 │    $40.65 │ ▏            2% │  $+3.26 │    — │ 0.75x │
+│ politics_us    │   6 │    $30.30 │ ▏            2% │  $+0.08 │  72% │ 0.77x │
+│ esports        │   4 │    $27.66 │ ▏            2% │  $+0.72 │   0% │ 1.00x │
+│ economics      │   5 │    $17.28 │              1% │  $+1.25 │  71% │ 1.00x │
+│ legal          │   2 │     $3.93 │              0% │  $-0.10 │ 100% │ 1.00x │
+├────────────────┼─────┼───────────┼─────────────────┼─────────┼──────┼───────┤
+│ Total          │ 224 │ $1,655.25 │                 │ $+80.77 │      │       │
+└────────────────┴─────┴───────────┴─────────────────┴─────────┴──────┴───────┘
+                     Strategy Books (realized = pnl_ledger)                     
+┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┓
+┃             ┃              ┃        open ┃         live ┃       paper ┃      ┃
+┃ book        ┃  open (live) ┃     (paper) ┃     realized ┃    realized ┃ win% ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━┩
+│ (none)      │            — │           — │         19 / │         2 / │  48% │
+│             │              │             │      $+15.55 │      $-5.60 │      │
+│ bias_harve… │            — │          31 │            — │        82 / │  88% │
+│             │              │             │              │     $-10.04 │      │
+│ exit        │            — │           — │   1 / $-1.00 │           — │   0% │
+│ kraken_dir… │            — │           — │         26 / │           — │   0% │
+│             │              │             │      $-36.53 │             │      │
+│ llm         │ 154 / $1,256 │           5 │        110 / │        56 / │  25% │
+│             │              │             │     $-151.17 │    $-121.81 │      │
+│ news_speed  │    10 / $130 │           2 │  32 / $-1.41 │        11 / │   9% │
+│             │              │             │              │    $-121.86 │      │
+│ order_moni… │            — │           — │   4 / $+8.11 │           — │  50% │
+│ resolution… │            — │          10 │            — │        20 / │  75% │
+│             │              │             │              │     $+12.92 │      │
+│ technical_… │            — │           — │   6 / $-3.00 │         1 / │   0% │
+│             │              │             │              │      $-2.79 │      │
+│ technical_… │            — │           — │            — │         1 / │   0% │
+│             │              │             │              │      $-5.90 │      │
+│ weather_te… │            — │           9 │            — │        48 / │  58% │
+│             │              │             │              │     $-57.31 │      │
+└─────────────┴──────────────┴─────────────┴──────────────┴─────────────┴──────┘
+19:09:35 | cash $32.55 | P&L -93.17 | 224 pos | PEAK
+19:10:14 >>> Will Alphabet Inc. (GOOGL) hit (HIGH) $370 Week of June 22 2026?
+  19:11:26 RESOLVED 69 market(s) — calibration updated
+19:11:30 | cash $32.55 | P&L -107.07 | 224 pos | PEAK
+19:12:56 | cash $32.55 | P&L -93.17 | 224 pos | PEAK
+19:13:03 >>> Major meteor strike (10kt+) in 2026?
+         > Claude: 15% vs Market: 12%  Edge: +3.5%  HIGH
+         APPROVED (18/18) $7.15 news_speed 1073738 grad:unproven
+         ORDER FAILED PAPER polymarket BUY $7.15 (59.6 tokens @ $0.120)

--- a/tests/test_arb_hardening.py
+++ b/tests/test_arb_hardening.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from auramaur.components import Components
 import pytest
 
 from auramaur.bot import AuramaurBot
@@ -24,7 +25,7 @@ def _bare_bot(*, held_row, is_live=True):
     bot = AuramaurBot.__new__(AuramaurBot)
     db = AsyncMock()
     db.fetchone = AsyncMock(return_value=held_row)
-    bot._components = {"db": db, "alerts": AsyncMock()}
+    bot._components = Components({"db": db, "alerts": AsyncMock()})
     bot.settings = SimpleNamespace(is_live=is_live)
     return bot, db
 

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from auramaur.components import Components
 import asyncio
 
 import pytest
@@ -183,7 +184,7 @@ async def test_internal_arb_uses_engine_exchange_attribute():
     db.fetchone = AsyncMock(return_value=None)  # pairing guard: not already held
     alerts = MagicMock()
     alerts.send = AsyncMock()
-    mixin._components = {"db": db, "alerts": alerts}
+    mixin._components = Components({"db": db, "alerts": alerts})
 
     market = Market(
         id="m1", exchange="polymarket", question="Will X?",

--- a/tests/test_cli_dust_exit.py
+++ b/tests/test_cli_dust_exit.py
@@ -1,5 +1,6 @@
 """Tests for the `dust-exit` CLI command."""
 
+from auramaur.components import Components
 import asyncio
 from unittest.mock import AsyncMock, patch
 
@@ -37,7 +38,7 @@ class _FakeBot:
     own event loop (so the aiosqlite connection is bound to the right loop)."""
 
     def __init__(self, *args, **kwargs):
-        self._components = {}
+        self._components = Components({})
 
     async def _init_components(self):
         db = Database(":memory:")
@@ -56,12 +57,12 @@ class _FakeBot:
                     (mid, "polymarket", "BUY", 10.0, 0.3, 0.2, "sports", "YES", f"tok-{mid}", is_paper),
                 )
         await db.commit()
-        self._components = {
+        self._components = Components({
             "db": db,
             "discoveries": {"polymarket": _FakeDiscovery()},
             "exchanges": {"polymarket": object()},
             "alerts": object(),
-        }
+        })
 
     async def shutdown(self):
         await self._components["db"].close()

--- a/tests/test_cross_arb.py
+++ b/tests/test_cross_arb.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from auramaur.components import Components
 import pytest
 
 from auramaur.bot import AuramaurBot
@@ -157,7 +158,7 @@ class TestFeeAwareProfit:
         settings.is_live = True
         settings.arbitrage.max_arb_size = 25.0
         bot = AuramaurBot(settings=settings)
-        bot._components = {"alerts": SimpleNamespace(send=AsyncMock())}
+        bot._components = Components({"alerts": SimpleNamespace(send=AsyncMock())})
 
         risk = FakeRisk()
         engines = {

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from auramaur.components import Components
 import pytest
 
 from auramaur.bot import AuramaurBot
@@ -41,7 +42,9 @@ def _setup(book: OrderBook, current_price: float = 0.90, max_slip_cents: int = 1
     bot = AuramaurBot(settings=settings)
     db = AsyncMock()
     db.fetchone = AsyncMock(return_value={"token_id": "tok-1"})
-    bot._components = {"db": db}
+    # pnl_tracker present-but-None preserves the prior `.get()` → None behavior
+    # now that the exit reads it via the typed accessor.
+    bot._components = Components({"db": db, "pnl_tracker": None})
 
     exchange = SimpleNamespace(
         get_order_book=AsyncMock(return_value=book),

--- a/tests/test_kraken_dir_signals.py
+++ b/tests/test_kraken_dir_signals.py
@@ -7,6 +7,7 @@
   shrink the crypto ceiling (hold more USDC), never grow it.
 """
 
+from auramaur.components import Components
 import asyncio
 import time
 from types import SimpleNamespace
@@ -28,7 +29,7 @@ def _conv_kcfg(*, enabled=True, min_mult=0.34):
 def _pillar(db, calib, kcfg, price):
     settings = SimpleNamespace(kraken=kcfg, is_live=False)
     k = SimpleNamespace(get_price=AsyncMock(return_value=price))
-    bot = SimpleNamespace(_components={"db": db, "calibration": calib})
+    bot = SimpleNamespace(_components=Components({"db": db, "calibration": calib}))
     return KrakenPillar(settings, k, bot=bot)
 
 

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -1,5 +1,6 @@
 """Tests for the Kraken directional spot pillar — asymmetric long bias."""
 
+from auramaur.components import Components
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -160,7 +161,7 @@ async def test_mirror_to_portfolio_upserts_held_and_deletes_closed():
     db.fetchall = AsyncMock(return_value=[{"market_id": "ETHUSDC"},
                                           {"market_id": "XBTUSDC"}])
     bot = MagicMock()
-    bot._components = {"db": db}
+    bot._components = Components({"db": db})
     p = KrakenPillar(settings=s, kraken_client=MagicMock(), bot=bot)
 
     await p._mirror_to_portfolio({"XBTUSDC": (90.0, 100.0, 0.5)}, ["ETHUSDC"])
@@ -219,7 +220,7 @@ async def test_mirror_removes_stale_rows_from_prior_sessions():
     await db.commit()
 
     bot = MagicMock()
-    bot._components = {"db": db}
+    bot._components = Components({"db": db})
     p = KrakenPillar(settings=s, kraken_client=MagicMock(), bot=bot)
     # Fresh process: _dir_long empty, closed empty — only XBT actually held.
     await p._mirror_to_portfolio({"XBTUSDC": (90.0, 100.0, 0.5)}, [])

--- a/tests/test_kraken_directional_exit.py
+++ b/tests/test_kraken_directional_exit.py
@@ -8,6 +8,7 @@ Two gaps were fixed:
   stop-loss (directional_stop_loss_pct) now exits regardless of momentum.
 """
 
+from auramaur.components import Components
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -186,7 +187,7 @@ def _live_pillar(db, query_fills):
     settings = SimpleNamespace(kraken=_kcfg(), is_live=True)
     k = _client(1.0)
     k.query_fill = AsyncMock(side_effect=query_fills)
-    bot = SimpleNamespace(_components={"db": db})
+    bot = SimpleNamespace(_components=Components({"db": db}))
     return KrakenPillar(settings, k, bot=bot)
 
 
@@ -224,7 +225,7 @@ def test_paper_mode_records_nothing():
         db = Database(":memory:")
         await db.connect()
         settings = SimpleNamespace(kraken=_kcfg(), is_live=False)
-        bot = SimpleNamespace(_components={"db": db})
+        bot = SimpleNamespace(_components=Components({"db": db}))
         p = KrakenPillar(settings, _client(1.0), bot=bot)
 
         out = await p._record_directional_fill(

--- a/tests/test_kraken_llm_signal.py
+++ b/tests/test_kraken_llm_signal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from auramaur.components import Components
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -68,9 +69,9 @@ def test_llm_view_returns_and_throttles():
     analyzer.analyze = AsyncMock(return_value=analysis)
     calib = MagicMock()
     calib.record_prediction = AsyncMock()
-    bot = SimpleNamespace(_components={
+    bot = SimpleNamespace(_components=Components({
         "aggregator": agg, "analyzer": analyzer, "cache": None, "calibration": calib,
-    })
+    }))
     p = _pillar(bot=bot)
 
     async def run():
@@ -88,7 +89,7 @@ def test_llm_view_returns_and_throttles():
 
 
 def test_llm_view_unknown_pair_returns_none():
-    bot = SimpleNamespace(_components={})
+    bot = SimpleNamespace(_components=Components({}))
     p = _pillar(bot=bot)
 
     async def run():
@@ -103,9 +104,9 @@ def test_llm_view_skipped_analysis_returns_none():
     analysis = SimpleNamespace(probability=0.5, confidence="LOW", skipped_reason="thin evidence")
     analyzer = MagicMock()
     analyzer.analyze = AsyncMock(return_value=analysis)
-    bot = SimpleNamespace(_components={
+    bot = SimpleNamespace(_components=Components({
         "aggregator": agg, "analyzer": analyzer, "cache": None, "calibration": None,
-    })
+    }))
     p = _pillar(bot=bot)
 
     async def run():

--- a/tests/test_no_unbound_names.py
+++ b/tests/test_no_unbound_names.py
@@ -23,6 +23,7 @@ _EXTRACTED = [
     "auramaur/bot_exits.py",
     "auramaur/bot_strategy_tasks.py",
     "auramaur/bot_order_monitor.py",
+    "auramaur/components.py",
 ]
 
 

--- a/tests/test_order_monitor.py
+++ b/tests/test_order_monitor.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from auramaur.components import Components
 import pytest
 
 from auramaur.bot import AuramaurBot
@@ -53,13 +54,13 @@ async def test_order_monitor_records_live_fill_once():
     db.execute = AsyncMock(return_value=db_cursor)
     db.commit = AsyncMock()
 
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": exchange,
         "discovery": AsyncMock(),
         "pnl_tracker": pnl_tracker,
         "db": db,
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -118,13 +119,13 @@ async def test_order_monitor_ttl_cancels_stale_live_order():
         check_fills=AsyncMock(return_value=[]),
         cancel_expired=AsyncMock(return_value=0),
     )
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": exchange,
         "discovery": AsyncMock(),
         "pnl_tracker": AsyncMock(),
         "db": AsyncMock(),
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -164,10 +165,10 @@ async def test_order_monitor_keeps_fresh_live_order():
         check_fills=AsyncMock(return_value=[]),
         cancel_expired=AsyncMock(return_value=0),
     )
-    bot._components = {
+    bot._components = Components({
         "paper": paper, "exchange": exchange, "discovery": AsyncMock(),
         "pnl_tracker": AsyncMock(), "db": AsyncMock(),
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -242,14 +243,14 @@ async def test_order_monitor_polls_all_live_exchanges():
     db.execute = AsyncMock(return_value=db_cursor)
     db.commit = AsyncMock()
 
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": poly,
         "exchanges": {"polymarket": poly, "kalshi": kalshi},
         "discovery": AsyncMock(),
         "pnl_tracker": pnl_tracker,
         "db": db,
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -304,13 +305,13 @@ async def test_ttl_cancel_writes_cancelled_status_to_db():
         cancel_expired=AsyncMock(return_value=0),
     )
     db = AsyncMock()
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": exchange,
         "discovery": AsyncMock(),
         "pnl_tracker": AsyncMock(),
         "db": db,
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -364,13 +365,13 @@ async def test_ttl_cancel_failure_keeps_order_tracked():
         cancel_expired=AsyncMock(return_value=0),
     )
     db = AsyncMock()
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": exchange,
         "discovery": AsyncMock(),
         "pnl_tracker": AsyncMock(),
         "db": db,
-    }
+    })
 
     async def stop_after_loop(_seconds):
         bot._running = False
@@ -406,7 +407,7 @@ async def test_reconcile_orphaned_pending_trades():
         {"order_id": "PAPER-abc123", "exchange": "polymarket"},
         {"order_id": "orphan-1", "exchange": "polymarket"},
     ])
-    bot._components = {"db": db}
+    bot._components = Components({"db": db})
 
     await bot._reconcile_orphaned_pending_trades([("polymarket", exchange)])
 
@@ -443,12 +444,12 @@ async def test_order_monitor_reconciles_orphans_periodically():
         check_fills=AsyncMock(return_value=[]),
         cancel_expired=AsyncMock(return_value=0),
     )
-    bot._components = {
+    bot._components = Components({
         "paper": paper,
         "exchange": exchange,
         "discovery": AsyncMock(),
         "db": AsyncMock(),
-    }
+    })
 
     calls = {"n": 0}
 

--- a/tests/test_shutdown_cancel.py
+++ b/tests/test_shutdown_cancel.py
@@ -13,11 +13,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from auramaur.bot import AuramaurBot
+from auramaur.components import Components
 
 
 def _bot_with(components: dict) -> AuramaurBot:
     bot = AuramaurBot(settings=MagicMock())
-    bot._components = components
+    bot._components = Components(components)
     bot._lock_file = None
     return bot
 


### PR DESCRIPTION
First of the two "orchestration sprawl" refactors from the rescue review. Done as the agent-scoped additive design — **no behavior change, suite green throughout.**

## Problem
The runtime service registry was a bare `dict[str, object]` accessed by string key: **85** untyped `self._components["…"]` lookups — no autocomplete, no type-checking, KeyError-on-a-live-path as the typo failure mode.

## Design
New `auramaur/components.py`: **`Components(dict)`** — it *is* a dict, so every existing subscript / `.get()` / `.items()` teardown and the external cli/kraken consumers keep working untouched. It adds typed `@property` accessors (always-present keys via subscript; optional keys via `.get()` → `T | None`). All component-type imports are under `TYPE_CHECKING`, so the module imports nothing at runtime → **no circular-import risk**.

## Migration
- `bot.py` wraps the registry literal in `Components(...)`.
- All 85 call sites across `bot.py` + the four mixins migrate `["x"]` / `.get("x")` → `.x`.
- **Behavior-preserving:** every key is always present in the registry (optionals stored as `None`), so subscript and `.get()` are equivalent in production. The only failures were minimal *test fixtures* injecting partial dicts — those now build `Components(...)`, and one adds `pnl_tracker=None` to preserve the prior `.get()`→None path.
- `components.py` added to the `test_no_unbound_names` AST guard (the incident guard).

## Verification
Full suite **878 passed**; `ruff check .` clean. This was the agent's "Slice 0 + all call sites" — reversible, and the bot is fully functional at every step because `Components` is a `dict`.

Assisted-by: Claude (Anthropic)