### PR TITLE
feat(settlement_arb): scan + trade Kalshi monthly macro bins

### DIFF
--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -196,6 +196,10 @@ class StrategyTaskMixin:
             pnl_tracker=self._components.pnl_tracker,
             fred_source=FREDSource(api_key=self.settings.fred_api_key),
             analyzer=self._components.analyzer,
+            # Kalshi monthly macro bins are where the settlement lag lives; pass
+            # the Kalshi venue when composed so the pillar scans + trades them.
+            kalshi_discovery=(self._components.discoveries or {}).get("kalshi"),
+            kalshi_exchange=(self._components.exchanges or {}).get("kalshi"),
         )
         interval = max(60, self.settings.settlement_arb.interval_seconds)
         while self._running:

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -24,6 +24,17 @@ from auramaur.exchange.paper import PaperTrader
 
 log = structlog.get_logger()
 
+
+def _opt_float(v) -> float | None:
+    """Parse an optional numeric strike field; None when absent/unparseable."""
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
 # Kalshi basic tier: 20 reads/sec
 _RATE_LIMIT = 20
 
@@ -1081,6 +1092,9 @@ class KalshiClient:
                 # into the ledger.
                 status=status,
                 result=str(_get("result", "") or "").lower(),
+                strike_type=str(_get("strike_type", "") or "").lower(),
+                floor_strike=_opt_float(_get("floor_strike")),
+                cap_strike=_opt_float(_get("cap_strike")),
             )
         except Exception as e:
             log.warning("kalshi.parse_error", error=str(e))

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -70,6 +70,15 @@ class Market(BaseModel):
     # settled into the ledger. Empty for venues that don't report these.
     status: str = ""
     result: str = ""
+    # Kalshi structured strike fields — the authoritative bin definition. A
+    # threshold market carries strike_type ("greater"/"greater_or_equal"/
+    # "less"/"less_or_equal") with floor_strike as the strike; a range/point bin
+    # is strike_type "between" with floor_strike/cap_strike. settlement_arb reads
+    # these to build the resolve predicate deterministically (no LLM). Empty for
+    # non-Kalshi venues.
+    strike_type: str = ""
+    floor_strike: float | None = None
+    cap_strike: float | None = None
     # Polymarket UMA optimistic-oracle resolution state, surfaced by Gamma.
     # `uma_status` is the current stage ("" → no proposal yet, "proposed" →
     # outcome proposed and in the liveness window, "disputed" → actively

--- a/auramaur/strategy/econ_pricing.py
+++ b/auramaur/strategy/econ_pricing.py
@@ -18,6 +18,7 @@ calibration prove it.
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 
 
@@ -35,6 +36,12 @@ class EconSpec:
     transform: str
     periods_per_year: int = 12  # 12 monthly, 4 quarterly — for YoY/horizon
     scale: float = 1.0          # mom_change unit fix (PAYEMS is in thousands)
+    # Precision the official agency REPORTS the figure to (CPI YoY & U3 to 0.1pp,
+    # payrolls to the nearest 1,000 jobs). A FRED-derived indicator is computed
+    # continuously (e.g. CPI YoY 4.4997%), but Kalshi/Poly bins resolve on the
+    # ROUNDED published figure — so round to this grid before the threshold test,
+    # else a value a hair off a strike boundary resolves the wrong side.
+    report_round_to: float = 0.0  # 0 => no rounding
 
 
 # Conservative starter registry — only series with an unambiguous transform.
@@ -45,10 +52,67 @@ ECON_SERIES: dict[str, EconSpec] = {
     # NOT-seasonally-adjusted index (CPIAUCNS). CPIAUCSL is the seasonally
     # adjusted series — its YoY can differ by a tenth or more, exactly the
     # margin a point-bin turns on, so the SA series would mis-resolve bins.
-    "KXCPIYOY": EconSpec("CPIAUCNS", "yoy", periods_per_year=12),
-    "KXU3": EconSpec("UNRATE", "level", periods_per_year=12),
-    "KXPAYROLLS": EconSpec("PAYEMS", "mom_change", periods_per_year=12, scale=1000.0),
+    "KXCPIYOY": EconSpec("CPIAUCNS", "yoy", periods_per_year=12, report_round_to=0.1),
+    "KXU3": EconSpec("UNRATE", "level", periods_per_year=12, report_round_to=0.1),
+    "KXPAYROLLS": EconSpec("PAYEMS", "mom_change", periods_per_year=12,
+                           scale=1000.0, report_round_to=1000.0),
 }
