### PR TITLE
fix(oddlot): tolerant price parse — a NAV-linked tender dropped the whole audit

### DIFF
--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -39,6 +39,18 @@ from auramaur.exchange.models import Fill, OrderSide
 
 log = structlog.get_logger()
 
+
+def _safe_float(value, default: float = 0.0) -> float:
+    """Coerce an LLM-returned value to float, tolerating non-numeric strings
+    (e.g. 'NAV', 'N/A', 'TBD' for NAV-linked or undetermined tenders). Returns
+    *default* rather than raising, so one unparseable field can't discard a
+    whole filing audit."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 ODDLOT_PROMPT = """You are auditing an SEC issuer tender-offer filing for the odd-lot arbitrage trade. Be adversarial: the default answer is that there is NO usable odd-lot priority.
 
 Company: {company} ({ticker})
@@ -115,16 +127,23 @@ class OddLotTenderPillar:
                     filed_at=f.filed_at, text=text[:40000],
                 ))
                 parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+                # Coerce per-field with a tolerant float: the LLM sometimes
+                # returns a non-numeric price for NAV-linked tenders (a closed-
+                # end fund tendering "at NAV" has no fixed price). float('NAV')
+                # used to raise inside verdict.update(), which evaluates all args
+                # before applying — so ONE bad field discarded the entire read,
+                # including a perfectly-parsed odd_lot_priority. A non-numeric
+                # price -> 0.0, which the downstream logic rejects as "no usable
+                # fixed premium" — the correct outcome, reached gracefully.
                 verdict.update(
                     odd_lot_priority=bool(parsed.get("odd_lot_priority", False)),
                     requires_record_date_holding=bool(
                         parsed.get("requires_record_date_holding", False)),
-                    tender_price=float(parsed.get("tender_price", 0.0) or 0.0),
-                    tender_price_high=float(
-                        parsed.get("tender_price_high", 0.0) or 0.0),
+                    tender_price=_safe_float(parsed.get("tender_price")),
+                    tender_price_high=_safe_float(parsed.get("tender_price_high")),
                     expiration=str(parsed.get("expiration", ""))[:10],
                     conditions=str(parsed.get("conditions", ""))[:300],
-                    confidence=float(parsed.get("confidence", 0.0) or 0.0),
+                    confidence=_safe_float(parsed.get("confidence")),
                 )
             except Exception as e:
                 log.warning("oddlot.llm_parse_error", accession=f.accession,

--- a/tests/test_oddlot_tender.py
+++ b/tests/test_oddlot_tender.py
@@ -230,3 +230,18 @@ def test_ledger_bare_ticker_fallback():
         await db.close()
 
     asyncio.run(run())
+
+
+def test_safe_float_tolerates_non_numeric_tender_prices():
+    """Regression: a NAV-linked tender returns a non-numeric price ('NAV') for
+    the price field. _safe_float must coerce it to 0.0 (downstream rejects as
+    'no usable fixed premium') instead of raising — a single bad field used to
+    discard the entire filing audit, including a well-parsed odd_lot_priority."""
+    from auramaur.strategy.oddlot_tender import _safe_float
+    assert _safe_float("NAV") == 0.0
+    assert _safe_float("N/A") == 0.0
+    assert _safe_float(None) == 0.0
+    assert _safe_float("") == 0.0
+    assert _safe_float("12.50") == 12.5
+    assert _safe_float(12.5) == 12.5
+    assert _safe_float("bad", default=-1.0) == -1.0


### PR DESCRIPTION
## Diagnostic (#3: why oddlot_tender has 0 trades)
- **EDGAR scanning works** — `edgar.search_done hits:1` every cycle.
- **The pool is genuinely tiny** — 1 qualifying tender filing in 7 days. Odd-lot tenders are rare; the strategy is a low-frequency, non-scalable specialty *by design*. The low sample rate is **not a bug**.
- **But the one candidate was lost to a parse error:** `could not convert string to float: 'NAV'`. A closed-end fund tendering *at NAV* has no fixed price, so the LLM returned "NAV"; `float()` raised inside `verdict.update()` (which evaluates all args before applying), discarding the entire read — including a well-parsed `odd_lot_priority`.

## Fix
Per-field tolerant `_safe_float` (non-numeric → default). NAV-linked tenders coerce to 0.0 → downstream rejects as "no usable fixed premium" (correct outcome, reached gracefully). Regression test added.

Assisted-by: Claude (Anthropic)