### PR TITLE
feat(bias_harvest): maker entry — post at the favored-side bid, not the observed price

### DIFF
--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -8,8 +8,14 @@ won 99.3% of 151 markets vs a 95.5% breakeven. The mirror control (buying
 the longshot side at the same moments) lost -87% per $1 in the deep band —
 the classic favorite-longshot bias, measured on the bot's own universe. The
 edge survives removing the Iran cluster and sports/junk (improves to +4.9%)
-but DIES at 4.4c slippage, so entries are passive limit orders at the
-observed price, never crossed.
+but DIES at 4.4c slippage. Live-microstructure research (GWU WP 2026-001 /
+Whelan: maker avg ~-9.6% vs taker ~-31.5%) confirms the bias accrues to
+MAKERS, not takers — so entries post the BUY at the favored-side BID to
+capture the spread (``maker_entry``), and only where a real spread exists
+(>= ``maker_min_spread``); never crossed. In paper, ``paper_maker_fill_rate``
+deterministically haircuts entries so the book reflects a realistic maker
+capture rate rather than assuming 100% fills (the real fill rate is the key
+live-validation risk).
 
 Design constraints:
   * PAPER-FORCED by default (``bias_harvest.paper: true``): orders carry
@@ -34,6 +40,7 @@ from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
 
+import hashlib
 from datetime import datetime, timezone
 
 import structlog
@@ -158,6 +165,59 @@ class BiasHarvestPillar:
             return False  # capital lock-up cap
         return True
 
