### PR TITLE
feat(resolution_lens): Kalshi paper measurement spike (default off)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1381,6 +1381,11 @@ class AuramaurBot(
         # Resolution-language lens (paper-forced until proven)
         if self.settings.resolution_lens.enabled:
             tasks.append(asyncio.create_task(self._task_resolution_lens(), name="resolution_lens"))
+            # Kalshi measurement spike — a second lens instance, paper-forced,
+            # attributed separately. Default off; flip resolution_lens.kalshi_enabled.
+            if self.settings.resolution_lens.kalshi_enabled:
+                tasks.append(asyncio.create_task(
+                    self._task_resolution_lens_kalshi(), name="resolution_lens_kalshi"))
 
         # Odd-lot tender harvester (detection always; entries paper-forced)
         if self.settings.oddlot_tender.enabled:

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -217,6 +217,46 @@ class StrategyTaskMixin:
                 log.error("lens.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_resolution_lens_kalshi(self) -> None:
+        """Kalshi resolution-lens measurement spike (paper-forced, default off).
+
+        A SECOND lens instance bound to the Kalshi discovery/exchange, attributed
+        to 'resolution_lens_kalshi' so it earns its own graduation cells and
+        cannot dilute the proven Polymarket lens. Tests whether Kalshi's
+        CFTC-legalistic resolution criteria carry fine-print mispricing. No-ops
+        cleanly if the Kalshi venue isn't composed.
+        """
+        from auramaur.strategy.resolution_lens import ResolutionLensPillar
+
+        discovery = self._components.discoveries.get("kalshi")
+        exchange = self._components.exchanges.get("kalshi")
+        if discovery is None or exchange is None:
+            log.info("lens.kalshi_spike_skipped", reason="kalshi venue not composed")
+            return
+
+        pillar = ResolutionLensPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=discovery,
+            exchange=exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+            analyzer=self._components.analyzer,
+            aggregator=self._components.aggregator,
+            exchange_name="kalshi",
+            source_tag="resolution_lens_kalshi",
+        )
+        interval = max(60, self.settings.resolution_lens.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("lens.kalshi_cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_oddlot_tender(self) -> None:
         """EDGAR odd-lot tender scan (detection always; entries paper-forced)."""
         from auramaur.data_sources.edgar import EdgarClient

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -130,7 +130,9 @@ class ResolutionLensPillar:
     name = "resolution_lens"
     execution_mode = ExecutionMode.GATEWAY_SINGLE
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, calibration, analyzer, aggregator=None) -> None:
+                 pnl_tracker, calibration, analyzer, aggregator=None,
+                 exchange_name: str = "polymarket",
+                 source_tag: str = "resolution_lens") -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
@@ -138,9 +140,15 @@ class ResolutionLensPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # The venue this instance scans. Default Polymarket (the proven lens);
+        # a second instance can bind Kalshi for the paper measurement spike.
+        self._exchange_name = exchange_name
+        # Attribution tag — the Kalshi spike uses a DISTINCT source so it gets
+        # its own graduation cells and can't dilute the proven Poly lens record.
+        self._source_tag = source_tag
         # Shared execution tail; no router (passive entry at the observed price).
         self._gateway = ExecutionGateway(
-            router=None, exchange=exchange, exchange_name="polymarket",
+            router=None, exchange=exchange, exchange_name=exchange_name,
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
         self._analyzer = analyzer
@@ -159,11 +167,15 @@ class ResolutionLensPillar:
         # paper thresholds; they revert to strict automatically if paper is
         # flipped to graduate the cell to live.
         min_liq = cfg.paper_min_liquidity if cfg.paper else cfg.min_liquidity
+        # Kalshi's book is thinner than Polymarket's — its own (lower) floor so
+        # the spike isn't starved of candidates by the Poly-tuned threshold.
+        if self._exchange_name == "kalshi":
+            min_liq = min(min_liq, cfg.kalshi_min_liquidity)
         min_hours = (cfg.paper_min_hours_to_resolution if cfg.paper
                      else cfg.min_hours_to_resolution)
         if not m.active or not (0.0 < m.outcome_yes_price < 1.0):
             return False
-        if (m.exchange or "polymarket") != "polymarket":
+        if (m.exchange or self._exchange_name) != self._exchange_name:
             return False
         if m.liquidity < min_liq:
             return False
@@ -384,7 +396,7 @@ class ResolutionLensPillar:
                       outcome_yes_price, outcome_no_price, liquidity,
                       clob_token_yes, clob_token_no
                FROM markets
-               WHERE active = 1 AND exchange = 'polymarket'
+               WHERE active = 1 AND exchange = ?
                  -- Only future-dated markets: the table is ~87% stale rows
                  -- (resolved markets keep active=1 with a past end_date), and the
                  -- lens can't trade a resolved market. Without this the scan loads
@@ -398,6 +410,7 @@ class ResolutionLensPillar:
                       OR question LIKE '%declare%' OR question LIKE '%ranked%'
                       OR question LIKE '%lasting%' OR question LIKE '%between %'
                       OR question LIKE '%state%' OR question LIKE '% #%')""",
+            (self._exchange_name,),
         )
         out: list[Market] = []
         for r in rows or []:
@@ -410,7 +423,7 @@ class ResolutionLensPillar:
                 except (ValueError, AttributeError):
                     pass
             out.append(Market(
-                id=r["id"], exchange="polymarket",
+                id=r["id"], exchange=self._exchange_name,
                 question=r["question"] or "", description=r["description"] or "",
                 category=r["category"] or "",
                 outcome_yes_price=r["outcome_yes_price"] or 0.0,
@@ -533,7 +546,7 @@ class ResolutionLensPillar:
             edge=abs(edge) * 100.0,
             evidence_summary=f"Resolution lens (gap {score:.2f}): {mech}",
             recommended_side=OrderSide.BUY if edge > 0 else OrderSide.SELL,
-            strategy_source="resolution_lens",
+            strategy_source=self._source_tag,
             mispricing_reason=f"behavioral: {mech}",
         )
         decision = await self._risk.evaluate(signal, m)
@@ -564,8 +577,8 @@ class ResolutionLensPillar:
             """INSERT OR IGNORE INTO markets (id, exchange, question, description,
                category, active, outcome_yes_price, outcome_no_price, volume,
                liquidity, last_updated)
-               VALUES (?, 'polymarket', ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
-            (market.id, market.question, (market.description or "")[:500],
+               VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, self._exchange_name, market.question, (market.description or "")[:500],
              ensure_category(market.question, market.description, market.category),
              market.outcome_yes_price,
              market.outcome_no_price, market.volume, market.liquidity),
@@ -573,21 +586,21 @@ class ResolutionLensPillar:
         await self._db.execute(
             """INSERT INTO signals (market_id, claude_prob, claude_confidence,
                market_prob, edge, evidence_summary, action, strategy_source)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 'resolution_lens')""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
              signal.market_prob, signal.edge, signal.evidence_summary,
-             signal.recommended_side.value),
+             signal.recommended_side.value, self._source_tag),
         )
         await self._db.execute(
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id,
                is_paper, updated_at)
-               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               VALUES (?, ?, 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
                    size = excluded.size, avg_price = excluded.avg_price,
                    current_price = excluded.current_price,
                    updated_at = excluded.updated_at""",
-            (order.market_id, fill_size, fill_price, fill_price,
+            (order.market_id, self._exchange_name, fill_size, fill_price, fill_price,
              market.category or "", order.token.value, order.token_id,
              1 if is_paper else 0),
         )

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -497,6 +497,13 @@ resolution_lens:
   # without a second audit call. PAPER-FORCED until the ledger proves it.
   enabled: true
   paper: true
+  # Kalshi measurement spike (default OFF). Flip true to run a SECOND, paper-
+  # forced lens instance over Kalshi's CFTC-legalistic markets, attributed to
+  # 'resolution_lens_kalshi' (its own graduation cells; can't dilute the proven
+  # Poly lens). Pre-registered kill: <5 signals in 2wk or negative paper
+  # realized -> flip back to false.
+  kalshi_enabled: false
+  kalshi_min_liquidity: 300.0
   min_gap_score: 0.4       # lens-judged headline/criteria divergence floor
   high_conf_gap_score: 0.7 # >= this -> HIGH confidence (clears divergence filter)
   min_edge: 0.08           # |strict fair - market| floor

--- a/config/settings.py
+++ b/config/settings.py
@@ -595,6 +595,13 @@ class ResolutionLensConfig(BaseModel):
     # flipped to graduate the cell to live.
     paper_min_hours_to_resolution: float = 1.0
     paper_min_liquidity: float = 250.0
+    # Kalshi measurement spike (default OFF). When true, a SECOND lens instance
+    # scans Kalshi — paper-forced, attributed to 'resolution_lens_kalshi' so it
+    # gets its own graduation cells and can't dilute the proven Poly lens. Tests
+    # the hypothesis that Kalshi's CFTC-legalistic resolution criteria carry
+    # fine-print mispricing. Kalshi's book is thinner, so it gets its own floor.
+    kalshi_enabled: bool = False
+    kalshi_min_liquidity: float = 300.0
 
 
 class GraduationConfig(BaseModel):

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -596,3 +596,43 @@ def test_lexical_candidates_scan_whole_table_not_volume_top():
             await db.close()
 
     asyncio.run(run())
+
+
+def test_kalshi_spike_instance_is_parametrized_and_isolated():
+    """The Kalshi measurement-spike instance binds the Kalshi venue, uses the
+    distinct 'resolution_lens_kalshi' source (own graduation cells), applies the
+    thinner Kalshi liquidity floor, and rejects Polymarket markets — while the
+    default Poly instance is unchanged."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = _settings()
+
+        # Kalshi-bound instance.
+        kalshi = _pillar(db, settings, [])
+        # rebuild with explicit kalshi params (the _pillar helper defaults Poly)
+        from auramaur.strategy.resolution_lens import ResolutionLensPillar
+        kalshi = ResolutionLensPillar(
+            db=db, settings=settings, discovery=MagicMock(),
+            exchange=_exchange(), risk_manager=_risk(),
+            pnl_tracker=PnLTracker(db, settings), calibration=MagicMock(),
+            analyzer=_analyzer(), exchange_name="kalshi",
+            source_tag="resolution_lens_kalshi",
+        )
+        assert kalshi._exchange_name == "kalshi"
+        assert kalshi._source_tag == "resolution_lens_kalshi"
+
+        # A Kalshi market passes the exchange filter; a Poly one is rejected.
+        k_mkt = _market(mid="k1", liquidity=350.0)
+        k_mkt.exchange = "kalshi"
+        assert kalshi._eligible(k_mkt) is True          # thin book OK on Kalshi floor
+        poly_mkt = _market(mid="p1", liquidity=5000.0)  # wrong venue for this instance
+        assert kalshi._eligible(poly_mkt) is False
+
+        # The default Poly instance still rejects Kalshi markets (isolation).
+        poly = _pillar(db, settings, [])
+        assert poly._exchange_name == "polymarket"
+        assert poly._source_tag == "resolution_lens"
+        assert poly._eligible(k_mkt) is False
+
+    asyncio.run(run())


### PR DESCRIPTION
Implements the scoped lens-on-Kalshi paper spike: does the fine-print lens find edge on Kalshi's CFTC-legalistic markets? Paper-only, **proven Poly lens untouched**.

## How
- **Parametrize `ResolutionLensPillar` by venue** — `exchange_name` + `source_tag`, both defaulting to Polymarket so the existing instance is byte-for-byte unchanged. The eligibility filter, candidate query, market construction, and markets/signals/portfolio writes all key off the bound exchange instead of a hardcoded `'polymarket'`.
- **Second instance binds the Kalshi venue**, paper-forced, attributed to `resolution_lens_kalshi` → its **own graduation cells**, so it can't dilute the proven Poly `lens×weather` record.
- **Separate task** (`_task_resolution_lens_kalshi`) gated by `resolution_lens.kalshi_enabled` (**default false**); no-ops cleanly if the Kalshi venue isn't composed. Thinner book → own floor (`kalshi_min_liquidity` $300).

## Pre-registered experiment
2 weeks paper; **success** = positive paper realized AND ≥10 events; **kill** = <5 signals in 2 weeks (universe too thin) or negative realized → flip back to false. Ships dark — flip the flag + restart to start.

## Tests
Kalshi instance binds the right venue/source, applies the thin floor, rejects Poly markets; the default Poly instance is unchanged. Full suite green (930).

Assisted-by: Claude (Anthropic)