### PR TITLE
fix(market_maker): bound the OUTER-loop Poly calls too (discovery + check_fills)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -892,14 +892,35 @@ class AuramaurBot(
             if await self._check_kill_switch():
                 return
             try:
+                # Watchdog: the per-op timeout inside run_cycle only covers the
+                # quote ops — the OUTER-loop Polymarket calls (market discovery,
+                # fill polling) were still unbounded and hung the loop (2026-06-30,
+                # silent ~16 min with NO op_timeout firing). Bound them too so no
+                # single stuck request can stall the MM task.
+                op_timeout = self.settings.market_maker.op_timeout_seconds
+
                 # Fetch liquid markets sorted by volume
-                markets = await discovery.get_markets(limit=50, order="liquidity")
+                try:
+                    markets = await asyncio.wait_for(
+                        discovery.get_markets(limit=50, order="liquidity"),
+                        timeout=op_timeout)
+                except asyncio.TimeoutError:
+                    log.warning("market_maker.op_timeout", op="get_markets",
+                                timeout=op_timeout)
+                    await asyncio.sleep(interval)
+                    continue
 
                 # Run the MM cycle
                 results = await mm.run_cycle(markets)
 
                 # Check for fills on pending live orders
-                fills = await mm.check_fills()
+                try:
+                    fills = await asyncio.wait_for(
+                        mm.check_fills(), timeout=op_timeout)
+                except asyncio.TimeoutError:
+                    log.warning("market_maker.op_timeout", op="check_fills",
+                                timeout=op_timeout)
+                    fills = []
 
                 if results:
                     total_profit = sum(r.get("expected_profit", 0) for r in results)


### PR DESCRIPTION
## Problem
#241 added a per-op watchdog inside `run_cycle`, but the MM **hung again right after** (silent ~16 min) with **zero op_timeout firing** — the stall was **outside** `run_cycle`. The outer task loop makes two more unbounded Polymarket calls: `discovery.get_markets` (first call each iteration) and `mm.check_fills` (`get_order_status` polling).

## Fix
Wrap both in `asyncio.wait_for(op_timeout_seconds)`: a stuck `get_markets` skips the cycle (sleep + continue), a stuck `check_fills` proceeds with no fills. Now no single Polymarket request anywhere in the MM task can hang the loop.

bot imports OK; full-repo ruff clean; 11 MM tests pass.

Assisted-by: Claude (Anthropic)