### PR TITLE
feat(strategies): bi-directional bias bands + mutual-exclusivity arb + kalshi risk floor (review-hardened)

### DIFF
--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -203,7 +203,10 @@ class RiskManager:
                 rc.divergence_filter_enabled and not is_paper_entry,
                 rc.divergence_adverse_low,
                 rc.divergence_adverse_high, rc.divergence_require_confidence),
-            await check_min_liquidity(max(market.liquidity, market.volume), rc.min_liquidity),
+            await check_min_liquidity(
+                max(market.liquidity, market.volume),
+                rc.kalshi_min_liquidity if (market.exchange or "").lower() == "kalshi" else rc.min_liquidity
+            ),
             await check_max_spread(market.spread, rc.max_spread_pct),
             await check_confidence_floor(signal.claude_confidence, rc.confidence_floor),
             await check_implied_prob_bounds(
@@ -239,8 +242,18 @@ class RiskManager:
         # a classifier gap costs opportunity, not money. The fresh keyword
         # classification stays the #17 tripwire for confidently-bad labels.
         if not is_paper_entry:
+            # Per-strategy extensions widen the allowlist ONLY for the named
+            # strategy_source (a proven ladder cell earning its category, e.g.
+            # bias_harvest x other). Putting the extension category on the
+            # GLOBAL list instead would also open it to every direct consumer
+            # of allowed_categories_live — the graduation-exempt market maker
+            # and arb executor — re-creating the fail-open hole the 2026-06
+            # mislabel incident closed.
+            allowed = list(rc.allowed_categories_live) + list(
+                (rc.allowed_categories_live_extra or {}).get(
+                    signal.strategy_source, []))
             pre_checks.append(await check_category_allowlist(
-                market.category or "", rc.allowed_categories_live,
+                market.category or "", allowed,
                 applies=category_applies,
                 fallback_category=fresh_category,
             ))

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 from auramaur.strategy.protocols import ExecutionMode
 
 import hashlib
+import time
 from datetime import datetime, timezone
 
 import structlog
@@ -55,6 +56,24 @@ from auramaur.exchange.models import (
 )
 
 log = structlog.get_logger()
+
+# Attribution tags. The deep band [LONGSHOT_HI, band_hi) keeps the original
+# tag (its graduation record was earned there); the widened regimes accrue
+# their own cells under the _wide tag and must graduate independently.
+SOURCE_TAG = "bias_harvest"
+SOURCE_TAG_WIDE = "bias_harvest_wide"
+
+# Regime pivots for the bi-directional rules. Deliberately code-level, not
+# config: they encode WHICH DIRECTION the measured bias points at a price,
+# and silently reinterpreting band_lo/band_hi overrides as direction changes
+# would be a trap. band_lo/band_hi still bound the overall harvested range.
+LONGSHOT_LO = 0.70
+LONGSHOT_HI = 0.90
+
+# How long to skip re-fetching the book for a market that showed no capturable
+# maker spread (in-memory, resets on restart). Spreads don't appear within a
+# cycle or two, and every fetch queues on the shared CLOB lock.
+NO_SPREAD_TTL_SECONDS = 3600.0
 
 
 class BiasHarvestPillar:
@@ -73,6 +92,9 @@ class BiasHarvestPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        # market_id -> monotonic deadline before which the book is not
+        # re-fetched (last fetch showed no capturable maker spread).
+        self._no_spread_until: dict[str, float] = {}
         # Shared execution tail (route -> place -> record_fill -> trades-mirror).
         # No router: bias_harvest enters passively at the observed price, so the
         # gateway falls back to prepare_order exactly as before.
@@ -116,8 +138,25 @@ class BiasHarvestPillar:
     # Entry pipeline
     # ------------------------------------------------------------------
 
-    def _band_check(self, market: Market) -> tuple[float, bool] | None:
-        """Return (favored_price, favored_is_yes) if in band, else None."""
+    def _band_check(self, market: Market) -> tuple[float, bool, str, str] | None:
+        """Return (favored_price, buy_yes, action_desc, source_tag) if in band.
+
+        Applies the bi-directional favorite-longshot bias rules:
+        - [0.60, 0.70): buy favored (underpriced favorite)
+        - [0.70, 0.90): buy longshot — paper showed the shallow tier's
+          favorites busting well above their implied rate (the band_lo
+          history in config/settings.py), i.e. the longshot side was the
+          cheap one there.
+        - [0.90, 0.97): buy favored (underpriced favorite) — the proven,
+          graduated deep-band rule.
+
+        The deep band keeps the original ``bias_harvest`` attribution (its
+        live probation record was earned there); the two NEW regimes are
+        tagged ``bias_harvest_wide`` so they get their OWN graduation cells —
+        unproven regimes start ladder-paper-forced and must earn live status
+        on their own ledger instead of inheriting the deep band's promotion
+        (same isolation idiom as resolution_lens_kalshi).
+        """
         cfg = self._settings.bias_harvest
         p_yes = market.outcome_yes_price
         if not (0.0 < p_yes < 1.0):
@@ -125,7 +164,17 @@ class BiasHarvestPillar:
         p_fav = max(p_yes, 1.0 - p_yes)
         if not (cfg.band_lo <= p_fav < cfg.band_hi):
             return None
-        return p_fav, p_yes >= 0.5
+        fav_is_yes = p_yes >= 0.5
+        if LONGSHOT_LO <= p_fav < LONGSHOT_HI:
+            # Buy the longshot side
+            buy_yes = not fav_is_yes
+            action_desc = "longshot side (favorite overpriced)"
+        else:
+            # Buy the favored side
+            buy_yes = fav_is_yes
+            action_desc = "favored side (favorite underpriced)"
+        tag = SOURCE_TAG if p_fav >= LONGSHOT_HI else SOURCE_TAG_WIDE
+        return p_fav, buy_yes, action_desc, tag
 
     def _eligible(self, market: Market) -> bool:
         cfg = self._settings.bias_harvest
@@ -165,7 +214,7 @@ class BiasHarvestPillar:
             return False  # capital lock-up cap
         return True
 
-    async def _maker_price(self, market: Market, fav_is_yes: bool) -> float | None:
+    async def _maker_price(self, market: Market, buy_yes: bool) -> float | None:
         """The favored-side BID to post a maker BUY at, or None if there is no
         capturable spread / no book.
 
@@ -176,7 +225,7 @@ class BiasHarvestPillar:
         cliff). Execution-only — the risk/divergence accounting stays on the
         observed price (see ``_try_enter``)."""
         cfg = self._settings.bias_harvest
-        token_id = market.clob_token_yes if fav_is_yes else market.clob_token_no
+        token_id = market.clob_token_yes if buy_yes else market.clob_token_no
         if not token_id:
             return None
         try:
@@ -210,18 +259,19 @@ class BiasHarvestPillar:
         h = int(hashlib.sha1(market_id.encode("utf-8")).hexdigest(), 16) % 1000
         return h < int(rate * 1000)
 
-    def _with_favored_price(self, market: Market, fav_is_yes: bool,
-                            maker_price: float) -> Market:
+    def _with_favored_price(self, market: Market, buy_yes: bool,
+                             maker_price: float) -> Market:
         """A copy of the market with the favored side repriced to the maker bid,
         so ``prepare_order`` builds the order at that price. Execution-only: the
         signal keeps the observed price for the risk/divergence gate."""
-        field = "outcome_yes_price" if fav_is_yes else "outcome_no_price"
+        field = "outcome_yes_price" if buy_yes else "outcome_no_price"
         return market.model_copy(update={field: maker_price})
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
+        # Both regime tags count: one shot per market across the whole pillar.
         row = await self._db.fetchone(
-            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'bias_harvest' LIMIT 1",
-            (market_id,),
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source IN (?, ?) LIMIT 1",
+            (market_id, SOURCE_TAG, SOURCE_TAG_WIDE),
         )
         if row is not None:
             return True  # one shot per market, ever
@@ -235,16 +285,18 @@ class BiasHarvestPillar:
             """SELECT COUNT(*) AS n FROM portfolio p
                WHERE EXISTS (SELECT 1 FROM signals s
                              WHERE s.market_id = p.market_id
-                               AND s.strategy_source = 'bias_harvest')""",
+                               AND s.strategy_source IN (?, ?))""",
+            (SOURCE_TAG, SOURCE_TAG_WIDE),
         )
         return int(row["n"]) if row else 0
 
-    def _build_signal(self, market: Market, p_fav: float, fav_is_yes: bool) -> Signal:
+    def _build_signal(self, market: Market, p_fav: float, buy_yes: bool,
+                      action_desc: str, source_tag: str = SOURCE_TAG) -> Signal:
         cfg = self._settings.bias_harvest
         uplift = cfg.edge_uplift
-        # claude_prob is P(YES): shift toward the favored side by the
+        # claude_prob is P(YES): shift toward the side we are buying by the
         # measured-bias uplift, clamped inside the book.
-        if fav_is_yes:
+        if buy_yes:
             claude_prob = min(0.99, market.outcome_yes_price + uplift)
         else:
             claude_prob = max(0.01, market.outcome_yes_price - uplift)
@@ -256,12 +308,12 @@ class BiasHarvestPillar:
             market_prob=market.outcome_yes_price,
             edge=uplift * 100.0,
             evidence_summary=(
-                f"Bias harvest: favored side at {p_fav:.2f} in band "
+                f"Bias harvest: {action_desc} at {p_fav:.2f} in band "
                 f"[{cfg.band_lo:.2f}, {cfg.band_hi:.2f}); measured "
                 f"favorite-longshot bias, no forecast claimed."
             ),
-            recommended_side=OrderSide.BUY if fav_is_yes else OrderSide.SELL,
-            strategy_source="bias_harvest",
+            recommended_side=OrderSide.BUY if buy_yes else OrderSide.SELL,
+            strategy_source=source_tag,
         )
 
     async def _try_enter(self, market: Market) -> bool:
@@ -271,7 +323,7 @@ class BiasHarvestPillar:
             return False
         if await self._already_entered_or_held(market.id):
             return False
-        p_fav, fav_is_yes = band
+        p_fav, buy_yes, action_desc, source_tag = band
 
         # Maker entry: post the BUY at the favored-side bid (capture the spread)
         # instead of paying the observed price. The signal/divergence accounting
@@ -281,18 +333,30 @@ class BiasHarvestPillar:
         # reads it. order_market carries the maker price for prepare_order only.
         order_market = market
         if cfg.maker_entry:
-            maker_price = await self._maker_price(market, fav_is_yes)
-            if maker_price is None:
-                return False  # no capturable spread -> don't harvest as a taker
             # Paper realism: not every posted maker bid is hit. Admit only a
             # deterministic fraction so the paper book reflects a real capture
-            # rate. Gate BEFORE persisting the signal so an un-admitted market
-            # stays retryable instead of burning its one-shot.
+            # rate. Gate BEFORE the book fetch and BEFORE persisting the signal
+            # — the hash verdict never changes, so fetching a book for a
+            # never-admitted market is pure wasted CLOB traffic.
             if cfg.paper and not self._paper_admits(market.id):
                 return False
-            order_market = self._with_favored_price(market, fav_is_yes, maker_price)
+            # No-spread cooldown: the widened band makes many more candidates
+            # reach this point every cycle, and each book fetch serializes on
+            # the shared CLOB lock (the #249 contention lock). A market that
+            # just showed no capturable spread won't grow one within a cycle
+            # or two — skip re-fetching it for a while.
+            now = time.monotonic()
+            until = self._no_spread_until.get(market.id, 0.0)
+            if now < until:
+                return False
+            maker_price = await self._maker_price(market, buy_yes)
+            if maker_price is None:
+                self._no_spread_until[market.id] = now + NO_SPREAD_TTL_SECONDS
+                return False  # no capturable spread -> don't harvest as a taker
+            self._no_spread_until.pop(market.id, None)
+            order_market = self._with_favored_price(market, buy_yes, maker_price)
 
-        signal = self._build_signal(market, p_fav, fav_is_yes)
+        signal = self._build_signal(market, p_fav, buy_yes, action_desc, source_tag)
         await self._persist_signal(signal, market)
 
         # Full risk gate — all checks apply; never bypassed.
@@ -344,10 +408,10 @@ class BiasHarvestPillar:
         await self._db.execute(
             """INSERT INTO signals (market_id, claude_prob, claude_confidence,
                market_prob, edge, evidence_summary, action, strategy_source)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 'bias_harvest')""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
              signal.market_prob, signal.edge, signal.evidence_summary,
