### PR TITLE
fix(lens): budget exhaustion is not a verdict failure + safe restart script

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -253,10 +253,21 @@ class ResolutionLensPillar:
             score = max(0.0, min(1.0, float(parsed.get("gap_score", 0.0))))
             mech = str(parsed.get("mechanism", "none"))[:400] or "none"
         except Exception as e:
-            # Do NOT cache the failure: the old neutral-row write made every
-            # LLM/parse error a PERMANENT no-gap verdict (the cache never
-            # expires). Retry next cycle, but give up after a few attempts so
-            # one confusing market can't eat the per-cycle budget forever.
+            # Budget exhaustion is GLOBAL, not this market's fault — no strike,
+            # no cache write, and no Gemini fallback either: the lens's calls
+            # are pinned because Gemini verdicts measurably never clear the
+            # entry floors, and a cached Gemini verdict would permanently
+            # blind Claude to the market (the 06-25 lobotomy, with memory).
+            # Retry when the budget window resets.
+            from auramaur.nlp.errors import BudgetExhausted
+            if isinstance(e, BudgetExhausted):
+                log.debug("lens.budget_exhausted", market_id=m.id)
+                return None
+            # Do NOT cache other failures either: the old neutral-row write
+            # made every LLM/parse error a PERMANENT no-gap verdict (the cache
+            # never expires). Retry next cycle, but give up after a few
+            # attempts so one confusing market can't eat the per-cycle budget
+            # forever.
             self._verdict_failures[m.id] = self._verdict_failures.get(m.id, 0) + 1
             if self._verdict_failures[m.id] < 3:
                 log.warning("lens.llm_parse_error", market_id=m.id, error=str(e))

--- a/scripts/restart_live.sh
+++ b/scripts/restart_live.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Restart the live Auramaur bot safely.
+#
+# Exists because the naive relaunch has two silent traps (both hit 2026-07-02):
+#   1. Launching without stopping the old process runs TWO bots at once.
+#   2. If the old process still holds the auramaur.db flock when the new one
+#      starts, the new bot silently falls back to a stale numbered instance
+#      DB (auramaur_2.db, ...) — right code, wrong book.
+# This script stops every running bot first, waits for the lock holder to
+# exit, launches exactly one instance, and FAILS LOUDLY if the new bot came
+# up on a fallback database.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -f ./KILL_SWITCH ]; then
+    echo "KILL_SWITCH present — refusing to start. Remove it first." >&2
+    exit 1
+fi
+
+# 1. Stop every running bot instance gracefully (SIGTERM -> shutdown path
+#    cancels resting orders and releases the DB flock).
+pids=$(pgrep -f 'auramaur run' || true)
+if [ -n "$pids" ]; then
+    echo "Stopping running bot instance(s): $pids"
+    kill -TERM $pids 2>/dev/null || true
+    for _ in $(seq 1 30); do
+        pgrep -f 'auramaur run' > /dev/null || break
+        sleep 1
+    done
+    if pgrep -f 'auramaur run' > /dev/null; then
+        echo "Old instance did not exit within 30s — refusing to force-kill" >&2
+        echo "a live trading process. Inspect it, then re-run." >&2
+        exit 1
+    fi
+fi
+
+# 2. Launch one instance, live-armed (still behind the config + per-order gates).
+ts=$(date +%Y%m%d_%H%M%S)
+log="logs/run_live_${ts}.out"
+AURAMAUR_LIVE=true nohup .venv/bin/auramaur run --hybrid > "$log" 2>&1 &
+pid=$!
+echo "Launched PID ${pid}, log: ${log}"
+
+# 3. Verify it came up on the PRIMARY database. The banner prints an
+#    "Instance: auramaur_N.db" line only on lock-contention fallback.
+for _ in $(seq 1 60); do
+    grep -q 'strategy books' "$log" 2>/dev/null && break
+    if ! kill -0 "$pid" 2>/dev/null; then
+        echo "Bot exited during startup — tail of ${log}:" >&2
+        tail -20 "$log" >&2
+        exit 1
+    fi
+    sleep 2
+done
+if grep -q 'Instance: auramaur_' "$log"; then
+    echo "FALLBACK DB DETECTED — the primary auramaur.db was still locked." >&2
+    echo "Stopping the wrong-book instance. Re-run once the lock holder exits." >&2
+    kill -TERM "$pid"
+    exit 1
+fi
+grep -E 'Build:|Mode:' "$log" | head -2
+echo "OK: single instance on the primary database."

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -831,3 +831,33 @@ def test_pin_claude_bypasses_router_and_uses_reserve():
                     pass  # got PAST the budget gate (reserved slice)
 
     asyncio.run(run())
+
+
+def test_budget_exhaustion_never_strikes_or_caches():
+    """BudgetExhausted is a GLOBAL condition, not the market's fault: it must
+    not count toward the 3-strike give-up, no matter how many cycles it lasts
+    — a day-long budget outage was permanently neutral-caching every scanned
+    market (5 markets poisoned on 2026-07-02 before this fix)."""
+    async def run():
+        from auramaur.nlp.errors import BudgetExhausted
+
+        db = Database(":memory:"); await db.connect()
+        m = _market()
+        a = MagicMock()
+        a._call_llm = AsyncMock(side_effect=BudgetExhausted("daily cap"))
+        p = _pillar(db, _settings(), [m], analyzer=a)
+        await p._ensure_schema()
+
+        for _ in range(10):  # many cycles of exhaustion
+            assert await p._verdict(m) is None
+        row = await db.fetchone(
+            "SELECT 1 FROM lens_verdicts WHERE market_id = ?", (m.id,))
+        assert row is None                       # nothing cached, ever
+        assert p._verdict_failures.get(m.id, 0) == 0  # no strikes accrued
+
+        # Budget returns -> the very next call succeeds normally.
+        p._analyzer = _analyzer()
+        v = await p._verdict(m)
+        assert v is not None and v[1] == 0.8
+
+    asyncio.run(run())


### PR DESCRIPTION
The 3-strike give-up on lens verdict errors (#252) counted `BudgetExhausted` as a market-specific failure — but budget exhaustion is **global**. During a budget outage, every scanned candidate accrued a strike per 30-minute cycle and received the permanent neutral verdict after three, quietly rebuilding the exact poisoned cache #252 removed. `BudgetExhausted` now skips with no strike and no cache write, retrying when the budget window resets.

Deliberately **no Gemini fallback** for lens calls: Gemini verdicts measurably never clear the entry floors, and because verdicts cache forever, a Gemini fallback wouldn't be a degraded answer — it would permanently blind Claude to that market.

Also adds `scripts/restart_live.sh`: stop-then-start restart with two guards learned the hard way — refuses to leave two instances running, and fails loudly if the new bot came up on a lock-contention fallback database instead of the primary (right code, wrong book).

Regression test: repeated budget exhaustion never strikes or caches; first call after budget returns succeeds normally. Full suite green (1019), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)