+
+# Kalshi monthly-period date codes: "26NOV" -> ("2026", 11).
+_KALSHI_MONTHS = {
+    "JAN": 1, "FEB": 2, "MAR": 3, "APR": 4, "MAY": 5, "JUN": 6,
+    "JUL": 7, "AUG": 8, "SEP": 9, "OCT": 10, "NOV": 11, "DEC": 12,
+}
+_KALSHI_PERIOD_RE = re.compile(r"^(\d{2})([A-Z]{3})$")
+# strike_type -> comparison operator for the YES outcome.
+_STRIKE_OPERATORS = {
+    "greater": ">", "greater_or_equal": ">=",
+    "less": "<", "less_or_equal": "<=",
+}
+
+
+def parse_kalshi_period(code: str) -> str | None:
+    """'26NOV' -> '2026-11'. None if the code isn't a YY-MON monthly period."""
+    m = _KALSHI_PERIOD_RE.match((code or "").strip().upper())
+    if not m:
+        return None
+    yy, mon = m.groups()
+    month = _KALSHI_MONTHS.get(mon)
+    if month is None:
+        return None
+    return f"20{yy}-{month:02d}"
+
+
+def kalshi_macro_predicate(market) -> dict | None:
+    """Build a settlement_arb predicate DETERMINISTICALLY from a Kalshi macro-bin
+    market's ticker + structured strike fields — no LLM extraction.
+
+    Returns {indicator, operator, threshold, reference_period} for a recognized
+    monthly econ-series threshold bin (e.g. KXCPIYOY-26NOV-T4.5, strike_type
+    'greater', floor 4.5 -> '> 4.5' on KXCPIYOY for 2026-11), else None
+    (unknown series, non-monthly period, or a 'between'/structured bin we don't
+    resolve with a single threshold).
+    """
+    ticker = (getattr(market, "ticker", "") or "")
+    parts = ticker.split("-")
+    if len(parts) < 3:
+        return None
+    series = parts[0].upper()
+    if series not in ECON_SERIES:
+        return None
+    period = parse_kalshi_period(parts[1])
+    if period is None:
+        return None
+    op = _STRIKE_OPERATORS.get((getattr(market, "strike_type", "") or "").lower())
+    if op is None:
+        return None  # 'between'/structured/unknown -> not a single-threshold bin
+    floor = getattr(market, "floor_strike", None)
+    cap = getattr(market, "cap_strike", None)
+    threshold = floor if op in (">", ">=") else (cap if cap is not None else floor)
+    if threshold is None:
+        return None
+    return {"indicator": series, "operator": op,
+            "threshold": float(threshold), "reference_period": period}
 
 
 def spec_for_series(series_ticker: str) -> EconSpec | None:

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -39,7 +39,12 @@ import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.exchange.models import Confidence, OrderSide, Signal
-from auramaur.strategy.econ_pricing import ECON_SERIES, EconSpec, spec_for_series
+from auramaur.strategy.econ_pricing import (
+    ECON_SERIES,
+    EconSpec,
+    kalshi_macro_predicate,
+    spec_for_series,
+)
 
 log = structlog.get_logger()
 
