### PR TITLE
fix(resolution_lens): proven LIVE cells get the budget before paper gaps

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -438,17 +438,24 @@ class ResolutionLensPillar:
     # -- main cycle --------------------------------------------------------
 
     async def _prioritize_known_gaps(self, markets: list[Market], cfg) -> list[Market]:
-        """Front-load candidates that ALREADY carry a qualifying cached verdict.
+        """Order the scan so the small per-cycle budget earns the most. Two tiers
+        of priority, highest first:
 
-        Entering a gap costs up to three LLM calls (verdict -> verify -> ground),
-        but the per-cycle budget (max_llm_calls_per_cycle) is small. Processing
-        the raw scan order spent that budget computing NEW verdicts every cycle,
-        so gaps the lens had already found never advanced to verify/enter — the
-        cell went silent 2026-06-24 while live SELL gaps (overpriced bins, the
-        floor-exempt side) sat unacted on the book. Sorting known qualifying gaps
-        to the front (highest first) spends the budget advancing them to entry;
-        fresh discovery still runs with whatever budget remains. Stable sort, so
-        order within each group is preserved.
+        1. Candidates that already carry a qualifying cached verdict, whose cell
+           trades LIVE (real money) — the proven edge.
+        2. Same, but on a PAPER-forced cell — unproven exploration.
+        Then fresh discovery with whatever budget remains.
+
+        Entering a gap costs up to three LLM calls (verdict -> verify -> ground)
+        against a small budget, so two things starve real money:
+          - Spending the budget computing NEW verdicts every cycle, so already-
+            found gaps never advance to verify/enter (the cell went silent
+            2026-06-24 while live SELL gaps sat unacted on the book).
+          - Letting a high-gap-but-PAPER cell (unproven/negative — e.g. politics
+            gaps scoring ~0.9) crowd out the proven LIVE weather entries (often
+            scoring lower) that actually earn. gap_score is NOT edge quality.
+        Graduation cells are cached, so the per-category live check is cheap.
+        Stable sort preserves order within each tier.
         """
         if not markets:
             return markets
@@ -458,9 +465,30 @@ class ResolutionLensPillar:
         known = {r["market_id"]: (r["gap_score"] or 0.0) for r in (rows or [])}
         if not known:
             return markets
-        markets.sort(key=lambda m: known.get(m.id, -1.0), reverse=True)
-        log.info("lens.prioritized_known_gaps",
-                 known_gaps=len(known), scanned=len(markets))
+        # Which categories among the known gaps currently trade live for this
+        # cell? Only those put real money to work; everything else is paper
+        # exploration and must not pre-empt it.
+        live_cats: set[str] = set()
+        grad = getattr(self._risk, "graduation", None)
+        if grad is not None and not cfg.paper:
+            for cat in {m.category for m in markets if m.id in known}:
+                try:
+                    cell = await grad.decide(self._source_tag, cat or "")
+                    if not getattr(cell, "force_paper", True):
+                        live_cats.add(cat)
+                except Exception:
+                    pass
+
+        def _rank(m: Market):
+            g = known.get(m.id)
+            if g is None:
+                return (0, 0.0)                       # fresh discovery -> last
+            tier = 2 if m.category in live_cats else 1  # live gaps over paper gaps
+            return (tier, g)
+
+        markets.sort(key=_rank, reverse=True)
+        log.info("lens.prioritized_known_gaps", known_gaps=len(known),
+                 live_gap_cells=len(live_cats), scanned=len(markets))
         return markets
 
     async def run_once(self) -> int:

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -439,6 +439,48 @@ def test_known_cached_gap_is_prioritized_over_fresh_under_tight_budget():
     asyncio.run(run())
 
 
+def test_live_cell_gap_beats_higher_gap_paper_cell_for_the_slot():
+    """gap_score is NOT edge quality. The proven LIVE cell (weather) must get the
+    scarce per-cycle entry slot before a HIGHER-gap PAPER cell (politics, which
+    the lens loses on) — otherwise paper exploration starves the one edge that
+    earns real money."""
+    async def run():
+        from types import SimpleNamespace
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ex = _exchange()
+            settings = _settings(paper=False, max_entries_per_cycle=1)
+            risk = _risk()
+
+            async def _decide(strategy, category):   # weather trades live; rest paper
+                return SimpleNamespace(force_paper=(category != "weather"))
+            risk.graduation = SimpleNamespace(decide=_decide)
+
+            wx = _market(mid="wx", yes=0.30); wx.category = "weather"
+            pol = _market(mid="pol", yes=0.30); pol.category = "politics_intl"
+            # politics has the HIGHER gap and is placed FIRST in scan order
+            pillar = _pillar(db, settings, [pol, wx], exchange=ex, risk=risk)
+            await pillar._ensure_schema()
+            await db.execute("INSERT INTO lens_verdicts (market_id, fair_prob, "
+                             "gap_score, mechanism, verified) VALUES ('pol',0.10,0.9,'bar',1)")
+            await db.execute("INSERT INTO lens_verdicts (market_id, fair_prob, "
+                             "gap_score, mechanism, verified) VALUES ('wx',0.10,0.4,'bar',1)")
+            await db.commit()
+
+            entered = await pillar.run_once()
+            assert entered == 1
+            # the LIVE weather cell took the single slot, not the higher-gap paper one
+            assert await db.fetchone(
+                "SELECT 1 FROM portfolio WHERE market_id='wx'") is not None
+            assert await db.fetchone(
+                "SELECT 1 FROM portfolio WHERE market_id='pol'") is None
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
 def test_lens_skips_weak_verdicts_and_caches():
     async def run():
         db = Database(":memory:")


### PR DESCRIPTION
Follow-up to #250. That fix front-loaded cached gaps by raw `gap_score` — but **gap_score is not edge quality**. The lens's highest-scoring current gaps are in PAPER-forced cells it *loses* on (other 0.97, politics_us 0.85), while the one proven LIVE cell (weather) scores lower (0.3–0.8). So #250 would spend the small per-cycle budget on unproven paper exploration before reaching the weather entries that actually earn — **paper plays starving real money**.

**Fix:** two-tier priority — known gaps on a cell that trades LIVE (graduation `not force_paper`) first, then known gaps on paper cells, then fresh discovery; gap_score within each tier. Graduation cells are cached (cheap). Skipped when the whole strategy is paper.

Test: a live-cell gap (0.4) takes the single slot over a higher-gap paper-cell gap (0.9); fails under the gap-only sort. 1007 pass, ruff clean.

Assisted-by: Claude (Anthropic)