### PR TITLE
feat(settlement_arb): FRED-first known-outcome / settlement-lag pillar

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1366,6 +1366,10 @@ class AuramaurBot(
         if self.settings.econ_indicator.enabled:
             tasks.append(asyncio.create_task(self._task_econ_indicator(), name="econ_indicator"))
 
+        # Settlement-lag / known-outcome arb (FRED-first). Paper-forced; default off.
+        if self.settings.settlement_arb.enabled:
+            tasks.append(asyncio.create_task(self._task_settlement_arb(), name="settlement_arb"))
+
         # Open-Meteo ensemble city-temperature pricing (paper-forced spike)
         if self.settings.weather_temp.enabled:
             tasks.append(asyncio.create_task(self._task_weather_temp(), name="weather_temp"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -126,6 +126,35 @@ class StrategyTaskMixin:
                 log.error("econ_indicator.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_settlement_arb(self) -> None:
+        """Settlement-lag / known-outcome arb over Polymarket econ markets,
+        resolved deterministically against FRED (paper-forced, default off)."""
+        from auramaur.data_sources.fred import FREDSource
+        from auramaur.strategy.settlement_arb import SettlementArbPillar
+
+        if not self.settings.fred_api_key:
+            log.info("settlement_arb.disabled", reason="missing FRED key")
+            return
+        pillar = SettlementArbPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            fred_source=FREDSource(api_key=self.settings.fred_api_key),
+            analyzer=self._components.analyzer,
+        )
+        interval = max(60, self.settings.settlement_arb.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("settlement_arb.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_intraday_drift(self) -> None:
         """Measurement spike: track post-signal price drift toward the LLM estimate
         (no trading). Gates the intraday-convergence strategy on real evidence."""

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -1,0 +1,350 @@
+"""Settlement-lag / known-outcome arb — FRED-first.
+
+The disciplined generalization of the one edge that graduated (resolution_lens ×
+weather). That edge is NOT category-specific — it is STRUCTURAL: read a PRECISE
+numeric criterion against an AUTHORITATIVE data feed, and trade only the
+CONVERGENCE, never the forecast. Weather had it (temp bin × Open-Meteo); econ
+releases have it too (CPI/unemployment/payrolls × FRED).
+
+This pillar trades a Polymarket econ market ONLY when:
+  1. the referenced indicator's print for the market's reference period is
+     ALREADY PUBLISHED by FRED (the official source), AND
+  2. that published value DETERMINISTICALLY satisfies or fails the market's
+     numeric criterion, AND
+  3. the market has NOT yet repriced to ~0/1 (the settlement LAG is the edge).
+
+No forecasting: if the print isn't out yet, or the criterion is compound /
+ambiguous, it SKIPS. The LLM only EXTRACTS the predicate (indicator, operator,
+threshold, period) — once, cached, adversarially verified; the RESOLVE step is a
+pure deterministic compare against FRED. PAPER-FORCED, its own graduation cell.
+"""
+
+from __future__ import annotations
+
+from auramaur.strategy.protocols import ExecutionMode
+
+import json
+import re
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, OrderSide, Signal
+from auramaur.strategy.econ_pricing import ECON_SERIES, EconSpec, spec_for_series
+
+log = structlog.get_logger()
+
+# Indicators this pillar understands, by the registry key (see econ_pricing).
+# Lexical hints route a market to a candidate series before the LLM extracts the
+# precise predicate; the series the LLM names must be one of these.
+_INDICATOR_HINTS: dict[str, tuple[str, ...]] = {
+    "KXCPIYOY": ("cpi", "inflation", "consumer price"),
+    "KXU3": ("unemployment", "jobless rate", "u-3", "unemployment rate"),
+    "KXPAYROLLS": ("payroll", "nonfarm", "jobs added", "jobs report"),
+}
+
+
+def has_econ_trigger(question: str) -> bool:
+    q = (question or "").lower()
+    return any(h in q for hints in _INDICATOR_HINTS.values() for h in hints)
+
+
+EXTRACT_PROMPT = """You convert a prediction-market question into a MACHINE-CHECKABLE econ predicate, or reject it. Be strict: only single, unambiguous numeric thresholds against ONE official indicator. Compound/qualified/multi-leg criteria -> reject.
+
+Question: "{question}"
+Resolution criteria: {description}
+Today is {today} (interpret 2-digit years like '26 = 2026 relative to today).
+
+The indicator MUST be exactly one of:
+  KXCPIYOY    — US CPI year-over-year inflation rate, in percent
+  KXU3        — US unemployment rate (U-3), in percent
+  KXPAYROLLS  — US nonfarm payrolls month-over-month change, in THOUSANDS of jobs
+
+Give the operator the YES outcome needs ('>=','>','<=','<','=='), the numeric
+threshold (in the indicator's units above), and the REFERENCE PERIOD the print
+is for as YYYY-MM (the month the data describes, NOT the announcement date). If
+the question is not a single clean threshold on one of these indicators, set
+indicator to "" (reject).
+
+Respond with ONLY this JSON:
+{{"indicator": "KXCPIYOY|KXU3|KXPAYROLLS|", "operator": ">=|>|<=|<|==", "threshold": <number>, "reference_period": "YYYY-MM", "confidence": <float 0-1>}}"""
+
+VERIFY_PROMPT = """Adversarially check an extracted econ predicate against the market. Default to REFUTED unless the predicate EXACTLY captures the market's YES condition under a literal reading.
+
+Question: "{question}"
+Resolution criteria: {description}
+Extracted predicate: indicator={indicator}, YES if value {operator} {threshold}, reference period {reference_period}.
+
+Refute if: the indicator is wrong, the operator/threshold is off, the period is wrong, the units don't match (e.g. payrolls in thousands vs absolute), OR the market is actually compound/qualified so a single threshold can't decide it.
+
+Respond with ONLY this JSON:
+{{"verdict": "confirmed|refuted", "confidence": <float 0-1>, "why": "<one sentence>"}}"""
+
+
+# ----------------------------------------------------------------------
+# Deterministic resolve — pure functions (the well-tested core)
+# ----------------------------------------------------------------------
+
+
+def indicator_at_period(
+    obs: list[tuple], spec: EconSpec, period: str
+) -> float | None:
+    """The indicator value FOR a reference period (YYYY-MM), or None if FRED has
+    not published the data needed yet (the print isn't out -> undetermined).
+
+    ``obs`` is the FRED ``get_observations`` output: (date, value) oldest-first,
+    dated by the observation period. Pure — no I/O.
+    """
+    by_month: dict[str, float] = {}
+    ordered: list[tuple[str, float]] = []
+    for date, value in obs:
+        key = f"{date.year:04d}-{date.month:02d}"
+        by_month[key] = float(value)
+        ordered.append((key, float(value)))
+
+    if period not in by_month:
+        return None  # the print for this period isn't out yet
+
+    if spec.transform == "level":
+        return by_month[period]
+
+    if spec.transform == "yoy":
+        y, m = period.split("-")
+        prior = f"{int(y) - 1:04d}-{m}"
+        base = by_month.get(prior)
+        if base in (None, 0):
+            return None
+        return (by_month[period] / base - 1.0) * 100.0
+
+    if spec.transform == "mom_change":
+        idx = next((i for i, (k, _) in enumerate(ordered) if k == period), None)
+        if idx is None or idx == 0:
+            return None
+        return (ordered[idx][1] - ordered[idx - 1][1]) * spec.scale
+
+    return None
+
+
+def is_satisfied(value: float, operator: str, threshold: float) -> bool:
+    """Does the published value satisfy the YES criterion?"""
+    if operator == ">=":
+        return value >= threshold
+    if operator == ">":
+        return value > threshold
+    if operator == "<=":
+        return value <= threshold
+    if operator == "<":
+        return value < threshold
+    if operator == "==":
+        return abs(value - threshold) < 1e-9
+    return False
+
+
+class SettlementArbPillar:
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "settlement_arb"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
+
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, fred_source, analyzer) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._fred = fred_source
+        self._analyzer = analyzer
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+        self._schema_ready = False
+
+    async def _ensure_schema(self) -> None:
+        if self._schema_ready:
+            return
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS settlement_extractions (
+                   market_id TEXT PRIMARY KEY,
+                   indicator TEXT NOT NULL DEFAULT '',
+                   operator TEXT NOT NULL DEFAULT '',
+                   threshold REAL,
+                   reference_period TEXT NOT NULL DEFAULT '',
+                   verified INTEGER NOT NULL DEFAULT 0,
+                   checked_at TEXT NOT NULL DEFAULT (datetime('now')))"""
+        )
+        await self._db.commit()
+        self._schema_ready = True
+
+    async def run_once(self) -> int:
+        cfg = self._settings.settlement_arb
+        if not cfg.enabled or self._fred is None:
+            return 0
+        await self._ensure_schema()
+        markets = await self._candidates()
+        entered = 0
+        for m in markets:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            try:
+                pred = await self._predicate(m)
+                if pred is None:
+                    continue
+                if await self._maybe_enter(m, pred):
+                    entered += 1
+            except Exception as e:
+                log.debug("settlement_arb.market_error", market_id=m.id, error=str(e))
+        if entered:
+            log.info("settlement_arb.cycle", entered=entered)
+        return entered
+
+    async def _candidates(self) -> list:
+        """Active Poly econ markets with a numeric-threshold shape, future-dated."""
+        rows = await self._db.fetchall(
+            """SELECT id, question, description, outcome_yes_price, outcome_no_price,
+                      liquidity, category, clob_token_yes, clob_token_no, end_date
+               FROM markets
+               WHERE active = 1 AND exchange = 'polymarket'
+                 AND (end_date IS NULL OR end_date >= strftime('%Y-%m-%dT%H:%M:%SZ','now'))""",
+        )
+        from auramaur.exchange.models import Market
+        out: list[Market] = []
+        for r in rows or []:
+            if not has_econ_trigger(r["question"]):
+                continue
+            if not (0.0 < (r["outcome_yes_price"] or 0.0) < 1.0):
+                continue
+            if (r["liquidity"] or 0.0) < self._settings.settlement_arb.min_liquidity:
+                continue
+            out.append(Market(
+                id=r["id"], exchange="polymarket", question=r["question"] or "",
+                description=r["description"] or "",
+                outcome_yes_price=r["outcome_yes_price"] or 0.0,
+                outcome_no_price=r["outcome_no_price"] or 0.0,
+                liquidity=r["liquidity"] or 0.0, volume=r["liquidity"] or 0.0,
+                category=r["category"] or "economics",
+                clob_token_yes=r["clob_token_yes"] or "",
+                clob_token_no=r["clob_token_no"] or "",
+            ))
+        return out
+
+    async def _predicate(self, m) -> dict | None:
+        """Extracted+verified predicate for a market (cached forever — the
+        criterion is static)."""
+        row = await self._db.fetchone(
+            "SELECT indicator, operator, threshold, reference_period, verified "
+            "FROM settlement_extractions WHERE market_id = ?", (m.id,))
+        if row is not None:
+            if not row["indicator"] or not row["verified"]:
+                return None
+            return {"indicator": row["indicator"], "operator": row["operator"],
+                    "threshold": row["threshold"],
+                    "reference_period": row["reference_period"]}
+
+        pred = await self._extract(m)
+        verified = pred is not None and await self._verify(m, pred)
+        await self._db.execute(
+            """INSERT OR REPLACE INTO settlement_extractions
+               (market_id, indicator, operator, threshold, reference_period, verified)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (m.id, (pred or {}).get("indicator", ""), (pred or {}).get("operator", ""),
+             (pred or {}).get("threshold"), (pred or {}).get("reference_period", ""),
+             1 if verified else 0))
+        await self._db.commit()
+        return pred if verified else None
+
+    async def _extract(self, m) -> dict | None:
+        if self._analyzer is None:
+            return None
+        from datetime import datetime, timezone
+        raw = await self._analyzer._call_llm(EXTRACT_PROMPT.format(
+            question=m.question, description=(m.description or "")[:2000],
+            today=datetime.now(timezone.utc).strftime("%Y-%m-%d")))
+        try:
+            p = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+        except (ValueError, json.JSONDecodeError):
+            return None
+        ind = str(p.get("indicator", "")).upper()
+        if ind not in ECON_SERIES:
+            return None
+        if not re.fullmatch(r"\d{4}-\d{2}", str(p.get("reference_period", ""))):
+            return None
+        if p.get("operator") not in (">=", ">", "<=", "<", "=="):
+            return None
+        try:
+            thr = float(p.get("threshold"))
+        except (TypeError, ValueError):
+            return None
+        if float(p.get("confidence", 0.0) or 0.0) < self._settings.settlement_arb.min_extract_confidence:
+            return None
+        return {"indicator": ind, "operator": p["operator"], "threshold": thr,
+                "reference_period": p["reference_period"]}
+
+    async def _verify(self, m, pred: dict) -> bool:
+        if self._analyzer is None:
+            return False
+        raw = await self._analyzer._call_llm(VERIFY_PROMPT.format(
+            question=m.question, description=(m.description or "")[:2000],
+            indicator=pred["indicator"], operator=pred["operator"],
+            threshold=pred["threshold"], reference_period=pred["reference_period"]))
+        try:
+            v = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+        except (ValueError, json.JSONDecodeError):
+            return False
+        return (str(v.get("verdict")) == "confirmed"
+                and float(v.get("confidence", 0.0) or 0.0)
+                >= self._settings.settlement_arb.verify_min_confidence)
+
+    async def _maybe_enter(self, m, pred: dict) -> bool:
+        """Deterministic resolve + settlement-lag gate."""
+        cfg = self._settings.settlement_arb
+        spec = spec_for_series(pred["indicator"])
+        if spec is None:
+            return False
+        obs = await self._fred.get_observations(spec.fred_series, n=cfg.history_n)
+        if not obs:
+            return False
+        value = indicator_at_period(obs, spec, pred["reference_period"])
+        if value is None:
+            return False  # print not out yet -> undetermined, never forecast
+
+        yes_locked = is_satisfied(value, pred["operator"], pred["threshold"])
+        yes_price = m.outcome_yes_price
+        # Fair is a HARD 0/1 — the print already decided it. The lag is the edge:
+        # only trade the un-converged distance. Same edge-sign convention as the
+        # graduated resolution_lens: edge>0 -> long YES (BUY); edge<0 -> short YES
+        # = long NO (SELL). |edge| < min_edge means the market already converged.
+        fair = 1.0 if yes_locked else 0.0
+        edge = fair - yes_price
+        if abs(edge) < cfg.min_edge:
+            return False  # already converged — no lag to capture
+        side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+
+        signal = Signal(
+            market_id=m.id, claude_prob=fair,
+            claude_confidence=Confidence.HIGH, market_prob=yes_price,
+            edge=abs(edge) * 100.0,
+            evidence_summary=(f"settlement_arb: {pred['indicator']} "
+                              f"{pred['reference_period']} = {value:.2f} "
+                              f"{pred['operator']} {pred['threshold']} -> "
+                              f"{'YES' if yes_locked else 'NO'} locked"),
+            recommended_side=side,
+            strategy_source="settlement_arb",
+            mispricing_reason="structural: official print already determines the criterion",
+        )
+        decision = await self._risk.evaluate(signal, m)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("settlement_arb.risk_rejected", market_id=m.id, reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=m, size_dollars=size, force_paper=force_paper))
+        ok = res.status in ("filled", "paper", "partial", "pending")
+        if ok:
+            log.info("settlement_arb.entered", market_id=m.id, side=side.value,
+                     locked="YES" if yes_locked else "NO", value=round(value, 2),
+                     market_price=round(yes_price, 3), paper=getattr(res.result, "is_paper", True))
+        return ok

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -440,6 +440,25 @@ econ_indicator:
   history_n: 60
   interval_seconds: 1800
 
+settlement_arb:
+  # Settlement-lag / known-outcome arb (FRED-first) — the structural generalization
+  # of the graduated resolution_lens x weather edge. Trades a Polymarket econ
+  # market ONLY when the referenced FRED indicator's print for the reference period
+  # is ALREADY PUBLISHED and deterministically satisfies/fails the criterion, and
+  # the market hasn't repriced (the lag is the edge). No forecasting; the LLM only
+  # extracts the predicate (adversarially verified, cached). PAPER-FORCED, own
+  # graduation cell. DEFAULT OFF — flip enabled:true to start the 2-week spike.
+  enabled: false
+  paper: true
+  stake_usd: 10.0
+  min_edge: 0.05
+  min_liquidity: 1000.0
+  min_extract_confidence: 0.8
+  verify_min_confidence: 0.8
+  max_entries_per_cycle: 5
+  history_n: 60
+  interval_seconds: 1800
+
 weather_temp:
   # Open-Meteo ensemble pricing of Polymarket daily city-temperature bins.
   # WOUND DOWN 2026-06-25: the measurement spike concluded NEGATIVE. In the SAME

--- a/config/settings.py
+++ b/config/settings.py
@@ -399,6 +399,32 @@ class EconIndicatorConfig(BaseModel):
     interval_seconds: int = 1800
 
 
+class SettlementArbConfig(BaseModel):
+    """Settlement-lag / known-outcome arb, FRED-first (strategy/settlement_arb.py).
+
+    The structural generalization of the graduated resolution_lens × weather edge:
+    trade a Polymarket econ market ONLY when the referenced FRED indicator's print
+    for the reference period is ALREADY PUBLISHED and deterministically
+    satisfies/fails the criterion, and the market hasn't repriced (the lag is the
+    edge). No forecasting — undetermined prints are skipped. PAPER-FORCED, its own
+    graduation cell. Default OFF; flip enabled:true to start the measurement.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    stake_usd: float = 10.0
+    # Required gap between the locked outcome (0/1) and the market price — the
+    # un-converged distance the lag leaves on the table.
+    min_edge: float = 0.05
+    min_liquidity: float = 1000.0
+    # The LLM only extracts the predicate; both gates default conservative.
+    min_extract_confidence: float = 0.8
+    verify_min_confidence: float = 0.8
+    max_entries_per_cycle: int = 5
+    history_n: int = 60
+    interval_seconds: int = 1800
+
+
 class IntradayDriftConfig(BaseModel):
     """Intraday-drift measurement spike (monitoring/intraday_drift.py). NO
     trading — reuses the signals table + snapshots mids to test whether price
@@ -995,6 +1021,7 @@ class Settings(BaseSettings):
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
+    settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))
     intraday_drift: IntradayDriftConfig = Field(default_factory=lambda: IntradayDriftConfig(**_DEFAULTS.get("intraday_drift", {})))

