### PR TITLE
feat(informed_flow): Kalshi trade-tape + abnormal-trade-size detector (data layer for #3)

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -146,6 +146,24 @@ class KalshiClient:
         data = json.loads(raw)
         return data.get("market")
 
+    async def get_trades(self, ticker: str, limit: int = 200) -> list[dict]:
+        """Recent PUBLIC trades for a market (v2 GET /markets/trades). Each trade
+        carries ``count`` (contracts) and ``taker_side`` ('yes'/'no') — the data
+        layer for abnormal-trade-size / informed-flow detection
+        (strategy/informed_flow.py). Returns [] on error (fail-soft: a missing
+        tape must not break a scan)."""
+        self._init_api()
+        try:
+            import json
+            raw = await self._call_raw(
+                self._markets_api.get_trades_without_preload_content,
+                ticker=ticker, limit=min(limit, 1000),
+            )
+            return json.loads(raw).get("trades", [])
+        except Exception as e:
+            log.error("kalshi.trades_fetch_error", ticker=ticker, error=str(e))
+            return []
+
     async def get_markets_by_series(self, series_ticker: str,
                                     limit: int = 200) -> list[Market]:
         """Fetch open markets for ONE series — i.e. all bins of a threshold

--- a/auramaur/strategy/informed_flow.py
+++ b/auramaur/strategy/informed_flow.py
@@ -1,0 +1,118 @@
+"""Informed-flow detection on Kalshi trades — the DATA layer for the
+abnormal-trade-size (ATS) follower.
+
+Research basis (Delvecchio, CMC thesis #4166, 2026; corroborated by Bartlett &
+O'Hara, "Adverse Selection in Prediction Markets: Evidence from Kalshi", 41.6M
+trades): abnormal trade size proxies non-liquidity-motivated (informed) order
+flow, which predicts the resolution and strengthens near it. The follower
+strategy mimics the informed side rather than forecasting.
+
+This module is the DATA layer ONLY — a pure detector over a Kalshi trades list,
+plus a thin tape wrapper that pulls trades via the Kalshi client. It does NOT
+trade. The follower pillar that consumes these signals is a separate, strictly
+PAPER-FORCED step (the evidence is a single in-sample thesis = medium confidence;
+and adverse selection means the edge depends on reliably being on the informed,
+not the picked-off, side — so it earns its own graduation cell before any live).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+
+import structlog
+
+log = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class InformedFlowSignal:
+    """Result of scanning one market's recent trade tape."""
+
+    has_signal: bool
+    informed_side: str | None    # 'yes' | 'no' | None
+    abnormal_count: int          # number of abnormally-large trades
+    baseline_size: float         # median trade size (the normal-flow yardstick)
+    signal_volume: float         # net abnormal contracts on the informed side
+    sample: int                  # trades examined
+
+
+_NO_SIGNAL = InformedFlowSignal(False, None, 0, 0.0, 0.0, 0)
+
+
+def _size(t: dict) -> float:
+    try:
+        return float(t.get("count", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _side(t: dict) -> str | None:
+    s = str(t.get("taker_side", "")).lower()
+    return s if s in ("yes", "no") else None
+
+
+def detect_informed_flow(
+    trades: list[dict],
+    *,
+    min_sample: int = 20,
+    size_mult: float = 3.0,
+    min_dominance: float = 0.6,
+) -> InformedFlowSignal:
+    """Flag abnormally-large trades vs the market's OWN recent size baseline and
+    infer the informed direction. Pure — no I/O.
+
+    - ``min_sample``: need at least this many sized trades for a stable baseline
+      (thin tapes give no signal — a single big print in a 3-trade market is
+      noise, not information).
+    - ``size_mult``: a trade is abnormal when its size >= ``size_mult`` x the
+      median trade size (the non-liquidity / ATS proxy).
+    - ``min_dominance``: the informed side must carry at least this share of the
+      abnormal volume, else the large flow is two-sided / inconclusive -> no
+      signal (don't follow a wash).
+    """
+    sized = [(s, side) for t in trades
+             if (s := _size(t)) > 0 and (side := _side(t)) is not None]
+    if len(sized) < min_sample:
+        return _NO_SIGNAL
+
+    baseline = median(s for s, _ in sized)
+    if baseline <= 0:
+        return _NO_SIGNAL
+    threshold = size_mult * baseline
+
+    abn_yes = sum(s for s, side in sized if s >= threshold and side == "yes")
+    abn_no = sum(s for s, side in sized if s >= threshold and side == "no")
+    abn_count = sum(1 for s, _ in sized if s >= threshold)
+    total_abn = abn_yes + abn_no
+    if total_abn <= 0:
+        return _NO_SIGNAL
+
+    if abn_yes >= min_dominance * total_abn:
+        side, net = "yes", abn_yes
+    elif abn_no >= min_dominance * total_abn:
+        side, net = "no", abn_no
+    else:
+        # Large flow on both sides — inconclusive, don't follow.
+        return InformedFlowSignal(False, None, abn_count, baseline, 0.0, len(sized))
+
+    return InformedFlowSignal(True, side, abn_count, baseline, net, len(sized))
+
+
+class KalshiTradeTape:
+    """Thin wrapper: pull a market's recent trades via the Kalshi client and run
+    :func:`detect_informed_flow`. Keeps the I/O out of the pure detector so the
+    detection logic stays unit-testable. Fail-soft — a fetch error yields no
+    signal, never an exception into the scan loop."""
+
+    def __init__(self, exchange) -> None:
+        self._exchange = exchange  # a KalshiExchange exposing get_trades()
+
+    async def informed_flow(self, ticker: str, *, limit: int = 200,
+                            **kwargs) -> InformedFlowSignal:
+        try:
+            trades = await self._exchange.get_trades(ticker, limit=limit)
+        except Exception as e:
+            log.debug("informed_flow.fetch_failed", ticker=ticker, error=str(e))
+            return _NO_SIGNAL
+        return detect_informed_flow(trades or [], **kwargs)

--- a/tests/test_informed_flow.py
+++ b/tests/test_informed_flow.py
@@ -1,0 +1,90 @@
+"""Tests for the informed-flow (abnormal-trade-size) detector — the data layer
+for the Kalshi ATS follower. The detector is pure, so these lock the logic
+without any network."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.strategy.informed_flow import (
+    InformedFlowSignal,
+    KalshiTradeTape,
+    detect_informed_flow,
+)
+
+
+def _t(count, side):
+    return {"count": count, "taker_side": side}
+
+
+def _normal(n, size, side="yes"):
+    return [_t(size, side) for _ in range(n)]
+
+
+def test_thin_tape_gives_no_signal():
+    """Below min_sample, a big print is noise, not information."""
+    sig = detect_informed_flow([_t(1000, "yes")] * 3, min_sample=20)
+    assert sig == InformedFlowSignal(False, None, 0, 0.0, 0.0, 0)
+
+
+def test_no_abnormal_trades_no_signal():
+    """A tape of uniform small trades has no abnormal flow -> the no-signal
+    sentinel (nothing actionable to report)."""
+    sig = detect_informed_flow(_normal(40, 5, "yes"), min_sample=20, size_mult=3.0)
+    assert sig.has_signal is False
+    assert sig.abnormal_count == 0
+    assert sig.informed_side is None
+
+
+def test_detects_abnormal_yes_flow_and_infers_side():
+    # 30 small (size 5) trades + 3 large (size 50 = 10x baseline) YES takers.
+    trades = _normal(30, 5, "yes") + _normal(30, 5, "no") + _normal(3, 50, "yes")
+    sig = detect_informed_flow(trades, min_sample=20, size_mult=3.0, min_dominance=0.6)
+    assert sig.has_signal is True
+    assert sig.informed_side == "yes"
+    assert sig.abnormal_count == 3
+    assert sig.signal_volume == 150  # 3 x 50
+
+
+def test_two_sided_large_flow_is_inconclusive():
+    """Large prints on BOTH sides (a wash) -> no directional signal."""
+    trades = _normal(40, 5, "yes") + _normal(3, 50, "yes") + _normal(3, 50, "no")
+    sig = detect_informed_flow(trades, min_sample=20, size_mult=3.0, min_dominance=0.6)
+    assert sig.has_signal is False
+    assert sig.informed_side is None
+    assert sig.abnormal_count == 6  # counted, but not followed
+
+
+def test_ignores_malformed_and_unsided_trades():
+    trades = (
+        _normal(25, 4, "yes")
+        + [{"count": None, "taker_side": "yes"}, {"count": 50}, {"taker_side": "no"}]
+        + _normal(3, 40, "no")
+    )
+    sig = detect_informed_flow(trades, min_sample=20, size_mult=3.0)
+    assert sig.has_signal is True
+    assert sig.informed_side == "no"
+    assert sig.sample == 28  # 25 + 3 well-formed; the 3 malformed dropped
+
+
+def test_tape_wrapper_fetches_and_detects():
+    async def run():
+        ex = MagicMock()
+        ex.get_trades = AsyncMock(
+            return_value=_normal(30, 5, "no") + _normal(4, 60, "no"))
+        tape = KalshiTradeTape(ex)
+        sig = await tape.informed_flow("KXTEST", limit=100, min_sample=20)
+        ex.get_trades.assert_awaited_once_with("KXTEST", limit=100)
+        assert sig.has_signal and sig.informed_side == "no"
+    asyncio.run(run())
+
+
+def test_tape_wrapper_fail_soft_on_fetch_error():
+    async def run():
+        ex = MagicMock()
+        ex.get_trades = AsyncMock(side_effect=RuntimeError("kalshi down"))
+        tape = KalshiTradeTape(ex)
+        sig = await tape.informed_flow("KXTEST")
+        assert sig.has_signal is False  # no exception escapes
+    asyncio.run(run())


### PR DESCRIPTION
## Why
Wires the data prerequisite for the informed-flow follower. Previously unbuildable: the Kalshi client had only orders/fills (no trade tape), and the only live trade feed wired is Polymarket-only. Research: Delvecchio CMC thesis #4166; Bartlett & O'Hara, *Adverse Selection in Prediction Markets* (41.6M trades) — abnormal trade size proxies informed order flow that predicts resolution.

## What
- `KalshiClient.get_trades(ticker)` — public v2 `GET /markets/trades` (per-trade `count` + `taker_side`); fail-soft.
- `strategy/informed_flow.py` — **pure** `detect_informed_flow()`: flags trades `>= size_mult ×` the market's own median size (the ATS proxy) and infers the informed side only when one side dominates the abnormal volume (a two-sided wash → no signal). Thin `KalshiTradeTape` wrapper keeps I/O out of the pure core.

## Scope
**Data layer only — no trading.** The follower pillar that consumes this is the next step and will be strictly **paper-forced** with its own graduation cell (single in-sample thesis = medium confidence; adverse selection means the edge depends on being on the informed, not picked-off, side).

## Tests
7 pass — thin-tape, no-abnormal, one-sided detection, two-sided wash, malformed rows, wrapper fetch + fail-soft.

Assisted-by: Claude (Anthropic)