### PR TITLE
refactor(strategy): uniform Strategy contract + declared execution modes

### DIFF
--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -6,6 +6,8 @@ markets, and checks within-exchange invariants (YES + NO should sum to ~1.0).
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import asyncio
 import re
 from dataclasses import dataclass
@@ -132,6 +134,10 @@ class ArbitrageScanner:
        ~1.0.  If the sum is < 0.97, buying both YES and NO guarantees a
        profit on resolution (one side pays $1.00, total cost < $0.97).
     """
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "arb_scanner"
+    execution_mode = ExecutionMode.GATEWAY_EXTERNAL
 
     def __init__(
         self,

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -32,6 +32,8 @@ Design constraints:
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 from datetime import datetime, timezone
 
 import structlog
@@ -50,6 +52,10 @@ log = structlog.get_logger()
 
 class BiasHarvestPillar:
     """Periodic favored-side scanner for Polymarket."""
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "bias_harvest"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
 
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, calibration) -> None:

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -26,6 +26,8 @@ Rides the standard rails as strategy_source='cross_venue_arb'.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import json
 from datetime import datetime, timezone
 
@@ -56,6 +58,10 @@ Respond with ONLY this JSON:
 
 
 class CrossVenueArbPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "cross_venue_arb"
+    execution_mode = ExecutionMode.GATEWAY_PAIRED
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, analyzer=None, kalshi_discovery=None,
                  exchanges=None) -> None:

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -17,6 +17,8 @@ and calibration prove or kill the edge before any live capital.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 from datetime import datetime, timezone
 
 import structlog
@@ -37,6 +39,10 @@ log = structlog.get_logger()
 
 class EconIndicatorPillar:
     """Periodic data-driven scanner for Kalshi economic-indicator bins."""
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "econ_indicator"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
 
     def __init__(self, db, settings, kalshi_discovery, fred_source, exchange,
                  risk_manager, pnl_tracker, calibration) -> None:

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -32,6 +32,8 @@ which the graduation ladder scores like any other cell.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import json
 import re
 from datetime import datetime, timezone
@@ -221,6 +223,10 @@ Respond with ONLY this JSON:
 # ----------------------------------------------------------------------
 
 class EntailmentArbPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "entailment_arb"
+    execution_mode = ExecutionMode.GATEWAY_PAIRED
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, analyzer=None, kalshi_discovery=None,
                  exchanges=None) -> None:

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -17,6 +17,8 @@ capping max inventory per market.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -78,6 +80,10 @@ class MarketMaker:
     The user has 0% maker fees on Polymarket, so all spread captured
     is pure profit when both legs fill.
     """
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "market_maker"
+    execution_mode = ExecutionMode.DIRECT_QUOTING
 
     def __init__(
         self,

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -29,6 +29,8 @@ row (exchange='ibkr', category='ibkr_equity'), signals/trades
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import json
 
 import structlog
@@ -56,6 +58,10 @@ Respond with ONLY this JSON:
 
 
 class OddLotTenderPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "oddlot_tender"
+    execution_mode = ExecutionMode.DIRECT_EQUITY
     def __init__(self, db, settings, edgar, analyzer, alerts=None,
                  equity_client=None, pnl_tracker=None) -> None:
         self._db = db

--- a/auramaur/strategy/protocols.py
+++ b/auramaur/strategy/protocols.py
@@ -2,11 +2,58 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from enum import Enum
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
 from auramaur.exchange.models import Market, Signal
+
+
+class ExecutionMode(str, Enum):
+    """How a strategy pillar commits its orders.
+
+    The bot's pillars share the pipeline discover → signal → risk → allocate →
+    execute, but they legitimately differ at the EXECUTE stage. This enum makes
+    each pillar's execution path an explicit, declared, testable contract — so a
+    justified gateway-bypass (market maker, concurrent arb, equities) is
+    distinguishable from an accidental one (the conformance guard asserts it).
+    """
+
+    # Route through the single ExecutionGateway money path:
+    GATEWAY_SINGLE = "gateway_single"      # gateway.submit() — directional pillars
+    GATEWAY_PAIRED = "gateway_paired"      # gateway.submit_paired() — both-or-nothing arb
+    GATEWAY_EXTERNAL = "gateway_external"  # gateway.record_external_fill() — concurrently-placed legs
+    # Documented, justified gateway bypasses:
+    DIRECT_QUOTING = "direct_quoting"      # market maker — resting two-sided quotes (no Signal/risk)
+    DIRECT_EQUITY = "direct_equity"        # oddlot tender — IBKR equities, outside the PM gateway
+
+
+# Modes that MUST run through the ExecutionGateway (no direct exchange.place_order).
+GATEWAY_MODES = frozenset({
+    ExecutionMode.GATEWAY_SINGLE,
+    ExecutionMode.GATEWAY_PAIRED,
+    ExecutionMode.GATEWAY_EXTERNAL,
+})
+
+
+@runtime_checkable
+class Strategy(Protocol):
+    """The uniform pillar contract.
+
+    Thin by design: the five pipeline stages (discover/signal/risk/allocate/
+    execute) are INTERNAL phases of ``run_once`` — pillars legitimately fuse them
+    differently (MM has no Signal, arb has two legs) — so they are not forced as
+    separate methods. What every pillar declares is its identity and HOW it
+    executes, which is what the conformance guard checks.
+    """
+
+    name: str
+    execution_mode: ExecutionMode
+
+    async def run_once(self) -> int:
+        """Run one cycle; return the number of entries/quotes placed."""
+        ...
 
 
 class TradeCandidate(BaseModel):

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -27,6 +27,8 @@ strategy_source='resolution_lens', scored by the graduation ladder.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 import json
 import re
 from datetime import datetime, timezone
@@ -123,6 +125,10 @@ Respond with ONLY this JSON:
 
 
 class ResolutionLensPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "resolution_lens"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, calibration, analyzer, aggregator=None) -> None:
         self._db = db

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -9,6 +9,8 @@ artifact, not edge) until the paper record validates the model.
 
 from __future__ import annotations
 
