### PR TITLE
feat(gateway): aggregate per-(market, token) stake cap at order placement

### DIFF
--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -110,10 +110,64 @@ class ExecutionGateway:
         )
         if order is None:
             return ExecutionResult(status="skipped", reason="not submitted")
+        capped = await self._exceeds_market_cap(order, is_live=is_live)
+        if capped is not None:
+            return ExecutionResult(status="skipped", reason=capped)
         return await self._place_and_record(
             order, strategy_source=intent.signal.strategy_source,
             signal_id=getattr(intent.signal, "id", None),
             exchange=self.exchange, exchange_name=self.exchange_name)
+
+    async def _exceeds_market_cap(self, order: Order, *, is_live: bool) -> str | None:
+        """Aggregate per-(market, token) stake cap. Returns a skip-reason string
+        when this BUY would push TOTAL exposure to a market SIDE past the
+        documented ceiling, else None.
+
+        The risk manager's max_stake check only sees a single order, so the bot
+        could STACK sub-cap entries into an over-cap position (legacy directional
+        favorites reached ~$90 across stacked orders, each individually under the
+        limit). This guard runs at the layer where the YES/NO token is finally
+        known, so it scopes by (market, token): a side's existing holdings plus
+        this order can't exceed the cap. Scoping by token, not market, is
+        deliberate — internal arb legitimately holds YES *and* NO of one market,
+        so a market-wide sum would false-block the opposite leg.
+
+        Only BUY entries are bounded (a SELL reduces exposure). Scoped to the
+        order's own mode (paper vs live) so a paper add isn't blocked by a live
+        holding and vice-versa.
+        """
+        if order.side != OrderSide.BUY:
+            return None
+        cap = getattr(self.settings.risk, "max_stake_abs_ceiling", 25.0)
+        is_paper_flag = 0 if is_live else 1
+        try:
+            row = await self.db.fetchone(
+                "SELECT COALESCE(SUM(size * avg_cost), 0) AS held "
+                "FROM cost_basis WHERE market_id = ? AND UPPER(token) = UPPER(?) "
+                "AND is_paper = ? AND size > 0",
+                (order.market_id, order.token.value, is_paper_flag),
+            )
+        except Exception:
+            # A read failure must not block trading — fail open (the per-order
+            # risk-manager cap still applies).
+            return None
+        held = float(row["held"]) if row else 0.0
+        proposed = order.size * order.price
+        if held + proposed > cap + 1e-9:
+            reason = (
+                f"market_cap: ${held:.2f} held + ${proposed:.2f} new on "
+                f"{order.market_id}/{order.token.value} exceeds ${cap:.2f}"
+            )
+            log.info(
+                "gateway.market_cap_block",
+                market_id=order.market_id,
+                token=order.token.value,
+                held=round(held, 2),
+                proposed=round(proposed, 2),
+                cap=cap,
+            )
+            return reason
+        return None
 
     async def submit_exit(
         self,

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -81,6 +81,77 @@ def test_submit_records_fill_cost_basis_and_trade():
     asyncio.run(run())
 
 
+def test_submit_blocks_buy_that_exceeds_aggregate_market_cap():
+    """A BUY that would push TOTAL (held + new) exposure on a (market, token)
+    past the $25 ceiling is skipped — even though the single order is sub-cap.
+    Guards against stacking sub-cap entries into an over-cap position."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # Seed the mode the gateway will actually query (is_live depends on the
+        # ambient .env; CI has none -> paper). Keeps the test deterministic.
+        flag = 0 if Settings().is_live else 1
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, is_paper)"
+            " VALUES ('m1', 'YES', 48.0, 0.50, 24.0, ?)", (flag,)
+        )
+        await db.commit()
+
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.50)
+        result = OrderResult(order_id="p1", market_id="m1", status="paper",
+                             filled_size=20.0, filled_price=0.50, is_paper=True)
+        ex = _paper_exchange(order, result)
+        gw = _gateway(db, ex)
+
+        # 24 held + 10 new = 34 > 25 -> skipped.
+        res = await gw.submit(TradeIntent(signal=_signal(), market=Market(id="m1", question="Q?"),
+                                          size_dollars=10.0))
+
+        assert res.status == "skipped"
+        assert "market_cap" in (res.reason or "")
+        ex.place_order.assert_not_awaited()             # never placed
+        fills = await db.fetchall("SELECT * FROM fills WHERE market_id='m1'")
+        assert fills == []                              # nothing recorded
+
+    asyncio.run(run())
+
+
+def test_submit_market_cap_does_not_block_opposite_token_leg():
+    """Internal arb holds YES and NO of one market. A large existing YES holding
+    must NOT block a NO buy — the cap is scoped per (market, token)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO markets (id, exchange, question, category, active, last_updated)"
+            " VALUES ('m1', 'polymarket', 'Q?', 'tech', 1, datetime('now'))"
+        )
+        # $24 of YES held; the NO leg should still be allowed.
+        flag = 0 if Settings().is_live else 1
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, is_paper)"
+            " VALUES ('m1', 'YES', 48.0, 0.50, 24.0, ?)", (flag,)
+        )
+        await db.commit()
+
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok_no",
+                      side=OrderSide.BUY, token=TokenType.NO, size=20.0, price=0.50)
+        result = OrderResult(order_id="p1", market_id="m1", status="paper",
+                             filled_size=20.0, filled_price=0.50, is_paper=True)
+        gw = _gateway(db, _paper_exchange(order, result))
+
+        res = await gw.submit(TradeIntent(signal=_signal(), market=Market(id="m1", question="Q?"),
+                                          size_dollars=10.0))
+
+        assert res.status == "paper"          # NO leg placed normally
+        no_cb = await db.fetchall(
+            "SELECT size FROM cost_basis WHERE market_id='m1' AND token='NO'")
+        assert len(no_cb) == 1
+
+    asyncio.run(run())
+
+
 def test_submit_skips_on_build_failure_without_recording():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
## Problem
The risk manager's `max_stake` check only sees a **single order**, so the bot could **stack** sub-cap entries into an over-cap position — legacy directional favorites reached ~$90 of exposure on one market across several orders, each individually under the $25 ceiling.

## Why the gateway (not the risk manager)
An earlier attempt to add this in `RiskManager.evaluate` was reverted: the `Signal` carries no YES/NO entry token (it's resolved downstream), and both internal-arb legs evaluate as `BUY` on the same market — so there's no clean key there to tell directional stacking from arb's second leg. The **gateway is the layer where `order.token` is finally known**, so the cap can be scoped per `(market, token)`.

## Scope (deliberate)
- per **(market, token)**, not per market — internal arb legitimately holds YES *and* NO of one market, so a market-wide sum would false-block the opposite leg.
- **BUY entries only** (a SELL reduces exposure).
- the order's **own mode** (paper vs live).
- **only in `submit()`** — arb (`place_legs`/`submit_paired`), the market maker (`place_quote_pair`), and exits (`submit_exit`) are untouched.
- **fails open** on a read error (the per-order risk check still applies).

## Tests
A stacking BUY is skipped (held+new > cap, nothing placed/recorded); an opposite-token leg on the same market is NOT blocked. Seeded to the resolved `is_live` mode so it's deterministic with or without an ambient `.env`. Full suite green (922).

Assisted-by: Claude (Anthropic)