### PR TITLE
fix(resolution_lens): act on known gaps first — the proven edge went silent

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -437,6 +437,32 @@ class ResolutionLensPillar:
 
     # -- main cycle --------------------------------------------------------
 
+    async def _prioritize_known_gaps(self, markets: list[Market], cfg) -> list[Market]:
+        """Front-load candidates that ALREADY carry a qualifying cached verdict.
+
+        Entering a gap costs up to three LLM calls (verdict -> verify -> ground),
+        but the per-cycle budget (max_llm_calls_per_cycle) is small. Processing
+        the raw scan order spent that budget computing NEW verdicts every cycle,
+        so gaps the lens had already found never advanced to verify/enter — the
+        cell went silent 2026-06-24 while live SELL gaps (overpriced bins, the
+        floor-exempt side) sat unacted on the book. Sorting known qualifying gaps
+        to the front (highest first) spends the budget advancing them to entry;
+        fresh discovery still runs with whatever budget remains. Stable sort, so
+        order within each group is preserved.
+        """
+        if not markets:
+            return markets
+        rows = await self._db.fetchall(
+            "SELECT market_id, gap_score FROM lens_verdicts WHERE gap_score >= ?",
+            (float(cfg.min_gap_score),))
+        known = {r["market_id"]: (r["gap_score"] or 0.0) for r in (rows or [])}
+        if not known:
+            return markets
+        markets.sort(key=lambda m: known.get(m.id, -1.0), reverse=True)
+        log.info("lens.prioritized_known_gaps",
+                 known_gaps=len(known), scanned=len(markets))
+        return markets
+
     async def run_once(self) -> int:
         cfg = self._settings.resolution_lens
         if not cfg.enabled:
@@ -449,6 +475,7 @@ class ResolutionLensPillar:
             log.info("lens.candidates", lexical=len(markets))
         else:
             markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        markets = await self._prioritize_known_gaps(markets, cfg)
         calls = 0
         entered = 0
         for m in markets:

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -400,6 +400,45 @@ def test_lens_enters_on_strong_verdict_with_named_reason():
     asyncio.run(run())
 
 
+def test_known_cached_gap_is_prioritized_over_fresh_under_tight_budget():
+    """The 2026-06-24 silence fix. A qualifying gap the lens already found (cached,
+    not yet verified) must be processed BEFORE fresh candidates, so its verify
+    call lands inside a tight per-cycle LLM budget. Placed LAST behind two fresh
+    candidates with a 1-call budget, the cached gap still enters — without
+    prioritization the fresh verdicts would eat the budget and starve it (the
+    failure mode that left the proven cell silent for six days)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ex = _exchange()
+            settings = _settings(max_llm_calls_per_cycle=1, max_entries_per_cycle=5)
+            fresh1 = _market(mid="fresh1", yes=0.30)
+            fresh2 = _market(mid="fresh2", yes=0.30)
+            cached = _market(mid="cached", yes=0.30)   # priced for a SELL (fair 0.10)
+            # cached LAST in scan order; fresh ones would otherwise consume budget
+            pillar = _pillar(db, settings, [fresh1, fresh2, cached], exchange=ex)
+            await pillar._ensure_schema()
+            # Pre-seed the cached qualifying gap, unverified (-1) so it needs a
+            # verify call — exactly the state that was being starved.
+            await db.execute(
+                "INSERT INTO lens_verdicts (market_id, fair_prob, gap_score, "
+                "mechanism, verified) VALUES ('cached', 0.10, 0.8, 'permanence bar', -1)")
+            await db.commit()
+
+            entered = await pillar.run_once()
+            assert entered == 1                       # the cached gap, not starved
+            # it is specifically the cached market that traded
+            assert await db.fetchone(
+                "SELECT 1 FROM portfolio WHERE market_id='cached'") is not None
+            assert await db.fetchone(
+                "SELECT 1 FROM portfolio WHERE market_id='fresh1'") is None
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
 def test_lens_skips_weak_verdicts_and_caches():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
**The one graduating edge (lens fine-print reading) stopped entering on 2026-06-24 and sat silent six days** while live opportunities were on the book.

**Diagnosis:** verdicts compute fine (~25/day), and 22 active candidates currently clear the gap+edge floors — **15 of them floor-exempt SELLs of overpriced bins, edges up to 0.96** — but all are `verified=-1` and zero were entered.

**Root cause:** entering a gap costs up to 3 LLM calls (verdict → verify → ground), but the per-cycle budget (`max_llm_calls_per_cycle=5`) is spent computing **new** verdicts on fresh scan candidates every cycle. Already-found gaps that only needed a verify/ground call were perpetually skipped at the budget wall. The lens kept *discovering* and never *acting*.

**Fix:** front-load candidates that already carry a qualifying cached verdict (`_prioritize_known_gaps`, highest gap first, stable sort) so the budget advances them to entry before fresh discovery. Fresh scanning still runs with remaining budget. Test: a cached unverified gap placed *last* behind two fresh candidates under a 1-call budget still enters — and fails without the reorder. 1006 tests pass, ruff clean.

Assisted-by: Claude (Anthropic)