### PR TITLE
fix(informed_flow): Kalshi-scale liquidity floor — pillar was dead-on-arrival

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -487,7 +487,11 @@ informed_flow:
   band_lo: 0.10
   band_hi: 0.90
   stake_usd: 10.0
-  min_liquidity: 1000.0
+  # Kalshi-scale floor — Kalshi liquidity runs ~40x smaller than Polymarket
+  # (active median ~26); the old Poly-scale 1000 gave informed_flow ZERO eligible
+  # markets (it never pulled a tape). 50 admits a real pool; the detector's
+  # >=20-trade min_abnormal_sample is the true activity gate.
+  min_liquidity: 50.0
   min_hours_to_resolution: 6.0
   max_days_to_resolution: 30.0
   max_open: 30

--- a/config/settings.py
+++ b/config/settings.py
@@ -414,7 +414,13 @@ class InformedFlowConfig(BaseModel):
     band_lo: float = 0.10
     band_hi: float = 0.90
     stake_usd: float = 10.0
-    min_liquidity: float = 1000.0
+    # Kalshi-SCALE liquidity floor. Kalshi's liquidity values run ~40x smaller
+    # than Polymarket's (active-market MEDIAN ~26, only ~9/589 clear 1000): the
+    # original Poly-scale 1000 left informed_flow with ZERO eligible markets — it
+    # never even pulled a trade tape (found 2026-06-29). 50 admits a real candidate
+    # pool; the detector's min_abnormal_sample (>=20 trades) is the true activity
+    # gate. (Matches the kalshi_min_liquidity=50 used elsewhere in config.)
+    min_liquidity: float = 50.0
     min_hours_to_resolution: float = 6.0
     max_days_to_resolution: float = 30.0
     max_open: int = 30

--- a/tests/test_informed_flow_pillar.py
+++ b/tests/test_informed_flow_pillar.py
@@ -211,3 +211,19 @@ def test_disabled_or_no_kalshi_noops():
         await db.close()
 
     asyncio.run(run())
+
+
+def test_kalshi_scale_liquidity_is_eligible():
+    """A Kalshi-realistic market (liquidity ~60, far below the old 1000 Poly-scale
+    floor) is now eligible — the floor that left informed_flow with zero markets
+    is fixed."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        ex = _exchange(trades=_trades(yes_big=4))
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.50, liquidity=60.0)], ex)
+        assert await pillar.run_once() == 1     # would have been 0 at min_liquidity=1000
+        ex.get_trades.assert_awaited_once()
+        await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Diagnostic
informed_flow emitted **zero** signals since launch. Root cause: `min_liquidity=1000` (copied from Polymarket scale), but **Kalshi liquidity runs ~40× smaller** (active median ~26; only ~9/589 clear 1000). Zero markets passed eligibility → it never even pulled a trade tape.

## Fix
Floor `1000 → 50` (admits a real candidate pool; matches `kalshi_min_liquidity=50` used elsewhere). The detector's `>=20-trade` min_abnormal_sample remains the true activity gate. Paper-forced.

## Tests
15 pass; new test locks in a Kalshi-scale (~60 liquidity) market is now eligible.

Assisted-by: Claude (Anthropic)