### PR TITLE
feat(graduation): restrict unproven spray — concentrate exploration, don't spray

### DIFF
--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -58,6 +58,7 @@ class GraduationLadder:
         self._db = db
         self._settings = settings
         self._cache: dict[tuple[str, str], tuple[float, CellDecision]] = {}
+        self._breadth: tuple[float, int] | None = None  # (monotonic_ts, count)
 
     # ------------------------------------------------------------------
 
@@ -108,6 +109,21 @@ class GraduationLadder:
             "paper_pnl": float(row["paper_pnl"] or 0.0) if row else 0.0,
         }
 
+    async def _paper_breadth(self) -> int:
+        """Concurrent open PAPER/exploratory positions — the spray breadth. Cached
+        for cache_seconds (a soft cap doesn't need an exact live count)."""
+        now = time.monotonic()
+        if self._breadth and now - self._breadth[0] < self._settings.graduation.cache_seconds:
+            return self._breadth[1]
+        try:
+            row = await self._db.fetchone(
+                "SELECT COUNT(*) AS n FROM portfolio WHERE is_paper = 1 AND size > 0")
+            n = int(row["n"] or 0) if row else 0
+        except Exception:
+            n = 0  # fail-open: a count failure must not block trading
+        self._breadth = (now, n)
+        return n
+
     async def _compute(self, strategy: str, category: str) -> CellDecision:
         cfg = self._settings.graduation
         s = await self._cell_stats(strategy, category)
@@ -126,6 +142,16 @@ class GraduationLadder:
             return CellDecision(
                 True, 1.0, "paper_negative",
                 f"paper record negative (${s['paper_pnl']:+.2f} over {s['paper_n']} events)")
+        # Unproven (still exploring). Restrict the spray: if the open paper book is
+        # already at the breadth cap, skip NEW unproven entries (size x0) so
+        # exploration concentrates instead of spraying. Restriction only — proven/
+        # probation/exempt cells and exits are never affected.
+        cap = cfg.max_unproven_positions
+        if cap > 0 and await self._paper_breadth() >= cap:
+            return CellDecision(
+                True, 0.0, "unproven_capped",
+                f"unproven spray cap hit (>= {cap} open paper positions) — "
+                f"concentrating; skip new unproven entry")
         return CellDecision(
             True, 1.0, "unproven",
             f"insufficient record (live {s['live_n']}, paper {s['paper_n']} "

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -336,6 +336,13 @@ class RiskManager:
         # trade.
         if all_passed and cell.size_multiplier != 1.0:
             position_size = position_size * cell.size_multiplier
+            # A zero multiplier (e.g. the unproven-spray cap) is a HARD SKIP:
+            # reject the entry outright. Leaving approved=True with size 0 would
+            # be unsafe — prepare_order bumps sub-minimum sizes back up to the
+            # order floor, which would defeat the cap.
+            if position_size <= 0:
+                all_passed = False
+                reason = cell.reason
 
         decision = RiskDecision(
             approved=all_passed,

--- a/config/settings.py
+++ b/config/settings.py
@@ -747,6 +747,14 @@ class GraduationConfig(BaseModel):
     probation_multiplier: float = 0.5
     cache_seconds: int = 300
     exempt_strategies: list[str] = ["arbitrage", "market_maker", "order_monitor"]
+    # Restrict unproven SPRAY (2026-06-29 winner reverse-engineering: winners are
+    # FEW + LARGE + SELECTIVE; the loser profile is high-frequency tiny-size spray
+    # across hundreds of low-conviction cells). When the open PAPER/exploratory
+    # book is already this wide, "unproven" cells stop opening NEW positions
+    # (size x0) so exploration concentrates rather than sprays. A RESTRICTION
+    # only — it never upsizes, never touches proven/probation/exempt cells, and
+    # never affects exits. 0 disables.
+    max_unproven_positions: int = 100
 
 
 class BrokerConfig(BaseModel):

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -205,3 +205,56 @@ def test_bias_harvest_honors_force_paper():
         await db.close()
 
     asyncio.run(run())
+
+
+async def _seed_paper_positions(db, n, offset=0):
+    for i in range(offset, offset + n):
+        await db.execute(
+            "INSERT INTO portfolio (market_id, exchange, side, size, avg_price, "
+            "current_price, is_paper) VALUES (?, 'polymarket', 'BUY', 5, 0.5, 0.5, 1)",
+            (f"pp-{i}",),
+        )
+    await db.commit()
+
+
+def test_unproven_spray_cap():
+    """When the open paper book is already at the breadth cap, an UNPROVEN cell
+    returns size x0 (skip) so exploration concentrates instead of spraying.
+    Proven/probation/exempt cells are unaffected."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ladder = GraduationLadder(db, _settings(max_unproven_positions=10))
+
+        # Under the cap: a fresh (unproven) cell still explores at full paper size.
+        await _seed_paper_positions(db, 5)
+        d = await ladder.decide("s_new", "tech")
+        assert (d.force_paper, d.size_multiplier, d.status) == (True, 1.0, "unproven")
+
+        # Cross the cap -> new unproven entries are skipped (x0).
+        ladder2 = GraduationLadder(db, _settings(max_unproven_positions=10))
+        await _seed_paper_positions(db, 8, offset=5)   # now 13 >= 10
+        d2 = await ladder2.decide("s_new2", "tech")
+        assert d2.size_multiplier == 0.0 and d2.status == "unproven_capped"
+
+        # A PROVEN (live-positive) cell is NOT capped — restriction targets spray.
+        await _seed(db, "s_live", "tech", n=5, pnl_each=1.0, is_paper=0)
+        ladder3 = GraduationLadder(db, _settings(max_unproven_positions=10))
+        d3 = await ladder3.decide("s_live", "tech")
+        assert (d3.force_paper, d3.size_multiplier, d3.status) == (False, 1.0, "live")
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_unproven_spray_cap_disabled_when_zero():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ladder = GraduationLadder(db, _settings(max_unproven_positions=0))
+        await _seed_paper_positions(db, 50)
+        d = await ladder.decide("s_new", "tech")
+        assert d.status == "unproven" and d.size_multiplier == 1.0  # cap off
+        await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Why
The winner reverse-engineering showed profitable wallets are **few + large + selective**; the loser profile is high-frequency tiny-size **spray** across hundreds of low-conviction cells — the bot's current shape (~164 open positions).

## What
A breadth cap on **unproven** exploration: when the open paper/exploratory book is at `graduation.max_unproven_positions` (default 100), unproven cells stop opening NEW positions (size ×0). Exploration concentrates instead of spraying.

## Safety
- **Restriction only** — consistent with the ladder invariant (never upsizes; proven/probation/exempt cells and exits untouched).
- Enforced **centrally** in `RiskManager.evaluate` as a **hard reject** when the multiplier zeroes the size — leaving `approved=True` with size 0 would be unsafe because `prepare_order` bumps sub-minimum sizes back to the order floor, defeating the cap.
- Breadth = cached COUNT of open paper positions (soft cap; fail-open on query error).

## Tests
8 pass — under-cap exploration, over-cap skip, proven-cell immunity, disable switch; 53 pass across risk+pillar suites (the change touches the central risk path).

Assisted-by: Claude (Anthropic)