-             signal.recommended_side.value),
+             signal.recommended_side.value, signal.strategy_source),
         )
         await self._db.commit()
 

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
 
-import json
 from datetime import datetime, timezone
 
 import structlog
@@ -168,7 +167,10 @@ class CrossVenueArbPillar:
             raw = await self._analyzer._call_llm(EQUIVALENCE_PROMPT.format(
                 question_a=a.question, description_a=(a.description or "")[:600],
                 question_b=b.question, description_b=(b.description or "")[:600]))
-            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            # Shared robust parser (fences, prose tails, braces inside strings)
+            # — one implementation for every LLM-JSON call site, not a clone.
+            from auramaur.nlp.analyzer import _parse_claude_json
+            parsed = _parse_claude_json(raw)
             orientation = str(parsed.get("orientation", "none"))
             confidence = float(parsed.get("confidence", 0.0))
             reasoning = str(parsed.get("counterexample", ""))[:400]

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
 
-import json
 import re
 from datetime import datetime, timezone
 
@@ -204,7 +203,7 @@ def kalshi_ladder_pairs(markets: list[Market]) -> list[tuple[Market, Market, str
 # LLM verification prompt (fuzzy pairs only)
 # ----------------------------------------------------------------------
 
-ENTAILMENT_PROMPT = """You are auditing two prediction markets for STRICT logical entailment at the resolution-criteria level. Be adversarial: the default answer is "none".
+ENTAILMENT_PROMPT = """You are auditing two prediction markets for STRICT logical entailment or mutual exclusivity at the resolution-criteria level. Be adversarial: the default answer is "none".
 
 Market A: "{question_a}"
 Resolution details A: {description_a}
@@ -212,10 +211,10 @@ Resolution details A: {description_a}
 Market B: "{question_b}"
 Resolution details B: {description_b}
 
-Strict entailment means: in EVERY possible world, if the implier resolves YES then the implied market MUST resolve YES under its own written criteria. Consider timing windows, qualifying language, different resolution sources, and edge cases. If you can construct ANY plausible scenario where the implier resolves YES and the implied resolves NO, the entailment fails.
+Strict entailment means: in EVERY possible world, if the implier resolves YES then the implied market MUST resolve YES under its own written criteria (or B resolves NO if they are mutually exclusive / a_implies_not_b). Consider timing windows, qualifying language, different resolution sources, and edge cases. If you can construct ANY plausible scenario where the relationship fails, answer "none".
 
 Respond with ONLY this JSON:
-{{"direction": "a_implies_b" | "b_implies_a" | "none", "confidence": 0.0-1.0, "counterexample": "<the best scenario that breaks the strongest candidate direction, or 'none found'>"}}"""
+{{"direction": "a_implies_b" | "b_implies_a" | "a_implies_not_b" | "none", "confidence": 0.0-1.0, "counterexample": "<the best scenario that breaks the strongest candidate direction, or 'none found'>"}}"""
 
 
 # ----------------------------------------------------------------------
@@ -317,15 +316,40 @@ class EntailmentArbPillar:
                      total=len(rows or []))
         return out
 
+    # Bump when ENTAILMENT_PROMPT's answer schema changes: cached verdicts from
+    # an older prompt can never contain the new directions (the v1 cache held
+    # permanent 'none' rows written before a_implies_not_b existed, silently
+    # killing mutual-exclusivity for every previously-scanned pair). Rows with
+    # an older source are ignored on read and re-verified once under the new
+    # prompt.
+    _VERDICT_SOURCE = "llm-v2"
+
+    @staticmethod
+    def _to_call_frame(direction: str, swapped: bool) -> str:
+        """Map a sorted-frame verdict back to the caller's (a, b) frame.
+
+        The prompt and the cache are canonicalized to sorted-id order, but the
+        caller interprets the direction in its own argument order. Without this
+        remap every fuzzy pair where a.id > b.id came back inverted — real
+        violations were dropped and legitimate spreads were entered backwards.
+        a_implies_not_b (mutual exclusivity) is symmetric; no remap needed."""
+        if not swapped:
+            return direction
+        return {"a_implies_b": "b_implies_a",
+                "b_implies_a": "a_implies_b"}.get(direction, direction)
+
     async def _verify_llm(self, a: Market, b: Market):
-        """Cached adversarial entailment verdict for a fuzzy pair."""
+        """Cached adversarial entailment verdict for a fuzzy pair, returned in
+        the CALLER's (a, b) frame."""
         key = tuple(sorted((a.id, b.id)))
+        swapped = key[0] != a.id
         row = await self._db.fetchone(
             "SELECT direction, confidence FROM entailment_verdicts "
-            "WHERE market_id_a = ? AND market_id_b = ?", key,
+            "WHERE market_id_a = ? AND market_id_b = ? AND source = ?",
+            (*key, self._VERDICT_SOURCE),
         )
         if row is not None:
-            return row["direction"], float(row["confidence"])
+            return self._to_call_frame(row["direction"], swapped), float(row["confidence"])
         if self._analyzer is None:
             return "none", 0.0
         first, second = (a, b) if key[0] == a.id else (b, a)
@@ -336,22 +360,23 @@ class EntailmentArbPillar:
         direction, confidence, reasoning = "none", 0.0, ""
         try:
             raw = await self._analyzer._call_llm(prompt)
-            parsed = json.loads(raw[raw.index("{"):raw.rindex("}") + 1])
+            from auramaur.nlp.analyzer import _parse_claude_json
+            parsed = _parse_claude_json(raw)
             direction = str(parsed.get("direction", "none"))
             confidence = float(parsed.get("confidence", 0.0))
             reasoning = str(parsed.get("counterexample", ""))[:400]
-            if direction not in ("a_implies_b", "b_implies_a"):
+            if direction not in ("a_implies_b", "b_implies_a", "a_implies_not_b"):
                 direction = "none"
         except Exception as e:
             log.warning("entailment.llm_parse_error", a=a.id, b=b.id, error=str(e))
         await self._db.execute(
             """INSERT OR REPLACE INTO entailment_verdicts
                (market_id_a, market_id_b, direction, confidence, source, reasoning)
-               VALUES (?, ?, ?, ?, 'llm', ?)""",
-            (key[0], key[1], direction, confidence, reasoning),
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (key[0], key[1], direction, confidence, self._VERDICT_SOURCE, reasoning),
         )
         await self._db.commit()
-        return direction, confidence
+        return self._to_call_frame(direction, swapped), confidence
 
     def _required_gap(self, implier: Market, implied: Market) -> float:
         """Minimum violation gap to be a real arb on these legs.
@@ -386,7 +411,7 @@ class EntailmentArbPillar:
                 log.debug("entailment.kalshi_series_error", series=series, error=str(e))
                 continue
             markets.extend(m for m in rows if self._real_book(m))
-        pairs = [(impl, imp, why, 1.0) for impl, imp, why in kalshi_ladder_pairs(markets)]
+        pairs = [(impl, imp, why, 1.0, False) for impl, imp, why in kalshi_ladder_pairs(markets)]
         if pairs:
             log.info("entailment.kalshi_ladders", pairs=len(pairs), markets=len(markets))
         return pairs
@@ -414,34 +439,44 @@ class EntailmentArbPillar:
         # 1. Deterministic ladders — direction known mathematically.
         #    Polymarket (question-keyed) + Kalshi econ bins (ticker-keyed,
         #    series-fetched, fee-cleared in the gate below).
-        candidates: list[tuple[Market, Market, str, float]] = (
+        candidates: list[tuple[Market, Market, str, float, bool]] = (
             await self._kalshi_ladder_candidates()
         )
         candidates += [
-            (impl, imp, why, 1.0) for impl, imp, why in ladder_pairs(good)
+            (impl, imp, why, 1.0, False) for impl, imp, why in ladder_pairs(good)
         ]
 
         # 2. Fuzzy conditional pairs — verify with the LLM ONLY when a
-        # violation is on the table (saves calls), direction never trusted
-        # from the correlator.
+        # violation is on the table (saves calls).
         if cfg.llm_enabled and self._analyzer is not None:
             for a, b in await self._conditional_pairs(by_id):
-                gap_ab = a.outcome_yes_price - b.outcome_yes_price
-                if abs(gap_ab) < cfg.min_gap:
+                pa, pb = a.outcome_yes_price, b.outcome_yes_price
+                has_pos_violation = abs(pa - pb) >= cfg.min_gap
+                has_neg_violation = (pa + pb - 1.0) >= cfg.min_gap
+                if not (has_pos_violation or has_neg_violation):
                     continue
                 direction, conf = await self._verify_llm(a, b)
                 if conf < cfg.llm_min_confidence:
                     continue
                 if direction == "a_implies_b":
-                    candidates.append((a, b, "llm-verified", conf))
+                    candidates.append((a, b, "llm-verified", conf, False))
                 elif direction == "b_implies_a":
-                    candidates.append((b, a, "llm-verified", conf))
+                    candidates.append((b, a, "llm-verified", conf, False))
+                elif direction == "a_implies_not_b":
+                    candidates.append((a, b, "llm-verified-neg", conf, True))
 
         placed = 0
-        for implier, implied, why, conf in candidates:
+        for implier, implied, why, conf, is_neg in candidates:
             if placed >= cfg.max_pairs_per_cycle:
                 break
-            gap = implier.outcome_yes_price - implied.outcome_yes_price
+            
+            if is_neg:
+                # Negative implication: P(A) + P(B) > 1.0
+                gap = implier.outcome_yes_price + implied.outcome_yes_price - 1.0
+            else:
+                # Positive implication: P(A) > P(B)
+                gap = implier.outcome_yes_price - implied.outcome_yes_price
+
             # Fee-aware floor: Polymarket uses min_gap; Kalshi must clear both
             # legs' taker fees + buffer, or the "free" arb loses to fees.
             if gap < self._required_gap(implier, implied):
@@ -449,7 +484,7 @@ class EntailmentArbPillar:
             if await self._already_traded(implier.id, implied.id):
                 continue
             try:
-                if await self._enter_pair(implier, implied, gap, why, conf):
+                if await self._enter_pair(implier, implied, gap, why, conf, is_neg):
                     placed += 1
             except Exception as e:
                 log.error("entailment.entry_error", a=implier.id, b=implied.id,
@@ -461,7 +496,12 @@ class EntailmentArbPillar:
     # -- execution --------------------------------------------------------
 
     def _leg_signal(self, market: Market, side: OrderSide, fair: float,
-                    gap: float, why: str) -> Signal:
+                    gap: float, why: str, is_neg: bool = False) -> Signal:
+        summary = (
+            f"Entailment arb ({why}): P(A) + P(B) must be <= 1.0."
+            if is_neg else
+            f"Entailment arb ({why}): P(implier) must be <= P(implied)."
+        )
         return Signal(
             market_id=market.id,
             market_question=market.question,
@@ -472,13 +512,13 @@ class EntailmentArbPillar:
             claude_confidence=Confidence.HIGH,
             market_prob=market.outcome_yes_price,
             edge=gap * 100.0,
-            evidence_summary=f"Entailment arb ({why}): P(implier) must be <= P(implied).",
+            evidence_summary=summary,
             recommended_side=side,
             strategy_source="entailment_arb",
         )
 
     async def _enter_pair(self, implier: Market, implied: Market,
-                          gap: float, why: str, conf: float) -> bool:
+                          gap: float, why: str, conf: float, is_neg: bool = False) -> bool:
         cfg = self._settings.entailment_arb
         exchange_a = self._exchange_for(implier)
         exchange_b = self._exchange_for(implied)
@@ -492,12 +532,20 @@ class EntailmentArbPillar:
             )
             return False
 
-        # Leg 1: NO on the implier (its YES is overpriced vs the bound).
-        sig_a = self._leg_signal(implier, OrderSide.SELL,
-                                 fair=implied.outcome_yes_price, gap=gap, why=why)
-        # Leg 2: YES on the implied (its YES is underpriced vs the bound).
-        sig_b = self._leg_signal(implied, OrderSide.BUY,
-                                 fair=implier.outcome_yes_price, gap=gap, why=why)
+        if is_neg:
+            # Leg 1: NO on implier/A (YES is overpriced vs the bound 1 - pb).
+            sig_a = self._leg_signal(implier, OrderSide.SELL,
+                                     fair=1.0 - implied.outcome_yes_price, gap=gap, why=why, is_neg=True)
+            # Leg 2: NO on implied/B (YES is overpriced vs the bound 1 - pa).
+            sig_b = self._leg_signal(implied, OrderSide.SELL,
+                                     fair=1.0 - implier.outcome_yes_price, gap=gap, why=why, is_neg=True)
+        else:
+            # Leg 1: NO on the implier (its YES is overpriced vs the bound).
+            sig_a = self._leg_signal(implier, OrderSide.SELL,
+                                     fair=implied.outcome_yes_price, gap=gap, why=why)
+            # Leg 2: YES on the implied (its YES is underpriced vs the bound).
+            sig_b = self._leg_signal(implied, OrderSide.BUY,
+                                     fair=implier.outcome_yes_price, gap=gap, why=why)
 
         dec_a = await self._risk.evaluate(sig_a, implier)
         dec_b = await self._risk.evaluate(sig_b, implied)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -77,6 +77,14 @@ risk:
   # where calibration shows edge; sports/politics_us stay out (see above).
   allowed_categories_live: ["crypto", "tech", "politics_intl", "economics",
                             "science", "legal", "weather"]
+  # Per-strategy live-category extensions (see settings.py). bias_harvest's
+  # 'other' cell graduated to probation on its own paper record; extending it
+  # HERE (gateway check #18 only) instead of on the global list keeps the
+  # catch-all label closed to the graduation-exempt market maker and arb
+  # executor, which consume allowed_categories_live directly — a global
+  # 'other' would re-open the 2026-06 mislabel fail-open lane for them.
+  allowed_categories_live_extra:
+    bias_harvest: ["other"]
   time_to_resolution_min_hours: 4
   time_to_resolution_max_days: 0   # 0 = no ceiling; set to 90 to reject 3+ month markets
   max_correlated_positions: 10
@@ -415,7 +423,11 @@ entailment_arb:
   # the real unknowns are fine-print entailment failures and leg risk.
   enabled: true
   paper: true
-  min_gap: 0.04          # violation must exceed this after both legs
+  # Floor for a violation to be tradeable after both legs. Keep >= 0.025:
+  # signals carry edge = gap*100 and the unconditional risk floor
+  # (risk.min_edge_pct = 2.5) rejects anything below 2.5 pts AFTER the LLM
+  # verification was already spent — a lower value here only buys dead calls.
+  min_gap: 0.025
   stake_usd: 10.0        # per leg, also capped by risk sizing
   max_pairs_per_cycle: 3
   scan_limit: 300
@@ -630,7 +642,7 @@ bias_harvest:
   # paper: false (still behind the three live gates).
   enabled: true
   paper: true
-  band_lo: 0.90
+  band_lo: 0.60
   band_hi: 0.97
   # claude_prob = favored price + uplift (the measured band gap is +4..+6pts).
   # MUST stay < 0.05 or the divergence filter blocks entries at MEDIUM conf.

--- a/config/settings.py
+++ b/config/settings.py
@@ -164,6 +164,14 @@ class RiskConfig(BaseModel):
         "crypto", "tech", "politics_intl", "economics", "science", "legal",
         "entertainment", "weather", "esports",
     ]
+    # Per-strategy live-category extensions, keyed by strategy_source. Lets a
+    # proven graduation cell (e.g. bias_harvest x other) earn its category
+    # WITHOUT adding it to the global list above — which the graduation-exempt
+    # market maker / arb executor consume directly, so a global 'other' would
+    # fail-open the exact classifier-gap hole the allowlist exists to close.
+    # Consulted only by the gateway's category allowlist check (#18).
+    allowed_categories_live_extra: dict[str, list[str]] = Field(
+        default_factory=dict)
 
 
 class KellyConfig(BaseModel):

--- a/tests/test_bias_harvest.py
+++ b/tests/test_bias_harvest.py
@@ -138,7 +138,7 @@ def test_enters_band_market_and_writes_all_rails():
         await db.connect()
         settings = _settings()
         ex = _exchange()
-        pillar, calibration = _pillar(db, settings, [_market(yes=0.85)], exchange=ex)
+        pillar, calibration = _pillar(db, settings, [_market(yes=0.92)], exchange=ex)
 
         entered = await pillar.run_once()
         assert entered == 1
@@ -148,7 +148,7 @@ def test_enters_band_market_and_writes_all_rails():
 
         sig = await db.fetchone("SELECT * FROM signals WHERE strategy_source='bias_harvest'")
         assert sig is not None
-        assert abs(sig["claude_prob"] - 0.89) < 1e-9  # 0.85 + 0.04 uplift
+        assert abs(sig["claude_prob"] - 0.96) < 1e-9  # 0.92 + 0.04 uplift
         assert sig["action"] == "BUY"
 
         trade = await db.fetchone("SELECT * FROM trades WHERE strategy_source='bias_harvest'")
@@ -183,16 +183,16 @@ def test_paper_false_passes_global_mode():
 
 
 def test_favored_no_side_enters_as_sell_signal():
-    """YES at 0.12 -> favored side is NO at 0.88 -> SELL signal (buys NO)."""
+    """YES at 0.05 -> favored side is NO at 0.95 -> SELL signal (buys NO)."""
     async def run():
         db = Database(":memory:")
         await db.connect()
-        pillar, _ = _pillar(db, _settings(), [_market(yes=0.12)])
+        pillar, _ = _pillar(db, _settings(), [_market(yes=0.05)])
         entered = await pillar.run_once()
         assert entered == 1
         sig = await db.fetchone("SELECT * FROM signals WHERE strategy_source='bias_harvest'")
         assert sig["action"] == "SELL"
-        assert abs(sig["claude_prob"] - 0.08) < 1e-9  # 0.12 - 0.04 uplift
+        assert abs(sig["claude_prob"] - 0.01) < 1e-9  # 0.05 - 0.04 uplift
         pos = await db.fetchone("SELECT token FROM portfolio WHERE market_id='m1'")
         assert pos["token"] == "NO"
         await db.close()
@@ -425,5 +425,61 @@ def test_paper_maker_fill_rate_haircut_gates_entries():
         assert 120 < admitted < 280  # not all, not none — a real partition
         await db.close()
         await db2.close()
+
+    asyncio.run(run())
+
+
+def test_bidirectional_regimes():
+    """Test the three distinct bands of the bidirectional strategy:
+    1. [0.60, 0.70) -> buy favored (yes=0.65 -> BUY YES, yes=0.35 -> BUY NO/SELL)
+    2. [0.70, 0.90) -> buy longshot (yes=0.80 -> BUY NO/SELL, yes=0.20 -> BUY YES)
+    3. [0.90, 0.97) -> buy favored (yes=0.95 -> BUY YES, yes=0.05 -> BUY NO/SELL)
+
+    The deep band keeps the proven 'bias_harvest' attribution; the two NEW
+    regimes are tagged 'bias_harvest_wide' so they accrue their own graduation
+    cells instead of inheriting the deep band's live probation record.
+    """
+    async def run():
+        # Band 1: yes=0.65 (favored YES) -> BUY YES, wide tag
+        db1 = Database(":memory:")
+        await db1.connect()
+        pillar1, _ = _pillar(db1, _settings(band_lo=0.60), [_market(yes=0.65)])
+        assert await pillar1.run_once() == 1
+        sig1 = await db1.fetchone("SELECT * FROM signals WHERE strategy_source='bias_harvest_wide'")
+        assert sig1 is not None and sig1["action"] == "BUY"
+        pos1 = await db1.fetchone("SELECT token FROM portfolio WHERE market_id='m1'")
+        assert pos1["token"] == "YES"
+        await db1.close()
+
+        # Band 2: yes=0.80 (favored YES) -> BUY NO (SELL action), wide tag
+        db2 = Database(":memory:")
+        await db2.connect()
+        pillar2, _ = _pillar(db2, _settings(band_lo=0.60), [_market(yes=0.80)])
+        assert await pillar2.run_once() == 1
+        sig2 = await db2.fetchone("SELECT * FROM signals WHERE strategy_source='bias_harvest_wide'")
+        assert sig2 is not None and sig2["action"] == "SELL"
+        pos2 = await db2.fetchone("SELECT token FROM portfolio WHERE market_id='m1'")
+        assert pos2["token"] == "NO"
+        await db2.close()
+
+        # Band 3: yes=0.95 (favored YES) -> BUY YES, PROVEN tag
+        db3 = Database(":memory:")
+        await db3.connect()
+        pillar3, _ = _pillar(db3, _settings(band_lo=0.60), [_market(yes=0.95)])
+        assert await pillar3.run_once() == 1
+        sig3 = await db3.fetchone("SELECT * FROM signals WHERE strategy_source='bias_harvest'")
+        assert sig3 is not None and sig3["action"] == "BUY"
+        pos3 = await db3.fetchone("SELECT token FROM portfolio WHERE market_id='m1'")
+        assert pos3["token"] == "YES"
+        await db3.close()
+
+        # One-shot rule spans BOTH tags: a wide entry blocks any later entry
+        # on the same market.
+        db4 = Database(":memory:")
+        await db4.connect()
+        pillar4, _ = _pillar(db4, _settings(band_lo=0.60), [_market(yes=0.80)])
+        assert await pillar4.run_once() == 1
+        assert await pillar4._already_entered_or_held("m1") is True
+        await db4.close()
 
     asyncio.run(run())

--- a/tests/test_entailment_arb.py
+++ b/tests/test_entailment_arb.py
@@ -489,3 +489,120 @@ def test_llm_low_confidence_blocks():
         await db.close()
 
     asyncio.run(run())
+
+
+def test_negative_implication_arbitrage():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        a = _market("ma", "Will Egypt win 2-0?", 0.65)
+        b = _market("mb", "Will total goals be over 7.5?", 0.45)
+        await db.execute(
+            "INSERT INTO market_relationships (market_id_a, market_id_b, "
+            "relationship_type, strength) VALUES ('ma', 'mb', 'conditional', 0.9)")
+        await db.commit()
+
+        analyzer = MagicMock()
+        analyzer._call_llm = AsyncMock(return_value=(
+            '{"direction": "a_implies_not_b", "confidence": 0.95, '
+            '"counterexample": "none"}'
+        ))
+        ex = _exchange()
+        pillar = _pillar(db, _settings(llm_enabled=True, min_gap=0.04), [a, b],
+                         exchange=ex, analyzer=analyzer)
+        assert await pillar.run_once() == 1
+        
+        # Verify that two SELL orders (NO orders) were submitted
+        assert ex.place_order.await_count == 2
+        calls = ex.place_order.await_args_list
+        
+        # First leg: NO on A
+        order_a = calls[0][0][0]
+        assert order_a.market_id == "ma"
+        assert order_a.token == TokenType.NO
+        assert order_a.price == 0.35  # 1 - 0.65
+        
+        # Second leg: NO on B
+        order_b = calls[1][0][0]
+        assert order_b.market_id == "mb"
+        assert order_b.token == TokenType.NO
+        assert order_b.price == 0.55  # 1 - 0.45
+        
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_verify_llm_direction_returned_in_caller_frame():
+    """_verify_llm canonicalizes the pair to sorted-id order for the prompt
+    and the cache, but the caller reasons in its own (a, b) argument order.
+    The verdict must be remapped: without it, every fuzzy pair where
+    a.id > b.id came back inverted (real violations dropped, legitimate
+    spreads entered backwards)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        # a.id 'mz' sorts AFTER b.id 'ma' -> prompt frame is swapped.
+        a = _market("mz", "Will X win the final?", 0.60)
+        b = _market("ma", "Will X reach the final?", 0.40)
+
+        analyzer = MagicMock()
+        # LLM answers in the SORTED frame: sorted-first ('ma') is implied by
+        # sorted-second ('mz'), i.e. "b_implies_a" in prompt terms.
+        analyzer._call_llm = AsyncMock(return_value=(
+            '{"direction": "b_implies_a", "confidence": 0.9, '
+            '"counterexample": "none found"}'))
+        pillar = _pillar(db, _settings(llm_enabled=True), [a, b],
+                         analyzer=analyzer)
+
+        # Caller frame: mz implies ma -> "a_implies_b".
+        direction, conf = await pillar._verify_llm(a, b)
+        assert direction == "a_implies_b" and conf == 0.9
+        # Cached read must remap identically...
+        direction2, _ = await pillar._verify_llm(a, b)
+        assert direction2 == "a_implies_b"
+        # ...and the swapped argument order sees the mirrored direction.
+        direction3, _ = await pillar._verify_llm(b, a)
+        assert direction3 == "b_implies_a"
+        assert analyzer._call_llm.await_count == 1  # one real call, then cache
+
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_verify_llm_ignores_stale_prompt_version_cache():
+    """Verdicts cached under an older prompt schema (source != current) are
+    ignored and re-verified once: the v1 cache predates a_implies_not_b, so
+    its permanent 'none' rows would otherwise silently kill mutual-exclusivity
+    for every previously-scanned pair."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        a = _market("ma", "Will Egypt win 2-0?", 0.65)
+        b = _market("mb", "Will total goals be over 7.5?", 0.45)
+        await db.execute(
+            "INSERT INTO entailment_verdicts (market_id_a, market_id_b, "
+            "direction, confidence, source, reasoning) "
+            "VALUES ('ma', 'mb', 'none', 0.9, 'llm', 'old prompt')")
+        await db.commit()
+
+        analyzer = MagicMock()
+        analyzer._call_llm = AsyncMock(return_value=(
+            '{"direction": "a_implies_not_b", "confidence": 0.95, '
+            '"counterexample": "none found"}'))
+        pillar = _pillar(db, _settings(llm_enabled=True), [a, b],
+                         analyzer=analyzer)
+
+        direction, conf = await pillar._verify_llm(a, b)
+        assert direction == "a_implies_not_b" and conf == 0.95
+        assert analyzer._call_llm.await_count == 1  # stale row did not satisfy
+
+        # The re-verified verdict replaced the stale row and now serves reads.
+        direction2, _ = await pillar._verify_llm(a, b)
+        assert direction2 == "a_implies_not_b"
+        assert analyzer._call_llm.await_count == 1
+
+        await db.close()
+
+    asyncio.run(run())

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -494,3 +494,66 @@ async def test_live_allowlist_skipped_in_paper_and_for_exempt(mock_kill):
     d2 = await manager2.evaluate(sig2, market, available_cash=500.0)
     gate = next(c for c in d2.checks if c.name == "category_allowlist")
     assert gate.passed is True
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_min_liquidity_floor_is_venue_scoped(mock_kill):
+    """Kalshi reports thin top-of-book liquidity, so its orders are gated on
+    risk.kalshi_min_liquidity while every other venue keeps the strict
+    min_liquidity floor."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    settings = _make_settings(min_liquidity=1000.0)
+    settings.risk.kalshi_min_liquidity = 300.0
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+
+    # $500 book: fails the Polymarket floor...
+    poly = _make_market(liquidity=500.0)
+    d = await manager.evaluate(sig, poly, available_cash=500.0)
+    gate = next(c for c in d.checks if c.name == "min_liquidity")
+    assert gate.passed is False
+
+    # ...but passes the Kalshi floor on the same numbers.
+    kalshi = _make_market(liquidity=500.0)
+    kalshi.exchange = "kalshi"
+    d2 = await manager.evaluate(sig, kalshi, available_cash=500.0)
+    gate2 = next(c for c in d2.checks if c.name == "min_liquidity")
+    assert gate2.passed is True
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_allowlist_extra_is_per_strategy(mock_kill):
+    """allowed_categories_live_extra widens the live allowlist ONLY for the
+    named strategy_source — other strategies (and by construction the direct
+    consumers of the global list) still see 'other' as fail-closed."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+    settings = _make_settings(is_live=True, allowed_categories_live=["tech"])
+    settings.risk.allowed_categories_live_extra = {"bias_harvest": ["other"]}
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+    market = _make_market(category="other")
+
+    # The extended strategy clears the gate on its earned category...
+    sig = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    sig.strategy_source = "bias_harvest"
+    d = await manager.evaluate(sig, market, available_cash=500.0)
+    gate = next(c for c in d.checks if c.name == "category_allowlist")
+    assert gate.passed is True
+
+    # ...while an unlisted strategy is still rejected on the same market.
+    sig2 = _make_signal(edge=10.0, claude_prob=0.60, market_prob=0.50)
+    sig2.strategy_source = "llm"
+    d2 = await manager.evaluate(sig2, market, available_cash=500.0)
+    gate2 = next(c for c in d2.checks if c.name == "category_allowlist")
+    assert gate2.passed is False


### PR DESCRIPTION
Operator tuning session + the confirmed findings from an adversarial multi-agent review of it, fixed in the same change.

## The session
- **bias_harvest bi-directional bands**: deep [0.90,0.97) keeps the proven buy-the-favorite rule; widened [0.60,0.70) buys favored, [0.70,0.90) buys the longshot (per the paper measurement that shallow-band favorites bust above their implied rate — see the band_lo history comment in `config/settings.py`).
- **entailment_arb mutual exclusivity** (`a_implies_not_b`): P(A)+P(B) > 1 + gap on a verified exclusive pair → NO on both legs.
- **Venue-scoped risk liquidity floor** for Kalshi's thin top-of-book reporting.

## Review fixes folded in (all CONFIRMED by verification agents)
1. **Direction-frame inversion (correctness)**: `_verify_llm` canonicalizes pairs to sorted-id order for the prompt/cache but the caller reads directions in call-order frame — every fuzzy pair with `a.id > b.id` came back inverted (real violations dropped; backwards leg-pairs entered on legitimate spreads). Now remapped to the caller's frame on both cache and fresh paths, with tests.
2. **Prompt-versioned verdict cache**: old-prompt `none` rows predate `a_implies_not_b` and would have permanently suppressed the new direction on every previously-scanned pair.
3. **Regime cell isolation**: the two NEW bias bands are tagged `bias_harvest_wide` — own graduation cells, ladder-paper-forced until they earn live on their own record, instead of inheriting the probation status the deep band earned (same idiom as `resolution_lens_kalshi`).
4. **Allowlist scoped per-strategy**: `"other"` on the GLOBAL live allowlist would also open the graduation-exempt market maker and arb executor to the entire catch-all bucket (the 2026-06 mislabel fail-open lane). Replaced with `risk.allowed_categories_live_extra`, consulted only by the gateway's allowlist check for the named strategy_source.
5. **min_gap floors at 0.025**: `edge = gap*100` and the unconditional 2.5-pt risk floor rejects anything lower *after* the LLM verification was spent — 0.02 only bought dead calls.
6. **Maker-path efficiency**: hash admission gate hoisted above the book fetch; no-spread markets get a fetch cooldown (the widened band multiplies candidates and every fetch serializes on the shared CLOB lock from the #249 incident).
7. **Shared JSON parser**: both new extraction loops replaced with `_parse_claude_json`.

Full suite green locally (1018 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)