### PR TITLE
fix(market_maker): per-op timeout watchdog so a stuck Poly call can't hang the loop

### DIFF
--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
 
+import asyncio
 import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -107,6 +108,7 @@ class MarketMaker:
         self._max_inventory: float = mm_cfg.max_inventory
         self._max_markets: int = mm_cfg.max_markets
         self._refresh_seconds: int = mm_cfg.refresh_seconds
+        self._op_timeout: float = mm_cfg.op_timeout_seconds
 
         # State
         self._active_quotes: dict[str, MMQuote] = {}  # market_id -> active quote
@@ -137,20 +139,35 @@ class MarketMaker:
             log.debug("market_maker.no_suitable_markets")
             return results
 
+        # Per-operation watchdog: a stuck Polymarket call (no timeout) would hang
+        # the whole loop indefinitely. Bound each op so a stalled request is
+        # abandoned and the cycle continues.
+        timeout = self._op_timeout
+
         # Step 2: Cancel stale quotes
-        cancelled = await self._cancel_stale_quotes()
-        if cancelled:
-            log.info("market_maker.cancelled_stale", count=cancelled)
+        try:
+            cancelled = await asyncio.wait_for(
+                self._cancel_stale_quotes(), timeout=timeout)
+            if cancelled:
+                log.info("market_maker.cancelled_stale", count=cancelled)
+        except asyncio.TimeoutError:
+            log.warning("market_maker.op_timeout", op="cancel_stale", timeout=timeout)
 
         # Step 3 & 4: Compute and place quotes for each market
         skip_reasons: dict[str, int] = {}
         for market in candidates[: self._max_markets]:
             try:
-                result, skip_reason = await self._quote_market(market)
+                result, skip_reason = await asyncio.wait_for(
+                    self._quote_market(market), timeout=timeout)
                 if result:
                     results.append(result)
                 elif skip_reason:
                     skip_reasons[skip_reason] = skip_reasons.get(skip_reason, 0) + 1
+            except asyncio.TimeoutError:
+                # A stuck call on THIS market must not stall the rest of the cycle.
+                log.warning("market_maker.op_timeout", op="quote_market",
+                            market_id=market.id, timeout=timeout)
+                skip_reasons["timeout"] = skip_reasons.get("timeout", 0) + 1
             except Exception as e:
                 log.error(
                     "market_maker.quote_error",

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -379,6 +379,10 @@ market_maker:
   max_inventory: 50.0       # max directional exposure per market
   max_markets: 5            # max simultaneous MM markets
   refresh_seconds: 30       # re-quote frequency
+  # Per-op watchdog: a stuck Polymarket call (no timeout) hung the whole MM loop
+  # twice on 2026-06-30 (silent 12-24 min). Bound each quote op so a stuck call is
+  # abandoned and the cycle continues.
+  op_timeout_seconds: 15.0
 
 arbitrage:
   enabled: true

--- a/config/settings.py
+++ b/config/settings.py
@@ -315,6 +315,12 @@ class MarketMakerConfig(BaseModel):
     max_inventory: float = 50.0  # max directional exposure per market
     max_markets: int = 5  # max simultaneous MM markets
     refresh_seconds: int = 30  # re-quote frequency
+    # Per-operation watchdog: a single Polymarket call (orderbook fetch, quote
+    # placement) that stalls without a timeout will hang the WHOLE MM loop
+    # indefinitely — observed twice 2026-06-30 (the loop went silent for 12-24
+    # min on a stuck request). Bound each per-market quote op and the stale-cancel
+    # with this timeout so a stuck call is abandoned and the cycle continues.
+    op_timeout_seconds: float = 15.0
 
 
 class TechnicalConfig(BaseModel):

--- a/tests/test_market_maker.py
+++ b/tests/test_market_maker.py
@@ -9,6 +9,7 @@ from auramaur.strategy.market_maker import MarketMaker
 
 
 def _maker(*, quote_size=10.0, max_inventory=50.0, is_live=False,
+           op_timeout_seconds=15.0,
            blocked_categories=("sports", "politics_us"),
            allowed_categories_live=("crypto", "tech", "politics_intl")) -> MarketMaker:
     settings = SimpleNamespace(
@@ -20,6 +21,7 @@ def _maker(*, quote_size=10.0, max_inventory=50.0, is_live=False,
             max_inventory=max_inventory,
             max_markets=5,
             refresh_seconds=30,
+            op_timeout_seconds=op_timeout_seconds,
         ),
         risk=SimpleNamespace(
             blocked_categories=list(blocked_categories),
@@ -323,3 +325,36 @@ async def test_mm_orders_self_stamp_market_maker_source():
     assert all(o.dry_run is False for o in placed)           # is_live=True
     # Bid leg buys YES, ask leg buys NO (synthetic sell-YES).
     assert {o.token for o in placed} == {TokenType.YES, TokenType.NO}
+
+
+def test_run_cycle_times_out_a_hung_quote_and_continues():
+    """A stuck per-market quote op (e.g. a Polymarket call with no timeout) must
+    NOT hang the whole MM loop — the watchdog abandons it after op_timeout and the
+    cycle completes. Regression for the 2026-06-30 MM hangs."""
+    import asyncio
+    from datetime import datetime, timedelta, timezone
+
+    mm = _maker(op_timeout_seconds=0.05)
+    mkt = Market(id="m1", exchange="polymarket", question="q", category="crypto",
+                 active=True, outcome_yes_price=0.5, outcome_no_price=0.5,
+                 liquidity=5000.0, volume=5000.0,
+                 end_date=datetime.now(timezone.utc) + timedelta(days=5),
+                 clob_token_yes="ty", clob_token_no="tn")
+
+    mm._select_mm_markets = lambda markets: [mkt]
+
+    async def _no_stale():
+        return 0
+    mm._cancel_stale_quotes = _no_stale
+
+    async def _hang(market):
+        await asyncio.sleep(10)  # simulate a stuck Polymarket call
+        return {}, None
+    mm._quote_market = _hang
+
+    async def run():
+        # Must return promptly (~op_timeout), NOT hang for 10s.
+        return await asyncio.wait_for(mm.run_cycle([mkt]), timeout=3.0)
+
+    results = asyncio.run(run())
+    assert results == []  # the hung market produced no quote, loop survived


### PR DESCRIPTION
## Problem
The MM loop went **fully silent twice on 2026-06-30** (12 and 24 min) while every other loop kept running — a Polymarket call (orderbook/quote) stalled **without a timeout** and blocked the whole cycle indefinitely. A restart cleared it but it recurred.

## Fix
Bound each per-market quote op AND the stale-cancel with `asyncio.wait_for(op_timeout_seconds=15)`: a stalled call is abandoned (logged `market_maker.op_timeout`, that market skipped with reason "timeout") and the cycle continues.

## Tests
Simulates a hung `_quote_market` and asserts `run_cycle` returns promptly instead of stalling. 11 MM tests pass; full-repo ruff clean.

Assisted-by: Claude (Anthropic)