--- a/tests/test_settlement_arb.py
+++ b/tests/test_settlement_arb.py
@@ -1,0 +1,179 @@
+"""Tests for settlement_arb — the FRED-first known-outcome / settlement-lag pillar.
+
+Focus on the deterministic core (indicator_at_period + is_satisfied + the lag
+gate), which is what makes this pillar low-variance: the LLM only extracts the
+predicate, the RESOLVE step is pure.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.strategy.econ_pricing import ECON_SERIES
+from auramaur.strategy.settlement_arb import (
+    SettlementArbPillar,
+    has_econ_trigger,
+    indicator_at_period,
+    is_satisfied,
+)
+
+
+def _obs(*pairs):
+    """(YYYY-MM, value) -> FRED-style (datetime, value), oldest-first."""
+    return [(datetime(int(p[:4]), int(p[5:7]), 1), v) for p, v in pairs]
+
+
+# ---------------------------------------------------------------------------
+# is_satisfied — the comparison
+# ---------------------------------------------------------------------------
+
+def test_is_satisfied_operators():
+    assert is_satisfied(3.0, ">=", 3.0) is True
+    assert is_satisfied(3.0, ">", 3.0) is False
+    assert is_satisfied(2.9, "<", 3.0) is True
+    assert is_satisfied(3.1, "<=", 3.0) is False
+    assert is_satisfied(3.0, "==", 3.0) is True
+    assert is_satisfied(3.0, "??", 3.0) is False   # unknown operator -> not satisfied
+
+
+# ---------------------------------------------------------------------------
+# indicator_at_period — the deterministic resolve
+# ---------------------------------------------------------------------------
+
+def test_level_indicator_returns_period_value():
+    spec = ECON_SERIES["KXU3"]   # UNRATE, level
+    obs = _obs(("2026-04", 4.0), ("2026-05", 4.1), ("2026-06", 4.3))
+    assert indicator_at_period(obs, spec, "2026-06") == 4.3
+
+
+def test_level_period_not_published_yet_is_none():
+    """The print for the reference period isn't out -> undetermined (skip)."""
+    spec = ECON_SERIES["KXU3"]
+    obs = _obs(("2026-04", 4.0), ("2026-05", 4.1))   # June not yet released
+    assert indicator_at_period(obs, spec, "2026-06") is None
+
+
+def test_yoy_indicator_computes_against_prior_year():
+    spec = ECON_SERIES["KXCPIYOY"]   # CPIAUCSL, yoy
+    # June 2025 = 100, June 2026 = 103 -> +3.0% YoY
+    obs = _obs(("2025-06", 100.0), ("2026-05", 102.5), ("2026-06", 103.0))
+    assert indicator_at_period(obs, spec, "2026-06") == pytest.approx(3.0)
+
+
+def test_yoy_missing_base_year_is_none():
+    spec = ECON_SERIES["KXCPIYOY"]
+    obs = _obs(("2026-05", 102.5), ("2026-06", 103.0))   # no June 2025 base
+    assert indicator_at_period(obs, spec, "2026-06") is None
+
+
+def test_mom_change_scaled():
+    spec = ECON_SERIES["KXPAYROLLS"]   # PAYEMS, mom_change, scale=1000 (thousands)
+    # +0.15 (millions) MoM -> 150 thousand jobs
+    obs = _obs(("2026-05", 159.00), ("2026-06", 159.15))
+    assert indicator_at_period(obs, spec, "2026-06") == pytest.approx(150.0)
+
+
+# ---------------------------------------------------------------------------
+# has_econ_trigger — candidate routing
+# ---------------------------------------------------------------------------
+
+def test_has_econ_trigger():
+    assert has_econ_trigger("Will CPI inflation be above 3% in June?")
+    assert has_econ_trigger("Unemployment rate under 4.2% for June?")
+    assert has_econ_trigger("Nonfarm payrolls above 150k in June?")
+    assert not has_econ_trigger("Will Bitcoin hit $200k?")
+    assert not has_econ_trigger("Will Trump win in 2028?")
+
+
+# ---------------------------------------------------------------------------
+# Lag gate — only trade the un-converged distance, on the right side
+# ---------------------------------------------------------------------------
+
+def _pillar(*, fred_obs, settings_min_edge=0.05):
+    settings = SimpleNamespace(settlement_arb=SimpleNamespace(
+        enabled=True, paper=True, stake_usd=10.0, min_edge=settings_min_edge,
+        min_liquidity=1000.0, min_extract_confidence=0.8, verify_min_confidence=0.8,
+        max_entries_per_cycle=5, history_n=60, interval_seconds=1800))
+    fred = SimpleNamespace(get_observations=AsyncMock(return_value=fred_obs))
+    p = SettlementArbPillar(
+        db=MagicMock(), settings=settings, discovery=MagicMock(), exchange=MagicMock(),
+        risk_manager=MagicMock(), pnl_tracker=MagicMock(), fred_source=fred, analyzer=None)
+    return p, settings
+
+
+@pytest.mark.asyncio
+async def test_locked_yes_underpriced_buys_yes():
+    """CPI YoY 3.0% already published, criterion '>=3.0' locks YES, market still
+    at 0.80 -> BUY (long YES) at the un-converged distance."""
+    obs = _obs(("2025-06", 100.0), ("2026-06", 103.0))
+    p, _ = _pillar(fred_obs=obs)
+    market = SimpleNamespace(id="m1", outcome_yes_price=0.80, outcome_no_price=0.20)
+    pred = {"indicator": "KXCPIYOY", "operator": ">=", "threshold": 3.0,
+            "reference_period": "2026-06"}
+
+    from auramaur.exchange.models import OrderSide
+    captured = {}
+
+    async def fake_eval(signal, m):
+        captured["side"] = signal.recommended_side
+        captured["fair"] = signal.claude_prob
+        return SimpleNamespace(approved=False, position_size=0, reason="paper-test-stop")
+    p._risk.evaluate = fake_eval
+
+    await p._maybe_enter(market, pred)
+    assert captured["fair"] == 1.0                       # YES locked
+    assert captured["side"] == OrderSide.BUY             # long YES
+
+
+@pytest.mark.asyncio
+async def test_locked_no_buys_no_via_sell_side():
+    """Criterion fails (YES locked NO), market still pricing YES at 0.30 ->
+    SELL (short YES = long NO)."""
+    obs = _obs(("2025-06", 100.0), ("2026-06", 101.0))   # YoY +1.0%, < 3.0 -> NO
+    p, _ = _pillar(fred_obs=obs)
+    market = SimpleNamespace(id="m2", outcome_yes_price=0.30, outcome_no_price=0.70)
+    pred = {"indicator": "KXCPIYOY", "operator": ">=", "threshold": 3.0,
+            "reference_period": "2026-06"}
+
+    from auramaur.exchange.models import OrderSide
+    captured = {}
+
+    async def fake_eval(signal, m):
+        captured["side"] = signal.recommended_side
+        captured["fair"] = signal.claude_prob
+        return SimpleNamespace(approved=False, position_size=0, reason="stop")
+    p._risk.evaluate = fake_eval
+
+    await p._maybe_enter(market, pred)
+    assert captured["fair"] == 0.0                       # NO locked
+    assert captured["side"] == OrderSide.SELL            # short YES = long NO
+
+
+@pytest.mark.asyncio
+async def test_already_converged_market_is_skipped():
+    """YES locked and market already at 0.99 -> no lag, no trade."""
+    obs = _obs(("2025-06", 100.0), ("2026-06", 103.0))
+    p, _ = _pillar(fred_obs=obs)
+    market = SimpleNamespace(id="m3", outcome_yes_price=0.99, outcome_no_price=0.01)
+    pred = {"indicator": "KXCPIYOY", "operator": ">=", "threshold": 3.0,
+            "reference_period": "2026-06"}
+    p._risk.evaluate = AsyncMock()
+    entered = await p._maybe_enter(market, pred)
+    assert entered is False
+    p._risk.evaluate.assert_not_awaited()                # never even evaluated
+
+
+@pytest.mark.asyncio
+async def test_print_not_published_never_trades():
+    """The reference-period print isn't out yet -> undetermined, never forecast."""
+    obs = _obs(("2026-05", 102.5))   # June not released, no 2025 base either
+    p, _ = _pillar(fred_obs=obs)
+    market = SimpleNamespace(id="m4", outcome_yes_price=0.50, outcome_no_price=0.50)
+    pred = {"indicator": "KXCPIYOY", "operator": ">=", "threshold": 3.0,
+            "reference_period": "2026-06"}
+    p._risk.evaluate = AsyncMock()
+    entered = await p._maybe_enter(market, pred)
+    assert entered is False
+    p._risk.evaluate.assert_not_awaited()


