### PR TITLE
feat(long_horizon): new pillar — long-horizon favorite underpricing

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1356,6 +1356,10 @@ class AuramaurBot(
         if self.settings.bias_harvest.enabled:
             tasks.append(asyncio.create_task(self._task_bias_harvest(), name="bias_harvest"))
 
+        # Long-horizon favorite underpricing (paper-forced; structural slope edge)
+        if self.settings.long_horizon.enabled:
+            tasks.append(asyncio.create_task(self._task_long_horizon(), name="long_horizon"))
+
         # Entailment arbitrage (paper-forced until proven)
         if self.settings.entailment_arb.enabled:
             tasks.append(asyncio.create_task(self._task_entailment_arb(), name="entailment_arb"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -43,6 +43,29 @@ class StrategyTaskMixin:
                 log.error("bias_harvest.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_long_horizon(self) -> None:
+        """Periodic long-horizon favorite-underpricing scan (paper-forced)."""
+        from auramaur.strategy.long_horizon import LongHorizonPillar
+
+        pillar = LongHorizonPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(60, self.settings.long_horizon.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("long_horizon.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_entailment_arb(self) -> None:
         """Periodic entailment-arbitrage scan (paper-forced by config)."""
         from auramaur.strategy.entailment_arb import EntailmentArbPillar

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -1,0 +1,292 @@
+"""Long-horizon favorite underpricing — structural underconfidence at long tenor.
+
+Research basis (arXiv 2602.19520, 292M trades across Kalshi+Polymarket):
+prediction-market prices are systematically UNDERCONFIDENT at long horizons — the
+calibration slope rises from ~0.99 within an hour of resolution to ~1.32 beyond a
+month, i.e. long-dated favorites are underpriced (a 70c contract resolves YES
+~75% of the time). This is a STRUCTURAL, cross-venue property, not a forecast: we
+apply the published ``slope`` to the market's OWN price (logit space) to get a
+fair, and trade only the favored side's underpricing — never a view of our own.
+
+Distinct from bias_harvest, which harvests the NEAR-resolution favorite-longshot
+bias in the deep band (0.90-0.97, <=45 days). This pillar trades the LONG-horizon
+(> min_days) MODERATE-favorite band where the slope correction is materially
+positive and capital lock-up is the cost.
+
+CAVEAT (why it's restricted + paper-forced): the paper's effect is STRONGEST in
+political markets — exactly the bot's documented no-edge zone (politics_us /
+politics_intl). Politics is therefore EXCLUDED: this cell exists to test whether
+the long-horizon underconfidence GENERALIZES to tech/crypto/macro net of cost.
+``slope`` defaults BELOW the paper's 1.32 because it rests on a single
+non-peer-reviewed preprint. PAPER-FORCED, its own graduation cell. v1 enters at
+the observed price; maker entry (see bias_harvest) is the obvious execution
+follow-up once gross edge holds.
+
+Rides the same rails as bias_harvest: signals + trades (attribution), the full
+RiskManager gate (all 15 checks, never bypassed), a calibration prediction, and a
+portfolio row the resolution tracker settles. One entry per market, ever; never
+enters a market already held by any strategy/mode.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.strategy.protocols import ExecutionMode
+
+log = structlog.get_logger()
+
+
+def calibrated_fair(price: float, slope: float) -> float:
+    """Slope-corrected fair probability for a price, in logit space:
+    ``true_logit = slope * logit(price)`` (arXiv 2602.19520). For a favorite
+    (price > 0.5) and slope > 1 this returns a value ABOVE the price — the
+    documented long-horizon underpricing. Pure function (the tested core)."""
+    p = min(max(price, 1e-6), 1.0 - 1e-6)
+    logit = math.log(p / (1.0 - p))
+    return 1.0 / (1.0 + math.exp(-slope * logit))
+
+
+class LongHorizonPillar:
+    """Periodic long-horizon favored-side scanner for Polymarket."""
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "long_horizon"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
+
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+
+    # ------------------------------------------------------------------
+    # Scan cycle
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.long_horizon
+        if not cfg.enabled:
+            return 0
+        open_count = await self._open_position_count()
+        if open_count >= cfg.max_open:
+            log.debug("long_horizon.book_full", open=open_count, cap=cfg.max_open)
+            return 0
+        markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        entered = 0
+        for market in markets:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            if open_count + entered >= cfg.max_open:
+                break
+            try:
+                if await self._try_enter(market):
+                    entered += 1
+            except Exception as e:
+                log.error("long_horizon.entry_error", market_id=market.id, error=str(e))
+        if entered:
+            log.info("long_horizon.cycle_done", entered=entered)
+        return entered
+
+    # ------------------------------------------------------------------
+    # Entry pipeline
+    # ------------------------------------------------------------------
+
+    def _favored(self, market: Market) -> tuple[float, bool] | None:
+        """(favored_price, favored_is_yes) if the favored side is in the moderate
+        band, else None."""
+        cfg = self._settings.long_horizon
+        p_yes = market.outcome_yes_price
+        if not (0.0 < p_yes < 1.0):
+            return None
+        p_fav = max(p_yes, 1.0 - p_yes)
+        if not (cfg.band_lo <= p_fav <= cfg.band_hi):
+            return None
+        return p_fav, p_yes >= 0.5
+
+    def _eligible(self, market: Market) -> bool:
+        cfg = self._settings.long_horizon
+        if not market.active:
+            return False
+        if (market.exchange or "polymarket") != "polymarket":
+            return False  # v1: Polymarket only (0% fees — the edge clears cleanly)
+        if market.liquidity < cfg.min_liquidity:
+            return False
+        # Classify before the block (mislabel-safe, like bias_harvest/the gateway):
+        # exclude the global block AND politics (the paper's effect is strongest
+        # there but it's the bot's no-edge zone — we test generalization elsewhere).
+        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        hit = blocked_category_hit(excluded, market.question, market.description,
+                                   market.category)
+        if hit:
+            log.debug("long_horizon.skip_category", market_id=market.id, category=hit)
+            return False
+        if market.end_date is None:
+            return False  # need a horizon to know it's long-dated
+        end = market.end_date
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        days_left = (end - datetime.now(timezone.utc)).total_seconds() / 86400.0
+        if days_left < cfg.min_days_to_resolution:
+            return False  # not a LONG-horizon market — no underconfidence edge
+        if days_left > cfg.max_days_to_resolution:
+            return False  # capital lock-up cap
+        return True
+
+    async def _already_entered_or_held(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'long_horizon' LIMIT 1",
+            (market_id,),
+        )
+        if row is not None:
+            return True  # one shot per market, ever
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,),
+        )
+        return row is not None  # held by any strategy/mode — stay out
+
+    async def _open_position_count(self) -> int:
+        row = await self._db.fetchone(
+            """SELECT COUNT(*) AS n FROM portfolio p
+               WHERE EXISTS (SELECT 1 FROM signals s
+                             WHERE s.market_id = p.market_id
+                               AND s.strategy_source = 'long_horizon')""",
+        )
+        return int(row["n"]) if row else 0
+
+    def _build_signal(self, market: Market, p_fav: float, fav_is_yes: bool,
+                      edge_fav: float) -> Signal:
+        cfg = self._settings.long_horizon
+        fair_fav = p_fav + edge_fav  # slope-corrected fair on the favored side
+        # Express the fair as P(YES) for the risk/divergence accounting.
+        claude_prob = min(0.99, fair_fav) if fav_is_yes else max(0.01, 1.0 - fair_fav)
+        return Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=claude_prob,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market.outcome_yes_price,
+            edge=edge_fav * 100.0,
+            evidence_summary=(
+                f"Long-horizon underconfidence: favored side at {p_fav:.2f}, "
+                f"slope {cfg.slope:.2f} -> fair {fair_fav:.2f} "
+                f"(+{edge_fav * 100:.1f}pts); no forecast claimed."
+            ),
+            recommended_side=OrderSide.BUY if fav_is_yes else OrderSide.SELL,
+            strategy_source="long_horizon",
+            # Names the structural gap so the name-the-gap divergence gate passes:
+            # the divergence IS the thesis (published calibration slope), not an
+            # unexplained model disagreement.
+            mispricing_reason=(
+                "structural: long-horizon underconfidence (arXiv 2602.19520) "
+                "underprices long-dated favorites"
+            ),
+        )
+
+    async def _try_enter(self, market: Market) -> bool:
+        cfg = self._settings.long_horizon
+        fav = self._favored(market)
+        if fav is None or not self._eligible(market):
+            return False
+        if await self._already_entered_or_held(market.id):
+            return False
+        p_fav, fav_is_yes = fav
+
+        edge_fav = calibrated_fair(p_fav, cfg.slope) - p_fav
+        if edge_fav < cfg.min_edge:
+            return False  # correction too small at this price to clear cost
+
+        signal = self._build_signal(market, p_fav, fav_is_yes, edge_fav)
+        await self._persist_signal(signal, market)
+
+        # Full risk gate — all checks apply; never bypassed.
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("long_horizon.risk_rejected", market_id=market.id,
+                     reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("long_horizon.order_rejected", market_id=market.id,
+                        status=res.status, error=res.reason)
+            return False
+
+        await self._record_position(signal, market, res.order, res.result)
+        log.info("long_horizon.entered", market_id=market.id,
+                 token=res.order.token.value, price=res.order.price,
+                 size=res.order.size, edge=round(edge_fav, 3),
+                 paper=res.result.is_paper)
+        return True
+
+    # ------------------------------------------------------------------
+    # Bookkeeping — same rails as bias_harvest / the engine
+    # ------------------------------------------------------------------
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.exchange or "polymarket", market.condition_id,
+             market.question, (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'long_horizon')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value),
+        )
+        await self._db.commit()
+
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        """Portfolio row (resolution tracker settles it) + calibration prediction.
+        The fill (-> cost_basis -> pnl_ledger) and the trades-mirror are owned by
+        ExecutionGateway; mirrors bias_harvest._record_position."""
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("long_horizon.calibration_error", error=str(e))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -440,6 +440,34 @@ econ_indicator:
   history_n: 60
   interval_seconds: 1800
 
+long_horizon:
+  # Long-horizon favorite underpricing — structural underconfidence at long tenor.
+  # arXiv 2602.19520 (292M trades, Kalshi+Polymarket): the calibration slope rises
+  # from ~0.99 near resolution to ~1.32 beyond a month, so long-dated favorites are
+  # underpriced (a 70c contract resolves YES ~75%). We apply `slope` to the
+  # market's OWN price (logit space) to get a fair and trade only the favored
+  # side's underpricing — no forecast. Distinct from bias_harvest (near-resolution
+  # deep band). POLITICS EXCLUDED: the effect is strongest there but politics is
+  # the bot's no-edge zone, so this cell tests whether it GENERALIZES to
+  # tech/crypto/macro net of cost. PAPER-FORCED, own graduation cell. slope is
+  # conservative vs the paper's 1.32 (single preprint). v1 enters at the observed
+  # price; maker entry (see bias_harvest) is the obvious follow-up.
+  enabled: true       # paper measurement spike
+  paper: true
+  slope: 1.25
+  band_lo: 0.55
+  band_hi: 0.92
+  min_edge: 0.03
+  stake_usd: 10.0
+  max_open: 30
+  max_entries_per_cycle: 5
+  scan_limit: 300
+  min_liquidity: 1000.0
+  min_days_to_resolution: 30.0
+  max_days_to_resolution: 180.0
+  interval_seconds: 1800
+  exclude_categories: ["politics_us", "politics_intl"]
+
 settlement_arb:
   # Settlement-lag / known-outcome arb (FRED-first) — the structural generalization
   # of the graduated resolution_lens x weather edge. Trades a Polymarket econ

--- a/config/settings.py
+++ b/config/settings.py
@@ -387,6 +387,47 @@ class BiasHarvestConfig(BaseModel):
     paper_maker_fill_rate: float = 0.5
 
 
+class LongHorizonConfig(BaseModel):
+    """Long-horizon favorite underpricing (strategy/long_horizon.py).
+
+    Research basis (arXiv 2602.19520, 292M trades): prices are systematically
+    UNDERCONFIDENT at long horizons — the calibration slope rises from ~0.99 near
+    resolution to ~1.32 beyond a month, so long-dated favorites are underpriced. We
+    apply ``slope`` to the market's OWN price (logit space) to get a fair and trade
+    only the favored side's underpricing — never a forecast of our own.
+
+    PAPER-FORCED. Politics is EXCLUDED (the paper's effect is strongest there, but
+    politics is the bot's documented no-edge zone) so this cell tests whether the
+    effect GENERALIZES to tech/crypto/macro net of cost. ``slope`` defaults below
+    the paper's 1.32 — it rests on a single non-peer-reviewed preprint, so we size
+    the correction conservatively.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    # Calibration slope applied in logit space. Conservative vs the paper's 1.32
+    # (one preprint); raise toward 1.32 only once the paper ledger shows edge.
+    slope: float = 1.25
+    # Moderate-favorite band. Below ~0.55 the slope correction is negligible;
+    # 0.90+ overlaps bias_harvest's near-resolution deep band and locks capital.
+    band_lo: float = 0.55
+    band_hi: float = 0.92
+    min_edge: float = 0.03
+    stake_usd: float = 10.0
+    max_open: int = 30
+    max_entries_per_cycle: int = 5
+    scan_limit: int = 300
+    min_liquidity: float = 1000.0
+    # LONG horizon only — the underconfidence is a "beyond one month" effect.
+    min_days_to_resolution: float = 30.0
+    max_days_to_resolution: float = 180.0   # cap capital lock-up
+    interval_seconds: int = 1800
+    # Politics excluded: that's where the effect is strongest in the paper but
+    # where the bot has no edge — so we test generalization elsewhere. Checked on
+    # top of risk.blocked_categories, against the CLASSIFIED category.
+    exclude_categories: list[str] = ["politics_us", "politics_intl"]
+
+
 class EconIndicatorConfig(BaseModel):
     """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
 
@@ -1045,6 +1086,7 @@ class Settings(BaseSettings):
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
+    long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
     settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))

--- a/tests/test_long_horizon.py
+++ b/tests/test_long_horizon.py
@@ -1,0 +1,231 @@
+"""Tests for the long-horizon favorite-underpricing pillar.
+
+Locks in:
+  1. calibrated_fair — the pure slope-correction core (favorites underpriced,
+     symmetry, slope=1 is identity).
+  2. Eligibility — only moderate favorites on active, liquid, LONG-dated,
+     non-politics Polymarket markets enter.
+  3. PAPER-FORCING — paper=true builds the order with is_live=False.
+  4. The favored side maps to the right BUY/SELL signal + fair P(YES).
+  5. min_edge / short-horizon / politics exclusions skip.
+  6. A fill writes the full rails (signal, trade, portfolio is_paper, calibration).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderResult,
+    OrderSide,
+    OrderType,
+    TokenType,
+)
+from auramaur.strategy.long_horizon import LongHorizonPillar, calibrated_fair
+from config.settings import Settings
+
+
+def _market(mid="m1", yes=0.70, liquidity=5000.0, category="tech",
+            active=True, days_out=60.0, exchange="polymarket") -> Market:
+    return Market(
+        id=mid, exchange=exchange, question=f"q-{mid}", category=category,
+        active=active, outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=liquidity, volume=10000.0,
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_out),
+        clob_token_yes="tok-yes", clob_token_no="tok-no",
+    )
+
+
+def _settings(**overrides) -> Settings:
+    s = Settings()
+    s.long_horizon.enabled = True
+    s.long_horizon.paper = True
+    for k, v in overrides.items():
+        setattr(s.long_horizon, k, v)
+    return s
+
+
+def _exchange(filled=True):
+    ex = MagicMock()
+
+    def prepare_order(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(
+            market_id=market.id, token_id="tok", side=OrderSide.BUY, token=token,
+            size=round(size / price, 2), price=round(price, 2),
+            order_type=OrderType.LIMIT, dry_run=not is_live,
+        )
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(side_effect=lambda order: OrderResult(
+        order_id="ord-1", market_id=order.market_id,
+        status="paper" if order.dry_run else "filled",
+        filled_size=order.size if filled else 0, filled_price=order.price,
+        is_paper=order.dry_run,
+    ))
+    return ex
+
+
+def _risk(approved=True, size=8.0, force_paper=False):
+    rm = MagicMock()
+    decision = MagicMock()
+    decision.approved = approved
+    decision.position_size = size if approved else 0.0
+    decision.reason = "" if approved else "blocked"
+    decision.force_paper = force_paper
+    rm.evaluate = AsyncMock(return_value=decision)
+    return rm
+
+
+def _pillar(db, settings, markets, exchange=None, risk=None):
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+    return LongHorizonPillar(
+        db=db, settings=settings, discovery=discovery,
+        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        pnl_tracker=PnLTracker(db, settings), calibration=calibration,
+    ), calibration
+
+
+# ----------------------------------------------------------------------
+# calibrated_fair — the pure core
+# ----------------------------------------------------------------------
+
+def test_calibrated_fair_lifts_favorites_and_is_identity_at_slope_one():
+    # slope 1.0 -> identity
+    assert abs(calibrated_fair(0.70, 1.0) - 0.70) < 1e-9
+    # slope > 1 lifts a favorite (the documented underpricing): 0.70 -> ~0.75
+    f = calibrated_fair(0.70, 1.32)
+    assert 0.74 < f < 0.76
+    # symmetry: a longshot is pushed DOWN by the same logit factor
+    assert abs((1 - calibrated_fair(0.30, 1.32)) - calibrated_fair(0.70, 1.32)) < 1e-9
+    # a 50/50 is unmoved
+    assert abs(calibrated_fair(0.50, 1.5) - 0.50) < 1e-9
+
+
+# ----------------------------------------------------------------------
+# Entry behaviour
+# ----------------------------------------------------------------------
+
+def test_enters_long_dated_favorite_and_writes_rails():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = _settings(slope=1.32)
+        ex = _exchange()
+        pillar, calibration = _pillar(db, settings, [_market(yes=0.70)], exchange=ex)
+        assert await pillar.run_once() == 1
+
+        # paper-forced: prepare_order saw is_live=False
+        assert ex.prepare_order.call_args[0][3] is False
+
+        sig = await db.fetchone(
+            "SELECT * FROM signals WHERE strategy_source='long_horizon'")
+        assert sig is not None and sig["action"] == "BUY"
+        # claude_prob is the slope-corrected fair (~0.75), above the 0.70 price.
+        assert sig["claude_prob"] > 0.74 and sig["market_prob"] == 0.70
+
+        trade = await db.fetchone(
+            "SELECT * FROM trades WHERE strategy_source='long_horizon'")
+        assert trade is not None and trade["is_paper"] == 1
+        pos = await db.fetchone("SELECT * FROM portfolio WHERE market_id='m1'")
+        assert pos is not None and pos["is_paper"] == 1 and pos["token"] == "YES"
+        calibration.record_prediction.assert_awaited_once()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_favored_no_side_enters_as_sell():
+    """YES at 0.30 -> favored NO at 0.70 -> SELL signal (buys NO)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        pillar, _ = _pillar(db, _settings(slope=1.32), [_market(yes=0.30)])
+        assert await pillar.run_once() == 1
+        sig = await db.fetchone(
+            "SELECT * FROM signals WHERE strategy_source='long_horizon'")
+        assert sig["action"] == "SELL"
+        pos = await db.fetchone("SELECT token FROM portfolio WHERE market_id='m1'")
+        assert pos["token"] == "NO"
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_skips_short_horizon_politics_thin_and_subedge():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        markets = [
+            _market("short", yes=0.70, days_out=10.0),        # < 30d horizon
+            _market("toolong", yes=0.70, days_out=400.0),     # > max horizon
+            _market("thin", yes=0.70, liquidity=100.0),       # < min_liquidity
+            _market("pol", yes=0.70, category="politics_us"),  # excluded category
+            _market("coinflip", yes=0.52),                    # below band_lo
+            _market("kalshi", yes=0.70, exchange="kalshi"),   # poly-only v1
+        ]
+        pillar, _ = _pillar(db, _settings(slope=1.32), markets)
+        assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_min_edge_blocks_when_slope_correction_too_small():
+    """A barely-favored market at a low slope yields a sub-min_edge correction."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # 0.58 favorite at slope 1.05: fair ~0.585 -> edge ~0.005 < min_edge 0.03.
+        pillar, _ = _pillar(db, _settings(slope=1.05, min_edge=0.03),
+                            [_market(yes=0.58)])
+        assert await pillar.run_once() == 0
+        # No signal persisted (gated before persist).
+        assert await db.fetchone("SELECT 1 FROM signals") is None
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_one_entry_per_market_and_skips_held():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = _settings(slope=1.32)
+        pillar, _ = _pillar(db, settings, [_market(yes=0.70)])
+        assert await pillar.run_once() == 1
+        assert await pillar.run_once() == 0  # signal exists -> no re-entry
+
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES ('held','polymarket','BUY',5,0.5,0.5,0)")
+        await db.commit()
+        pillar2, _ = _pillar(db, settings, [_market("held", yes=0.70)])
+        assert await pillar2.run_once() == 0  # held by another strategy -> skip
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_risk_rejection_places_no_order():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange()
+        pillar, _ = _pillar(db, _settings(slope=1.32), [_market(yes=0.70)],
+                            exchange=ex, risk=_risk(approved=False))
+        assert await pillar.run_once() == 0
+        ex.place_order.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -16,6 +16,7 @@ import pathlib
 import pytest
 
 from auramaur.strategy.bias_harvest import BiasHarvestPillar
+from auramaur.strategy.long_horizon import LongHorizonPillar
 from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
 from auramaur.strategy.econ_indicator import EconIndicatorPillar
 from auramaur.strategy.entailment_arb import EntailmentArbPillar
@@ -32,6 +33,7 @@ _ROOT = pathlib.Path(__file__).resolve().parent.parent
 # (pillar class, source module) — every pillar the bot drives.
 PILLARS = [
     (BiasHarvestPillar, "auramaur/strategy/bias_harvest.py"),
+    (LongHorizonPillar, "auramaur/strategy/long_horizon.py"),
     (ResolutionLensPillar, "auramaur/strategy/resolution_lens.py"),
     (WeatherTempPillar, "auramaur/strategy/weather_temp.py"),
     (EconIndicatorPillar, "auramaur/strategy/econ_indicator.py"),


### PR DESCRIPTION
## Why
arXiv 2602.19520 (292M trades, Kalshi+Polymarket): prices are systematically **underconfident at long horizons** — the calibration slope rises from ~0.99 near resolution to ~1.32 beyond a month, so long-dated favorites are underpriced (a 70¢ contract resolves YES ~75%).

## What
- New pillar: apply `slope` to the market's **own** price in logit space → fair; trade only the favored side's underpricing. **No forecast.**
- Distinct from `bias_harvest` (near-resolution deep band); this is the **long-horizon moderate-favorite** band (`min_days_to_resolution: 30`).
- **Politics excluded** — the effect is strongest there but it's the bot's no-edge zone, so this cell tests whether it **generalizes** to tech/crypto/macro net of cost.
- `slope` defaults `1.25` (conservative vs the paper's 1.32 — single preprint). Structural gap is named so the name-the-gap divergence gate passes.
- Full risk gate; same rails as bias_harvest. Wired into the run loop + gateway-contract conformance list.

## Safety
**Paper-forced**, own graduation cell. v1 enters at the observed price; maker entry (per #227) is the documented execution follow-up.

## Tests
7 new + protocol conformance; 61 pass across the strategy/settings suites. Covers the pure slope core, favored YES/NO mapping, paper-forcing, horizon/politics/thin/sub-edge skips, one-shot, risk rejection.

Assisted-by: Claude (Anthropic)