### PR TITLE
fix(db): raise busy_timeout 5s->30s — restart write-burst dropped live fills

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -29,8 +29,14 @@ class Database:
         await self._db.execute("PRAGMA foreign_keys=OFF")
         # CLI commands share the file with the running bot; without a busy
         # timeout a writer collision fails instantly ("database is locked" —
-        # bit the ledger backfill 2026-06-10). 5s covers any sane write txn.
-        await self._db.execute("PRAGMA busy_timeout=5000")
+        # bit the ledger backfill 2026-06-10). The writer WAITS up to this long
+        # for the lock instead of erroring. Raised 5s -> 30s on 2026-06-25 after
+        # a restart write-burst exceeded 5s and DROPPED 3 LIVE polymarket fills
+        # in order_monitor.record_fill (logged, then skipped — record_fill is
+        # not idempotent mid-transaction, so a retry could double-book; making
+        # the lock WAIT is the safe fix). 30s covers transient bursts; a lock
+        # beyond it would signal sustained write saturation, a capacity problem.
+        await self._db.execute("PRAGMA busy_timeout=30000")
         await self._init_schema()
         log.info("database.connected", path=self.db_path)
 


### PR DESCRIPTION
## Bug (High, actively occurring)
Diagnostics found **3 LIVE polymarket fills lost to `database is locked`** in `order_monitor.record_fill` during today's restart write-burst (13:32). The error was logged and the order skipped → the fill never booked (0 fills / 0 trades for those order_ids). The **5s** `busy_timeout` was too short when many async write paths (fills, signals, portfolio, trades, markets, ledger) initialize at once.

## Fix
Raise `busy_timeout` to **30s** so a contended writer **waits** for the lock instead of erroring. `record_fill` is **not idempotent mid-transaction** (the fills insert has no dedup key, so a naive retry could double-book) — which is exactly why making the lock *wait* is the safe fix rather than retrying. A lock beyond 30s would signal sustained write saturation (a capacity problem), not a transient burst.

## Impact of the 3 already-dropped
Positions are recovered independently by the venue position syncer (reconciles on-chain holdings); only their precise per-fill cost-basis attribution was lost — bounded and historical.

Assisted-by: Claude (Anthropic)