### PR TITLE
refactor(#4): ExecutionGateway is the single placement choke point (place_legs + place_quote_pair)

### DIFF
--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -134,14 +134,10 @@ class ArbExecutionMixin:
         )
 
         try:
-            buy_result, sell_result = await asyncio.gather(
-                buy_client.place_order(buy_order),
-                sell_client.place_order(sell_order),
-            )
-            for _o, _r in ((buy_order, buy_result), (sell_order, sell_result)):
-                await self._exit_gateway.record_external_fill(
-                    _o, _r, strategy_source="conditional_arb",
-                    exchange_name=_o.exchange or "polymarket")
+            (buy_result, _), (sell_result, _) = await self._exit_gateway.place_legs(
+                [(buy_order, buy_client, buy_order.exchange or "polymarket"),
+                 (sell_order, sell_client, sell_order.exchange or "polymarket")],
+                strategy_source="conditional_arb", concurrent=True)
             buy_ok = buy_result.status not in ("rejected", "error")
             sell_ok = sell_result.status not in ("rejected", "error")
             mode = "PAPER" if not is_live else "LIVE"
@@ -492,13 +488,10 @@ class ArbExecutionMixin:
         )
 
         try:
-            results = await asyncio.gather(
-                *[exchange_client.place_order(o) for o in orders]
-            )
-            for _o, _r in zip(orders, results):
-                await self._exit_gateway.record_external_fill(
-                    _o, _r, strategy_source="negrisk_arb",
-                    exchange_name=_o.exchange or "polymarket")
+            placed = await self._exit_gateway.place_legs(
+                [(o, exchange_client, o.exchange or "polymarket") for o in orders],
+                strategy_source="negrisk_arb", concurrent=True)
+            results = [r for r, _ in placed]
             n_ok = sum(1 for r in results if r.status not in ("rejected", "error"))
             mode = "PAPER" if not is_live else "LIVE"
             if n_ok == len(orders):
@@ -648,12 +641,10 @@ class ArbExecutionMixin:
             return
 
         try:
-            yes_result = await exchange_client.place_order(yes_order)
-            no_result = await exchange_client.place_order(no_order)
-            for _o, _r in ((yes_order, yes_result), (no_order, no_result)):
-                await self._exit_gateway.record_external_fill(
-                    _o, _r, strategy_source="internal_arb",
-                    exchange_name=_o.exchange or "polymarket")
+            (yes_result, _), (no_result, _) = await self._exit_gateway.place_legs(
+                [(yes_order, exchange_client, yes_order.exchange or "polymarket"),
+                 (no_order, exchange_client, no_order.exchange or "polymarket")],
+                strategy_source="internal_arb", concurrent=False)
 
             log.info(
                 "arb_scanner.internal_executed",
@@ -823,20 +814,16 @@ class ArbExecutionMixin:
             }
 
         try:
-            yes_result, no_result = await asyncio.gather(
-                cheap_client.place_order(yes_order),
-                expensive_client.place_order(no_order),
-            )
-
-            # Record both legs through the gateway so they get the same invariant
-            # as every other money path (fills + cost_basis + pnl_ledger + the
-            # pending trades-mirror the order monitor finalizes). The legs were
-            # placed concurrently above to minimize the leg-risk window, so they
-            # use record_external_fill rather than submit_*.
-            for _o, _r, _exn in ((yes_order, yes_result, cheap_exchange),
-                                 (no_order, no_result, expensive_exchange)):
-                await self._exit_gateway.record_external_fill(
-                    _o, _r, strategy_source="cross_exchange_arb", exchange_name=_exn)
+            # Place + record both legs through the gateway (the single placement
+            # choke point). place_legs gathers them concurrently to minimize the
+            # leg-risk window and records each with the cross_exchange_arb
+            # invariant (fills + cost_basis + pnl_ledger + the pending
+            # trades-mirror the monitor finalizes). Raw results drive the
+            # half-fill rollback below.
+            (yes_result, _), (no_result, _) = await self._exit_gateway.place_legs(
+                [(yes_order, cheap_client, cheap_exchange),
+                 (no_order, expensive_client, expensive_exchange)],
+                strategy_source="cross_exchange_arb", concurrent=True)
 
             yes_ok = yes_result.status not in ("rejected", "error")
             no_ok = no_result.status not in ("rejected", "error")
@@ -1037,16 +1024,9 @@ class ArbExecutionMixin:
                 if order.size < 1:
                     continue
 
