### PR TITLE
fix(cli): status used a non-existent CLOB method for open-order count

### DIFF
--- a/auramaur/cli/run.py
+++ b/auramaur/cli/run.py
@@ -115,8 +115,9 @@ def status():
                             api_passphrase=settings.polymarket_passphrase,
                         ),
                     )
-                    orders = client.get_orders()
-                    console.print(f"Polymarket: [green]connected[/] — {len(orders)} open orders")
+                    orders = client.get_open_orders()
+                    n = len(orders) if isinstance(orders, list) else 0
+                    console.print(f"Polymarket: [green]connected[/] — {n} open orders")
                 except Exception as e:
                     console.print(f"Polymarket: [red]error[/] — {str(e)[:60]}")
         finally:


### PR DESCRIPTION
## Problem
The live-only branch of `status` / `cockpit` called `client.get_orders()`, a method `py_clob_client_v2`'s `ClobClient` does not expose. Result: the Polymarket connection line always rendered an error and the live open-order count was never shown — the live resting-order view was effectively blind.

## Fix
Switch to `get_open_orders()` — the method the canonical order path in `exchange/client.py` already uses — and guard `len()` against a non-list return.

## Scope
Display-only. No trading, risk, or order-placement path is touched. Verified locally: the status line now reports the live open-order count instead of erroring.

Assisted-by: Claude (Anthropic)