### PR TITLE
feat(settlement_arb): target illiquid tail bins where the settlement lag survives

### DIFF
--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -17,6 +17,15 @@ No forecasting: if the print isn't out yet, or the criterion is compound /
 ambiguous, it SKIPS. The LLM only EXTRACTS the predicate (indicator, operator,
 threshold, period) — once, cached, adversarially verified; the RESOLVE step is a
 pure deterministic compare against FRED. PAPER-FORCED, its own graduation cell.
+
+WHERE THE EDGE LIVES (NBER w34702, 2026): liquid macro contracts reprice
+intraday and are well-calibrated — so the settlement LAG survives mostly in
+ILLIQUID, low-volume tail/bin contracts with stale prices. Because this pillar
+holds to resolution (known-outcome convergence, no exit), illiquidity does not
+block an exit, so the candidate scan keeps only a low DUST floor (min_liquidity)
+to admit those tail bins rather than demanding liquid headline contracts. The
+min_edge gate still drops anything that has already converged, so a liquid
+un-repriced market (the easy fill) is never wrongly excluded.
 """
 
 from __future__ import annotations

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -452,7 +452,13 @@ settlement_arb:
   paper: true
   stake_usd: 10.0
   min_edge: 0.05
-  min_liquidity: 1000.0
+  # Dust guard, not a quality filter — lowered 1000 -> 100 so the scan ADMITS the
+  # illiquid tail/bin contracts where the settlement lag actually survives (NBER
+  # w34702: liquid macro reprices intraday; the lag lives in low-volume stale
+  # bins). Safe here because the pillar holds to resolution — illiquidity doesn't
+  # block an exit. Kalshi macro-bin coverage is the natural next step (the NBER
+  # evidence is Kalshi-specific) but needs the Kalshi gateway wired in.
+  min_liquidity: 100.0
   min_extract_confidence: 0.8
   verify_min_confidence: 0.8
   max_entries_per_cycle: 5

--- a/config/settings.py
+++ b/config/settings.py
@@ -431,7 +431,16 @@ class SettlementArbConfig(BaseModel):
     # Required gap between the locked outcome (0/1) and the market price — the
     # un-converged distance the lag leaves on the table.
     min_edge: float = 0.05
-    min_liquidity: float = 1000.0
+    # Liquidity floor is a DUST guard, not a quality filter. NBER w34702 (2026):
+    # liquid macro contracts reprice intraday and are well-calibrated — the
+    # settlement LAG survives mostly in illiquid, low-volume TAIL/bin contracts
+    # with stale prices. This pillar holds to resolution (known-outcome
+    # convergence, no exit), so illiquidity does NOT block the exit the way it
+    # would for a round-trip strategy. So the floor is set low — just high enough
+    # to exclude untradeable dust — to ADMIT the tail bins where the edge lives,
+    # not to demand the liquid headline contracts where it doesn't. (Live
+    # execution against a single stale quote is the key validation risk.)
+    min_liquidity: float = 100.0
     # The LLM only extracts the predicate; both gates default conservative.
     min_extract_confidence: float = 0.8
     verify_min_confidence: float = 0.8

--- a/tests/test_settlement_arb.py
+++ b/tests/test_settlement_arb.py
@@ -177,3 +177,40 @@ async def test_print_not_published_never_trades():
     entered = await p._maybe_enter(market, pred)
     assert entered is False
     p._risk.evaluate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Candidate scan — admit illiquid tail bins (NBER w34702), reject only dust
+# ---------------------------------------------------------------------------
+
+def _row(mid, question, yes=0.7, liquidity=150.0):
+    return {
+        "id": mid, "question": question, "description": "",
+        "outcome_yes_price": yes, "outcome_no_price": round(1 - yes, 2),
+        "liquidity": liquidity, "category": "economics",
+        "clob_token_yes": "ty", "clob_token_no": "tn", "end_date": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_candidates_admit_tail_bins_reject_dust_and_noneon():
+    """The low liquidity floor admits an illiquid tail-bin econ market (where the
+    settlement lag lives) but still rejects untradeable dust below the floor and
+    non-econ markets."""
+    rows = [
+        _row("tail", "CPI YoY above 3.0% in June?", liquidity=150.0),  # admit
+        _row("dust", "Unemployment above 4% in June?", liquidity=20.0),  # < floor
+        _row("noneon", "Will Bitcoin hit $200k?", liquidity=5000.0),     # no trigger
+        _row("converged", "Payrolls above 150k in June?", yes=1.0),      # price out of (0,1)
+    ]
+    settings = SimpleNamespace(settlement_arb=SimpleNamespace(min_liquidity=100.0))
+    db = MagicMock()
+    db.fetchall = AsyncMock(return_value=rows)
+    p = SettlementArbPillar(
+        db=db, settings=settings, discovery=MagicMock(), exchange=MagicMock(),
+        risk_manager=MagicMock(), pnl_tracker=MagicMock(), fred_source=MagicMock(),
+        analyzer=None)
+
+    cands = await p._candidates()
+    ids = {m.id for m in cands}
+    assert ids == {"tail"}


### PR DESCRIPTION
## Why
NBER w34702 (2026): liquid macro contracts reprice intraday and are well-calibrated — the settlement lag survives mostly in **illiquid, low-volume tail/bin contracts** with stale prices. The candidate scan's `min_liquidity: 1000` excluded exactly those bins.

## What
- Floor lowered `1000 → 100` — a **dust guard**, not a quality filter — to admit tail bins. Safe because the pillar **holds to resolution** (known-outcome convergence, no exit), so illiquidity doesn't block an exit.
- **No `max_liquidity` cap**: `min_edge` already drops converged markets, so a liquid un-repriced market (the easiest fill) is never wrongly excluded.
- Kalshi macro-bin coverage (where the NBER evidence is strongest) documented as the follow-up — needs the Kalshi gateway wired in.

## Safety
Paper-forced. Test covers tail-bin admit vs dust/non-econ reject.

Assisted-by: Claude (Anthropic)