### PR TITLE
fix(readiness): source win-rate + net-PnL criteria from pnl_ledger, not trades

### DIFF
--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -364,14 +364,21 @@ async def check_win_rate(
     threshold_pct: float = 52.0,
     min_samples: int = 30,
 ) -> CriterionResult:
+    # Source: pnl_ledger, the authoritative realized-P&L store (one row per
+    # sell/settlement). The legacy `trades.pnl` column is never populated in the
+    # current path — the gateway co-writes a trades-mirror but realized P&L lives
+    # only in the ledger — so reading `trades.pnl` always returned 0 rows and
+    # this criterion was permanently INSUFFICIENT_DATA despite hundreds of
+    # realization events. `venue` is the ledger's exchange column; `realized_at`
+    # is the realization time.
     clause = ""
     params: list = [since.isoformat()]
     if exchange:
-        clause = " AND exchange = ?"
+        clause = " AND venue = ?"
         params.append(exchange)
     rows = await db.fetchall(
-        f"SELECT pnl FROM trades "
-        f"WHERE timestamp >= ? AND is_paper = 1 AND pnl IS NOT NULL{clause}",
+        f"SELECT pnl FROM pnl_ledger "
+        f"WHERE realized_at >= ? AND is_paper = 1{clause}",
         tuple(params),
     )
     if len(rows) < min_samples:
@@ -407,14 +414,20 @@ async def check_pnl_after_fees(
     fee_rate: float,
     min_samples: int = 30,
 ) -> CriterionResult:
+    # Source: pnl_ledger (see check_win_rate). IMPORTANT — the ledger's `pnl` is
+    # ALREADY NET OF FEES (record_fill books `(price-avg_cost)*size - fee`), so
+    # the net-after-fees figure is simply SUM(pnl); re-applying the fee_rate
+    # estimate the legacy path used would DOUBLE-COUNT fees. The actual fees are
+    # summed from the ledger's `fees` column for display. `fee_rate` is retained
+    # in the signature for caller compatibility but no longer estimates drag.
     clause = ""
     params: list = [since.isoformat()]
     if exchange:
-        clause = " AND exchange = ?"
+        clause = " AND venue = ?"
         params.append(exchange)
     rows = await db.fetchall(
-        f"SELECT pnl FROM trades "
-        f"WHERE timestamp >= ? AND is_paper = 1 AND pnl IS NOT NULL{clause}",
+        f"SELECT pnl, fees FROM pnl_ledger "
+        f"WHERE realized_at >= ? AND is_paper = 1{clause}",
         tuple(params),
     )
     if len(rows) < min_samples:
@@ -425,15 +438,14 @@ async def check_pnl_after_fees(
             threshold=f"≥{min_samples} resolved; net PnL ≥ $0",
             n_samples=len(rows),
         )
