### PR TITLE
fix(order_monitor): don't write phantom trade rows for cancelled/expired orders

### DIFF
--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -141,7 +141,25 @@ class OrderMonitorMixin:
                                                WHERE order_id = ?""",
                                             (result.status, size, price, order_id),
                                         )
-                                        if getattr(cur, "rowcount", 0) == 0:
+                                        # Only INSERT a fallback row for an actual
+                                        # EXECUTION. The UPDATE above already marks a
+                                        # gateway-placed order's pre-written row with
+                                        # its terminal status (cancelled/expired/...).
+                                        # When rowcount==0 the order had no pre-written
+                                        # row (placed outside the gateway) — but a
+                                        # cancelled/expired/rejected order never traded,
+                                        # so inserting a row would fabricate a phantom
+                                        # "BUY" at the full quoted size that never
+                                        # filled. The market maker cancels/expires the
+                                        # vast majority of its post-only quotes, so this
+                                        # was flooding the trades table (~1.6k/wk) and
+                                        # corrupting strategy attribution. A non-fill
+                                        # terminal status with no pre-existing row has
+                                        # nothing to record.
+                                        if (
+                                            getattr(cur, "rowcount", 0) == 0
+                                            and result.status == "filled"
+                                        ):
                                             await db.execute(
                                                 """INSERT INTO trades
                                                    (market_id, side, size, price, is_paper,

--- a/tests/test_order_monitor.py
+++ b/tests/test_order_monitor.py
@@ -80,6 +80,80 @@ async def test_order_monitor_records_live_fill_once():
 
 
 @pytest.mark.asyncio
+async def test_order_monitor_cancelled_order_writes_no_phantom_trade():
+    """A cancelled live order with no pre-written trades row (rowcount==0, i.e.
+    placed outside the gateway) must NOT insert a fallback trades row — it never
+    executed. Regression: the market maker cancels/expires the bulk of its
+    post-only quotes, and the unconditional fallback INSERT was fabricating a
+    phantom 'BUY' at the full quoted size for each one (~1.6k/week), corrupting
+    strategy attribution. Only an actual fill may insert a fallback row."""
+    settings = MagicMock()
+    settings.execution.limit_order_ttl_seconds = 60
+
+    bot = AuramaurBot(settings=settings)
+    bot._running = True
+
+    order = Order(
+        market_id="m1",
+        exchange="polymarket",
+        token_id="tok_yes",
+        token=TokenType.YES,
+        side=OrderSide.BUY,
+        size=10,
+        price=0.50,
+        dry_run=False,
+    )
+    exchange = SimpleNamespace(
+        _live_pending={"live-1": order},
+        get_order_status=AsyncMock(
+            return_value=OrderResult(
+                order_id="live-1",
+                market_id="m1",
+                status="cancelled",   # terminal, but NOT a fill
+                filled_size=0,
+                filled_price=0.0,
+                is_paper=False,
+            )
+        ),
+    )
+    paper = SimpleNamespace(
+        pending_orders=[],
+        check_fills=AsyncMock(return_value=[]),
+        cancel_expired=AsyncMock(return_value=0),
+    )
+    pnl_tracker = AsyncMock()
+    db_cursor = MagicMock()
+    db_cursor.rowcount = 0   # no pre-existing gateway row to UPDATE
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=db_cursor)
+    db.commit = AsyncMock()
+
+    bot._components = Components({
+        "paper": paper,
+        "exchange": exchange,
+        "discovery": AsyncMock(),
+        "pnl_tracker": pnl_tracker,
+        "db": db,
+    })
+
+    async def stop_after_loop(_seconds):
+        bot._running = False
+
+    with patch("asyncio.sleep", new=AsyncMock(side_effect=stop_after_loop)):
+        await bot._task_order_monitor()
+
+    # No fill recorded (it didn't execute) ...
+    pnl_tracker.record_fill.assert_not_awaited()
+    # ... and crucially, NO INSERT INTO trades for the cancelled order.
+    inserts = [
+        c for c in db.execute.await_args_list
+        if "INSERT INTO trades" in str(c.args[0])
+    ]
+    assert inserts == []
+    assert "live-1" not in exchange._live_pending  # still cleaned up
+
+
+@pytest.mark.asyncio
 async def test_order_monitor_ttl_cancels_stale_live_order():
     """A live limit order still resting past the TTL is cancelled to free balance.
 


### PR DESCRIPTION
## Problem
While investigating an apparent live-Poly decline, the live book looked like it was churning **thousands of buys/week** ($8.3k recorded vs only ~$339 of real executions). Root cause: the order monitor's trades UPDATE/INSERT block ran for **every terminal order status** (filled/cancelled/expired/rejected), not just fills.

- The UPDATE correctly stamps a gateway-placed order's pre-written row with its terminal status.
- But when `rowcount==0` (order placed outside the gateway → no pre-existing row), the **fallback INSERT fired unconditionally** — fabricating a new `BUY` trade row at the full quoted size for an order that **never executed**.

The market maker cancels/expires the bulk of its post-only quotes, so this produced **~1.6k phantom cancelled BUY rows/week** (3,030 historical). `cost_basis` / `pnl_ledger` / `portfolio` were never affected — they key off fills, not these rows — so it was **cosmetic but badly misleading** (corrupted strategy attribution, made the book look like massive churn).

## Fix
Gate the fallback INSERT on `result.status == "filled"`. A non-fill terminal status with no pre-existing row has no execution to record. The UPDATE stays unconditional so gateway rows still get their cancelled/expired status.

## Tests
New regression: a cancelled order with `rowcount==0` inserts no trades row and records no fill; existing fill path unchanged. Full suite green (920 passed).

> Note: the underlying live P&L was never actually "tanking" — realized live-Poly was **positive** over the week; the UI decline was unrealized mark-to-market on a fully-deployed favorite-longshot book. This PR fixes the logging bug that obscured that read.

Assisted-by: Claude (Anthropic)