### PR TITLE
test(exits): name the IBKR-equity exit as the sole exit-path placement bypass

### DIFF
--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -366,6 +366,12 @@ class ExitExecutionMixin:
             dry_run=not self.settings.is_live,
             source="exit",
         )
+        # DIRECT_EQUITY exception (the one named direct placement in the exit
+        # path): IBKR options are off the prediction-market ExecutionGateway and
+        # carry their own fill/position accounting, so this exit places directly
+        # rather than via submit_exit (poly/kalshi exits go through the gateway).
+        # test_exit_path_only_ibkr_places_directly locks this as the SOLE exit
+        # bypass — a direct place_order on any other exit method fails the guard.
         result = await exchange.place_order(order)
         from auramaur.monitoring.display import show_order
         show_order(

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -81,3 +81,24 @@ def test_arb_mixin_does_not_place_orders_directly():
     assert ".place_order(" not in src, (
         "bot_arb.py must place through ExecutionGateway.place_legs, not call "
         "exchange.place_order directly")
+
+
+def test_exit_path_only_ibkr_places_directly():
+    """Exit-path perimeter: the poly/kalshi exits route through the gateway's
+    submit_exit; the ONLY direct exchange.place_order in bot_exits.py is the IBKR
+    equity/options exit (the DIRECT_EQUITY exception — IBKR is off the
+    prediction-market gateway, with its own accounting). This names that
+    exception so a new direct placement on the gateway-venue exits fails."""
+    import ast
+    src = (_ROOT / "auramaur/bot_exits.py").read_text()
+    tree = ast.parse(src)
+    ibkr = next(n for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and n.name == "_execute_ibkr_exit")
+    bad = [node.lineno for node in ast.walk(tree)
+           if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+           and node.func.attr == "place_order"
+           and not (ibkr.lineno <= node.lineno <= ibkr.end_lineno)]
+    assert not bad, (
+        f"direct exchange.place_order in bot_exits.py outside the named IBKR "
+        f"equity exit (lines {bad}) — poly/kalshi exits must use gateway.submit_exit")


### PR DESCRIPTION
Review follow-up — closes the last perimeter gap. `bot_exits.py:_execute_ibkr_exit` places directly via `exchange.place_order`, while the poly/kalshi exits go through `gateway.submit_exit`. That's a legitimate **DIRECT_EQUITY** exception (IBKR options are off the prediction-market gateway, with their own fill/position accounting) — but it was unnamed and unguarded.

Per the reviewer's option (b), I **name it** rather than route it (routing an off-gateway venue through `submit_exit` would risk mis/double-recording):
- A code comment at the call site marking it the DIRECT_EQUITY exit exception.
- `test_exit_path_only_ibkr_places_directly`: an AST guard asserting the **only** direct `place_order` in `bot_exits.py` is inside `_execute_ibkr_exit`. A direct placement on any other exit method (poly/kalshi) now fails the guard.

This extends the "only the gateway places" perimeter to the exit path. Full suite **903 passed**; ruff clean.

Assisted-by: Claude (Anthropic)