### PR TITLE
fix(llm): pin lens calls to Claude + reserve budget slice + cache arb pairing

### DIFF
--- a/auramaur/composition.py
+++ b/auramaur/composition.py
@@ -421,6 +421,7 @@ async def assemble_components(
         blocked_categories=s.risk.blocked_categories,
         allowed_categories_live=(s.risk.allowed_categories_live
                                  if s.is_live else None),
+        llm_match_cache_seconds=s.arbitrage.llm_match_cache_seconds,
     )
 
     # News reactor — monitors RSS for breaking news, triggers fast analysis

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -117,7 +117,8 @@ class ClaudeAnalyzer:
         self._settings = settings
         self._model = settings.nlp.model
 
-    async def _call_claude_cli(self, prompt: str, *, effort: str | None = None) -> str:
+    async def _call_claude_cli(self, prompt: str, *, effort: str | None = None,
+                               reserved: bool = False) -> str:
         """Call Claude via the CLI using the Max+ subscription.
 
         Uses `claude -p <prompt> --output-format text` which authenticates
@@ -126,6 +127,12 @@ class ClaudeAnalyzer:
         ``effort`` is the CLI effort level (low|medium|high|max); defaults to
         ``nlp.effort_primary``.
 
+        ``reserved`` callers (pin_claude paths — the proven edges) may spend up
+        to the full daily budget; everyone else stops ``claude_reserve_for_pinned``
+        calls early, so bulk consumers can't starve the money-making calls
+        (2026-07: the arb matcher burned the whole budget by 07:00 UTC daily
+        while the lens never got a Claude call).
+
         Retries up to 3 times on transient failures (timeout, non-zero exit).
         """
         from auramaur.nlp import call_budget
@@ -133,11 +140,15 @@ class ClaudeAnalyzer:
         use_effort = effort or self._settings.nlp.effort_primary
 
         budget = self._settings.nlp.daily_claude_call_budget