@@ -170,7 +175,8 @@ class SettlementArbPillar:
     execution_mode = ExecutionMode.GATEWAY_SINGLE
 
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, fred_source, analyzer) -> None:
+                 pnl_tracker, fred_source, analyzer,
+                 kalshi_discovery=None, kalshi_exchange=None) -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
@@ -182,6 +188,19 @@ class SettlementArbPillar:
         self._gateway = ExecutionGateway(
             router=None, exchange=exchange, exchange_name="polymarket",
             settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+        # Kalshi monthly macro bins (KXCPIYOY/KXU3/KXPAYROLLS) are where the
+        # settlement lag actually lives — the Poly econ universe is all annual /
+        # compound markets. Wired when the Kalshi venue is composed; its
+        # predicate comes from structured strike fields (no LLM) and execution
+        # routes through a Kalshi-named gateway.
+        self._kalshi = kalshi_discovery
+        self._kalshi_gateway = (
+            ExecutionGateway(
+                router=None, exchange=kalshi_exchange, exchange_name="kalshi",
+                settings=settings, db=db, pnl_tracker=pnl_tracker,
+            )
+            if kalshi_exchange is not None else None
         )
         self._schema_ready = False
 
@@ -258,11 +277,42 @@ class SettlementArbPillar:
                 clob_token_yes=r["clob_token_yes"] or "",
                 clob_token_no=r["clob_token_no"] or "",
             ))
+        out.extend(await self._kalshi_candidates())
+        return out
+
+    async def _kalshi_candidates(self) -> list:
+        """Kalshi monthly macro-bin markets for the registered econ series.
+
+        Fetched live per-series (the bins aren't in the local market cache) and
+        kept only when they carry a real two-sided price — a no-bid far-dated bin
+        (yes_price collapses to 0/1) has no lag to capture and nothing to fill.
+        No min_liquidity gate: the thesis is that the lag survives in the thin,
+        low-volume bins, and the pillar holds to resolution so illiquidity never
+        strands an exit. Predicate/operator come from strike fields downstream.
+        """
+        if self._kalshi is None or not hasattr(self._kalshi, "get_markets_by_series"):
+            return []
+        out: list = []
+        for series in ECON_SERIES:
+            try:
+                markets = await self._kalshi.get_markets_by_series(series, limit=200)
+            except Exception as e:
+                log.debug("settlement_arb.kalshi_fetch_error", series=series, error=str(e))
+                continue
+            for km in markets or []:
+                if 0.0 < (km.outcome_yes_price or 0.0) < 1.0:
+                    out.append(km)
         return out
 
     async def _predicate(self, m) -> dict | None:
-        """Extracted+verified predicate for a market (cached forever — the
-        criterion is static)."""
+        """Resolve predicate for a market.
+
+        Kalshi macro bins carry the predicate in structured strike fields, so it
+        is parsed DETERMINISTICALLY (no LLM extract/verify, no cost, no parse
+        error). Polymarket markets fall back to the cached LLM extract+verify.
+        """
+        if (getattr(m, "exchange", "") or "") == "kalshi":
+            return kalshi_macro_predicate(m)
         row = await self._db.fetchone(
             "SELECT indicator, operator, threshold, reference_period, verified "
             "FROM settlement_extractions WHERE market_id = ?", (m.id,))
@@ -339,6 +389,12 @@ class SettlementArbPillar:
         value = indicator_at_period(obs, spec, pred["reference_period"])
         if value is None:
             return False  # print not out yet -> undetermined, never forecast
+        # Resolve on the figure as the agency REPORTS it (CPI YoY/U3 to 0.1pp,
+        # payrolls to 1,000) — the bins settle on the rounded print, not the
+        # continuous FRED-derived value, so a hair-off-boundary value would
+        # otherwise resolve the wrong side of a strike.
+        if spec.report_round_to:
+            value = round(value / spec.report_round_to) * spec.report_round_to
 
         yes_locked = is_satisfied(value, pred["operator"], pred["threshold"])
         yes_price = m.outcome_yes_price
@@ -370,7 +426,11 @@ class SettlementArbPillar:
             return False
         size = min(decision.position_size, cfg.stake_usd)
         force_paper = cfg.paper or getattr(decision, "force_paper", False)
