### PR TITLE
fix(informed_flow): two walls that forced zero signals — count_fp + near-dated discovery

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -164,6 +164,36 @@ class KalshiClient:
             log.error("kalshi.trades_fetch_error", ticker=ticker, error=str(e))
             return []
 
+    async def get_markets_by_close_window(self, min_close_ts: int,
+                                          max_close_ts: int,
+                                          limit: int = 200) -> list[Market]:
+        """Open markets CLOSING within [min_close_ts, max_close_ts] (unix secs).
+
+        The generic get_markets() scans the /events endpoint in default order,
+        which surfaces only ultra-long-dated novelty markets (Elon-to-Mars etc.;
+        median horizon ~18 years) and IGNORES close-time filters — so a
+        near-dated scanner (informed_flow) finds nothing. The /markets endpoint
+        DOES honor min/max_close_ts, returning the actually-tradeable near-dated
+        slice (econ ladders, MVE, event markets). Returns [] on error."""
+        self._init_api()
+        try:
+            import json
+            raw = await self._call_raw(
+                self._markets_api.get_markets_without_preload_content,
+                status="open", min_close_ts=min_close_ts,
+                max_close_ts=max_close_ts, limit=min(limit, 1000),
+            )
+            rows = json.loads(raw).get("markets", [])
+            out: list[Market] = []
+            for m in rows:
+                parsed = self._parse_market(m)
+                if parsed is not None:
+                    out.append(parsed)
+            return out
+        except Exception as e:
+            log.error("kalshi.close_window_fetch_error", error=str(e))
+            return []
+
     async def get_markets_by_series(self, series_ticker: str,
                                     limit: int = 200) -> list[Market]:
         """Fetch open markets for ONE series — i.e. all bins of a threshold

--- a/auramaur/strategy/informed_flow.py
+++ b/auramaur/strategy/informed_flow.py
@@ -41,8 +41,13 @@ _NO_SIGNAL = InformedFlowSignal(False, None, 0, 0.0, 0.0, 0)
 
 
 def _size(t: dict) -> float:
+    # Kalshi migrated the per-trade contract count `count` -> `count_fp` (a
+    # fixed-point string, e.g. "225.25"), the same *_fp migration that hit market
+    # parsing. Reading the dead `count` made every trade size 0, so the detector
+    # ALWAYS returned no-signal — informed_flow could never fire. Prefer count_fp,
+    # fall back to the legacy field.
     try:
-        return float(t.get("count", 0) or 0)
+        return float(t.get("count_fp", t.get("count", 0)) or 0)
     except (TypeError, ValueError):
         return 0.0
 

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -62,7 +62,19 @@ class InformedFlowPillar:
         if open_count >= cfg.max_open:
             log.debug("informed_flow.book_full", open=open_count, cap=cfg.max_open)
             return 0
-        markets = await self._kalshi.get_markets(limit=cfg.scan_limit)
+        # Scan the NEAR-DATED slice by close-time window, not get_markets() — the
+        # /events scan get_markets() uses surfaces only ~18-yr novelty markets
+        # (median horizon ~18 years), so every market failed the horizon gate and
+        # the tape was never pulled. /markets honors the close window and returns
+        # the actually-tradeable near-dated markets (econ ladders, MVE, events).
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        min_close_ts = now_ts + int(cfg.min_hours_to_resolution * 3600)
+        max_close_ts = now_ts + int(cfg.max_days_to_resolution * 86400)
+        if hasattr(self._kalshi, "get_markets_by_close_window"):
+            markets = await self._kalshi.get_markets_by_close_window(
+                min_close_ts, max_close_ts, limit=cfg.scan_limit)
+        else:  # fallback (e.g. a discovery without the windowed fetch / tests)
+            markets = await self._kalshi.get_markets(limit=cfg.scan_limit)
         entered = 0
         for market in markets:
             if entered >= cfg.max_entries_per_cycle:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -505,7 +505,7 @@ informed_flow:
   max_days_to_resolution: 30.0
   max_open: 30
   max_entries_per_cycle: 5
-  scan_limit: 60
+  scan_limit: 200          # near-dated /markets close-window; tape pulled per eligible
   interval_seconds: 1800
 
 settlement_arb:

--- a/config/settings.py
+++ b/config/settings.py
@@ -431,7 +431,7 @@ class InformedFlowConfig(BaseModel):
     max_days_to_resolution: float = 30.0
     max_open: int = 30
     max_entries_per_cycle: int = 5
-    scan_limit: int = 60             # bounded — we fetch a tape per eligible market
+    scan_limit: int = 200            # near-dated /markets window; tape pulled per eligible
     interval_seconds: int = 1800
 
 

--- a/tests/test_informed_flow.py
+++ b/tests/test_informed_flow.py
@@ -15,7 +15,17 @@ from auramaur.strategy.informed_flow import (
 
 
 def _t(count, side):
-    return {"count": count, "taker_side": side}
+    # Kalshi emits the per-trade size as count_fp (a fixed-point STRING), e.g.
+    # "60.00" — mirror that so the detector tests exercise the real field.
+    return {"count_fp": f"{count}", "taker_side": side}
+
+
+def test_reads_count_fp_string_and_legacy_count():
+    """_size handles the live count_fp string AND the legacy count field."""
+    from auramaur.strategy.informed_flow import _size
+    assert abs(_size({"count_fp": "225.25"}) - 225.25) < 1e-9
+    assert _size({"count": 50}) == 50.0           # legacy fallback
+    assert _size({"count_fp": "nope"}) == 0.0      # malformed -> 0, no raise
 
 
 def _normal(n, size, side="yes"):

--- a/tests/test_informed_flow_pillar.py
+++ b/tests/test_informed_flow_pillar.py
@@ -90,6 +90,8 @@ def _risk(approved=True, size=8.0):
 def _pillar(db, settings, markets, exchange, risk=None):
     disc = MagicMock()
     disc.get_markets = AsyncMock(return_value=markets)
+    # The pillar scans the near-dated close-time window via this method.
+    disc.get_markets_by_close_window = AsyncMock(return_value=markets)
     cal = MagicMock()
     cal.record_prediction = AsyncMock()
     return InformedFlowPillar(


### PR DESCRIPTION
Live diagnosis: informed_flow emitted **zero** signals ever. Two independent walls, each alone enough:

1. **Data layer (latent, total):** Kalshi renamed per-trade `count` → `count_fp` (fixed-point string). `_size()` read the dead field → every trade sized 0 → detector always no-signal, even on a full tape. Fix: read `count_fp` (fallback to `count`). Verified live: fires on 31/33 eligible markets after the fix, still suppresses 2-sided flow.
2. **Discovery (binding today):** `get_markets()` scans `/events` in default order → only ~18-yr-horizon novelty markets → 100% fail the 30-day gate → **tape never pulled**. `/markets` honors `min/max_close_ts`. Added `KalshiClient.get_markets_by_close_window` + scan the near-dated window. `scan_limit 60→200`.

Both needed. Paper-forced. Honest note: near-dated Kalshi flow is mostly sports (blocked) / crypto-15m (under min_hours), so the eligible pool is thin but real — thresholds NOT loosened. 16 tests pass; full-repo ruff clean.

Assisted-by: Claude (Anthropic)