-        if budget > 0 and call_budget.calls_today() >= budget:
-            from auramaur.nlp.errors import BudgetExhausted
-            raise BudgetExhausted(
-                f"Daily Claude call budget ({budget}) exhausted"
-            )
+        if budget > 0:
+            limit = budget if reserved else max(
+                0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            if call_budget.calls_today() >= limit:
+                from auramaur.nlp.errors import BudgetExhausted
+                raise BudgetExhausted(
+                    f"Daily Claude call budget ({limit}/{budget}"
+                    f"{' reserved' if reserved else ''}) exhausted"
+                )
 
         max_attempts = 3
         backoff_seconds = [5, 10, 20]
@@ -182,12 +193,21 @@ class ClaudeAnalyzer:
 
         raise last_error  # type: ignore[misc]
 
-    async def _call_llm(self, prompt: str, *, effort: str | None = None) -> str:
-        """Route to Gemini (off-hours / Claude budget low) else Claude."""
+    async def _call_llm(self, prompt: str, *, effort: str | None = None,
+                        pin_claude: bool = False) -> str:
+        """Route to Gemini (off-hours / Claude budget low) else Claude.
+
+        ``pin_claude=True`` bypasses routing entirely and always calls Claude
+        (against the reserved budget slice). For calls where the model identity
+        IS the edge — the resolution lens's fine-print reads collapsed when
+        conservation routing silently handed them to Gemini (2026-06-25 →
+        2026-07-02: zero qualifying gaps, zero entries)."""
         from functools import partial
 
         from auramaur.nlp.llm_router import route
         from auramaur.nlp import call_budget
+        if pin_claude:
+            return await self._call_claude_cli(prompt, effort=effort, reserved=True)
         claude_fn = partial(self._call_claude_cli, effort=effort)
         return await route(self._settings, call_budget.calls_today(), prompt, claude_fn)
 

--- a/auramaur/strategy/arbitrage_scanner.py
+++ b/auramaur/strategy/arbitrage_scanner.py
@@ -44,6 +44,7 @@ _STOP_WORDS = frozenset({
     "yes", "has", "have", "had", "can", "could", "would", "should", "may",
     "if", "but", "so", "than", "then", "what", "which", "who", "whom",
     "how", "when", "where", "why", "before", "after", "during", "between",
+    "next",
 })
 
 
@@ -147,6 +148,7 @@ class ArbitrageScanner:
         min_profit_after_fees_pct: float = 1.5,
         blocked_categories: list[str] | None = None,
         allowed_categories_live: list[str] | None = None,
+        llm_match_cache_seconds: int = 21600,
     ) -> None:
         """Initialize with the discoveries dict from bot components.
 
@@ -174,6 +176,14 @@ class ArbitrageScanner:
         self._allowed_categories_live = (
             set(allowed_categories_live) if allowed_categories_live is not None
             else None)
+        # LLM batch-pairing cache keyed by the candidate id sets. Matching is a
+        # function of the QUESTIONS, not prices, and the top-N lists barely
+        # churn cycle to cycle — without this the scanner re-asked the same
+        # pairing every ~100s and single-handedly exhausted the daily Claude
+        # budget by 07:00 UTC (2026-07-02 audit), starving every other caller.
+        # In-memory: one call per distinct id-set per TTL, resets on restart.
+        self._llm_match_cache_seconds = llm_match_cache_seconds
+        self._match_cache: dict[str, tuple[float, list[tuple[str, str]]]] = {}
 
     def _category_ok(self, market: Market) -> bool:
         """Category gate for scan candidates (stored label or fresh classify)."""
@@ -339,6 +349,20 @@ class ArbitrageScanner:
         if not markets_a or not markets_b:
             return []
 
+        # Serve a still-fresh LLM pairing for this exact candidate set from
+        # cache (matching depends on questions, not prices — stable for hours).
+        import hashlib
+        import time
+        map_a = {m.id: m for m in markets_a}
+        map_b = {m.id: m for m in markets_b}
+        cache_key = hashlib.sha256(
+            ("|".join(sorted(map_a)) + "||" + "|".join(sorted(map_b))).encode()
+        ).hexdigest()
+        cached = self._match_cache.get(cache_key)
+        if cached is not None and time.monotonic() - cached[0] < self._llm_match_cache_seconds:
+            return [(map_a[a], map_b[b]) for a, b in cached[1]
+                    if a in map_a and b in map_b]
+
         # Strategy A: LLM Batch Pairing (Preferred)
         if self._analyzer:
             try:
@@ -364,14 +388,21 @@ class ArbitrageScanner:
                     return []
 
                 # Map IDs back to Market objects
-                map_a = {m.id: m for m in markets_a}
-                map_b = {m.id: m for m in markets_b}
                 results: list[tuple[Market, Market]] = []
 
                 for m in matches:
                     id_a, id_b = m.get("id_a"), m.get("id_b")
                     if id_a in map_a and id_b in map_b:
                         results.append((map_a[id_a], map_b[id_b]))
+
+                # Cache the id pairs (empty results too — "no matches" is just
+                # as expensive to recompute) and drop expired entries.
+                now = time.monotonic()
+                self._match_cache = {
+                    k: v for k, v in self._match_cache.items()
+                    if now - v[0] < self._llm_match_cache_seconds}
+                self._match_cache[cache_key] = (
+                    now, [(a.id, b.id) for a, b in results])
 
                 if results:
                     log.info(

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -156,6 +156,10 @@ class ResolutionLensPillar:
         # so the pillar still constructs without it (grounding then no-ops and the
         # lens falls back to the criteria-strict fair).
         self._aggregator = aggregator
+        # Per-market verdict-call failure counts (in-memory; resets on restart).
+        # Errors are retried, not cached — but after 3 strikes the market gets
+        # the permanent neutral verdict so it can't eat the budget forever.
+        self._verdict_failures: dict[str, int] = {}
 
     # -- candidate filtering ---------------------------------------------
 
@@ -234,20 +238,31 @@ class ResolutionLensPillar:
                     row["mechanism"], int(row["verified"]))
         if self._analyzer is None:
             return None
-        fair, score, mech = m.outcome_yes_price, 0.0, "none"
+        # pin_claude: the fine-print read IS the edge — never let budget
+        # routing silently hand it to a different model (that's what went
+        # dark 2026-06-25 → 07-02: Gemini verdicts never cleared the floors).
         try:
             raw = await self._analyzer._call_llm(LENS_PROMPT.format(
                 question=m.question,
                 description=self._criteria_text(m.description),  # Phase 1: full criteria
                 market_prob=m.outcome_yes_price,
                 today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-            ))
+            ), pin_claude=True)
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
-            fair = max(0.01, min(0.99, float(parsed.get("fair_prob", fair))))
+            fair = max(0.01, min(0.99, float(parsed.get("fair_prob", m.outcome_yes_price))))
             score = max(0.0, min(1.0, float(parsed.get("gap_score", 0.0))))
             mech = str(parsed.get("mechanism", "none"))[:400] or "none"
         except Exception as e:
-            log.warning("lens.llm_parse_error", market_id=m.id, error=str(e))
+            # Do NOT cache the failure: the old neutral-row write made every
+            # LLM/parse error a PERMANENT no-gap verdict (the cache never
+            # expires). Retry next cycle, but give up after a few attempts so
+            # one confusing market can't eat the per-cycle budget forever.
+            self._verdict_failures[m.id] = self._verdict_failures.get(m.id, 0) + 1
+            if self._verdict_failures[m.id] < 3:
+                log.warning("lens.llm_parse_error", market_id=m.id, error=str(e))
+                return None
+            log.warning("lens.verdict_gave_up", market_id=m.id, error=str(e))
+            fair, score, mech = m.outcome_yes_price, 0.0, "none"
         await self._db.execute(
             """INSERT OR REPLACE INTO lens_verdicts
                (market_id, fair_prob, gap_score, mechanism, verified)
