### PR TITLE
fix(market_maker): bound CLOB lock acquisition + add MM heartbeat

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -891,6 +891,13 @@ class AuramaurBot(
         while self._running:
             if await self._check_kill_switch():
                 return
+            # Heartbeat at INFO every iteration. run_cycle logs only at debug when
+            # there are no quotable markets, so an idle MM looked identical to a
+            # dead one to the health monitor (false STALE) — and when it DID wedge
+            # (2026-06-30, ~16 min), the last log before silence didn't pinpoint
+            # where. This line makes "alive but idle" distinguishable from "hung",
+            # and the first missing op after it localizes any future stall.
+            log.info("market_maker.cycle_start")
             try:
                 # Watchdog: the per-op timeout inside run_cycle only covers the
                 # quote ops — the OUTER-loop Polymarket calls (market discovery,

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -67,14 +67,29 @@ class PolymarketClient:
         stalled get_market call froze the live bot for 84 minutes until ^C).
         Worker thread + wait_for means a stall costs one abandoned thread and
         a TimeoutError instead. The SDK is not thread-safe, so calls
-        serialize behind one lock; a timed-out call releases the lock and
-        abandons its thread.
+        serialize behind one lock.
+
+        Acquire the lock WITH the same deadline, not unconditionally: a worker
+        thread that never returns (asyncio can't truly cancel to_thread) leaves
+        the wait_for below hung AND still holding the lock, so every later CLOB
+        call would block on acquisition forever — with no timeout firing. That is
+        a silent wedge (2026-06-30: the market_maker task went dormant ~16 min
+        with no op_timeout logged, while the rest of the bot stayed healthy).
+        Bounding acquisition turns that into a logged, recoverable clob.lock_timeout
+        the callers' existing timeout handling already copes with.
         """
-        async with self._clob_lock:
+        deadline = timeout if timeout is not None else self._call_timeout
+        try:
+            await asyncio.wait_for(self._clob_lock.acquire(), timeout=deadline)
+        except asyncio.TimeoutError:
+            log.warning("clob.lock_timeout",
+                        fn=getattr(fn, "__name__", str(fn)), timeout=deadline)
+            raise
+        try:
             return await asyncio.wait_for(
-                asyncio.to_thread(fn, *args, **kwargs),
-                timeout if timeout is not None else self._call_timeout,
-            )
+                asyncio.to_thread(fn, *args, **kwargs), deadline)
+        finally:
+            self._clob_lock.release()
 
     def _load_real_positions(self) -> None:
         """Load actual on-chain positions from CLOB trade history."""

--- a/tests/test_clob_call.py
+++ b/tests/test_clob_call.py
@@ -87,6 +87,25 @@ async def test_timeout_releases_lock_for_next_call():
 
 
 @pytest.mark.asyncio
+async def test_lock_acquisition_is_bounded_when_stuck_held():
+    """A worker thread that never returns leaves the lock held; a NEW call must
+    time out on acquisition (logged clob.lock_timeout), not block forever — the
+    silent MM-dormancy failure mode from 2026-06-30."""
+    client = _client()
+    client._call_timeout = 0.1
+    await client._clob_lock.acquire()          # simulate a wedged prior call
+    try:
+        # wait_for guard: if acquisition regressed to unbounded, this fails fast
+        # instead of hanging the suite.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(client.clob_call(lambda: "never"), timeout=1.0)
+    finally:
+        client._clob_lock.release()
+    # Lock is healthy again once the stuck holder releases.
+    assert await client.clob_call(lambda: "ok") == "ok"
+
+
+@pytest.mark.asyncio
 async def test_get_order_book_survives_hanging_sdk():
     """A hung book fetch degrades to an empty book, not a frozen bot."""
     client = _client()


### PR DESCRIPTION
**market_maker went dormant ~16 min (2026-06-30)** with the rest of the bot healthy and **no `op_timeout` logged** — every existing watchdog fired clean, yet MM wedged.

**Root cause** (`clob_call`): the `_clob_lock` was acquired **outside** the `wait_for`. asyncio can't truly cancel `asyncio.to_thread`, so if a worker thread ever fails to return, `wait_for` hangs on it **and keeps holding the lock** → every later CLOB call blocks on acquisition forever, **no timeout firing**. The old comment claimed a timed-out call "releases the lock and abandons its thread" — it doesn't. MM is the most frequent CLOB caller, so it wedges first, silently, while gamma/kalshi/reconciler (different clients) stay healthy.

**Fix:**
- `clob_call`: acquire the lock **with the same deadline**; on failure log `clob.lock_timeout` and raise (callers' existing timeout handling copes). A stuck thread can no longer silently wedge every other CLOB call.
- `bot.py`: `market_maker.cycle_start` heartbeat at INFO every iteration — run_cycle only logs at debug when idle, so an idle MM looked dead to the health monitor (**false STALE**), and a real wedge didn't pinpoint where. Now "idle" vs "hung" is visible and any future stall is localized.

Tests cover the bounded acquisition under a stuck-held lock + recovery. 1005 pass, ruff clean.

Assisted-by: Claude (Anthropic)