### PR TITLE
chore: leaner log rotation + accurate README safety claims + ExecutionMode consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ and trades when there's edge after fees.
 
 1. Paper trading is the default. Live orders require **all three gates**:
    `AURAMAUR_LIVE=true`, `execution.live=true`, and per-order `dry_run=False`.
-2. A `KILL_SWITCH` file in the working directory halts all trading.
-3. Every order passes through 15 risk checks. None can be bypassed.
+2. A `KILL_SWITCH` file (at the repo root or the working directory) halts all trading.
+3. **Directional entries** pass the 15 risk checks via the single `ExecutionGateway`.
+   The market maker (resting two-sided quotes) and concurrent arb legs run
+   *declared, test-enforced* direct-execution contracts — see `ExecutionMode` in
+   `auramaur/strategy/protocols.py` and the conformance guard
+   `tests/test_strategy_protocol.py` — not the directional risk path. Exits have
+   their own contract. The bypasses are intentional and checked, not implicit.
 4. No API keys in code — all secrets come from environment variables.
 
 ## Quickstart

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1489,6 +1489,8 @@ class AuramaurBot(
             level=self.settings.logging.level,
             json_format=False,  # Console-friendly output
             log_file=self.settings.logging.file,
+            rotate_max_mb=self.settings.logging.rotate_max_mb,
+            rotate_backups=self.settings.logging.rotate_backups,
         )
 
         mode = "LIVE" if self.settings.is_live else "PAPER"

--- a/auramaur/monitoring/logger.py
+++ b/auramaur/monitoring/logger.py
@@ -46,12 +46,14 @@ class _RotatingWriter:
         self._file = open(self._path, "a", encoding="utf-8")
 
 
-def setup_logging(level: str = "INFO", json_format: bool = True, log_file: str | None = None):
+def setup_logging(level: str = "INFO", json_format: bool = True, log_file: str | None = None,
+                  rotate_max_mb: int = 10, rotate_backups: int = 3):
     """Configure structlog for the application.
 
     When json_format=False (interactive terminal), structlog output goes to the
     log file only so it doesn't clutter the Rich console output.  The console
-    receives only the curated Rich display calls.
+    receives only the curated Rich display calls. The file is size-rotated at
+    ``rotate_max_mb`` keeping ``rotate_backups`` older files.
     """
 
     log_level = getattr(logging, level, logging.INFO)
@@ -84,7 +86,8 @@ def setup_logging(level: str = "INFO", json_format: bool = True, log_file: str |
                 processors=[*shared_processors, structlog.processors.JSONRenderer()],
                 wrapper_class=structlog.make_filtering_bound_logger(log_level),
                 context_class=dict,
-                logger_factory=structlog.WriteLoggerFactory(file=_RotatingWriter(log_file)),
+                logger_factory=structlog.WriteLoggerFactory(file=_RotatingWriter(
+                    log_file, max_bytes=rotate_max_mb * 1024 * 1024, backups=rotate_backups)),
                 cache_logger_on_first_use=True,
             )
         else:

--- a/auramaur/strategy/protocols.py
+++ b/auramaur/strategy/protocols.py
@@ -21,19 +21,25 @@ class ExecutionMode(str, Enum):
     """
 
     # Route through the single ExecutionGateway money path:
+    # Gateway-submitted — the pillar never calls exchange.place_order itself;
+    # the gateway places AND records (this is what the conformance guard asserts):
     GATEWAY_SINGLE = "gateway_single"      # gateway.submit() — directional pillars
     GATEWAY_PAIRED = "gateway_paired"      # gateway.submit_paired() — both-or-nothing arb
-    GATEWAY_EXTERNAL = "gateway_external"  # gateway.record_external_fill() — concurrently-placed legs
-    # Documented, justified gateway bypasses:
+    # Places directly for timing/atomicity reasons, but still RECORDS through the
+    # gateway (record_external_fill) — so it does call place_order and is NOT a
+    # gateway-pure mode:
+    GATEWAY_EXTERNAL = "gateway_external"  # concurrently-placed arb legs, then record_external_fill()
+    # Fully direct, justified bypasses (own accounting):
     DIRECT_QUOTING = "direct_quoting"      # market maker — resting two-sided quotes (no Signal/risk)
     DIRECT_EQUITY = "direct_equity"        # oddlot tender — IBKR equities, outside the PM gateway
 
 
-# Modes that MUST run through the ExecutionGateway (no direct exchange.place_order).
-GATEWAY_MODES = frozenset({
+# Gateway-PURE modes: the pillar must not call exchange.place_order at all (the
+# gateway submits on its behalf). GATEWAY_EXTERNAL is deliberately excluded — it
+# places directly then records — matching the conformance guard's skip set.
+GATEWAY_PURE_MODES = frozenset({
     ExecutionMode.GATEWAY_SINGLE,
     ExecutionMode.GATEWAY_PAIRED,
-    ExecutionMode.GATEWAY_EXTERNAL,
 })
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -889,6 +889,12 @@ class LoggingConfig(BaseModel):
     level: str = "INFO"
     json_format: bool = True
     file: str = "auramaur.log"
+    # Size-based rotation of the structlog file. Tighter than the old hardcoded
+    # 50MB×5 (≈300MB of mostly-noise): 10MB×3 keeps the on-disk log current and
+    # bounded at ~40MB so a noisy source can't bury the recent signal in a giant
+    # file. Tune up if you need deeper history.
+    rotate_max_mb: int = 10
+    rotate_backups: int = 3
 
 
 class Settings(BaseSettings):

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -22,7 +22,7 @@ from auramaur.strategy.entailment_arb import EntailmentArbPillar
 from auramaur.strategy.market_maker import MarketMaker
 from auramaur.strategy.momentum_coupling import MomentumCouplingPillar
 from auramaur.strategy.oddlot_tender import OddLotTenderPillar
-from auramaur.strategy.protocols import ExecutionMode
+from auramaur.strategy.protocols import ExecutionMode, GATEWAY_PURE_MODES
 from auramaur.strategy.resolution_lens import ResolutionLensPillar
 from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
 from auramaur.strategy.weather_temp import WeatherTempPillar
@@ -43,10 +43,10 @@ PILLARS = [
     (OddLotTenderPillar, "auramaur/strategy/oddlot_tender.py"),
 ]
 
-# Directional pillars: orders MUST flow through the gateway (submit / submit_paired),
-# never a direct exchange.place_order. The other modes legitimately place directly
-# (MM quotes, concurrent arb legs that then record_external_fill, equities).
-_GATEWAY_PURE = {ExecutionMode.GATEWAY_SINGLE, ExecutionMode.GATEWAY_PAIRED}
+# GATEWAY_PURE_MODES (single source of truth in protocols.py): the pillar must
+# not call exchange.place_order at all. The other modes legitimately place
+# directly (MM quotes; concurrent arb legs that then record_external_fill;
+# equities) and are skipped with their declared reason below.
 
 
 def test_every_pillar_declares_a_unique_named_contract():
@@ -63,7 +63,7 @@ def test_gateway_pillars_do_not_place_orders_directly(cls, modfile):
     """A GATEWAY_SINGLE/PAIRED pillar must route through the ExecutionGateway —
     it must not call exchange.place_order in its own module. The direct-placement
     modes are skipped with their declared reason (this is the whitelist)."""
-    if cls.execution_mode not in _GATEWAY_PURE:
+    if cls.execution_mode not in GATEWAY_PURE_MODES:
         pytest.skip(
             f"{cls.name} is {cls.execution_mode.value}: direct placement is its "
             f"declared, intentional path (not a gateway bypass)")


### PR DESCRIPTION
Operational cleanup + two consistency fixes from the latest review.

## Log rotation (leaner + configurable)
The structlog file already rotated, but at a hardcoded **50MB × 5** (~300MB). Made it configurable (`logging.rotate_max_mb` / `rotate_backups`) and defaulted leaner — **10MB × 3** (~40MB cap). Separately reclaimed ~250MB of old historical backups on the box.

## README safety claim (item 5)
"Every order passes through 15 risk checks. None can be bypassed" was **not literally true** — MM/arb/oddlot place directly under declared `ExecutionMode` contracts. Rewritten to the real invariant: *directional entries* pass the checks via the `ExecutionGateway`; MM/arb/oddlot run declared, test-enforced direct contracts; exits have their own. Also corrected the kill-switch claim (now repo-root-aware, not just CWD).

## ExecutionMode consistency (item 3)
The unused `GATEWAY_MODES` set wrongly listed `GATEWAY_EXTERNAL` as "no direct place_order" — but external mode *does* place directly then records via `record_external_fill`. Replaced with `GATEWAY_PURE_MODES` (SINGLE + PAIRED only) as the **single source of truth**, and the conformance test now imports it instead of a duplicated local set. Clarified each mode's docstring.

Full suite **887 passed, 3 skipped**; ruff clean.

Assisted-by: Claude (Anthropic)