@@ -260,22 +275,24 @@ class ResolutionLensPillar:
     async def _verify_mechanism(self, m: Market, fair: float, mechanism: str) -> bool:
         """Phase 2: adversarial check of the named mechanism. Returns True only
         when the second pass CONFIRMS it at >= verify_min_confidence. Persists
-        the verdict (0/1) so it isn't re-checked. Fails closed (refuted) on
-        parse/LLM error — a hallucinated mechanism must not slip through."""
+        the verdict (0/1) so it isn't re-checked. A parsed refutation fails
+        closed and persists — a hallucinated mechanism must not slip through.
+        An infra/parse ERROR is not a refutation: skip this cycle without
+        persisting, so a budget blip can't permanently kill a real gap."""
         cfg = self._settings.resolution_lens
-        confirmed = False
         try:
             raw = await self._analyzer._call_llm(VERIFY_PROMPT.format(
                 question=m.question,
                 description=self._criteria_text(m.description),
                 market_prob=m.outcome_yes_price, fair=fair, mechanism=mechanism,
                 today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-            ))
+            ), pin_claude=True)
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
             confirmed = (str(parsed.get("verdict", "refuted")).lower() == "confirmed"
                          and float(parsed.get("confidence", 0.0)) >= cfg.verify_min_confidence)
         except Exception as e:
             log.warning("lens.verify_parse_error", market_id=m.id, error=str(e))
+            return False  # verified stays -1; retried next cycle
         await self._db.execute(
             "UPDATE lens_verdicts SET verified = ? WHERE market_id = ?",
             (1 if confirmed else 0, m.id))
@@ -334,7 +351,7 @@ class ResolutionLensPillar:
                 deadline=deadline, mechanism=mech, fair=fair,
                 evidence="\n".join(ev_lines),
                 today=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-            ))
