### PR TITLE
fix(classifier): structural live-event detection, not keyword whack-a-mole

### DIFF
--- a/auramaur/strategy/classifier.py
+++ b/auramaur/strategy/classifier.py
@@ -40,13 +40,32 @@ SPORTS_WEAK_KEYWORDS: list[str] = [
 # 2026-03-26?". A plain keyword can't express the year, so it's a pattern.
 # "vs" without the period ("Linette vs Pohankova") is a word-boundary pattern
 # so it can't match inside words.
-SPORTS_PATTERNS: list[str] = [r"win on 20\d\d", r"\bolympics?\b", r"\bf1\b",
-                              r"\bvs\b"]
+# Note: a bare "vs" is intentionally NOT a priority sports marker. It fired
+# eagerly on every "A vs B" question and stole edge match-ups (Trump vs Biden ->
+# sports, Bitcoin vs Ethereum -> sports) before they could score politics/crypto.
+# An unclassified match-up is instead caught in the fallthrough (see
+# _MATCHUP_RE in classify_market), AFTER edge categories get their chance.
+SPORTS_PATTERNS: list[str] = [r"win on 20\d\d", r"\bolympics?\b", r"\bf1\b"]
 
 # Checked BEFORE sports so award-show markets ("Eurovision ... Jury Winner",
 # "win the Oscar") aren't stolen by the sports "winner"/"win" markers.
 ENTERTAINMENT_PRIORITY: list[str] = [
     "eurovision", "song contest", "oscar", "grammy", "academy award",
+    # Added 2026-06-25 after a live-gate audit found these stored as 'other'
+    # (so they dodged the entertainment block): celebrity weddings, movie/TV
+    # casting, album/box-office, TV season releases. Entertainment is a BLOCKED
+    # no-edge category, so a classifier gap = live exposure.
+    "emmy", "golden globe", "box office", "bridesmaid", "groomsman",
+    "album", "wedding", "james bond",
+]
+# Regex markers for entertainment patterns a literal keyword can't express.
+# Conservative on purpose (word boundaries; "Season 3" not "season 2026") to
+# avoid stealing weather ("hurricane season") or election ("cast a vote").
+ENTERTAINMENT_PATTERNS: list[str] = [
+    r"\bcast(ed)? in\b",          # "casted in the next Pirates...", "cast in"
+    r"\bseason \d{1,2}\b",        # "The Last of Us Season 3 ... released"
+    r"perform .*\bsong\b",        # "perform the next James Bond Song"
+    r"\bbox office\b",
 ]
 
 WEATHER_KEYWORDS: list[str] = [
@@ -167,7 +186,7 @@ def _compile_many(keywords: list[str], extra_patterns: list[str] | None = None) 
 
 _ESPORTS_RE = _compile_many(ESPORTS_KEYWORDS, ESPORTS_PATTERNS)
 _ESPORTS_STRONG_RE = _compile_many(ESPORTS_STRONG_KEYWORDS)
-_ENTERTAINMENT_PRIORITY_RE = _compile_many(ENTERTAINMENT_PRIORITY)
+_ENTERTAINMENT_PRIORITY_RE = _compile_many(ENTERTAINMENT_PRIORITY, ENTERTAINMENT_PATTERNS)
 _SPORTS_STRONG_RE = _compile_many(SPORTS_STRONG_KEYWORDS)
 _SPORTS_RE = _compile_many(SPORTS_STRONG_KEYWORDS + SPORTS_WEAK_KEYWORDS,
                            SPORTS_PATTERNS)
@@ -186,6 +205,11 @@ _PRIORITY_CATEGORIES: list[tuple[str, list[re.Pattern]]] = [
 _CATEGORY_RES: dict[str, list[re.Pattern]] = {
     cat: _compile_many(kws) for cat, kws in CATEGORY_KEYWORDS.items()
 }
+
+# Head-to-head match-up: "<word> vs <word>" / "<word> vs. <word>". Used as the
+# last-resort live-event-outcome detector (see classify_market). Word boundary
+# on both sides so it can't fire inside other words.
+_MATCHUP_RE = re.compile(r"\b[\w.'-]+ vs\.? [\w.'-]+", re.IGNORECASE)
 
 _POLITICS_US_RE = _compile_many(POLITICS_US_KEYWORDS, POLITICS_US_PATTERNS)
 _POLITICS_INTL_RE = _compile_many(POLITICS_INTL_KEYWORDS)
@@ -323,6 +347,17 @@ def classify_market(question: str, description: str = "") -> str:
         scores["politics_us"] = gov
 
     if not scores:
+        # Structural fail-safe for live-event-outcome markets. A head-to-head
+        # match-up ("Team A vs Team B") that reached here carries NO edge-category
+        # signal — it's almost always a sport/esports fixture, the exact thing
+        # we block. Rather than enumerate every game, league and roster
+        # (unsustainable whack-a-mole), default an unclassified match-up to the
+        # blocked 'sports' bucket. Real "X vs Y" markets with edge signal
+        # (Trump vs Biden -> politics, BTC vs ETH -> crypto) scored above and
+        # never reach here. The authoritative path is still the venue tag
+        # (classify_tags); this only catches markets whose tag wasn't captured.
+        if _MATCHUP_RE.search(question):
+            return "sports"
         return "other"
 
     return max(scores, key=scores.get)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -249,3 +249,56 @@ def test_classify_tags_inconclusive():
 
 def test_classify_tags_esports_beats_sports():
     assert classify_tags(["Sports", "Esports", "CS2"]) == "esports"
+
+
+def test_entertainment_structural_patterns_2026_06_25_audit():
+    """Live-gate audit (2026-06-25): celebrity weddings, movie/TV casting,
+    album/box-office and TV-season markets were stored as 'other' and dodged the
+    entertainment block. The classifier must now catch them."""
+    cases = [
+        "Will Brittany Mahomes be a Bridesmaid for the wedding of Travis Kelce and Taylor Swift?",
+        "Who will perform the next James Bond Song?",
+        "When will The Last of Us Season 3 be released?",
+        "Will Johnny Depp be casted in the next Pirates of the Caribbean?",
+        "Will Glen Powell be casted in the next Miami Vice?",
+        "New Playboi Carti Album before GTA VI?",
+    ]
+    for q in cases:
+        assert classify_market(q) == "entertainment", q
+
+
+def test_unclassified_matchups_default_to_blocked_without_enumeration():
+    """The sustainable fix: a head-to-head match-up with no edge-category signal
+    is a live-event outcome and defaults to the blocked 'sports' bucket — we do
+    NOT enumerate every game/league/roster. Call of Duty, an invented sport, and
+    a tennis fixture all land in a BLOCKED category (sports or esports) with no
+    game name in the keyword lists."""
+    blocked = {"sports", "esports"}
+    assert classify_market(
+        "Call of Duty: Los Angeles Thieves vs Carolina Royal Ravens") in blocked
+    assert classify_market("Madeupball: Team Alpha vs Team Beta") in blocked
+    assert classify_market("Perugia: Pablo Llamas Ruiz vs Michele Ribecai") in blocked
+
+
+def test_vs_no_longer_steals_edge_matchups():
+    """Moving 'vs' out of the eager priority check: edge match-ups now score
+    their real category instead of being stolen into sports."""
+    assert classify_market("Trump vs Biden 2028 election?") == "politics_us"
+    assert classify_market("Bitcoin vs Ethereum market cap by 2027?") == "crypto"
+
+
+def test_cricket_caught_via_venue_tag():
+    """The authoritative path is the VENUE TAG, not question keywords. A bare
+    'Will New Zealand win?' is unclassifiable from text, but Polymarket tags it
+    'Cricket' -> classify_tags maps that to sports (blocked)."""
+    from auramaur.strategy.classifier import classify_tags
+    assert classify_tags(["Cricket", "International", "Sports"]) == "sports"
+
+
+def test_new_patterns_dont_false_block_legit_categories():
+    """The new entertainment/sports markers must not steal weather/politics/
+    econ/crypto markets."""
+    assert classify_market("Will a Category 5 hurricane make landfall this season?") != "entertainment"
+    assert classify_market("Will Trump win the 2028 election?") not in ("entertainment", "sports")
+    assert classify_market("Will the Fed cut rates in Q3?") == "economics"
+    assert classify_market("Will Bitcoin hit $200k?") == "crypto"


### PR DESCRIPTION
## The problem with the reflex fix
A live-gate audit found sports/esports/entertainment markets stored as `other`, dodging the blocked-category gate. Adding `"call of duty"`, `"overwatch"`, … to keyword lists **doesn't scale** — every new game, league, roster and celebrity is another miss.

## Structural fix instead of enumeration
1. **Move bare `vs` out of the eager priority sports check into the fallthrough.** A head-to-head match-up with *no edge-category signal* is almost always a live-event outcome → default it to the blocked `sports` bucket, **no game names required**. Bonus: fixes a pre-existing false-positive — `Trump vs Biden` / `Bitcoin vs Ethereum` were stolen into sports by the eager `vs`; they now score politics/crypto first.
2. **Entertainment structural patterns** (not titles): wedding/bridesmaid, `cast(ed) in`, `Season \d`, album, box office, `perform .* song`. Generic across celebrity weddings, movie/TV casting, music/TV releases.

The authoritative path remains the **venue tag** (`classify_tags`) — Polymarket already tags these (Cricket/Esports/Pop Culture). The keyword classifier is the fallback for markets whose tag wasn't captured, and it now **fails toward the blocked bucket** for match-ups instead of toward tradeable `other`.

## Impact
The improved classifier reclassifies **106 active markets `other`→`entertainment`** (remediated separately via `repair-categories`).

Tests: match-ups (incl. an invented sport) → blocked with no game in the lists; edge match-ups keep their category; cricket via venue tag; entertainment patterns; false-positive guards. Full suite green (929).

Assisted-by: Claude (Anthropic)