### PR TITLE
fix(paper): stop the paper wallet draining to zero

### DIFF
--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -43,27 +43,42 @@ class PaperTrader:
                 token_id=token_id or "",
             )
 
-        # Calculate balance from trade history
-        row = await self.db.fetchone(
-            "SELECT COALESCE(SUM(CASE WHEN side='BUY' THEN -size*price ELSE size*price END), 0) as net FROM trades WHERE is_paper=1"
-        )
-        if row:
-            self.balance = self.initial_balance + float(row["net"])
-
+        self.balance = await self._compute_balance()
         log.info("paper.state_loaded", balance=self.balance, positions=len(self.positions))
+
+    async def _compute_balance(self) -> float:
+        """Spendable paper cash from AUTHORITATIVE state — NOT the old
+        ``SUM(trades)`` (which debits every BUY but is never credited on
+        resolution, so it drained to ~$0 over months and blocked all paper
+        entries). Spendable = initial + realized paper P&L (pnl_ledger) - cost
+        tied up in OPEN paper positions (cost_basis). This SELF-HEALS: when a
+        position resolves, its cost leaves `open cost` and its payout lands in
+        realized P&L, so the cash returns automatically — no resolution-path
+        coupling, no `trades` pollution."""
+        pnl_row = await self.db.fetchone(
+            "SELECT COALESCE(SUM(pnl), 0) AS p FROM pnl_ledger WHERE is_paper = 1")
+        cost_row = await self.db.fetchone(
+            "SELECT COALESCE(SUM(size * avg_cost), 0) AS c FROM cost_basis "
+            "WHERE is_paper = 1 AND size > 0")
+        realized = float(pnl_row["p"]) if pnl_row else 0.0
+        open_cost = float(cost_row["c"]) if cost_row else 0.0
+        return self.initial_balance + realized - open_cost
 
     async def execute(self, order: Order) -> OrderResult:
         """Simulate order execution."""
         order_id = f"PAPER-{uuid.uuid4().hex[:12]}"
         cost = order.size * order.price
 
-        if order.side == OrderSide.BUY and cost > self.balance:
+        # Gate on the freshly-computed spendable balance (self-healing), not the
+        # stale incrementally-mutated cache.
+        spendable = await self._compute_balance()
+        if order.side == OrderSide.BUY and cost > spendable:
             log.warning(
                 "paper.insufficient_balance",
                 market_id=order.market_id,
                 cost=round(cost, 2),
-                balance=round(self.balance, 2),
-                shortfall=round(cost - self.balance, 2),
+                balance=round(spendable, 2),
+                shortfall=round(cost - spendable, 2),
             )
             return OrderResult(
                 order_id=order_id,
@@ -72,7 +87,8 @@ class PaperTrader:
                 is_paper=True,
             )
 
-        # Update balance
+        # In-memory display balance (the authoritative gate above is
+        # _compute_balance; this cache self-corrects on the next load_state).
         if order.side == OrderSide.BUY:
             self.balance -= cost
         else:

--- a/tests/test_paper_trader.py
+++ b/tests/test_paper_trader.py
@@ -11,7 +11,9 @@ from auramaur.exchange.paper import PaperTrader
 def mock_db():
     db = AsyncMock()
     db.fetchall = AsyncMock(return_value=[])
-    db.fetchone = AsyncMock(return_value={"net": 0})
+    # _compute_balance reads pnl_ledger ("p") + cost_basis ("c"); both empty here
+    # so spendable == initial_balance, keeping the incremental-arithmetic tests valid.
+    db.fetchone = AsyncMock(return_value={"p": 0, "c": 0})
     db.execute = AsyncMock()
     db.commit = AsyncMock()
     return db
@@ -59,3 +61,53 @@ async def test_position_closed_on_full_sell(paper):
     await paper.execute(Order(market_id="m1", side=OrderSide.BUY, size=10, price=0.5))
     await paper.execute(Order(market_id="m1", side=OrderSide.SELL, size=10, price=0.6))
     assert "m1" not in paper.positions
+
+
+# ---------------------------------------------------------------------------
+# Spendable balance from authoritative state (the drain-bug fix)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_compute_balance_from_ledger_and_open_cost():
+    """Spendable = initial + realized paper P&L - cost tied up in OPEN paper
+    positions — NOT the old SUM(trades) that drained to ~0."""
+    from auramaur.db.database import Database
+    db = Database(":memory:")
+    await db.connect()
+    # $300 tied up in open paper positions; +$50 realized paper P&L.
+    await db.execute("INSERT INTO cost_basis (market_id, token, size, avg_cost, "
+                     "total_cost, is_paper) VALUES ('a','YES',100,2.0,200,1)")
+    await db.execute("INSERT INTO cost_basis (market_id, token, size, avg_cost, "
+                     "total_cost, is_paper) VALUES ('b','YES',100,1.0,100,1)")
+    await db.execute("INSERT INTO pnl_ledger (market_id, venue, category, "
+                     "strategy_source, kind, token, qty, pnl, fees, is_paper, "
+                     "source_ref) VALUES ('c','polymarket','x','llm','sell','YES',1,50,0,1,'r1')")
+    # LIVE rows must NOT count.
+    await db.execute("INSERT INTO cost_basis (market_id, token, size, avg_cost, "
+                     "total_cost, is_paper) VALUES ('live','YES',100,5.0,500,0)")
+    await db.commit()
+
+    pt = PaperTrader(db=db, initial_balance=1000.0)
+    bal = await pt._compute_balance()
+    assert bal == pytest.approx(1000 + 50 - 300)  # 750
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_resolved_position_does_not_drain_balance():
+    """The OLD bug: a BUY debited forever and resolution never credited, so the
+    wallet drained. Now a resolved position (gone from open cost_basis, its P&L
+    in the ledger) leaves the balance healthy — no drain."""
+    from auramaur.db.database import Database
+    db = Database(":memory:")
+    await db.connect()
+    # A position that was bought for $100 and resolved to a $30 loss: it is NOT
+    # in open cost_basis (closed), and its -30 sits in the ledger.
+    await db.execute("INSERT INTO pnl_ledger (market_id, venue, category, "
+                     "strategy_source, kind, token, qty, pnl, fees, is_paper, "
+                     "source_ref) VALUES ('done','polymarket','x','llm','sell','YES',1,-30,0,1,'r1')")
+    await db.commit()
+    pt = PaperTrader(db=db, initial_balance=1000.0)
+    # Spendable = 1000 - 30 = 970 (NOT 1000 - 100 the BUY cost): cash recovered.
+    assert await pt._compute_balance() == pytest.approx(970)
+    await db.close()


### PR DESCRIPTION
## Diagnostic
The paper wallet had drained to **~$0.28 of $5000**, so every paper strategy was rejected with `paper.insufficient_balance` — the entire paper-measurement apparatus was stalled (the new pillars clear risk but can't enter).

## Root cause
Spendable balance was `initial + SUM(trades)` — debits every BUY but is **never credited on resolution** (settlement books to `pnl_ledger`, not a balancing SELL). Monotonic drain over months.

## Fix
Compute spendable from **authoritative state**: `initial + realized paper P&L (pnl_ledger) − cost in OPEN paper positions (cost_basis)`. **Self-heals** as positions resolve. Entry gate uses a fresh computation each order; `self.balance` stays a display cache. Restores the live book's spendable from $0.28 → healthy.

## Tests
Formula (live rows excluded) + the no-drain property. 48 pass across paper/pillar suites; full-repo ruff clean.

Assisted-by: Claude (Anthropic)