### PR TITLE
fix(nlp): parse JSON arrays + value-then-prose from Claude (kills arb_scanner.llm_match_failed)

### DIFF
--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -40,8 +40,40 @@ class AnalysisResult(BaseModel):
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _parse_claude_json(text: str) -> dict:
-    """Robustly parse JSON from Claude's response."""
+def _extract_json_span(text: str) -> str | None:
+    """Return the first COMPLETE JSON array or object in ``text`` — the leading
+    value followed by balanced brackets — or None. Tracks nesting and quoted
+    strings so brackets inside string literals don't fool it. This recovers the
+    common LLM shape of a valid JSON value followed by explanatory prose, e.g.
+    ``[]\\n\\nNo matches found...`` (which the old object-only regex missed
+    because it never looked for arrays)."""
+    start = next((i for i, ch in enumerate(text) if ch in "[{"), None)
+    if start is None:
+        return None
+    depth = 0
+    in_str = esc = False
+    for j in range(start, len(text)):
+        ch = text[j]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+        elif ch in "[{":
+            depth += 1
+        elif ch in "]}":
+            depth -= 1
+            if depth == 0:
+                return text[start:j + 1]
+    return None
+
+
+def _parse_claude_json(text: str) -> dict | list:
+    """Robustly parse JSON (object OR array) from Claude's response."""
     # Strip markdown code fences if present
     fenced = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
     if fenced:
@@ -53,11 +85,12 @@ def _parse_claude_json(text: str) -> dict:
     except json.JSONDecodeError:
         pass
 
-    # Extract first JSON object
-    match = re.search(r"\{[\s\S]*\}", text)
-    if match:
+    # The model often emits a valid JSON value then trails off into prose —
+    # extract the leading balanced array/object and parse that.
+    span = _extract_json_span(text)
+    if span is not None:
         try:
-            return json.loads(match.group(0))
+            return json.loads(span)
         except json.JSONDecodeError:
             pass
 

--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -387,7 +387,9 @@ class ArbitrageScanner:
                 # below still matches pairs without an LLM call.
                 log.debug("arb_scanner.llm_budget_skipped", error=str(e))
             except Exception as e:
-                log.error("arb_scanner.llm_match_failed", error=str(e))
+                # Fail-soft: the word-overlap fallback below still matches pairs
+                # without the LLM, so this is a warning, not an error.
+                log.warning("arb_scanner.llm_match_failed", error=str(e))
                 # Fall through to word-overlap fallback
 
         # Strategy B: Word-Overlap Fallback

--- a/tests/test_parse_claude_json.py
+++ b/tests/test_parse_claude_json.py
@@ -1,0 +1,50 @@
+"""Tests for the robust Claude JSON parser — it must recover a JSON value
+(object OR array) even when the model trails off into prose, which is what
+caused the benign-but-noisy arb_scanner.llm_match_failed errors."""
+
+from __future__ import annotations
+
+import pytest
+
+from auramaur.nlp.analyzer import _extract_json_span, _parse_claude_json
+
+
+def test_parses_plain_object_and_array():
+    assert _parse_claude_json('{"a": 1}') == {"a": 1}
+    assert _parse_claude_json("[1, 2, 3]") == [1, 2, 3]
+
+
+def test_empty_array_followed_by_prose():
+    # The exact shape that errored: a valid [] then an explanation.
+    raw = '[]\n\nNo matches found. List B consists entirely of "next SecGen" markets.'
+    assert _parse_claude_json(raw) == []
+
+
+def test_array_of_objects_followed_by_prose():
+    raw = '[{"id_a": "x", "id_b": "y"}]\nThese two markets describe the same event.'
+    assert _parse_claude_json(raw) == [{"id_a": "x", "id_b": "y"}]
+
+
+def test_object_followed_by_prose():
+    raw = '{"probability": 0.7}\nHere is my reasoning: the base rate is high.'
+    assert _parse_claude_json(raw) == {"probability": 0.7}
+
+
+def test_markdown_fenced_json():
+    assert _parse_claude_json('```json\n{"a": 2}\n```') == {"a": 2}
+
+
+def test_brackets_inside_strings_do_not_fool_extraction():
+    # A ']' inside a string literal must not end the array early.
+    raw = '[{"q": "Will the S&P close in [4000, 4100]?"}] then some prose.'
+    assert _parse_claude_json(raw) == [{"q": "Will the S&P close in [4000, 4100]?"}]
+
+
+def test_extract_span_handles_nesting():
+    assert _extract_json_span('xx [1, [2, 3], 4] yy') == "[1, [2, 3], 4]"
+    assert _extract_json_span("no json here") is None
+
+
+def test_unparseable_still_raises():
+    with pytest.raises(ValueError):
+        _parse_claude_json("totally not json at all")


### PR DESCRIPTION
## Problem
The arb scanner asks the LLM for a JSON **array** of matches; the model often returns a valid value (e.g. `[]` = no matches) **followed by prose**. `_parse_claude_json`'s fallback only extracted JSON **objects** (`\{...\}`), so an array + trailing prose failed → `arb_scanner.llm_match_failed` (benign — falls through to word-overlap fallback — but noisy, at error level). Same parser is behind `analyze.primary_failed`, so the fix helps broadly.

## Fix
Replace the object-only regex with a **balanced-bracket extractor** returning the first complete JSON array OR object, tracking nesting + quoted strings (brackets inside string literals don't fool it). Downgrade the arb-scanner log error→warning (fail-soft).

## Tests
8 cover the exact `[]`+prose case, arrays-of-objects+prose, objects+prose, fenced JSON, brackets-in-strings, unparseable→raises. 990 pass across the suite; full-repo ruff clean.

Assisted-by: Claude (Anthropic)