+from auramaur.strategy.protocols import ExecutionMode
+
 from datetime import timezone
 
 import structlog
@@ -25,6 +27,10 @@ log = structlog.get_logger()
 
 
 class WeatherTempPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "weather_temp"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
     def __init__(self, db, settings, discovery, exchange, risk_manager,
                  pnl_tracker, calibration, weather) -> None:
         self._db = db

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -1,0 +1,71 @@
+"""Conformance guard for the uniform Strategy pillar contract.
+
+Every pillar declares ``name`` + ``execution_mode`` (strategy/protocols.py). The
+point of the contract is to make the EXECUTE stage explicit and *checked*: a
+pillar that should route through the single ExecutionGateway must not quietly
+grow a direct ``exchange.place_order`` bypass, while the legitimate bypasses
+(market maker resting quotes, concurrent arb legs, IBKR equities) are declared
+and whitelisted with a reason. That turns "is this gateway-bypass intentional?"
+from an unanswerable code-reading question into a test.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from auramaur.strategy.bias_harvest import BiasHarvestPillar
+from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
+from auramaur.strategy.econ_indicator import EconIndicatorPillar
+from auramaur.strategy.entailment_arb import EntailmentArbPillar
+from auramaur.strategy.market_maker import MarketMaker
+from auramaur.strategy.oddlot_tender import OddLotTenderPillar
+from auramaur.strategy.protocols import ExecutionMode
+from auramaur.strategy.resolution_lens import ResolutionLensPillar
+from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
+from auramaur.strategy.weather_temp import WeatherTempPillar
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# (pillar class, source module) — every pillar the bot drives.
+PILLARS = [
+    (BiasHarvestPillar, "auramaur/strategy/bias_harvest.py"),
+    (ResolutionLensPillar, "auramaur/strategy/resolution_lens.py"),
+    (WeatherTempPillar, "auramaur/strategy/weather_temp.py"),
+    (EconIndicatorPillar, "auramaur/strategy/econ_indicator.py"),
+    (EntailmentArbPillar, "auramaur/strategy/entailment_arb.py"),
+    (CrossVenueArbPillar, "auramaur/strategy/cross_venue_arb.py"),
+    (MarketMaker, "auramaur/strategy/market_maker.py"),
+    (ArbitrageScanner, "auramaur/strategy/arbitrage_scanner.py"),
+    (OddLotTenderPillar, "auramaur/strategy/oddlot_tender.py"),
+]
+
+# Directional pillars: orders MUST flow through the gateway (submit / submit_paired),
+# never a direct exchange.place_order. The other modes legitimately place directly
+# (MM quotes, concurrent arb legs that then record_external_fill, equities).
+_GATEWAY_PURE = {ExecutionMode.GATEWAY_SINGLE, ExecutionMode.GATEWAY_PAIRED}
+
+
+def test_every_pillar_declares_a_unique_named_contract():
+    names: set[str] = set()
+    for cls, _ in PILLARS:
+        assert isinstance(cls.execution_mode, ExecutionMode), cls.__name__
+        assert isinstance(cls.name, str) and cls.name, cls.__name__
+        assert cls.name not in names, f"duplicate pillar name: {cls.name}"
+        names.add(cls.name)
+
+
+@pytest.mark.parametrize("cls,modfile", PILLARS, ids=[c.name for c, _ in PILLARS])
+def test_gateway_pillars_do_not_place_orders_directly(cls, modfile):
+    """A GATEWAY_SINGLE/PAIRED pillar must route through the ExecutionGateway —
+    it must not call exchange.place_order in its own module. The direct-placement
+    modes are skipped with their declared reason (this is the whitelist)."""
+    if cls.execution_mode not in _GATEWAY_PURE:
+        pytest.skip(
+            f"{cls.name} is {cls.execution_mode.value}: direct placement is its "
+            f"declared, intentional path (not a gateway bypass)")
+    src = (_ROOT / modfile).read_text()
+    assert ".place_order(" not in src, (
+        f"{cls.name} ({cls.execution_mode.value}) must submit through the "
+        f"ExecutionGateway, not call place_order directly")


### PR DESCRIPTION
Second of the two "orchestration sprawl" refactors. Additive — **declarations + a test, no behavior change.**

## Key finding (from the scoping)
The pillars were **already mechanically uniform** (discover → signal → risk → execute): 6 of 9 route through the `ExecutionGateway`. The real gap was that the EXECUTE stage was uniform only *by convention*, and the 3 legitimate gateway-bypasses (MM resting quotes, concurrent arb legs, IBKR equities) were **silent** — nothing distinguished a justified bypass from an accidental one.

## Change
- `strategy/protocols.py`: an `ExecutionMode` enum + a thin `Strategy` Protocol (`name`, `execution_mode`, `run_once`). The five pipeline stages stay *internal* to `run_once` — pillars legitimately fuse them differently (MM has no Signal, arb has two legs) — so the Protocol stays thin and nothing is forced to reshape.
- All 9 pillars **declare** their mode:
  - `GATEWAY_SINGLE`: bias_harvest, resolution_lens, weather_temp, econ_indicator
  - `GATEWAY_PAIRED`: entailment_arb, cross_venue_arb
  - `DIRECT_QUOTING`: market_maker · `GATEWAY_EXTERNAL`: arb_scanner · `DIRECT_EQUITY`: oddlot_tender
- `tests/test_strategy_protocol.py`: the **conformance guard**. Asserts every pillar declares a unique named contract, and that `GATEWAY_SINGLE/PAIRED` pillars never call `exchange.place_order` directly. The direct-placement modes are skipped *with their declared reason* — that's the whitelist. The silent bypass is now a checked, intentional one.

## Verification
Full suite **885 passed, 3 skipped** (the declared exceptions), ruff clean. No money-path edits.

Assisted-by: Claude (Anthropic)