+            ), pin_claude=True)
             parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
             g = max(0.01, min(0.99, float(parsed.get("grounded_prob", fair))))
             conf = max(0.0, min(1.0, float(parsed.get("confidence", 0.0))))
@@ -362,9 +379,11 @@ class ResolutionLensPillar:
         return float(row["grounded_fair"]) if row else None
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
+        # Per-instance tag: the Kalshi spike (resolution_lens_kalshi) must
+        # check ITS OWN signals, not the Poly lens's.
         row = await self._db.fetchone(
-            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'resolution_lens' LIMIT 1",
-            (market_id,),
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = ? LIMIT 1",
+            (market_id, self._source_tag),
         )
         if row is not None:
             return True

--- a/config/settings.py
+++ b/config/settings.py
@@ -228,6 +228,11 @@ class NLPConfig(BaseModel):
     max_markets_per_cycle: int = 10
     evidence_per_source: int = 3
     daily_claude_call_budget: int = 100
+    # Slice of the daily budget held back for pin_claude callers (the proven
+    # edges whose quality depends on the specific model). Unpinned callers stop
+    # at budget - reserve; pinned callers can spend up to the full budget, so a
+    # bulk consumer can never starve the money-making calls.
+    claude_reserve_for_pinned: int = 25
 
     # Tool-use analyzer — refines strategic-batch results on top-edge markets
     # by letting Claude Code drive its own web_search / web_fetch. "auto"
@@ -1019,6 +1024,10 @@ class ArbitrageConfig(BaseModel):
     enabled: bool = True
     min_profit_after_fees_pct: float = 1.5
     max_arb_size: float = 25.0
+    # TTL for the LLM batch-pairing cache keyed by the candidate id sets. The
+    # scanner re-matches near-identical top-N lists every cycle; matching is a
+    # function of the QUESTIONS, not prices, so answers are stable for hours.
+    llm_match_cache_seconds: int = 21600
     cross_exchange_auto_execute: bool = True
     negrisk_auto_execute: bool = False
     # Flat per-exchange TAKER fee coefficients (fee = rate * P*(1-P)).

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -214,3 +214,45 @@ async def test_internal_arb_uses_engine_exchange_attribute():
     legs = mixin._exit_gateway.place_legs.await_args.args[0]
     assert len(legs) == 2
     assert all(client is exchange for _order, client, _exn in legs)