-        res = await self._gateway.submit(TradeIntent(
+        gateway = (self._kalshi_gateway
+                   if (getattr(m, "exchange", "") or "") == "kalshi"
+                   and self._kalshi_gateway is not None
+                   else self._gateway)
+        res = await gateway.submit(TradeIntent(
             signal=signal, market=m, size_dollars=size, force_paper=force_paper))
         ok = res.status in ("filled", "paper", "partial", "pending")
         if ok:

--- a/tests/test_econ_pricing.py
+++ b/tests/test_econ_pricing.py
@@ -3,16 +3,72 @@
 from __future__ import annotations
 
 
+from dataclasses import dataclass
+
 from auramaur.strategy.econ_pricing import (
     ECON_SERIES,
     EconSpec,
     bin_edge,
     estimate_distribution,
     indicator_series,
+    kalshi_macro_predicate,
     normal_cdf,
+    parse_kalshi_period,
     prob_above,
     spec_for_series,
 )
+
+
+@dataclass
+class _FakeKalshiMarket:
+    ticker: str = ""
+    exchange: str = "kalshi"
+    strike_type: str = ""
+    floor_strike: float | None = None
+    cap_strike: float | None = None
+
+
+def test_parse_kalshi_period():
+    assert parse_kalshi_period("26NOV") == "2026-11"
+    assert parse_kalshi_period("26jun") == "2026-06"
+    assert parse_kalshi_period("26Q4") is None      # not a monthly code
+    assert parse_kalshi_period("") is None
+
+
+def test_kalshi_macro_predicate_greater_threshold():
+    m = _FakeKalshiMarket(ticker="KXCPIYOY-26NOV-T4.5", strike_type="greater",
+                          floor_strike=4.5)
+    assert kalshi_macro_predicate(m) == {
+        "indicator": "KXCPIYOY", "operator": ">",
+        "threshold": 4.5, "reference_period": "2026-11"}
+
+
+def test_kalshi_macro_predicate_payrolls_absolute_threshold():
+    m = _FakeKalshiMarket(ticker="KXPAYROLLS-26JUN-T175000",
+                          strike_type="greater", floor_strike=175000.0)
+    p = kalshi_macro_predicate(m)
+    assert p["indicator"] == "KXPAYROLLS" and p["threshold"] == 175000.0
+    assert p["reference_period"] == "2026-06" and p["operator"] == ">"
+
+
+def test_kalshi_macro_predicate_rejects_unknown_or_compound():
+    # unknown series prefix
+    assert kalshi_macro_predicate(
+        _FakeKalshiMarket(ticker="KXNFL-26NOV-T4.5", strike_type="greater",
+                          floor_strike=4.5)) is None
+    # 'between' / structured bin -> no single-threshold predicate
+    assert kalshi_macro_predicate(
+        _FakeKalshiMarket(ticker="KXCPIYOY-26NOV-B4.5", strike_type="between",
+                          floor_strike=4.4, cap_strike=4.5)) is None
+    # non-monthly period
+    assert kalshi_macro_predicate(
+        _FakeKalshiMarket(ticker="KXU3-26Q4-T4.5", strike_type="greater",
+                          floor_strike=4.5)) is None
+
+
+def test_cpi_series_carry_report_rounding():
+    assert ECON_SERIES["KXCPIYOY"].report_round_to == 0.1
+    assert ECON_SERIES["KXPAYROLLS"].report_round_to == 1000.0
 
 
 def test_normal_cdf_basics():

--- a/tests/test_settlement_arb.py
+++ b/tests/test_settlement_arb.py
@@ -232,3 +232,66 @@ async def test_candidates_admit_tail_bins_reject_dust_and_noneon():
     cands = await p._candidates()
     ids = {m.id for m in cands}
     assert ids == {"tail"}
+
+
+# ---------------------------------------------------------------------------
+# Kalshi monthly macro-bin path — deterministic predicate, per-series scan,
+# resolve on the published (rounded) figure
+# ---------------------------------------------------------------------------
+
+def _kx(ticker, yes=0.7, strike_type="greater", floor=4.5):
+    from auramaur.exchange.models import Market
+    return Market(id=ticker, exchange="kalshi", ticker=ticker, question="",
+                  outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+                  strike_type=strike_type, floor_strike=floor)
+
+
+@pytest.mark.asyncio
+async def test_kalshi_candidates_scanned_per_series_priced_only():
+    """The Kalshi branch pulls each registered econ series and keeps only bins
+    with a real two-sided price (a no-bid far-dated bin has no lag to trade)."""
+    kdisc = SimpleNamespace(get_markets_by_series=AsyncMock(side_effect=lambda s, limit=200: [
+        _kx(f"{s}-26NOV-T4.5", yes=0.6),     # priced -> keep
+        _kx(f"{s}-26NOV-T9.9", yes=0.0),     # no price -> drop
+    ]))
+    settings = SimpleNamespace(settlement_arb=SimpleNamespace(min_liquidity=100.0))
+    db = MagicMock(); db.fetchall = AsyncMock(return_value=[])  # no Poly candidates
+    p = SettlementArbPillar(
+        db=db, settings=settings, discovery=MagicMock(), exchange=MagicMock(),
+        risk_manager=MagicMock(), pnl_tracker=MagicMock(), fred_source=MagicMock(),
+        analyzer=None, kalshi_discovery=kdisc, kalshi_exchange=MagicMock())
+    cands = await p._candidates()
+    assert {m.id for m in cands} == {
+        "KXCPIYOY-26NOV-T4.5", "KXU3-26NOV-T4.5", "KXPAYROLLS-26NOV-T4.5"}
+    assert kdisc.get_markets_by_series.await_count == 3   # one call per series
+
+
+@pytest.mark.asyncio
+async def test_kalshi_predicate_is_deterministic_no_llm():
+    """A Kalshi macro bin's predicate comes from strike fields — analyzer/db
+    never touched (analyzer=None would crash the LLM path)."""
+    p, _ = _pillar(fred_obs=[])
+    pred = await p._predicate(_kx("KXCPIYOY-26NOV-T4.5", strike_type="greater", floor=4.5))
+    assert pred == {"indicator": "KXCPIYOY", "operator": ">",
+                    "threshold": 4.5, "reference_period": "2026-11"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_published_rounded_figure():
+    """CPI YoY computes to 4.449% continuously, but BLS reports 4.4% — a bin
+    'above 4.4' must resolve NO (4.4 is not > 4.4), not YES off the raw value."""
+    obs = _obs(("2025-06", 100.0), ("2026-06", 104.449))   # raw YoY = +4.449%
+    p, _ = _pillar(fred_obs=obs)
+    market = SimpleNamespace(id="KXCPIYOY-26JUN-T4.4", exchange="kalshi",
+                             outcome_yes_price=0.80, outcome_no_price=0.20)
+    pred = {"indicator": "KXCPIYOY", "operator": ">", "threshold": 4.4,
+            "reference_period": "2026-06"}
+    captured = {}
+
+    async def fake_eval(signal, m):
+        captured["fair"] = signal.claude_prob
+        return SimpleNamespace(approved=False, position_size=0, reason="stop")
+    p._risk.evaluate = fake_eval
+
+    await p._maybe_enter(market, pred)
+    assert captured["fair"] == 0.0    # rounded 4.4 is NOT > 4.4 -> NO locked


### PR DESCRIPTION
settlement_arb's actual edge — the settlement lag in low-volume econ bins (NBER w34702) — lives on **Kalshi**, but its scan was Polymarket-only, where the econ universe is all not-yet-settled annual / compound markets (**~0 actionable**). This wires the Kalshi monthly macro-bin path.

- **Per-series fetch** of KXCPIYOY / KXU3 / KXPAYROLLS (priced bins only). Live smoke test: **249 priced bins** (vs 22 Poly), **100% deterministic parse rate**.
- **Deterministic predicate** from Kalshi's structured strike fields (`strike_type`+`floor/cap_strike`) + ticker period — **no LLM** extract/verify, no cost, no parse error. Adds the strike fields to the Market model + Kalshi parser.
- **Resolve on the published (rounded) figure**: round the continuous FRED indicator to BLS precision (CPI YoY/U3 → 0.1pp, payrolls → 1,000) before the threshold test, so a value a hair off a boundary doesn't settle the wrong side.
- **Venue-routed execution** via a Kalshi-named gateway; Poly keeps its LLM path + Poly gateway.

Paper-forced, own graduation cell. The lag window is narrow (Kalshi closes near the print) so this is a measurement spike, not a fill promise — but the pillar can finally see its real universe. 1003 tests pass (7 new), full-repo ruff clean.

Assisted-by: Claude (Anthropic)