-                result = await engine.exchange.place_order(order)
-                from auramaur.monitoring.display import show_order
-                show_order(
-                    result.status, result.order_id, "SELL", order.size,
-                    order.price, result.is_paper, exchange="kalshi",
-                    error_message=result.error_message,
-                    market_id=pos["mid"],
-                )
-                await self._exit_gateway.record_external_fill(
-                    order, result, strategy_source="rebalance", exchange_name="kalshi")
+                (result, _), = await self._exit_gateway.place_legs(
+                    [(order, engine.exchange, "kalshi")],
+                    strategy_source="rebalance", concurrent=False, show=True)
 
                 if result.status not in ("rejected",):
                     sell_value = order.size * order.price

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -21,6 +21,7 @@ per-leg ``submit`` could not.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Literal
 
@@ -294,6 +295,64 @@ class ExecutionGateway:
         return await self._record_result(
             order, result, strategy_source=strategy_source,
             signal_id=None, exchange_name=exchange_name)
+
+    async def place_legs(
+        self,
+        legs: list[tuple[Order, ExchangeClient, str]],
+        *,
+        strategy_source: str,
+        concurrent: bool = True,
+        show: bool = False,
+    ) -> list[tuple[OrderResult, ExecutionResult]]:
+        """Place multiple already-built legs through the gateway, then record each.
+
+        The single owned entry point for multi-leg flows that must place directly
+        rather than via ``submit_paired``'s A-then-B atomicity: arb legs placed
+        CONCURRENTLY (asyncio.gather, to minimize the leg-risk window) or
+        SEQUENTIALLY for same-exchange pairs. Each placed leg is recorded with the
+        same invariant as ``record_external_fill`` (slippage, record_fill, the
+        pending trades-mirror the monitor finalizes for live fills). Returns the
+        raw ``OrderResult`` alongside the ``ExecutionResult`` per leg so the caller
+        keeps its own half-fill / rollback / inventory logic. ``legs`` items are
+        ``(order, exchange_client, exchange_name)``.
+        """
+        if concurrent:
+            results = await asyncio.gather(
+                *(client.place_order(order) for order, client, _ in legs))
+        else:
+            results = [await client.place_order(order) for order, client, _ in legs]
+        out: list[tuple[OrderResult, ExecutionResult]] = []
+        for (order, _client, exchange_name), result in zip(legs, results):
+            if show:
+                show_order(result.status, result.order_id, order.side.value,
+                           order.size, order.price, result.is_paper,
+                           exchange=exchange_name,
+                           error_message=result.error_message,
+                           market_id=order.market_id)
+            exec_res = await self.record_external_fill(
+                order, result, strategy_source=strategy_source,
+                exchange_name=exchange_name)
+            out.append((result, exec_res))
+        return out
+
+    async def place_quote_pair(
+        self, bid_order: Order, ask_order: Order, *,
+        exchange: ExchangeClient,
+    ) -> tuple[OrderResult, OrderResult]:
+        """Place a two-sided maker quote (bid then ask) through the gateway.
+
+        The market maker's owned placement entry point. The MM has already built
+        fully-priced ``post_only`` orders (source stamped) and needs BOTH raw
+        ``OrderResult``s back to run its own inventory / pending-order /
+        partial-leg-cancel bookkeeping, so this places SEQUENTIALLY (matching the
+        MM's order, NOT both-or-nothing — the MM owns one-legged cleanup) and
+        returns the pair. Recording stays with the order monitor (orders carry
+        ``source="market_maker"``); the gateway owns the placement so no strategy
+        calls ``exchange.place_order`` directly.
+        """
+        bid_result = await exchange.place_order(bid_order)
+        ask_result = await exchange.place_order(ask_order)
+        return bid_result, ask_result
 
     async def _record_result(
         self, order: Order, result: OrderResult, *,

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -90,10 +90,14 @@ class MarketMaker:
         settings,
         exchange: PolymarketClient,
         db,
+        gateway=None,
     ):
         self._settings = settings
         self._exchange = exchange
         self._db = db
+        # Placement runs through the ExecutionGateway (the single choke point);
+        # lazily built if not injected so existing callers/tests keep working.
+        self._gateway = gateway
 
         # MM configuration from settings
         mm_cfg = settings.market_maker
@@ -462,9 +466,16 @@ class MarketMaker:
             source="market_maker",
         )
 
-        # Place both legs
-        bid_result = await self._exchange.place_order(bid_order)
-        ask_result = await self._exchange.place_order(ask_order)
+        # Place both legs through the gateway's two-sided adapter (bid then ask,
+        # not both-or-nothing — the MM owns one-legged cleanup below). The gateway
+        # is the single placement choke point; no direct exchange.place_order here.
+        if self._gateway is None:
+            from auramaur.broker.execution_gateway import ExecutionGateway
+            self._gateway = ExecutionGateway(
+                router=None, exchange=self._exchange, exchange_name="polymarket",
+                settings=self._settings, db=self._db, pnl_tracker=None)
+        bid_result, ask_result = await self._gateway.place_quote_pair(
+            bid_order, ask_order, exchange=self._exchange)
 
         # Track order IDs
         quote.bid_order_id = bid_result.order_id

