### PR TITLE
fix(risk): remove esports from live allowlist + block it (live gate leak)

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -62,7 +62,12 @@ risk:
   # 0 wins / 5 settlements — a no-edge speculation bucket. The counterfactual
   # (excluding politics_us/sports/entertainment) lifts lifetime live realized
   # from -$126 to -$44, so these three carry ~$82 of the loss.
-  blocked_categories: ["sports", "politics_us", "entertainment"]
+  # esports added 2026-06-25: it was simultaneously on the LIVE ALLOWLIST and
+  # the news_speed loser list (~$65 lost over 3 events). Live esports entries
+  # (Call of Duty, LoL match-ups) kept clearing the gate via the allowlist — a
+  # live-event match outcome a headline/model can't price. Blocked AND removed
+  # from allowed_categories_live below: live-event-outcome markets are out.
+  blocked_categories: ["sports", "esports", "politics_us", "entertainment"]
   # LIVE entries are allowlist-gated (fail-safe, 2026-06-12): a category must
   # be ON this list to trade real money. Unknown/''/'other'/mislabeled
   # categories paper-trade but never go live — a blocklist fails OPEN on
@@ -71,8 +76,7 @@ risk:
   # opportunity instead of money. Edge map: tech/crypto/intl-politics is
   # where calibration shows edge; sports/politics_us stay out (see above).
   allowed_categories_live: ["crypto", "tech", "politics_intl", "economics",
-                            "science", "legal", "weather",
-                            "esports"]
+                            "science", "legal", "weather"]
   time_to_resolution_min_hours: 4
   time_to_resolution_max_days: 0   # 0 = no ceiling; set to 90 to reject 3+ month markets
   max_correlated_positions: 10


### PR DESCRIPTION
esports was on the live allowlist AND a proven loser (news_speed ~-$65/3 events). Live Call of Duty + LoL esports entries kept clearing the gate via the allowlist (a live esports BUY landed 06-21, post paper-forcing flip). Remove from allowed_categories_live + add to blocked_categories. Config-only.

Assisted-by: Claude (Anthropic)