+    async def _maker_price(self, market: Market, fav_is_yes: bool) -> float | None:
+        """The favored-side BID to post a maker BUY at, or None if there is no
+        capturable spread / no book.
+
+        The favorite-longshot edge accrues to makers (capture the spread), not
+        takers (pay it). We only harvest where we can actually be a maker: there
+        must be at least ``maker_min_spread`` between bid and ask, else posting at
+        the bid is ~ taking and the edge dies in slippage (the backtest's 4.4c
+        cliff). Execution-only — the risk/divergence accounting stays on the
+        observed price (see ``_try_enter``)."""
+        cfg = self._settings.bias_harvest
+        token_id = market.clob_token_yes if fav_is_yes else market.clob_token_no
+        if not token_id:
+            return None
+        try:
+            book = await self._exchange.get_order_book(token_id)
+        except Exception as e:
+            log.debug("bias_harvest.book_fetch_failed", market_id=market.id, error=str(e))
+            return None
+        best_bid, best_ask = book.best_bid, book.best_ask
+        if best_bid is None or best_ask is None:
+            return None
+        if (best_ask - best_bid) < cfg.maker_min_spread:
+            return None  # nothing to capture — posting at the bid ~= crossing
+        maker_price = round(best_bid, 2)
+        if not (0.01 <= maker_price <= 0.99):
+            return None
+        return maker_price
+
+    def _paper_admits(self, market_id: str) -> bool:
+        """Deterministic maker-capture gate for the PAPER book: admit only
+        ``paper_maker_fill_rate`` of markets (stable hash), modelling that not
+        every posted maker bid gets hit. Without it the paper ledger would assume
+        100% maker fills and read far too rosy — risky because the graduation
+        ladder auto-promotes at 20 positive events. Stable (sha1, not the
+        salted built-in hash) so the admitted set is reproducible across runs and
+        tests. Live fills are governed by the real book, never this gate."""
+        rate = self._settings.bias_harvest.paper_maker_fill_rate
+        if rate >= 1.0:
+            return True
+        if rate <= 0.0:
+            return False
+        h = int(hashlib.sha1(market_id.encode("utf-8")).hexdigest(), 16) % 1000
+        return h < int(rate * 1000)
+
+    def _with_favored_price(self, market: Market, fav_is_yes: bool,
+                            maker_price: float) -> Market:
+        """A copy of the market with the favored side repriced to the maker bid,
+        so ``prepare_order`` builds the order at that price. Execution-only: the
+        signal keeps the observed price for the risk/divergence gate."""
+        field = "outcome_yes_price" if fav_is_yes else "outcome_no_price"
+        return market.model_copy(update={field: maker_price})
+
     async def _already_entered_or_held(self, market_id: str) -> bool:
         row = await self._db.fetchone(
             "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'bias_harvest' LIMIT 1",
@@ -213,6 +273,25 @@ class BiasHarvestPillar:
             return False
         p_fav, fav_is_yes = band
 
+        # Maker entry: post the BUY at the favored-side bid (capture the spread)
+        # instead of paying the observed price. The signal/divergence accounting
+        # stays on the observed price (so the divergence filter still passes at
+        # edge_uplift); only the ORDER is built at the maker bid, so the captured
+        # spread lands in the fill -> cost_basis -> pnl_ledger where graduation
+        # reads it. order_market carries the maker price for prepare_order only.
+        order_market = market
+        if cfg.maker_entry:
+            maker_price = await self._maker_price(market, fav_is_yes)
+            if maker_price is None:
+                return False  # no capturable spread -> don't harvest as a taker
+            # Paper realism: not every posted maker bid is hit. Admit only a
+            # deterministic fraction so the paper book reflects a real capture
+            # rate. Gate BEFORE persisting the signal so an un-admitted market
+            # stays retryable instead of burning its one-shot.
+            if cfg.paper and not self._paper_admits(market.id):
+                return False
+            order_market = self._with_favored_price(market, fav_is_yes, maker_price)
+
         signal = self._build_signal(market, p_fav, fav_is_yes)
         await self._persist_signal(signal, market)
 
@@ -233,7 +312,8 @@ class BiasHarvestPillar:
         # portfolio + calibration writes below.
         force_paper = cfg.paper or getattr(decision, "force_paper", False)
         res = await self._gateway.submit(TradeIntent(
-            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+            signal=signal, market=order_market, size_dollars=size,
+            force_paper=force_paper))
         if res.status not in ("filled", "paper", "partial", "pending"):
             log.warning("bias_harvest.order_rejected", market_id=market.id,
                         status=res.status, error=res.reason)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -569,6 +569,15 @@ bias_harvest:
   min_hours_to_resolution: 6.0
   max_days_to_resolution: 45.0   # cap capital lock-up (backtest avg hold ~15d)
   interval_seconds: 600
+  # Maker entry — the favorite-longshot edge accrues to makers, not takers
+  # (GWU WP 2026-001 / Whelan: maker ~-9.6% vs taker ~-31.5%). Post the BUY at the
+  # favored-side BID to capture the spread instead of paying the observed price.
+  # Only fires when there is >= maker_min_spread to capture; paper admits only
+  # paper_maker_fill_rate of eligible markets (deterministic) so the paper book
+  # isn't a 100%-fill fantasy. Real maker fill rate is the live-validation risk.
+  maker_entry: true
+  maker_min_spread: 0.02
+  paper_maker_fill_rate: 0.5
 
 analysis:
   mode: "strategic"   # "pipeline", "strategic", or "agent"

--- a/config/settings.py
+++ b/config/settings.py
@@ -370,6 +370,21 @@ class BiasHarvestConfig(BaseModel):
     # risk.blocked_categories, against the CLASSIFIED category (not the raw label
     # that an unclassified market would slip through). See [[bias-harvest-strategy]].
     exclude_categories: list[str] = ["weather", "sports", "politics_us"]
+    # Maker entry (research: GWU WP 2026-001 / Whelan — the favorite-longshot edge
+    # accrues to MAKERS (~-9.6% avg return) not TAKERS (~-31.5%); the prior entry
+    # paid the observed price = taker economics, which the paper ledger surfaced as
+    # the strategy being "slippage-bled" despite 88% win). When true, post the BUY
+    # at the favored-side BID (capture the spread) instead of the last price, and
+    # only when there is a real spread to capture (>= maker_min_spread).
+    maker_entry: bool = True
+    maker_min_spread: float = 0.02
+    # Paper realism: maker posts do NOT always get hit. Without modelling this the
+    # paper book would assume 100% maker fills and read far too rosy — dangerous
+    # because the graduation ladder auto-promotes at 20 positive events. So in
+    # paper, deterministically (stable market-id hash) admit only this fraction of
+    # otherwise-eligible markets, modelling a realistic maker CAPTURE rate. The
+    # real fill rate is THE risk to validate before any live-arm. 1.0 disables.
+    paper_maker_fill_rate: float = 0.5
 
 
 class EconIndicatorConfig(BaseModel):

--- a/tests/test_bias_harvest.py
+++ b/tests/test_bias_harvest.py
@@ -23,6 +23,8 @@ from auramaur.db.database import Database
 from auramaur.exchange.models import (
     Market,
     Order,
+    OrderBook,
+    OrderBookLevel,
     OrderResult,
     OrderSide,
     OrderType,
@@ -57,13 +59,25 @@ def _settings(**overrides) -> Settings:
     s.bias_harvest.band_lo = 0.80
     s.bias_harvest.band_hi = 0.97
     s.bias_harvest.stake_usd = 10.0
+    # Default the maker fill-rate haircut OFF in tests (admit every market) so
+    # entries are deterministic; the haircut has its own focused test.
+    s.bias_harvest.paper_maker_fill_rate = 1.0
     for k, v in overrides.items():
         setattr(s.bias_harvest, k, v)
     return s
 
 
-def _exchange(filled=True):
+def _book(best_bid=0.84, best_ask=0.86) -> OrderBook:
+    """A book with a capturable spread on the favored side (default 2c)."""
+    return OrderBook(
+        bids=[OrderBookLevel(price=best_bid, size=200.0)],
+        asks=[OrderBookLevel(price=best_ask, size=200.0)],
+    )
+
+
+def _exchange(filled=True, book=None):
     ex = MagicMock()
+    ex.get_order_book = AsyncMock(return_value=book if book is not None else _book())
 
     def prepare_order(signal, market, size, is_live):
         token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
@@ -317,5 +331,99 @@ def test_stake_cap_applies():
         size_arg = ex.prepare_order.call_args[0][2]
         assert abs(size_arg - 10.0) < 1e-9
         await db.close()
+
+    asyncio.run(run())
+
+
+# ----------------------------------------------------------------------
+# Maker entry (GWU WP 2026-001 / Whelan: the edge accrues to makers, not takers)
+# ----------------------------------------------------------------------
+
+
+def test_maker_entry_builds_order_at_the_bid_not_the_observed_price():
+    """The ORDER is built at the favored-side bid (capture the spread), while the
+    SIGNAL keeps the observed price (so the divergence filter still passes)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(book=_book(best_bid=0.90, best_ask=0.93))
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.92)], exchange=ex)
+        assert await pillar.run_once() == 1
+
+        # prepare_order saw the maker bid (0.90), NOT the observed 0.92.
+        order_market = ex.prepare_order.call_args[0][1]
+        assert abs(order_market.outcome_yes_price - 0.90) < 1e-9
+
+        # Signal accounting is unchanged: claude_prob = observed 0.92 + 0.04.
+        sig = await db.fetchone(
+            "SELECT * FROM signals WHERE strategy_source='bias_harvest'")
+        assert abs(sig["claude_prob"] - 0.96) < 1e-9
+        assert abs(sig["market_prob"] - 0.92) < 1e-9
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_maker_entry_skips_when_spread_too_thin_to_capture():
+    """With a sub-maker_min_spread book, posting at the bid ~= crossing — so we
+    skip rather than harvest as a taker (the 4.4c-slippage cliff)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(book=_book(best_bid=0.85, best_ask=0.86))  # 1c < 2c floor
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.85)], exchange=ex)
+        assert await pillar.run_once() == 0
+        ex.prepare_order.assert_not_called()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_maker_entry_disabled_falls_back_to_observed_price():
+    """maker_entry=false keeps the old taker behaviour (enter at observed price,
+    no book lookup) — preserves the prior contract for an explicit opt-out."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange()
+        pillar, _ = _pillar(db, _settings(maker_entry=False), [_market(yes=0.85)],
+                            exchange=ex)
+        assert await pillar.run_once() == 1
+        order_market = ex.prepare_order.call_args[0][1]
+        assert abs(order_market.outcome_yes_price - 0.85) < 1e-9  # observed
+        ex.get_order_book.assert_not_called()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_paper_maker_fill_rate_haircut_gates_entries():
+    """In paper, the deterministic fill-rate haircut blocks entries so the book
+    reflects a realistic maker capture rate. rate=0 -> nothing fills; rate=1 ->
+    eligible market fills. The gate is stable (same id -> same verdict)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # rate 0.0: an otherwise-perfect in-band market is gated out.
+        pillar0, _ = _pillar(db, _settings(paper_maker_fill_rate=0.0),
+                             [_market(yes=0.90)])
+        assert await pillar0.run_once() == 0
+
+        # rate 1.0: it enters.
+        db2 = Database(":memory:")
+        await db2.connect()
+        pillar1, _ = _pillar(db2, _settings(paper_maker_fill_rate=1.0),
+                             [_market(yes=0.90)])
+        assert await pillar1.run_once() == 1
+
+        # Stability + partition: same id is deterministic; ~half a sample admits.
+        assert pillar1._paper_admits("x") == pillar1._paper_admits("x")
+        sample = [f"m{i}" for i in range(400)]
+        half = _settings(paper_maker_fill_rate=0.5)
+        p, _ = _pillar(db2, half, [])
+        admitted = sum(p._paper_admits(mid) for mid in sample)
+        assert 120 < admitted < 280  # not all, not none — a real partition
+        await db.close()
+        await db2.close()
 
     asyncio.run(run())