--- a/auramaur/strategy/protocols.py
+++ b/auramaur/strategy/protocols.py
@@ -20,27 +20,21 @@ class ExecutionMode(str, Enum):
     distinguishable from an accidental one (the conformance guard asserts it).
     """
 
-    # Route through the single ExecutionGateway money path:
-    # Gateway-submitted — the pillar never calls exchange.place_order itself;
-    # the gateway places AND records (this is what the conformance guard asserts):
+    # Every mode below routes ALL placement through the ExecutionGateway — no
+    # pillar/flow calls exchange.place_order directly — EXCEPT DIRECT_EQUITY.
     GATEWAY_SINGLE = "gateway_single"      # gateway.submit() — directional pillars
     GATEWAY_PAIRED = "gateway_paired"      # gateway.submit_paired() — both-or-nothing arb
-    # Places directly for timing/atomicity reasons, but still RECORDS through the
-    # gateway (record_external_fill) — so it does call place_order and is NOT a
-    # gateway-pure mode:
-    GATEWAY_EXTERNAL = "gateway_external"  # concurrently-placed arb legs, then record_external_fill()
-    # Fully direct, justified bypasses (own accounting):
-    DIRECT_QUOTING = "direct_quoting"      # market maker — resting two-sided quotes (no Signal/risk)
+    GATEWAY_EXTERNAL = "gateway_external"  # gateway.place_legs() — concurrent arb legs, then records
+    DIRECT_QUOTING = "direct_quoting"      # market maker — gateway.place_quote_pair() (resting two-sided)
+    # The one genuine off-gateway exception:
     DIRECT_EQUITY = "direct_equity"        # oddlot tender — IBKR equities, outside the PM gateway
 
 
-# Gateway-PURE modes: the pillar must not call exchange.place_order at all (the
-# gateway submits on its behalf). GATEWAY_EXTERNAL is deliberately excluded — it
-# places directly then records — matching the conformance guard's skip set.
-GATEWAY_PURE_MODES = frozenset({
-    ExecutionMode.GATEWAY_SINGLE,
-    ExecutionMode.GATEWAY_PAIRED,
-})
+# Modes whose module must NOT contain a raw exchange.place_order — placement goes
+# through a gateway method (submit / submit_paired / place_legs / place_quote_pair).
+# Only DIRECT_EQUITY (IBKR, genuinely off the prediction-market gateway) is exempt.
+NO_DIRECT_PLACE_MODES = frozenset(
+    m for m in ExecutionMode if m is not ExecutionMode.DIRECT_EQUITY)
 
 
 @runtime_checkable

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -175,11 +175,15 @@ async def test_internal_arb_uses_engine_exchange_attribute():
         order_id=f"ord-{o.token_id}", market_id=o.market_id, status="paper",
         filled_size=o.size, filled_price=o.price, is_paper=True))
 
+    _placed = OrderResult(order_id="ord", market_id="m1", status="paper",
+                          filled_size=20.0, filled_price=0.40, is_paper=True)
     mixin = ArbExecutionMixin.__new__(ArbExecutionMixin)
     mixin.settings = MagicMock()
     mixin.settings.is_live = False
     mixin._exit_gateway = MagicMock()
-    mixin._exit_gateway.record_external_fill = AsyncMock()
+    # internal arb now routes placement through the gateway's place_legs.
+    mixin._exit_gateway.place_legs = AsyncMock(
+        return_value=[(_placed, MagicMock()), (_placed, MagicMock())])
     db = MagicMock()
     db.fetchone = AsyncMock(return_value=None)  # pairing guard: not already held
     alerts = MagicMock()
@@ -203,6 +207,10 @@ async def test_internal_arb_uses_engine_exchange_attribute():
 
     await mixin._execute_internal_arb(opp, risk, engines)
 
-    # Both legs placed through engine.exchange — proves the attribute resolves.
-    assert exchange.place_order.await_count == 2
-    assert mixin._exit_gateway.record_external_fill.await_count == 2
+    # Reached place_legs with both legs bound to engine.exchange — proves the
+    # `.exchange` attribute resolves (old `._exchange` would AttributeError first)
+    # and that internal arb places through the gateway choke point.
+    mixin._exit_gateway.place_legs.assert_awaited_once()
+    legs = mixin._exit_gateway.place_legs.await_args.args[0]
+    assert len(legs) == 2
+    assert all(client is exchange for _order, client, _exn in legs)

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -344,3 +344,78 @@ def test_submit_paired_build_failure_places_neither():
         ex_b.place_order.assert_not_awaited()  # neither leg placed
 
     asyncio.run(run())
+
+
+def test_place_legs_concurrent_places_all_and_records_each():
+    """place_legs gathers concurrent legs and records each (fills+trades),
+    returning the raw OrderResults for the caller's rollback logic."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        legs = []
+        clients = []
+        for i in range(3):
+            order = Order(market_id=f"m{i}", exchange="polymarket", token_id="tok",
+                          side=OrderSide.BUY, token=TokenType.YES, size=10.0, price=0.30)
+            result = OrderResult(order_id=f"o{i}", market_id=f"m{i}", status="paper",
+                                 filled_size=10.0, filled_price=0.30, is_paper=True)
+            client = MagicMock(); client.place_order = AsyncMock(return_value=result)
+            clients.append(client)
+            legs.append((order, client, "polymarket"))
+        gw = _gateway(db, MagicMock())
+        out = await gw.place_legs(legs, strategy_source="negrisk_arb", concurrent=True)
+        # raw results returned in order
+        assert [r.order_id for r, _ in out] == ["o0", "o1", "o2"]
+        for c in clients:
+            c.place_order.assert_awaited_once()
+        # each leg recorded with the strategy attribution
+        rows = await db.fetchall("SELECT strategy_source FROM trades")
+        assert len(rows) == 3 and all(dict(r)["strategy_source"] == "negrisk_arb" for r in rows)
+        assert len(await db.fetchall("SELECT 1 FROM fills")) == 3
+    asyncio.run(run())
+
+
+def test_place_legs_sequential_preserves_order():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        seen = []
+        legs = []
+        for i in range(2):
+            order = Order(market_id="m", exchange="polymarket", token_id=f"t{i}",
+                          side=OrderSide.BUY, token=TokenType.YES, size=5.0, price=0.4)
+            async def _place(o, _i=i):
+                seen.append(_i)
+                return OrderResult(order_id=f"o{_i}", market_id="m", status="paper",
+                                   filled_size=5.0, filled_price=0.4, is_paper=True)
+            client = MagicMock(); client.place_order = _place
+            legs.append((order, client, "polymarket"))
+        gw = _gateway(db, MagicMock())
+        await gw.place_legs(legs, strategy_source="internal_arb", concurrent=False)
+        assert seen == [0, 1]  # sequential, in order
+    asyncio.run(run())
+
+
+def test_place_quote_pair_places_bid_then_ask_and_returns_both():
+    """The MM's owned placement entry point: bid then ask, both raw results back,
+    sequential (not both-or-nothing)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        order_seen = []
+        bid = Order(market_id="mm", exchange="polymarket", token_id="yes",
+                    side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.40,
+                    post_only=True, source="market_maker")
+        ask = Order(market_id="mm", exchange="polymarket", token_id="no",
+                    side=OrderSide.BUY, token=TokenType.NO, size=20.0, price=0.55,
+                    post_only=True, source="market_maker")
+        async def _place(o):
+            order_seen.append(o.token_id)
+            return OrderResult(order_id=f"oid-{o.token_id}", market_id="mm",
+                               status="pending", is_paper=False)
+        ex = MagicMock(); ex.place_order = _place
+        gw = _gateway(db, ex)
+        bid_res, ask_res = await gw.place_quote_pair(bid, ask, exchange=ex)
+        assert order_seen == ["yes", "no"]  # bid then ask
+        assert bid_res.order_id == "oid-yes" and ask_res.order_id == "oid-no"
+    asyncio.run(run())

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -293,11 +293,11 @@ async def test_partial_quote_cancels_surviving_leg():
 
 @pytest.mark.asyncio
 async def test_mm_orders_self_stamp_market_maker_source():
-    """Invariant for the documented direct-placement exception: the market maker
-    places orders straight through the exchange (bypassing ExecutionGateway), so
-    it MUST self-stamp source='market_maker' and post_only — that source is what
-    lets the order monitor write a correctly-attributed trades-mirror for the
-    fill (preserving fill<->trades parity), and post_only keeps it maker-only."""
+    """The MM routes placement through the gateway's place_quote_pair, but it
+    still builds the orders, so they MUST self-stamp source='market_maker' and
+    post_only — that source is what lets the order monitor write a
+    correctly-attributed trades-mirror for the fill (preserving fill<->trades
+    parity), and post_only keeps it maker-only."""
     from types import SimpleNamespace
 
     from auramaur.exchange.models import TokenType

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -22,7 +22,7 @@ from auramaur.strategy.entailment_arb import EntailmentArbPillar
 from auramaur.strategy.market_maker import MarketMaker
 from auramaur.strategy.momentum_coupling import MomentumCouplingPillar
 from auramaur.strategy.oddlot_tender import OddLotTenderPillar
-from auramaur.strategy.protocols import ExecutionMode, GATEWAY_PURE_MODES
+from auramaur.strategy.protocols import ExecutionMode, NO_DIRECT_PLACE_MODES
 from auramaur.strategy.resolution_lens import ResolutionLensPillar
 from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
 from auramaur.strategy.weather_temp import WeatherTempPillar
@@ -43,7 +43,7 @@ PILLARS = [
     (OddLotTenderPillar, "auramaur/strategy/oddlot_tender.py"),
 ]
 
-# GATEWAY_PURE_MODES (single source of truth in protocols.py): the pillar must
+# NO_DIRECT_PLACE_MODES (single source of truth in protocols.py): the pillar must
 # not call exchange.place_order at all. The other modes legitimately place
 # directly (MM quotes; concurrent arb legs that then record_external_fill;
 # equities) and are skipped with their declared reason below.
@@ -63,7 +63,7 @@ def test_gateway_pillars_do_not_place_orders_directly(cls, modfile):
     """A GATEWAY_SINGLE/PAIRED pillar must route through the ExecutionGateway —
     it must not call exchange.place_order in its own module. The direct-placement
     modes are skipped with their declared reason (this is the whitelist)."""
-    if cls.execution_mode not in GATEWAY_PURE_MODES:
+    if cls.execution_mode not in NO_DIRECT_PLACE_MODES:
         pytest.skip(
             f"{cls.name} is {cls.execution_mode.value}: direct placement is its "
             f"declared, intentional path (not a gateway bypass)")

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -71,3 +71,13 @@ def test_gateway_pillars_do_not_place_orders_directly(cls, modfile):
     assert ".place_order(" not in src, (
         f"{cls.name} ({cls.execution_mode.value}) must submit through the "
         f"ExecutionGateway, not call place_order directly")
+
+
+def test_arb_mixin_does_not_place_orders_directly():
+    """The arb execution mixin (bot_arb.py) places legs via the gateway's
+    place_legs adapter, never exchange.place_order directly — extending the
+    'only the gateway places' perimeter beyond the pillar modules."""
+    src = (_ROOT / "auramaur/bot_arb.py").read_text()
+    assert ".place_order(" not in src, (
+        "bot_arb.py must place through ExecutionGateway.place_legs, not call "
+        "exchange.place_order directly")


### PR DESCRIPTION
Review item #4. Moves the two flows that still called `exchange.place_order` directly (arb concurrent legs, MM two-sided quotes) behind explicit, named ExecutionGateway adapter methods — so the gateway is the literal single placement point, while those flows keep their timing/atomicity and own bookkeeping.

## What changed
- **New gateway methods:** `place_legs(legs, *, strategy_source, concurrent, show)` (owns the `asyncio.gather`/sequential placement + per-leg record for all 5 arb sites) and `place_quote_pair(bid, ask, *, exchange)` (owns the MM's bid-then-ask placement). Both return the **raw `OrderResult`s** so callers keep half-fill rollback / inventory / cancel logic.
- **Arb:** all 5 sites in `bot_arb.py` (conditional, negrisk, internal, cross-exchange, rebalance) migrated to `place_legs` — same concurrency, same recording. **Zero `place_order` left in `bot_arb.py`**, asserted by a new guard test.
- **MM:** `_place_two_sided` migrated to `place_quote_pair` (lazy gateway sharing the MM's db). No accounting change — recording still via the order monitor (`source="market_maker"`). The MM-trades-mirror co-write (the one real behavior change) was the plan's optional slice 6 and is **deliberately deferred**.
- **Perimeter tightened:** `GATEWAY_PURE_MODES` → `NO_DIRECT_PLACE_MODES` (every mode except `DIRECT_EQUITY`). The conformance guard now also enforces no-direct-`place_order` on `market_maker.py` and `arbitrage_scanner.py`. Only `DIRECT_EQUITY` (IBKR equities) stays exempt.

## Safety
No change to arb concurrency (single `gather` preserved), MM partial-leg cancel (stays in the pillar), or the leg-risk window. Pure parity. Full suite **893 passed, 1 skipped**; ruff clean.

Assisted-by: Claude (Anthropic)