### PR TITLE
ci: make ruff lint blocking (backlog cleared)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,11 @@ jobs:
         run: uv run pytest -q
 
   lint:
-    name: Lint (ruff, non-blocking)
+    name: Lint (ruff)
     runs-on: ubuntu-latest
-    # Advisory only for now: the tree has known hygiene debt being paid down
-    # incrementally. Surfaces issues on every PR without gating merges. Flip
-    # continue-on-error to false once the backlog is clear to make it required.
-    continue-on-error: true
+    # Blocking: the backlog was cleared (214 -> 0) and the tree is ruff-clean, so
+    # lint is now a required gate — a new violation fails the PR instead of just
+    # being surfaced.
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Now that the ruff backlog was cleared (214 → 0, #194) and the tree is clean, flip the advisory lint job to a **required gate**: a newly-introduced violation fails the PR instead of just being surfaced. (`continue-on-error: true` removed.)

Verified `ruff check .` is clean on the current tree, so this won't block existing work.

Assisted-by: Claude (Anthropic)