### PR TITLE
fix(settlement_arb): memoize FRED per cycle — Kalshi fan-out spiked the API

### DIFF
--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -225,6 +225,11 @@ class SettlementArbPillar:
         if not cfg.enabled or self._fred is None:
             return 0
         await self._ensure_schema()
+        # Per-cycle FRED observation cache. Kalshi scanning yields ~250 candidate
+        # bins but only ~3 distinct FRED series (CPIAUCNS/UNRATE/PAYEMS); without
+        # this each candidate re-fetches in _maybe_enter, bursting ~250 calls/cycle
+        # past FRED's rate limit (fred_observations_failed spike). Keyed by series.
+        self._fred_cycle_cache = {}
         markets = await self._candidates()
         entered = 0
         with_pred = 0
@@ -377,13 +382,24 @@ class SettlementArbPillar:
                 and float(v.get("confidence", 0.0) or 0.0)
                 >= self._settings.settlement_arb.verify_min_confidence)
 
+    async def _fred_observations(self, series: str, history_n: int):
+        """FRED observations for a series, memoized for the current cycle so a
+        fan-out of same-series candidate bins makes ONE API call, not hundreds
+        (the cache is reset at the top of each run_once)."""
+        cache = getattr(self, "_fred_cycle_cache", None)
+        if cache is None:
+            return await self._fred.get_observations(series, n=history_n)
+        if series not in cache:
+            cache[series] = await self._fred.get_observations(series, n=history_n)
+        return cache[series]
+
     async def _maybe_enter(self, m, pred: dict) -> bool:
         """Deterministic resolve + settlement-lag gate."""
         cfg = self._settings.settlement_arb
         spec = spec_for_series(pred["indicator"])
         if spec is None:
             return False
-        obs = await self._fred.get_observations(spec.fred_series, n=cfg.history_n)
+        obs = await self._fred_observations(spec.fred_series, cfg.history_n)
         if not obs:
             return False
         value = indicator_at_period(obs, spec, pred["reference_period"])

--- a/tests/test_settlement_arb.py
+++ b/tests/test_settlement_arb.py
@@ -267,6 +267,32 @@ async def test_kalshi_candidates_scanned_per_series_priced_only():
 
 
 @pytest.mark.asyncio
+async def test_run_once_fetches_each_fred_series_once_per_cycle():
+    """A fan-out of same-series Kalshi bins must collapse to ONE FRED call per
+    series per cycle — not one per candidate (which bursts past FRED's rate
+    limit, the fred_observations_failed spike)."""
+    bins = [_kx(f"KXCPIYOY-26NOV-T{t}", yes=0.5) for t in (4.3, 4.4, 4.5, 4.6, 4.7)]
+    kdisc = SimpleNamespace(get_markets_by_series=AsyncMock(
+        side_effect=lambda s, limit=200: bins if s == "KXCPIYOY" else []))
+    settings = SimpleNamespace(settlement_arb=SimpleNamespace(
+        enabled=True, paper=True, stake_usd=10.0, min_edge=0.05, min_liquidity=100.0,
+        min_extract_confidence=0.8, verify_min_confidence=0.8, max_entries_per_cycle=5,
+        history_n=60, interval_seconds=1800))
+    fred = SimpleNamespace(get_observations=AsyncMock(return_value=[]))  # print not out
+    db = MagicMock()
+    db.fetchall = AsyncMock(return_value=[])
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    p = SettlementArbPillar(
+        db=db, settings=settings, discovery=MagicMock(), exchange=MagicMock(),
+        risk_manager=MagicMock(), pnl_tracker=MagicMock(), fred_source=fred,
+        analyzer=None, kalshi_discovery=kdisc, kalshi_exchange=MagicMock())
+    await p.run_once()
+    # 5 same-series bins -> ONE get_observations call (memoized), not 5
+    assert fred.get_observations.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_kalshi_predicate_is_deterministic_no_llm():
     """A Kalshi macro bin's predicate comes from strike fields — analyzer/db
     never touched (analyzer=None would crash the LLM path)."""


### PR DESCRIPTION
**Regression from #247.** Scanning Kalshi took the candidate count from ~22 to ~250 bins that all reach `_maybe_enter`, which fetched FRED **per-candidate**. Those ~250 bins span only **3 distinct series**, so each cycle burst ~250 calls at FRED and tripped its rate limit — a `fred_observations_failed` spike (15 PAYEMS failures in one cycle, err rate 0.0→0.1/min) the first time the Kalshi path ran live.

**Fix:** memoize `get_observations` by series for the duration of a `run_once` cycle (reset at the top of the loop) → ~250 calls collapse to 3. Caching empty/failed results also stops a down-series being retried once per candidate. Test asserts 5 same-series bins → 1 FRED call. 32 tests pass, ruff clean.

Assisted-by: Claude (Anthropic)