### PR TITLE
fix(settlement_arb): point-bins priced fair=0; CPI-YoY used the SA series

### DIFF
--- a/auramaur/data_sources/fred.py
+++ b/auramaur/data_sources/fred.py
@@ -20,7 +20,8 @@ _DEFAULT_SERIES: dict[str, str] = {
     "ICSA": "Initial Jobless Claims",
     "JTSJOL": "Job Openings (JOLTS)",
     # Prices
-    "CPIAUCSL": "Consumer Price Index (CPI)",
+    "CPIAUCSL": "Consumer Price Index (CPI, seasonally adj.)",
+    "CPIAUCNS": "Consumer Price Index (CPI, not seasonally adj.)",
     "CPILFESL": "Core CPI (ex Food & Energy)",
     "PCEPI": "PCE Price Index",
     "PPIFIS": "Producer Price Index (PPI)",

--- a/auramaur/strategy/econ_pricing.py
+++ b/auramaur/strategy/econ_pricing.py
@@ -41,7 +41,11 @@ class EconSpec:
 # (GDP annualization / Fed-decision categoricals are intentionally omitted
 # until each is validated against a real print.)
 ECON_SERIES: dict[str, EconSpec] = {
-    "KXCPIYOY": EconSpec("CPIAUCSL", "yoy", periods_per_year=12),
+    # Kalshi CPI-YoY markets resolve on the headline BLS number, which is the
+    # NOT-seasonally-adjusted index (CPIAUCNS). CPIAUCSL is the seasonally
+    # adjusted series — its YoY can differ by a tenth or more, exactly the
+    # margin a point-bin turns on, so the SA series would mis-resolve bins.
+    "KXCPIYOY": EconSpec("CPIAUCNS", "yoy", periods_per_year=12),
     "KXU3": EconSpec("UNRATE", "level", periods_per_year=12),
     "KXPAYROLLS": EconSpec("PAYEMS", "mom_change", periods_per_year=12, scale=1000.0),
 }

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -134,6 +134,18 @@ def indicator_at_period(
     return None
 
 
+def _bin_half_width(threshold: float) -> float:
+    """Half-width of the point-bin centered on ``threshold``, derived from the
+    threshold's own decimal precision (Kalshi econ point-bins are one grid step
+    wide: 3.8 -> the [3.75, 3.85) bin, half-width 0.05). Needed because the
+    indicator is computed CONTINUOUSLY from FRED (e.g. CPI YoY = 3.7841%), so an
+    exact ``== 3.8`` test never matches and every point-bin would price fair=0.
+    """
+    s = f"{threshold:.10f}".rstrip("0")
+    decimals = len(s.split(".")[1]) if "." in s else 0
+    return 0.5 * (10.0 ** -decimals)
+
+
 def is_satisfied(value: float, operator: str, threshold: float) -> bool:
     """Does the published value satisfy the YES criterion?"""
     if operator == ">=":
@@ -145,7 +157,9 @@ def is_satisfied(value: float, operator: str, threshold: float) -> bool:
     if operator == "<":
         return value < threshold
     if operator == "==":
-        return abs(value - threshold) < 1e-9
+        # Point-bin: YES iff the continuous indicator rounds INTO this bin, i.e.
+        # falls within half a grid step of the threshold — not exact equality.
+        return abs(value - threshold) < _bin_half_width(threshold) + 1e-12
     return False
 
 

--- a/tests/test_settlement_arb.py
+++ b/tests/test_settlement_arb.py
@@ -38,6 +38,24 @@ def test_is_satisfied_operators():
     assert is_satisfied(3.0, "??", 3.0) is False   # unknown operator -> not satisfied
 
 
+def test_point_bin_uses_grid_tolerance_not_exact_equality():
+    """A CPI YoY point-bin '== 3.8' must resolve YES for any continuous indicator
+    that ROUNDS into the [3.75, 3.85) bin — exact float equality never matched,
+    so every point-bin priced fair=0 and the pillar entered nothing."""
+    assert is_satisfied(3.7841, "==", 3.8) is True    # rounds to 3.8 -> in bin
+    assert is_satisfied(3.84, "==", 3.8) is True       # still in [3.75, 3.85)
+    assert is_satisfied(3.86, "==", 3.8) is False      # rounds to 3.9 -> out
+    assert is_satisfied(3.74, "==", 3.8) is False      # rounds to 3.7 -> out
+    # precision follows the threshold: an integer bin is one whole unit wide
+    assert is_satisfied(3.4, "==", 3.0) is True
+    assert is_satisfied(3.6, "==", 3.0) is False
+
+
+def test_cpi_yoy_resolves_on_non_seasonally_adjusted_series():
+    """Kalshi CPI-YoY markets settle on the NSA headline index (CPIAUCNS)."""
+    assert ECON_SERIES["KXCPIYOY"].fred_series == "CPIAUCNS"
+
+
 # ---------------------------------------------------------------------------
 # indicator_at_period — the deterministic resolve
 # ---------------------------------------------------------------------------
@@ -56,7 +74,7 @@ def test_level_period_not_published_yet_is_none():
 
 
 def test_yoy_indicator_computes_against_prior_year():
-    spec = ECON_SERIES["KXCPIYOY"]   # CPIAUCSL, yoy
+    spec = ECON_SERIES["KXCPIYOY"]   # CPIAUCNS, yoy
     # June 2025 = 100, June 2026 = 103 -> +3.0% YoY
     obs = _obs(("2025-06", 100.0), ("2026-05", 102.5), ("2026-06", 103.0))
     assert indicator_at_period(obs, spec, "2026-06") == pytest.approx(3.0)


### PR DESCRIPTION
Two correctness bugs in the FRED settlement-lag pillar, both of which bite before the July CPI window:

1. **Point-bin `==` used exact float equality.** The indicator is computed *continuously* from FRED (CPI YoY = 3.7841%), so `abs(value - 3.8) < 1e-9` is never true → **every point-bin priced fair=0**, so the pillar would short every YES on a bin it should be holding. Kalshi point-bins cover a one-grid-step interval centered on the threshold (`3.8` = the [3.75, 3.85) bin) → resolve by half-bin tolerance derived from the threshold's own precision.
2. **KXCPIYOY resolved off CPIAUCSL (seasonally adjusted).** Headline BLS CPI that Kalshi settles on is **not** seasonally adjusted (CPIAUCNS); the two YoY prints differ by ~a tenth — the margin a point-bin turns on.

Paper-forced. 27 tests pass; full-repo ruff clean.

Assisted-by: Claude (Anthropic)