-    gross = sum(r["pnl"] or 0 for r in rows)
-    winning_profit = sum(r["pnl"] for r in rows if (r["pnl"] or 0) > 0)
-    fee_drag = winning_profit * fee_rate
-    net = gross - fee_drag
+    net = sum(r["pnl"] or 0 for r in rows)          # already net of fees
+    fees = sum(r["fees"] or 0 for r in rows)
+    gross = net + fees
     status: Status = "PASS" if net >= 0 else "FAIL"
     return CriterionResult(
         name="pnl_after_fees",
         status=status,
-        value=f"${net:+.2f} (gross ${gross:+.2f}, fee drag ${fee_drag:.2f})",
+        value=f"${net:+.2f} (gross ${gross:+.2f}, fees ${fees:.2f})",
         threshold="≥ $0",
         n_samples=len(rows),
     )

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -88,6 +88,32 @@ async def _seed_trades(
     await db.commit()
 
 
+async def _seed_ledger(
+    db: Database,
+    *,
+    pnls: list[float],
+    fees: float = 0.0,
+    venue: str = "kalshi",
+    is_paper: int = 1,
+    timestamp_offset_days: float = 0.0,
+) -> None:
+    """Seed realization events into pnl_ledger — the authoritative source the
+    win-rate / pnl-after-fees readiness criteria now read (the legacy
+    trades.pnl column is never populated)."""
+    ts = (
+        datetime.now(timezone.utc) - timedelta(days=timestamp_offset_days)
+    ).isoformat()
+    for i, pnl in enumerate(pnls):
+        await db.execute(
+            "INSERT INTO pnl_ledger (market_id, venue, kind, token, qty, pnl, "
+            "fees, is_paper, source_ref, realized_at) "
+            "VALUES (?, ?, 'sell', 'YES', 10.0, ?, ?, ?, ?, ?)",
+            (f"led-mkt-{i}", venue, pnl, fees, is_paper,
+             f"ledtest:{venue}:{i}:{ts}", ts),
+        )
+    await db.commit()
+
+
 async def _seed_calibration(
     db: Database,
     *,
@@ -307,7 +333,7 @@ async def test_brier_vs_market_fail_when_market_better(db: Database):
 @pytest.mark.asyncio
 async def test_win_rate_pass_above_52(db: Database):
     pnls = [1.0] * 16 + [-1.0] * 14
-    await _seed_trades(db, pnls=pnls)
+    await _seed_ledger(db, pnls=pnls)
     now = datetime.now(timezone.utc)
     result = await check_win_rate(db, since=now - timedelta(days=7), exchange="kalshi")
     assert result.status == "PASS"
@@ -316,7 +342,7 @@ async def test_win_rate_pass_above_52(db: Database):
 @pytest.mark.asyncio
 async def test_win_rate_fail_at_50(db: Database):
     pnls = [1.0] * 15 + [-1.0] * 15
-    await _seed_trades(db, pnls=pnls)
+    await _seed_ledger(db, pnls=pnls)
     now = datetime.now(timezone.utc)
     result = await check_win_rate(db, since=now - timedelta(days=7), exchange="kalshi")
     assert result.status == "FAIL"
@@ -330,12 +356,41 @@ async def test_win_rate_fail_at_50(db: Database):
 @pytest.mark.asyncio
 async def test_pnl_after_fees_pass_when_net_positive(db: Database):
     pnls = [5.0] * 20 + [-1.0] * 10
-    await _seed_trades(db, pnls=pnls)
+    await _seed_ledger(db, pnls=pnls)
     now = datetime.now(timezone.utc)
     result = await check_pnl_after_fees(
         db, since=now - timedelta(days=7), exchange="kalshi", fee_rate=0.07
     )
     assert result.status == "PASS"
+
+
+@pytest.mark.asyncio
+async def test_pnl_after_fees_uses_ledger_net_not_double_counted(db: Database):
+    """pnl_ledger.pnl is ALREADY net of fees — the criterion must SUM it, not
+    re-apply a fee estimate. Seed fees and assert net == sum(pnl) (gross adds
+    the fees back for display)."""
+    await _seed_ledger(db, pnls=[2.0] * 30, fees=0.10)
+    now = datetime.now(timezone.utc)
+    result = await check_pnl_after_fees(
+        db, since=now - timedelta(days=7), exchange="kalshi", fee_rate=0.07
+    )
+    assert result.status == "PASS"
+    assert "$+60.00" in result.value          # net = 30 * 2.0, not re-discounted
+    assert "fees $3.00" in result.value       # 30 * 0.10, reported from ledger
+
+
+@pytest.mark.asyncio
+async def test_readiness_ignores_legacy_trades_pnl(db: Database):
+    """Regression: the win-rate/pnl criteria must read pnl_ledger, NOT the legacy
+    trades.pnl column (never populated in the current path). Seeding only the
+    trades table must leave both criteria INSUFFICIENT_DATA."""
+    await _seed_trades(db, pnls=[1.0] * 40)   # legacy table only, no ledger rows
+    now = datetime.now(timezone.utc)
+    wr = await check_win_rate(db, since=now - timedelta(days=7), exchange="kalshi")
+    pf = await check_pnl_after_fees(
+        db, since=now - timedelta(days=7), exchange="kalshi", fee_rate=0.07)
+    assert wr.status == "INSUFFICIENT_DATA"
+    assert pf.status == "INSUFFICIENT_DATA"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug (High)
`check_win_rate` and `check_pnl_after_fees` read `SELECT pnl FROM trades` — but `trades.pnl` is **never populated** in the current path (the gateway co-writes the trades-mirror; realized P&L lives only in `pnl_ledger`). **0** non-null `trades.pnl` rows vs **233** paper realization events in the ledger → both criteria permanently `INSUFFICIENT_DATA`. Readiness was blind on its two most important signals and could misclassify live-readiness.

## Fix
Move both to `pnl_ledger` (`realized_at` window, `venue` filter, `is_paper`). **Semantic correction:** `pnl_ledger.pnl` is already net of fees (`record_fill` subtracts the fee), so net = `SUM(pnl)` — re-applying the legacy `fee_rate` estimate would double-count. Actual fees summed from the ledger's `fees` column for display.

Against the live DB this now reports **win 60.1% / net -$371.96 over 233 events** — real numbers instead of INSUFFICIENT_DATA.

## Tests
Ledger-backed seeding; a double-count guard; a regression that seeding only the legacy `trades` table leaves both criteria INSUFFICIENT_DATA. Full suite green (932).

Assisted-by: Claude (Anthropic)