### PR TITLE
fix(resolution): venue settlement sweep must reach holdings whose portfolio row is gone

### DIFF
--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -205,21 +205,40 @@ class ResolutionTracker:
         if not venue_positions:
             return []
 
+        # Match on actual HOLDINGS (portfolio ∪ cost_basis), keyed by token_id.
+        # The portfolio row is dropped the moment a leg sells/settles, but
+        # cost_basis is the holdings source of truth and lingers until its size
+        # zeroes — which is exactly the set the venue still reports as
+        # redeemable. A portfolio-only match silently skipped every position
+        # whose portfolio row was already gone (by_token_id.get → None →
+        # continue), so the sweep could never settle or drain them and their
+        # cost_basis legs resurrected forever. Union in cost_basis (the same
+        # portfolio∪cost_basis holdings union check_resolutions() already uses)
+        # so the sweep reaches them. Portfolio rows are listed first and win the
+        # de-dup (they carry the live current_price/category context).
         rows = await self._db.fetchall(
-            """SELECT p.market_id, p.token, p.token_id, p.size, p.avg_price
-               FROM portfolio p WHERE p.is_paper = 0 AND p.size > 0""")
-        by_token_id = {r["token_id"]: dict(r) for r in (rows or [])
-                       if r["token_id"]}
+            """SELECT market_id, token, token_id, size, avg_price FROM (
+                   SELECT market_id, token, token_id, size, avg_price
+                   FROM portfolio WHERE is_paper = 0 AND size > 0
+                   UNION ALL
+                   SELECT market_id, token, token_id, size, avg_cost AS avg_price
+                   FROM cost_basis WHERE is_paper = 0 AND size > 0
+               )""")
+        by_token_id: dict[str, dict] = {}
+        for r in (rows or []):
+            tid = r["token_id"]
+            if tid and tid not in by_token_id:
+                by_token_id[tid] = dict(r)
 
         settlements: list[dict] = []
         for vp in venue_positions:
             row = by_token_id.get(vp.asset_id)
             if row is None:
+                # No OPEN holding for this token — portfolio row dropped AND
+                # cost_basis already zeroed. Nothing left to settle or drain,
+                # even though the wallet still holds the now-worthless token
+                # (loser tokens are never redeemed). Correctly skipped.
                 continue
-            # Already settled in a prior pass (the wallet still holds the
-            # tokens until redemption, so the syncer can resurrect the row).
-            # Only the ledger insert is idempotent — re-running settlement
-            # would re-add the P&L to daily_stats and cost_basis.
             held_token = row["token"] or "YES"
             # Match the canonical (side-keyed) source_ref used by _settle_position
             # so a side already booked under a different label ("YES" vs the
@@ -237,12 +256,18 @@ class ResolutionTracker:
             venue_pnl = (exit_price - row["avg_price"]) * row["size"]
             outcome_yes = vp.is_winner if canon == "YES" else (not vp.is_winner)
 
-            # An already-settled side whose booked value MATCHES the venue is
-            # done — skip (the syncer resurrects the row until redemption).
+            # The leg may already be booked in the ledger (settlement is
+            # idempotent on source_ref), but a non-zero cost_basis holding is
+            # precisely why the venue still reports it — so we must STILL run
+            # _settle_position to DRAIN that residual size, not skip. Skipping a
+            # value-matching prior here was the resurrection bug: the cost_basis
+            # leg never zeroed, so the position reappeared every cycle. Only the
+            # corrective re-book is conditional on the booked value disagreeing.
             prior = await self._db.fetchone(
                 "SELECT pnl FROM pnl_ledger WHERE source_ref = ?", (ref,))
-            if prior is not None and abs(prior["pnl"] - venue_pnl) <= 0.01:
-                continue
+            needs_correction = (
+                prior is not None and abs(prior["pnl"] - venue_pnl) > 0.01
+            )
 
             settlements.append({
                 "market_id": row["market_id"],
@@ -253,12 +278,12 @@ class ResolutionTracker:
                 "pnl": venue_pnl,
                 "status": vp.status,
                 "outcome_yes": outcome_yes,
-                "correction": prior is not None,
+                "correction": needs_correction,
             })
             if dry_run:
                 continue
 
-            if prior is not None:
+            if needs_correction:
                 # A STALE prior settlement disagrees with the authoritative venue
                 # outcome (e.g. it booked the winning side at $0). The venue wins:
                 # correct the booked value in place — one row per side with the

