### PR TITLE
feat(informed_flow): Kalshi informed-flow follower pillar

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1360,6 +1360,10 @@ class AuramaurBot(
         if self.settings.long_horizon.enabled:
             tasks.append(asyncio.create_task(self._task_long_horizon(), name="long_horizon"))
 
+        # Informed-flow follower over Kalshi (paper-forced; abnormal-trade-size)
+        if self.settings.informed_flow.enabled:
+            tasks.append(asyncio.create_task(self._task_informed_flow(), name="informed_flow"))
+
         # Entailment arbitrage (paper-forced until proven)
         if self.settings.entailment_arb.enabled:
             tasks.append(asyncio.create_task(self._task_entailment_arb(), name="entailment_arb"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -66,6 +66,35 @@ class StrategyTaskMixin:
                 log.error("long_horizon.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_informed_flow(self) -> None:
+        """Periodic Kalshi informed-flow follower (abnormal-trade-size). Paper-
+        forced; no-ops cleanly when the Kalshi venue isn't composed."""
+        from auramaur.strategy.informed_flow_pillar import InformedFlowPillar
+
+        kalshi_discovery = (self._components.discoveries or {}).get("kalshi")
+        kalshi_exchange = (self._components.exchanges or {}).get("kalshi")
+        if kalshi_discovery is None or kalshi_exchange is None:
+            log.info("informed_flow.disabled", reason="kalshi venue not composed")
+            return
+        pillar = InformedFlowPillar(
+            db=self._components.db,
+            settings=self.settings,
+            kalshi_discovery=kalshi_discovery,
+            exchange=kalshi_exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(60, self.settings.informed_flow.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("informed_flow.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_entailment_arb(self) -> None:
         """Periodic entailment-arbitrage scan (paper-forced by config)."""
         from auramaur.strategy.entailment_arb import EntailmentArbPillar

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -1,0 +1,251 @@
+"""Informed-flow follower over Kalshi — mimic the informed side of abnormal flow.
+
+Consumes the data layer in :mod:`auramaur.strategy.informed_flow` (the Kalshi
+trade tape + pure abnormal-trade-size detector). When a market shows abnormally
+large, one-sided order flow — the ATS proxy for informed (non-liquidity) trading
+that predicts resolution (Delvecchio CMC thesis #4166; Bartlett & O'Hara,
+"Adverse Selection in Prediction Markets") — we FOLLOW that side with a small
+uplift. Forecast-free: we claim no probability of our own, only that informed
+flow favors the detected side.
+
+Why it's hedged: the evidence is a single in-sample thesis (medium confidence),
+and adverse selection cuts both ways — the edge exists only if we are reliably on
+the INFORMED side, not the picked-off one. So this is PAPER-FORCED with its own
+graduation cell, the uplift stays under the divergence-filter floor (it's not a
+high-confidence call), and the scan is bounded (a trade tape is pulled per
+eligible market, so cheap filters run FIRST). No-ops cleanly without a Kalshi
+venue. Rides the full RiskManager gate and the same rails as the other pillars.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.strategy.informed_flow import KalshiTradeTape
+from auramaur.strategy.protocols import ExecutionMode
+
+log = structlog.get_logger()
+
+
+class InformedFlowPillar:
+    """Periodic Kalshi scanner that follows abnormal informed order flow."""
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "informed_flow"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
+
+    def __init__(self, db, settings, kalshi_discovery, exchange, risk_manager,
+                 pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._kalshi = kalshi_discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._tape = KalshiTradeTape(exchange)
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="kalshi",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+
+    async def run_once(self) -> int:
+        cfg = self._settings.informed_flow
+        if not cfg.enabled or self._kalshi is None or self._exchange is None:
+            return 0
+        open_count = await self._open_position_count()
+        if open_count >= cfg.max_open:
+            log.debug("informed_flow.book_full", open=open_count, cap=cfg.max_open)
+            return 0
+        markets = await self._kalshi.get_markets(limit=cfg.scan_limit)
+        entered = 0
+        for market in markets:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            if open_count + entered >= cfg.max_open:
+                break
+            try:
+                if await self._try_enter(market):
+                    entered += 1
+            except Exception as e:
+                log.error("informed_flow.entry_error", market_id=market.id, error=str(e))
+        if entered:
+            log.info("informed_flow.cycle_done", entered=entered)
+        return entered
+
+    # ------------------------------------------------------------------
+    # Eligibility (CHEAP filters first — a trade tape is fetched only after)
+    # ------------------------------------------------------------------
+
+    def _eligible(self, market: Market) -> bool:
+        cfg = self._settings.informed_flow
+        if not market.active:
+            return False
+        if (market.exchange or "kalshi") != "kalshi":
+            return False
+        if not market.ticker:
+            return False  # need the ticker to pull the tape
+        p_yes = market.outcome_yes_price
+        if not (cfg.band_lo <= p_yes <= cfg.band_hi):
+            return False  # extremes: ATS is noise / already near-resolved
+        if market.liquidity < cfg.min_liquidity:
+            return False
+        hit = blocked_category_hit(set(self._settings.risk.blocked_categories),
+                                   market.question, market.description, market.category)
+        if hit:
+            log.debug("informed_flow.skip_category", market_id=market.id, category=hit)
+            return False
+        if market.end_date is None:
+            return False
+        end = market.end_date
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        hours_left = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+        if hours_left < cfg.min_hours_to_resolution:
+            return False
+        if hours_left > cfg.max_days_to_resolution * 24.0:
+            return False
+        return True
+
+    async def _try_enter(self, market: Market) -> bool:
+        cfg = self._settings.informed_flow
+        if not self._eligible(market):
+            return False
+        if await self._already_entered_or_held(market.id):
+            return False
+
+        # Only NOW pull the tape (bounded API cost) and detect informed flow.
+        flow = await self._tape.informed_flow(
+            market.ticker, limit=cfg.trades_limit,
+            min_sample=cfg.min_abnormal_sample, size_mult=cfg.size_mult,
+            min_dominance=cfg.min_dominance,
+        )
+        if not flow.has_signal or flow.informed_side is None:
+            return False
+
+        fav_is_yes = flow.informed_side == "yes"
+        p_yes = market.outcome_yes_price
+        # Forecast-free: follow the informed side with a small uplift (stays under
+        # the 0.05 divergence-filter floor so a MEDIUM-confidence follow isn't
+        # blocked, as in bias_harvest).
+        claude_prob = (min(0.99, p_yes + cfg.uplift) if fav_is_yes
+                       else max(0.01, p_yes - cfg.uplift))
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=claude_prob,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=p_yes,
+            edge=cfg.uplift * 100.0,
+            evidence_summary=(
+                f"Informed-flow follow: {flow.abnormal_count} abnormal trades "
+                f"({flow.signal_volume:.0f} contracts) on the {flow.informed_side.upper()} "
+                f"side vs a {flow.baseline_size:.0f}-size baseline (n={flow.sample})."
+            ),
+            recommended_side=OrderSide.BUY if fav_is_yes else OrderSide.SELL,
+            strategy_source="informed_flow",
+            mispricing_reason=(
+                "structural: abnormal-trade-size (informed) order flow favors the "
+                "followed side (ATS proxy)"
+            ),
+        )
+        await self._persist_signal(signal, market)
+
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("informed_flow.risk_rejected", market_id=market.id,
+                     reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size, force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.warning("informed_flow.order_rejected", market_id=market.id,
+                        status=res.status, error=res.reason)
+            return False
+
+        await self._record_position(signal, market, res.order, res.result)
+        log.info("informed_flow.entered", market_id=market.id,
+                 side=signal.recommended_side.value, informed=flow.informed_side,
+                 abnormal=flow.abnormal_count, paper=res.result.is_paper)
+        return True
+
+    # ------------------------------------------------------------------
+    # Bookkeeping — same rails as the other pillars
+    # ------------------------------------------------------------------
+
+    async def _already_entered_or_held(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'informed_flow' LIMIT 1",
+            (market_id,),
+        )
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,),
+        )
+        return row is not None
+
+    async def _open_position_count(self) -> int:
+        row = await self._db.fetchone(
+            """SELECT COUNT(*) AS n FROM portfolio p
+               WHERE EXISTS (SELECT 1 FROM signals s
+                             WHERE s.market_id = p.market_id
+                               AND s.strategy_source = 'informed_flow')""",
+        )
+        return int(row["n"]) if row else 0
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.exchange or "kalshi", market.condition_id,
+             market.question, (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'informed_flow')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value),
+        )
+        await self._db.commit()
+
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'kalshi', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("informed_flow.calibration_error", error=str(e))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -468,6 +468,33 @@ long_horizon:
   interval_seconds: 1800
   exclude_categories: ["politics_us", "politics_intl"]
 
+informed_flow:
+  # Informed-flow follower over Kalshi — mimic the side of abnormally-large
+  # (informed) order flow. Abnormal trade size (ATS) proxies non-liquidity trading
+  # that predicts resolution (Delvecchio CMC thesis #4166; Bartlett & O'Hara). The
+  # data layer is strategy/informed_flow.py (Kalshi trade tape + pure detector);
+  # this pillar follows the detected informed side with a small uplift (forecast-
+  # free). MEDIUM confidence (single in-sample thesis) + adverse-selection risk ->
+  # PAPER-FORCED, own graduation cell. No-ops when the Kalshi venue isn't composed.
+  # scan_limit is bounded because we pull a trade tape per eligible market.
+  enabled: true       # paper measurement spike
+  paper: true
+  min_abnormal_sample: 20
+  size_mult: 3.0
+  min_dominance: 0.6
+  trades_limit: 200
+  uplift: 0.04
+  band_lo: 0.10
+  band_hi: 0.90
+  stake_usd: 10.0
+  min_liquidity: 1000.0
+  min_hours_to_resolution: 6.0
+  max_days_to_resolution: 30.0
+  max_open: 30
+  max_entries_per_cycle: 5
+  scan_limit: 60
+  interval_seconds: 1800
+
 settlement_arb:
   # Settlement-lag / known-outcome arb (FRED-first) — the structural generalization
   # of the graduated resolution_lens x weather edge. Trades a Polymarket econ

--- a/config/settings.py
+++ b/config/settings.py
@@ -387,6 +387,42 @@ class BiasHarvestConfig(BaseModel):
     paper_maker_fill_rate: float = 0.5
 
 
+class InformedFlowConfig(BaseModel):
+    """Informed-flow follower over Kalshi (strategy/informed_flow_pillar.py).
+
+    Mimics the side of abnormally-large (informed) order flow — abnormal trade
+    size (ATS) proxies non-liquidity-motivated trading that predicts resolution
+    (Delvecchio CMC thesis #4166; Bartlett & O'Hara). Forecast-free: we don't
+    estimate a probability, we follow the informed side with a small uplift.
+
+    MEDIUM confidence (single in-sample thesis) + adverse-selection risk (the edge
+    needs us on the informed, not picked-off, side) -> PAPER-FORCED, own cell.
+    No-ops cleanly when the Kalshi venue isn't composed.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    # Detector params (see strategy/informed_flow.detect_informed_flow).
+    min_abnormal_sample: int = 20    # min sized trades for a stable baseline
+    size_mult: float = 3.0           # abnormal = size >= this x median size
+    min_dominance: float = 0.6       # informed side must carry this abnormal share
+    trades_limit: int = 200          # tape depth pulled per market
+    # Follow with a small uplift; MUST stay < 0.05 (divergence filter floor) so
+    # the forecast-free entry isn't blocked at MEDIUM confidence (as bias_harvest).
+    uplift: float = 0.04
+    # Skip extremes: near 0/1 the ATS signal is noise / already-resolved.
+    band_lo: float = 0.10
+    band_hi: float = 0.90
+    stake_usd: float = 10.0
+    min_liquidity: float = 1000.0
+    min_hours_to_resolution: float = 6.0
+    max_days_to_resolution: float = 30.0
+    max_open: int = 30
+    max_entries_per_cycle: int = 5
+    scan_limit: int = 60             # bounded — we fetch a tape per eligible market
+    interval_seconds: int = 1800
+
+
 class LongHorizonConfig(BaseModel):
     """Long-horizon favorite underpricing (strategy/long_horizon.py).
 
@@ -1087,6 +1123,7 @@ class Settings(BaseSettings):
     cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
+    informed_flow: InformedFlowConfig = Field(default_factory=lambda: InformedFlowConfig(**_DEFAULTS.get("informed_flow", {})))
     settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))
     hydro_watch: HydroWatchConfig = Field(default_factory=lambda: HydroWatchConfig(**_DEFAULTS.get("hydro_watch", {})))

--- a/tests/test_informed_flow_pillar.py
+++ b/tests/test_informed_flow_pillar.py
@@ -1,0 +1,213 @@
+"""Tests for the Kalshi informed-flow follower pillar.
+
+Locks in: it follows the detected informed side (BUY yes / SELL = buy no), is
+paper-forced, fetches a tape only for eligible markets, skips when there's no
+signal or the market is ineligible, one-shot per market, and respects risk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderResult,
+    OrderSide,
+    OrderType,
+    TokenType,
+)
+from auramaur.strategy.informed_flow_pillar import InformedFlowPillar
+from config.settings import Settings
+
+
+def _market(mid="K1", ticker="KXTEST", yes=0.50, liquidity=5000.0, category="economics",
+            active=True, days_out=10.0, exchange="kalshi") -> Market:
+    return Market(
+        id=mid, exchange=exchange, ticker=ticker, question=f"q-{mid}",
+        category=category, active=active, outcome_yes_price=yes,
+        outcome_no_price=round(1 - yes, 2), liquidity=liquidity, volume=10000.0,
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_out),
+        clob_token_yes="ty", clob_token_no="tn",
+    )
+
+
+def _trades(yes_big=0, no_big=0, small=30, small_size=5, big_size=60):
+    out = [{"count": small_size, "taker_side": "yes"} for _ in range(small)]
+    out += [{"count": small_size, "taker_side": "no"} for _ in range(small)]
+    out += [{"count": big_size, "taker_side": "yes"} for _ in range(yes_big)]
+    out += [{"count": big_size, "taker_side": "no"} for _ in range(no_big)]
+    return out
+
+
+def _settings(**overrides) -> Settings:
+    s = Settings()
+    s.informed_flow.enabled = True
+    s.informed_flow.paper = True
+    for k, v in overrides.items():
+        setattr(s.informed_flow, k, v)
+    return s
+
+
+def _exchange(trades=None, filled=True):
+    ex = MagicMock()
+    ex.get_trades = AsyncMock(return_value=trades if trades is not None else [])
+
+    def prepare_order(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(
+            market_id=market.id, token_id="tok", side=OrderSide.BUY, token=token,
+            size=round(size / price, 2), price=round(price, 2),
+            order_type=OrderType.LIMIT, dry_run=not is_live,
+        )
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(side_effect=lambda order: OrderResult(
+        order_id="ord-1", market_id=order.market_id,
+        status="paper" if order.dry_run else "filled",
+        filled_size=order.size if filled else 0, filled_price=order.price,
+        is_paper=order.dry_run,
+    ))
+    return ex
+
+
+def _risk(approved=True, size=8.0):
+    rm = MagicMock()
+    d = MagicMock()
+    d.approved = approved
+    d.position_size = size if approved else 0.0
+    d.reason = "" if approved else "blocked"
+    d.force_paper = False
+    rm.evaluate = AsyncMock(return_value=d)
+    return rm
+
+
+def _pillar(db, settings, markets, exchange, risk=None):
+    disc = MagicMock()
+    disc.get_markets = AsyncMock(return_value=markets)
+    cal = MagicMock()
+    cal.record_prediction = AsyncMock()
+    return InformedFlowPillar(
+        db=db, settings=settings, kalshi_discovery=disc, exchange=exchange,
+        risk_manager=risk or _risk(), pnl_tracker=PnLTracker(db, settings),
+        calibration=cal,
+    ), cal
+
+
+def test_follows_abnormal_yes_flow_as_buy():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))   # abnormal YES flow
+        pillar, cal = _pillar(db, _settings(), [_market(yes=0.50)], ex)
+        assert await pillar.run_once() == 1
+
+        ex.get_trades.assert_awaited_once()           # tape pulled for the market
+        assert ex.prepare_order.call_args[0][3] is False  # paper-forced
+        sig = await db.fetchone(
+            "SELECT * FROM signals WHERE strategy_source='informed_flow'")
+        assert sig["action"] == "BUY"
+        assert abs(sig["claude_prob"] - 0.54) < 1e-9  # 0.50 + 0.04 uplift
+        pos = await db.fetchone("SELECT * FROM portfolio WHERE market_id='K1'")
+        assert pos["is_paper"] == 1 and pos["token"] == "YES"
+        cal.record_prediction.assert_awaited_once()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_follows_abnormal_no_flow_as_sell():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(no_big=4))     # abnormal NO flow
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.50)], ex)
+        assert await pillar.run_once() == 1
+        sig = await db.fetchone(
+            "SELECT * FROM signals WHERE strategy_source='informed_flow'")
+        assert sig["action"] == "SELL"
+        assert abs(sig["claude_prob"] - 0.46) < 1e-9  # 0.50 - 0.04 uplift
+        pos = await db.fetchone("SELECT token FROM portfolio WHERE market_id='K1'")
+        assert pos["token"] == "NO"
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_no_signal_no_entry():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades())             # uniform — no abnormal flow
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.50)], ex)
+        assert await pillar.run_once() == 0
+        ex.place_order.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_ineligible_markets_skip_tape_fetch():
+    """Cheap eligibility runs BEFORE the tape fetch — an extreme-priced /
+    short-dated / thin / non-kalshi market never hits get_trades."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))
+        markets = [
+            _market("ext", yes=0.97),                 # outside band
+            _market("short", yes=0.5, days_out=0.1),  # too soon
+            _market("thin", yes=0.5, liquidity=10.0),  # illiquid
+            _market("poly", yes=0.5, exchange="polymarket"),  # wrong venue
+        ]
+        pillar, _ = _pillar(db, _settings(), markets, ex)
+        assert await pillar.run_once() == 0
+        ex.get_trades.assert_not_awaited()            # no tape pulled for any
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_one_entry_per_market():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))
+        settings = _settings()
+        pillar, _ = _pillar(db, settings, [_market(yes=0.50)], ex)
+        assert await pillar.run_once() == 1
+        assert await pillar.run_once() == 0           # signal exists -> no re-entry
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_risk_rejection_places_no_order():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.50)], ex,
+                            risk=_risk(approved=False))
+        assert await pillar.run_once() == 0
+        ex.place_order.assert_not_awaited()
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_disabled_or_no_kalshi_noops():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))
+        pillar, _ = _pillar(db, _settings(enabled=False), [_market()], ex)
+        assert await pillar.run_once() == 0
+        await db.close()
+
+    asyncio.run(run())

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -16,6 +16,7 @@ import pathlib
 import pytest
 
 from auramaur.strategy.bias_harvest import BiasHarvestPillar
+from auramaur.strategy.informed_flow_pillar import InformedFlowPillar
 from auramaur.strategy.long_horizon import LongHorizonPillar
 from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
 from auramaur.strategy.econ_indicator import EconIndicatorPillar
@@ -34,6 +35,7 @@ _ROOT = pathlib.Path(__file__).resolve().parent.parent
 PILLARS = [
     (BiasHarvestPillar, "auramaur/strategy/bias_harvest.py"),
     (LongHorizonPillar, "auramaur/strategy/long_horizon.py"),
+    (InformedFlowPillar, "auramaur/strategy/informed_flow_pillar.py"),
     (ResolutionLensPillar, "auramaur/strategy/resolution_lens.py"),
     (WeatherTempPillar, "auramaur/strategy/weather_temp.py"),
     (EconIndicatorPillar, "auramaur/strategy/econ_indicator.py"),


### PR DESCRIPTION
## Why
Completes the informed-flow edge on top of the data layer (#230). Follows the side of abnormally-large (informed) order flow — abnormal trade size proxies non-liquidity trading that predicts resolution (Delvecchio CMC thesis #4166; Bartlett & O'Hara).

## What
- New Kalshi pillar `InformedFlowPillar`: forecast-free — claims no probability, just follows the detected informed side with a small uplift (kept under the divergence-filter floor, like bias_harvest).
- **Bounded by design**: cheap eligibility (venue/band/liquidity/horizon/not-held) runs **first**, so a trade tape is pulled only for eligible markets. Extremes skipped.
- Full RiskManager gate; same rails as the other pillars; no-ops without a Kalshi venue. Added to the gateway-contract conformance list.

## Safety
**Paper-forced**, own graduation cell — single in-sample thesis (medium confidence) + adverse selection (the edge needs us on the informed, not picked-off, side), so paper ledger + calibration must prove it first.

## Tests
14 across the data layer + pillar (yes/no follow, no-signal skip, eligibility-before-fetch, one-shot, risk rejection, disabled/no-venue no-op); 76 pass across the strategy/settings suites.

Assisted-by: Claude (Anthropic)