### PR DESCRIPTION
## Why
Live-microstructure research (GWU WP 2026-001 / Whelan, 300k+ Kalshi contracts) shows the favorite-longshot bias accrues to **makers** (~-9.6% avg) not **takers** (~-31.5%). The prior entry paid the observed price = taker economics — which the paper ledger surfaced as the strategy being slippage-bled despite a high win rate.

## What
- Post the BUY at the favored-side **bid** (capture the spread), only where a real spread exists (`>= maker_min_spread`); never crossed.
- The **signal/divergence accounting stays on the observed price** (divergence filter still passes at `edge_uplift`); only the **order** is built at the maker bid, so the captured spread lands in the fill → `cost_basis` → `pnl_ledger` where the graduation ladder reads it.
- `paper_maker_fill_rate` deterministically haircuts paper entries so the book reflects a realistic maker **capture** rate, not a 100%-fill fantasy. The real fill rate is the key live-validation risk (documented).

## Safety
Strictly **paper-forced** (`bias_harvest.paper: true`); no live capital. Opt-out via `maker_entry: false` preserves the prior taker behaviour.

## Tests
13 pass — bid-entry pricing, thin-spread skip, maker_entry opt-out, fill-rate haircut (stability + partition), plus all prior rails.

Assisted-by: Claude (Anthropic)