### PR TITLE
fix(news_speed): don't trade live-event-outcome categories (esports/sports)

### DIFF
--- a/auramaur/strategy/news_reactor.py
+++ b/auramaur/strategy/news_reactor.py
@@ -69,6 +69,14 @@ class NewsReactor:
     advantage — we can trade before the broader market adjusts to the news.
     """
 
+    # Categories news-reaction structurally cannot price: a breaking headline
+    # ("Team X beats Team Y") doesn't predict a LIVE MATCH OUTCOME the way it
+    # predicts a policy/geopolitical event, yet the keyword search readily
+    # matches team/player names. The news_speed paper book lost ~$65 over 3
+    # esports events (Counter-Strike, Dota) doing exactly this. Block the
+    # live-event-outcome categories so the reactor never flags them.
+    BLOCKED_CATEGORIES = frozenset({"esports", "sports"})
+
     def __init__(
         self,
         rss_source: RSSSource,
@@ -141,6 +149,18 @@ class NewsReactor:
                     if engine is None:
                         continue
                     for market in markets:
+                        # Skip live-event-outcome categories news-reaction can't
+                        # price (esports/sports). Classify off the stored label
+                        # when present, else the question text — the loser
+                        # esports markets carried the category, but match-ups can
+                        # also be caught structurally.
+                        if self._is_blocked_category(market):
+                            log.info(
+                                "news_reactor.category_skip",
+                                market_id=market.id,
+                                category=getattr(market, "category", "") or "",
+                            )
+                            continue
                         engine.flag_market_from_news(market.id)
                         flagged.append({
                             "exchange": exchange_name,
@@ -196,6 +216,15 @@ class NewsReactor:
     def _get_market_liquidity(flagged_entry: dict) -> float:
         """Extract liquidity from a flagged entry for ranking."""
         return flagged_entry.get("liquidity", 0.0)
+
+    @classmethod
+    def _is_blocked_category(cls, market: Market) -> bool:
+        """True if the market is a live-event-outcome (esports/sports) the
+        reactor must not trade. Category-only on purpose: the proven loser
+        markets all carried the label, and a fuzzy ``A vs B`` text fallback
+        would false-block legitimate political head-to-heads (Trump vs Biden)."""
+        category = (getattr(market, "category", "") or "").strip().lower()
+        return category in cls.BLOCKED_CATEGORIES
 
     def _filter_new(self, items: list[NewsItem]) -> list[NewsItem]:
         """Return only items we haven't processed yet."""

--- a/tests/test_news_reactor.py
+++ b/tests/test_news_reactor.py
@@ -1,10 +1,59 @@
 """Tests for news-reactor integration contracts."""
 
 from inspect import signature
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from auramaur.data_sources.base import NewsItem
+from auramaur.exchange.models import Market
 from auramaur.strategy.engine import TradingEngine
+from auramaur.strategy.news_reactor import NewsReactor
 
 
 def test_trading_engine_accepts_news_strategy_source():
     params = signature(TradingEngine.analyze_market).parameters
     assert "strategy_source" in params
+
+
+def _market(mid, category="", question="Q?"):
+    return Market(id=mid, question=question, category=category,
+                  clob_token_yes="y", clob_token_no="n")
+
+
+def test_is_blocked_category_blocks_live_event_outcomes():
+    # esports / sports (any case) are blocked; news-tractable categories are not.
+    assert NewsReactor._is_blocked_category(_market("a", "esports")) is True
+    assert NewsReactor._is_blocked_category(_market("b", "Sports")) is True
+    assert NewsReactor._is_blocked_category(_market("c", "politics_intl")) is False
+    assert NewsReactor._is_blocked_category(_market("d", "crypto")) is False
+    # A political head-to-head must NOT be blocked just for reading "vs".
+    assert NewsReactor._is_blocked_category(
+        _market("e", "politics_us", "Trump vs Biden 2028?")) is False
+
+
+@pytest.mark.asyncio
+async def test_check_for_news_skips_blocked_category_markets():
+    """A flagged esports market is dropped; the tractable match still flags."""
+    reactor = NewsReactor(
+        rss_source=MagicMock(),
+        discoveries={"polymarket": MagicMock()},
+        engines={"polymarket": MagicMock()},
+        db=MagicMock(),
+    )
+    # One new story.
+    reactor._rss.fetch = AsyncMock(return_value=[
+        NewsItem(id="n1", source="rss", title="Breaking developments today"),
+    ])
+    esports = _market("esp", "esports", "Team A vs Team B: map 1 winner")
+    geo = _market("geo", "politics_intl", "Will the ceasefire hold by July?")
+    reactor._find_related_markets = AsyncMock(
+        return_value={"polymarket": [esports, geo]})
+    reactor._engines["polymarket"].flag_market_from_news = MagicMock()
+
+    flagged = await reactor.check_for_news()
+
+    flagged_ids = {f["market_id"] for f in flagged}
+    assert "esp" not in flagged_ids        # esports dropped
+    assert "geo" in flagged_ids            # tractable match kept
+    reactor._engines["polymarket"].flag_market_from_news.assert_called_once_with("geo")


### PR DESCRIPTION
## Problem
The news reactor keyword-searches headlines for related markets, which readily matches team/player names — but a breaking headline doesn't predict a **live match outcome** the way it predicts a policy/geopolitical event. The `news_speed` paper book's single worst concentration was **~$65 lost over 3 esports events** (Counter-Strike, Dota) doing exactly this.

## Fix
Block the live-event-outcome categories (`esports`, `sports`) at the flag step, so the reactor never registers them for analysis.

**Category-only on purpose:** the proven loser markets all carried the label, and a fuzzy "A vs B" text fallback would false-block legitimate political head-to-heads (Trump vs Biden). Other strategies are unaffected — the filter lives in the reactor's own matching loop, not the shared risk path.

## Tests
The classifier blocks esports/sports (any case) and not politics/crypto (incl. a "vs" political market); `check_for_news` drops a flagged esports market while keeping a tractable geopolitical one. Full suite green (924).

Assisted-by: Claude (Anthropic)