+
+
+@pytest.mark.asyncio
+async def test_llm_match_cached_per_candidate_set():
+    """The LLM batch pairing must be served from cache for an unchanged
+    candidate set — re-asking every ~100s cycle burned the entire daily
+    Claude budget by 07:00 UTC and starved every other caller. Empty results
+    cache too, and a changed id set is a fresh call."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from auramaur.exchange.models import Market
+    from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
+
+    def _mkt(mid, q, ex):
+        return Market(id=mid, question=q, exchange=ex)
+
+    a1 = _mkt("a1", "Will X happen?", "polymarket")
+    b1 = _mkt("b1", "Will X happen?", "kalshi")
+    b2 = _mkt("b2", "Will Y happen?", "kalshi")
+
+    analyzer = MagicMock()
+    analyzer._call_claude_cli = AsyncMock(
+        return_value='[{"id_a": "a1", "id_b": "b1"}]')
+    sc = ArbitrageScanner(discoveries={}, analyzer=analyzer,
+                          llm_match_cache_seconds=3600)
+
+    first = await sc._match_markets([a1], [b1], "poly", "kalshi")
+    again = await sc._match_markets([a1], [b1], "poly", "kalshi")
+    assert [(x.id, y.id) for x, y in first] == [("a1", "b1")]
+    assert [(x.id, y.id) for x, y in again] == [("a1", "b1")]
+    assert analyzer._call_claude_cli.await_count == 1  # served from cache
+
+    # Different candidate set -> new call; empty answers cache as well.
+    analyzer._call_claude_cli.return_value = "[]"
+    assert await sc._match_markets([a1], [b2], "poly", "kalshi") == []
+    assert await sc._match_markets([a1], [b2], "poly", "kalshi") == []
+    assert analyzer._call_claude_cli.await_count == 2
+
+    # TTL expiry -> refetch.
+    sc._llm_match_cache_seconds = 0
+    await sc._match_markets([a1], [b1], "poly", "kalshi")
+    assert analyzer._call_claude_cli.await_count == 3

--- a/tests/test_claude_retry.py
+++ b/tests/test_claude_retry.py
@@ -13,6 +13,7 @@ def settings():
     s = MagicMock()
     s.nlp.model = "claude-sonnet-4-20250514"
     s.nlp.daily_claude_call_budget = 100
+    s.nlp.claude_reserve_for_pinned = 0
     s.nlp.skip_second_opinion = False
     s.nlp.cache_ttl_breaking_seconds = 900
     return s

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -717,3 +717,117 @@ def test_kalshi_spike_instance_is_parametrized_and_isolated():
         assert poly._eligible(k_mkt) is False
 
     asyncio.run(run())
+
+
+# ----------------------------------------------------------------------
+# Error-path caching + Claude pinning (2026-07 lens salvage)
+# ----------------------------------------------------------------------
+
+def test_verdict_error_not_cached_then_gives_up_after_three():
+    """An LLM/parse error must NOT write the permanent neutral verdict (that
+    poisoned the cache for every market scanned while calls were failing).
+    Retry instead — but after 3 strikes persist the neutral row so one
+    confusing market can't eat the per-cycle budget forever."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        m = _market()
+        a = MagicMock()
+        a._call_llm = AsyncMock(side_effect=RuntimeError("boom"))
+        p = _pillar(db, _settings(), [m], analyzer=a)
+        await p._ensure_schema()
+
+        assert await p._verdict(m) is None
+        assert await p._verdict(m) is None
+        row = await db.fetchone(
+            "SELECT 1 FROM lens_verdicts WHERE market_id = ?", (m.id,))
+        assert row is None  # nothing persisted while retrying
+
+        v = await p._verdict(m)  # third strike -> neutral row, permanent
+        assert v == (m.outcome_yes_price, 0.0, "none", -1)
+        row = await db.fetchone(
+            "SELECT gap_score, mechanism FROM lens_verdicts WHERE market_id = ?",
+            (m.id,))
+        assert row["gap_score"] == 0.0 and row["mechanism"] == "none"
+
+    asyncio.run(run())
+
+
+def test_verify_infra_error_leaves_verdict_unverified():
+    """A verify-pass ERROR is not a refutation: verified must stay -1 (retry
+    next cycle), not be persisted as 0 (permanent kill of a real gap)."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        m = _market()
+        good = _analyzer()
+        p = _pillar(db, _settings(), [m], analyzer=good)
+        await p._ensure_schema()
+        await p._verdict(m)  # seed a cached gap (verified=-1)
+
+        p._analyzer = MagicMock()
+        p._analyzer._call_llm = AsyncMock(side_effect=RuntimeError("budget"))
+        assert await p._verify_mechanism(m, 0.10, "mech") is False
+        row = await db.fetchone(
+            "SELECT verified FROM lens_verdicts WHERE market_id = ?", (m.id,))
+        assert row["verified"] == -1  # NOT 0
+
+    asyncio.run(run())
+
+
+def test_lens_calls_pin_to_claude():
+    """All three lens LLM calls must pass pin_claude=True — the fine-print
+    read is the edge; routing it to another model is what silenced the cell
+    (2026-06-25 -> 07-02)."""
+    async def run():
+        db = Database(":memory:"); await db.connect()
+        m = _market()
+        a = _analyzer3()
+        p = _pillar3(db, _settings(), [m], analyzer=a,
+                     aggregator=_aggregator_mock())
+        await p._ensure_schema()
+        await p._verdict(m)
+        await p._verify_mechanism(m, 0.10, "mech")
+        await p._ground(m, 0.10, "mech")
+        assert a._call_llm.await_count == 3
+        for call in a._call_llm.await_args_list:
+            assert call.kwargs.get("pin_claude") is True
+
+    asyncio.run(run())
+
+
+def test_pin_claude_bypasses_router_and_uses_reserve():
+    """ClaudeAnalyzer._call_llm(pin_claude=True) must skip Gemini routing and
+    spend against the full budget; unpinned callers stop at budget - reserve."""
+    async def run():
+        from auramaur.nlp.analyzer import ClaudeAnalyzer
+        from auramaur.nlp.errors import BudgetExhausted
+
+        s = Settings()
+        s.gemini.enabled = True
+        s.gemini.off_hours_utc = list(range(24))  # router would pick Gemini
+        s.nlp.daily_claude_call_budget = 100
+        s.nlp.claude_reserve_for_pinned = 25
+
+        a = ClaudeAnalyzer(settings=s)
+        with patch.object(a, "_call_claude_cli", new=AsyncMock(return_value="ok")) as cli, \
+             patch("auramaur.nlp.llm_router.call_gemini", new=AsyncMock(return_value="gem")):
+            s.gemini_api_key = "k"
+            assert await a._call_llm("p", pin_claude=True) == "ok"
+            assert cli.await_args.kwargs.get("reserved") is True
+            assert await a._call_llm("p") == "gem"  # unpinned -> routed
+
+        # Budget math: unpinned stops 25 early, pinned runs to the cap.
+        with patch("auramaur.nlp.call_budget.calls_today", return_value=80):
+            try:
+                await a._call_claude_cli("p")
+                raise AssertionError("unpinned should be exhausted at 80/100")
+            except BudgetExhausted:
+                pass
+            with patch.object(
+                    asyncio, "create_subprocess_exec",
+                    side_effect=AssertionError("stop before real CLI")):
+                try:
+                    await a._call_claude_cli("p", reserved=True)
+                except AssertionError:
+                    pass  # got PAST the budget gate (reserved slice)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Root cause

The resolution lens went silent on 2026-06-24; #250/#251 fixed queue ordering but entries never resumed. The actual chain:

1. A local (gitignored) conservation override routed **all** analyzer calls to Gemini 24/7. Lens gap scores collapsed below the entry floors the same day it took effect — the fine-print read is model-specific.
2. The arb scanner bypasses the router (`_call_claude_cli` direct) and re-asked the same batch pairing every ~cycle, exhausting the daily Claude budget by early morning UTC — so the "conservation" never conserved, and router-obeying callers were pinned to Gemini both by hours and by threshold.
3. Two cache-poisoning bugs made it sticky: `_verdict` persisted a permanent neutral verdict on any LLM/parse error, and `_verify_mechanism` persisted a permanent `verified=0` on infra errors.

## Fixes

- `ClaudeAnalyzer._call_llm(pin_claude=True)` — bypasses routing for calls where the model identity is the edge; wired into all three lens calls (verdict/verify/ground).
- `nlp.claude_reserve_for_pinned` — unpinned callers stop short of the daily budget by a reserved slice; bulk consumers can't starve pinned calls.
- Arb scanner LLM pairing cached per candidate id-set with TTL (matching depends on questions, not prices). Same match quality, a handful of Claude calls per day instead of every cycle.
- Lens verdict/verify error paths no longer persist permanent negative state; errors retry (3-strike cap on verdicts).
- `_already_entered_or_held` uses the instance's own source tag (the Kalshi spike instance was reading the Poly lens's signals).

Note: includes one pre-existing working-tree line (a stop-word addition in the scanner's fallback matcher) that was in the tree before this change set.

Tests: full suite green locally (1014 passed); new tests cover error-path non-caching, verify infra-error handling, pin routing, budget reserve math, and pairing-cache behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)