### PR DESCRIPTION
The structural generalization of the one edge that **graduated** (`resolution_lens × weather`). That edge isn't category-specific — it's *reading a precise numeric criterion against an authoritative feed and trading only the convergence, never the forecast*. Weather had it (temp bin × Open-Meteo); econ releases have it too (CPI/unemployment/payrolls × FRED).

## What it does
Trades a Polymarket econ market **only when** the referenced FRED indicator's print for the reference period is **already published** and **deterministically** satisfies/fails the numeric criterion, **and** the market hasn't repriced (the **lag is the edge**). If the print isn't out, or the criterion is compound/ambiguous → **skip**. No forecasting.

## Architecture (mirrors the proven lens)
- LLM **only extracts** the predicate (indicator, operator, threshold, reference period) — once, cached, adversarially verified.
- **RESOLVE is pure**: `indicator_at_period` + `is_satisfied` against FRED (unit-tested). Reuses `econ_pricing`'s `EconSpec`/series registry + the FRED source.
- Same edge-sign convention as the lens (edge>0 → long YES BUY; edge<0 → long NO SELL). Routes through `ExecutionGateway`, **paper-forced**, own graduation cell.
- Scheduled task gated by `settlement_arb.enabled` (**default off**).

## Tests
Deterministic core (level/yoy/mom transforms, period-not-published → None) + lag gate (locked-YES → BUY, locked-NO → SELL, converged → skip, unpublished → never evaluates). Full suite green (944). **15 econ candidates** exist in the live universe.

Pre-registered 2-week paper measurement spike. Ships dark — flip `enabled: true` to start.

Assisted-by: Claude (Anthropic)