### PR TITLE
chore(resolution_lens): start the Kalshi paper spike (kalshi_enabled: true)

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -502,7 +502,7 @@ resolution_lens:
   # 'resolution_lens_kalshi' (its own graduation cells; can't dilute the proven
   # Poly lens). Pre-registered kill: <5 signals in 2wk or negative paper
   # realized -> flip back to false.
-  kalshi_enabled: false
+  kalshi_enabled: true     # spike STARTED 2026-06-25 — 2wk paper measurement
   kalshi_min_liquidity: 300.0
   min_gap_score: 0.4       # lens-judged headline/criteria divergence floor
   high_conf_gap_score: 0.7 # >= this -> HIGH confidence (clears divergence filter)


### PR DESCRIPTION
Flip the #216 measurement spike on. Paper-only; attributed resolution_lens_kalshi; 2-week pre-registered window (kill if <5 signals or negative paper realized).

Assisted-by: Claude (Anthropic)