--- a/tests/test_resolution_tracker.py
+++ b/tests/test_resolution_tracker.py
@@ -827,19 +827,20 @@ async def test_venue_sweep_ignores_unmatched_and_no_proxy(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_venue_sweep_skips_already_settled_token(monkeypatch):
-    """A settled-but-unredeemed leg resurrected by the syncer must NOT
-    settle twice — only the ledger insert is idempotent; daily_stats and
-    cost_basis would double-count."""
+async def test_venue_sweep_drains_already_settled_token_without_double_book(monkeypatch):
+    """A settled-but-unredeemed leg whose cost_basis size never zeroed must be
+    DRAINED (size→0, market inactive) so it stops resurrecting every cycle — but
+    WITHOUT double-booking: the ledger insert and daily_stats stay untouched when
+    a matching prior already exists. (Previously the sweep skipped it entirely,
+    which left the cost_basis leg lingering forever — the resurrection bug.)"""
     row = {"market_id": "m1", "token": "NO", "token_id": "tok-no-1",
            "size": 20.0, "avg_price": 0.62, "side": "BUY", "is_paper": 0}
     db = _make_sweep_db([row])
 
     async def _fetchone(sql, params=None):
         if "pnl_ledger" in sql:
-            assert params == ("settle:m1:NO:0",)
-            # NO @ 0.62 won (is_winner) => (1.0-0.62)*20 = 7.6; a matching prior
-            # is consistent, so the leg is skipped (not re-settled/corrected).
+            # NO @ 0.62 won (is_winner) => (1.0-0.62)*20 = 7.6; the prior matches,
+            # so no correction and no re-book — only the drain proceeds.
             return {"pnl": (1.0 - 0.62) * 20.0}
         return row
     db.fetchone = AsyncMock(side_effect=_fetchone)
@@ -852,6 +853,15 @@ async def test_venue_sweep_skips_already_settled_token(monkeypatch):
     monkeypatch.setattr("auramaur.broker.redeemer.fetch_redeemable_positions",
                         _fake_fetch)
 
-    assert await tracker.settle_via_venue("0xproxy") == []
+    settled = await tracker.settle_via_venue("0xproxy")
+
+    # The leg is now processed (drained), not skipped — and not a correction.
+    assert len(settled) == 1
+    assert settled[0]["correction"] is False
     executed_sql = " ".join(str(c.args[0]) for c in db.execute.call_args_list)
-    assert "DELETE FROM portfolio" not in executed_sql
+    # Drain happened: cost_basis zeroed + the resurrected portfolio row removed.
+    assert "UPDATE cost_basis" in executed_sql and "size = 0" in executed_sql
+    assert "DELETE FROM portfolio" in executed_sql
+    # No double-book: the matching prior means no re-insert and no daily_stats.
+    assert "INSERT OR IGNORE INTO pnl_ledger" not in executed_sql
+    assert "daily_stats" not in executed_sql

--- a/tests/test_resolution_venue_sweep.py
+++ b/tests/test_resolution_venue_sweep.py
@@ -1,0 +1,122 @@
+"""Regression: settle_via_venue must reach holdings whose portfolio row is gone.
+
+The venue sweep used to match resolved positions only against the `portfolio`
+table. A live position drops its portfolio row the moment a leg sells/settles,
+but the wallet keeps holding the (now worthless) loser token and cost_basis
+keeps a non-zero size — so the venue kept reporting it, the sweep kept skipping
+it (portfolio miss), and the cost_basis leg resurrected every cycle, never
+booking and never draining. The fix unions cost_basis into the match set and
+stops skipping already-booked legs before the drain.
+"""
+
+import pytest
+
+from auramaur.broker import redeemer as redeemer_mod
+from auramaur.broker.redeemer import RedeemablePosition
+from auramaur.db.database import Database
+from auramaur.strategy.resolution_tracker import ResolutionTracker
+
+
+def _vp(asset_id: str, *, is_winner: bool, token_label: str = "No",
+        size: float = 10.0, avg: float = 0.30) -> RedeemablePosition:
+    return RedeemablePosition(
+        condition_id="0xcond", asset_id=asset_id, title="Will X?",
+        outcome=token_label, size=size, avg_price=avg,
+        cur_price=1.0 if is_winner else 0.0,
+        payout=size if is_winner else 0.0, is_winner=is_winner,
+        redeemable_now=True, status="redeemable", neg_risk=False,
+        mergeable=False, end_date="2026-05-01T00:00:00+00:00", slug="x",
+    )
+
+
+async def _tracker(tmp_path):
+    db = Database(str(tmp_path / "auramaur.db"))
+    await db.connect()
+    await db.execute(
+        "INSERT INTO markets (id, question, active, condition_id, last_updated) "
+        "VALUES ('mkt1','Will X?',1,'0xcond','now')")
+    await db.commit()
+    return db, ResolutionTracker(db, None, {}, proxy_address="0xproxy")
+
+
+async def _cost_basis(db, *, token, token_id, size, avg, market="mkt1"):
+    await db.execute(
+        "INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost, "
+        "total_cost, is_paper) VALUES (?,?,?,?,?,?,0)",
+        (market, token, token_id, size, avg, avg * size))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_settles_holding_with_no_portfolio_row(tmp_path, monkeypatch):
+    """A loser held only in cost_basis (no portfolio row) settles + drains."""
+    db, tracker = await _tracker(tmp_path)
+    try:
+        await _cost_basis(db, token="No", token_id="TOK_NO", size=10.0, avg=0.30)
+
+        async def fake_fetch(proxy, *a, **k):
+            return [_vp("TOK_NO", is_winner=False, size=10.0, avg=0.30)]
+        monkeypatch.setattr(redeemer_mod, "fetch_redeemable_positions", fake_fetch)
+
+        settled = await tracker.settle_via_venue("0xproxy")
+
+        assert len(settled) == 1
+        # Loss booked: (0 - 0.30) * 10 = -3.00
+        led = await db.fetchone(
+            "SELECT pnl FROM pnl_ledger WHERE market_id='mkt1' AND is_paper=0")
+        assert led is not None and led["pnl"] == pytest.approx(-3.0)
+        # cost_basis drained, market marked inactive.
+        cb = await db.fetchone("SELECT size FROM cost_basis WHERE market_id='mkt1'")
+        assert cb["size"] == pytest.approx(0.0)
+        active = await db.fetchone("SELECT active FROM markets WHERE id='mkt1'")
+        assert active["active"] == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_already_booked_leg_still_drains_cost_basis(tmp_path, monkeypatch):
+    """An already-booked settlement with a lingering cost_basis size must drain
+    (the resurrection bug) without double-booking the P&L."""
+    db, tracker = await _tracker(tmp_path)
+    try:
+        await _cost_basis(db, token="No", token_id="TOK_NO", size=10.0, avg=0.30)
+        # Pre-book the settlement at the correct venue value (-3.00).
+        await db.execute(
+            "INSERT INTO pnl_ledger (market_id, kind, token, qty, pnl, is_paper, "
+            "source_ref) VALUES ('mkt1','settlement','NO',10,-3.0,0,'settle:mkt1:NO:0')")
+        await db.commit()
+
+        async def fake_fetch(proxy, *a, **k):
+            return [_vp("TOK_NO", is_winner=False, size=10.0, avg=0.30)]
+        monkeypatch.setattr(redeemer_mod, "fetch_redeemable_positions", fake_fetch)
+
+        await tracker.settle_via_venue("0xproxy")
+
+        # Still exactly one ledger row, value unchanged (no double-book)...
+        rows = await db.fetchall(
+            "SELECT pnl FROM pnl_ledger WHERE source_ref='settle:mkt1:NO:0'")
+        assert len(rows) == 1 and rows[0]["pnl"] == pytest.approx(-3.0)
+        # ...but the lingering cost_basis leg is now drained.
+        cb = await db.fetchone("SELECT size FROM cost_basis WHERE market_id='mkt1'")
+        assert cb["size"] == pytest.approx(0.0)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fully_drained_position_is_not_reprocessed(tmp_path, monkeypatch):
+    """Once cost_basis is zero and no portfolio row exists, the venue still lists
+    the worthless token but the sweep must skip it (nothing to drain)."""
+    db, tracker = await _tracker(tmp_path)
+    try:
+        await _cost_basis(db, token="No", token_id="TOK_NO", size=0.0, avg=0.30)
+
+        async def fake_fetch(proxy, *a, **k):
+            return [_vp("TOK_NO", is_winner=False)]
+        monkeypatch.setattr(redeemer_mod, "fetch_redeemable_positions", fake_fetch)
+
+        settled = await tracker.settle_via_venue("0xproxy")
+        assert settled == []
+    finally:
+        await db.close()


### PR DESCRIPTION
## Problem
`settle_via_venue` (the venue-truth settlement sweep) matched venue-resolved positions **only against the `portfolio` table**, keyed by `token_id`. A live position drops its `portfolio` row the moment a leg sells/settles, but the wallet keeps holding the now-worthless loser token and `cost_basis` keeps a non-zero `size`. So the venue kept reporting these as redeemable, the sweep kept missing them (`by_token_id.get → None → continue`), and their `cost_basis` legs **resurrected every cycle** — never draining, the position lingering on the books indefinitely.

## Root cause (verified against live state)
The venue's redeemable set matched **0** portfolio rows but **all** of them matched on `cost_basis.token_id`. Most already had a `pnl_ledger` row (loss booked) — the residual defect was purely the lingering `cost_basis` legs that never zeroed.

## Fix (both in `settle_via_venue`)
1. **Match against actual holdings** — `portfolio UNION cost_basis` (size>0), keyed by `token_id` (the same holdings union `check_resolutions()` already uses). Reaches positions whose portfolio row is gone.
2. **Stop skipping a value-matching prior before the drain.** A non-zero `cost_basis` holding is *why* the venue still reports the leg, so settlement must run to zero it. `_settle_position` is already idempotent (no re-insert, no `daily_stats` double-count when already booked) and **always** zeroes `cost_basis`, so the drain is safe; only the corrective re-book stays gated on a value mismatch.

Self-terminating: once `cost_basis` hits 0 and no portfolio row remains, the holdings union no longer lists it, so the sweep skips it thereafter.

## Tests
New venue-sweep regression suite + updated the existing skip-test to assert the corrected drain contract. Full suite green.

Assisted-by: Claude (Anthropic)