### PR TITLE
feat(intel): read-only Polymarket leaderboard whale-watch intelligence feed

### DIFF
--- a/auramaur/cli/__init__.py
+++ b/auramaur/cli/__init__.py
@@ -12,7 +12,7 @@ from auramaur.cli._base import console, log, main  # noqa: F401
 
 # Importing these registers their commands onto `main` (side effect).
 from auramaur.cli import (  # noqa: E402,F401
-    diagnostics, kraken, maintenance, redeem, reporting, run,
+    diagnostics, intel, kraken, maintenance, redeem, reporting, run,
 )
 
 if __name__ == "__main__":

--- a/auramaur/cli/intel.py
+++ b/auramaur/cli/intel.py
@@ -1,0 +1,69 @@
+"""Auramaur CLI — market-intelligence commands (read-only)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+from rich.table import Table
+
+from auramaur.cli._base import console, main
+
+
+@main.command()
+@click.option("--period", default="MONTH", type=click.Choice(["DAY", "WEEK", "MONTH", "ALL"]),
+              help="Leaderboard window (default: MONTH = current winners).")
+@click.option("--limit", default=25, help="How many top-PnL wallets to scan.")
+@click.option("--activity/--no-activity", default=False,
+              help="Also show each directional winner's most recent trade.")
+def whales(period, limit, activity):
+    """Whale watch — top-PnL Polymarket wallets, classified by archetype.
+
+    INTELLIGENCE ONLY (read-only public data) — not a trading signal. The
+    reverse-engineering showed winners split into DIRECTIONAL conviction (the
+    replicable archetype) vs MM/ARB (turnover machine). This surfaces the
+    directional winners to watch — copy-trading is a documented money-loser, so
+    this is for situational awareness, not mirroring.
+    """
+    from auramaur.data_sources.polymarket_leaderboard import PolymarketLeaderboard
+
+    async def _run():
+        lb = PolymarketLeaderboard()
+        leaders = await lb.top(period=period, limit=limit)
+        if not leaders:
+            console.print("[yellow]no leaderboard data (API unreachable?)[/]")
+            return
+
+        counts = {"directional": 0, "mm_arb": 0, "mixed": 0, "unknown": 0}
+        for ld in leaders:
+            counts[ld.archetype] = counts.get(ld.archetype, 0) + 1
+
+        t = Table(title=f"Polymarket top-PnL wallets — {period} (intelligence, read-only)")
+        for c in ("rank", "name", "PnL $M", "Vol $M", "PnL/Vol", "archetype"):
+            t.add_column(c, justify="right" if "$" in c or c in ("rank", "PnL/Vol") else "left")
+        for ld in leaders:
+            style = "green" if ld.archetype == "directional" else (
+                "dim" if ld.archetype == "mm_arb" else "")
+            t.add_row(str(ld.rank), (ld.name or ld.wallet[:10])[:20],
+                      f"{ld.pnl/1e6:.1f}", f"{ld.vol/1e6:.0f}",
+                      f"{ld.pnl_vol_ratio:.0%}", f"[{style}]{ld.archetype}[/]" if style else ld.archetype)
+        console.print(t)
+        console.print(
+            f"[bold]{counts['directional']}[/] directional · "
+            f"{counts['mm_arb']} mm/arb · {counts['mixed']} mixed  "
+            f"[dim](directional = the conviction archetype worth watching)[/]")
+
+        if activity:
+            direc = [ld for ld in leaders if ld.archetype == "directional"][:8]
+            console.print("\n[bold]Recent accumulations by directional winners:[/]")
+            for ld in direc:
+                acts = await lb.recent_activity(ld.wallet, limit=3)
+                if not acts:
+                    continue
+                a = acts[0]
+                console.print(
+                    f"  [green]{(ld.name or ld.wallet[:8])[:16]}[/]: "
+                    f"{a.get('side','?')} {a.get('outcome','?')} @ "
+                    f"{float(a.get('price',0) or 0):.2f} — {str(a.get('title',''))[:50]}")
+
+    asyncio.run(_run())

--- a/auramaur/data_sources/polymarket_leaderboard.py
+++ b/auramaur/data_sources/polymarket_leaderboard.py
@@ -1,0 +1,122 @@
+"""Polymarket leaderboard — read-only "whale watch" INTELLIGENCE feed.
+
+Reverse-engineering (2026-06-29) showed the profitable Polymarket wallets split
+into two machines: DIRECTIONAL conviction (~75% of profit on ~15% of volume;
+PnL/vol 20-68%) and MARKET-MAKER/ARB (~85% of volume for ~25% of profit; PnL/vol
+<3%). The directional archetype is the one a small model-driven bot could
+plausibly learn from. This module pulls the public leaderboard + per-wallet
+activity and classifies winners by that PnL/volume ratio.
+
+INTELLIGENCE ONLY — this is NOT a trading signal and does NOT place orders.
+Copy-trading is documented to be a money-loser (lagged fills, baitable), so this
+exists to WATCH what proven directional winners accumulate, not to mirror them.
+A confirmation-gate use (a human/strategy cross-check) could come later.
+
+Public data-api, no auth: GET /v1/leaderboard, /activity, /positions, /value.
+Use the proxyWallet (Gnosis Safe) address.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import aiohttp
+import structlog
+
+log = structlog.get_logger()
+
+DATA_API = "https://data-api.polymarket.com"
+_TIMEOUT = aiohttp.ClientTimeout(total=20, sock_connect=10, sock_read=15)
+
+# PnL/volume thresholds separating the empirically-observed archetypes.
+_DIRECTIONAL_MIN = 0.10   # >=10% edge per dollar traded = conviction/info edge
+_MM_ARB_MAX = 0.03        # <3% = thin-margin high-turnover MM/arb
+
+
+def classify_archetype(pnl: float, vol: float) -> str:
+    """Classify a wallet by profit-per-dollar-of-volume (the empirical
+    discriminator from the winner reverse-engineering). Pure."""
+    if vol <= 0:
+        return "unknown"
+    ratio = pnl / vol
+    if ratio >= _DIRECTIONAL_MIN:
+        return "directional"
+    if ratio < _MM_ARB_MAX:
+        return "mm_arb"
+    return "mixed"
+
+
+@dataclass(frozen=True)
+class Leader:
+    rank: int
+    wallet: str
+    name: str
+    pnl: float
+    vol: float
+    archetype: str
+
+    @property
+    def pnl_vol_ratio(self) -> float:
+        return self.pnl / self.vol if self.vol else 0.0
+
+
+def parse_leader(entry: dict) -> Leader | None:
+    """Turn a raw leaderboard row into a classified Leader, or None if malformed.
+    Pure."""
+    try:
+        pnl = float(entry.get("pnl", 0) or 0)
+        vol = float(entry.get("vol", 0) or 0)
+        wallet = str(entry.get("proxyWallet", "") or "")
+        if not wallet:
+            return None
+        return Leader(
+            rank=int(entry.get("rank", 0) or 0), wallet=wallet,
+            name=str(entry.get("userName", "") or ""), pnl=pnl, vol=vol,
+            archetype=classify_archetype(pnl, vol),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+class PolymarketLeaderboard:
+    """Async read-only client for the public Polymarket leaderboard + activity."""
+
+    def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
+        self._session = session
+        self._owned = session is None
+
+    async def _get(self, path: str, **params):
+        sess = self._session or aiohttp.ClientSession(timeout=_TIMEOUT)
+        try:
+            async with sess.get(f"{DATA_API}{path}", params=params) as r:
+                if r.status != 200:
+                    log.debug("leaderboard.bad_status", path=path, status=r.status)
+                    return None
+                return await r.json()
+        except Exception as e:
+            log.debug("leaderboard.fetch_failed", path=path, error=str(e))
+            return None
+        finally:
+            if self._owned:
+                await sess.close()
+
+    async def top(self, *, order_by: str = "PNL", period: str = "ALL",
+                  limit: int = 50, offset: int = 0) -> list[Leader]:
+        rows = await self._get("/v1/leaderboard", orderBy=order_by,
+                               timePeriod=period, limit=min(limit, 50), offset=offset)
+        if not isinstance(rows, list):
+            return []
+        return [ld for r in rows if (ld := parse_leader(r)) is not None]
+
+    async def top_directional(self, **kwargs) -> list[Leader]:
+        """The replicable archetype: winners whose edge is conviction, not
+        turnover (the lane a small model-driven bot could learn from)."""
+        return [ld for ld in await self.top(**kwargs) if ld.archetype == "directional"]
+
+    async def recent_activity(self, wallet: str, *, limit: int = 20) -> list[dict]:
+        """A wallet's recent TRADE activity (read-only intelligence). Returns []
+        on error."""
+        rows = await self._get("/activity", user=wallet, limit=limit)
+        if not isinstance(rows, list):
+            return []
+        return [r for r in rows if str(r.get("type", "TRADE")).upper() == "TRADE"]

--- a/tests/test_polymarket_leaderboard.py
+++ b/tests/test_polymarket_leaderboard.py
@@ -1,0 +1,41 @@
+"""Tests for the leaderboard intelligence feed — the pure archetype classifier
+and row parser (no network)."""
+
+from __future__ import annotations
+
+from auramaur.data_sources.polymarket_leaderboard import (
+    Leader,
+    classify_archetype,
+    parse_leader,
+)
+
+
+def test_classify_archetype_by_pnl_vol_ratio():
+    # directional: huge edge per dollar (Theo4 ~51%)
+    assert classify_archetype(22.0e6, 43.0e6) == "directional"
+    # mm/arb: thin margin x gigantic turnover (swisstony ~1.1%)
+    assert classify_archetype(14.6e6, 1298e6) == "mm_arb"
+    # mixed: between the thresholds (kch123 ~3.9%)
+    assert classify_archetype(11.4e6, 293.7e6) == "mixed"
+    # degenerate
+    assert classify_archetype(100, 0) == "unknown"
+
+
+def test_classify_threshold_boundaries():
+    assert classify_archetype(10, 100) == "directional"   # exactly 10%
+    assert classify_archetype(9.9, 100) == "mixed"         # just under 10%
+    assert classify_archetype(2.9, 100) == "mm_arb"        # under 3%
+    assert classify_archetype(3.0, 100) == "mixed"         # exactly 3% -> mixed
+
+
+def test_parse_leader_classifies_and_handles_malformed():
+    ld = parse_leader({"rank": "1", "proxyWallet": "0xabc", "userName": "Theo4",
+                       "pnl": 22.0e6, "vol": 43.0e6})
+    assert isinstance(ld, Leader)
+    assert ld.archetype == "directional" and ld.name == "Theo4"
+    assert abs(ld.pnl_vol_ratio - 0.512) < 0.01
+
+    # missing wallet -> dropped
+    assert parse_leader({"rank": "2", "pnl": 1, "vol": 2}) is None
+    # non-numeric -> dropped, no exception
+    assert parse_leader({"proxyWallet": "0xz", "pnl": "NaNish", "vol": "x"}) is None


### PR DESCRIPTION
## Why
The winner reverse-engineering showed profitable wallets split into two machines by profit-per-dollar-of-volume: **directional conviction** (~75% of profit on ~15% of volume, PnL/vol 20–68%) vs **MM/arb** (~85% of volume for ~25% of profit, PnL/vol <3%). The directional archetype is the one a small model-driven bot could learn from.

## What
- Read-only client over the public data-api (`/v1/leaderboard`, `/activity`) + a **pure PnL/vol archetype classifier**.
- `auramaur whales` CLI digest surfacing the directional winners to watch (optionally their recent accumulations).

## Scope
**Intelligence only — no trading, no order path touched.** Copy-trading is a documented money-loser (lagged, baitable), so this is situational awareness, not mirroring. A confirmation-gate use could come later.

## Tests
3 pass — classifier thresholds + malformed-row handling. CLI verified live against the real leaderboard.

Assisted-by: Claude (Anthropic)