### PR TITLE
fix(resolution_lens): feed the Kalshi lens the near-dated close-window slice

### DIFF
--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -521,6 +521,32 @@ class ResolutionLensPillar:
                  live_gap_cells=len(live_cats), scanned=len(markets))
         return markets
 
+    async def _close_window_candidates(self) -> list[Market]:
+        """Near-dated tradeable slice fetched LIVE from the venue, for venues
+        whose generic discovery starves the DB scan.
+
+        Kalshi's /events default ordering surfaces mostly ultra-long-dated
+        novelty markets, so the markets table almost never holds Kalshi rows
+        inside the lens's 12h-90d resolution window (funnel audit 2026-07-03:
+        9 of 218 trigger candidates in-window, 0 passing all gates) — the
+        same discovery bias that starved informed_flow. The close-window
+        endpoint returns the actually-tradeable slice (econ ladders, event
+        markets) with fresh rules text. No-op for venues whose discovery
+        lacks the method (Polymarket's Gamma scan doesn't have this bias)."""
+        fetch = getattr(self._discovery, "get_markets_by_close_window", None)
+        if fetch is None:
+            return []
+        cfg = self._settings.resolution_lens
+        now = int(datetime.now(timezone.utc).timestamp())
+        min_ts = now + int(cfg.min_hours_to_resolution * 3600)
+        max_ts = now + int(cfg.max_days_to_resolution * 86400)
+        try:
+            rows = await fetch(min_ts, max_ts, limit=cfg.scan_limit)
+        except Exception as e:
+            log.debug("lens.close_window_error", error=str(e))
+            return []
+        return [m for m in rows or [] if has_lens_trigger(m.question)]
+
     async def run_once(self) -> int:
         cfg = self._settings.resolution_lens
         if not cfg.enabled:
@@ -529,8 +555,16 @@ class ResolutionLensPillar:
         # Lexical pre-filter over the whole universe; fall back to the volume
         # scan only if the markets table is empty (cold start).
         markets = await self._lexical_candidates()
+        lexical_n = len(markets)
+        # Merge the live near-dated venue slice (dedup by id; DB rows first so
+        # cached-verdict prioritization keeps working on known ids).
+        fresh = await self._close_window_candidates()
+        if fresh:
+            seen_ids = {m.id for m in markets}
+            markets += [m for m in fresh if m.id not in seen_ids]
         if markets:
-            log.info("lens.candidates", lexical=len(markets))
+            log.info("lens.candidates", lexical=lexical_n,
+                     close_window=len(markets) - lexical_n)
         else:
             markets = await self._discovery.get_markets(limit=cfg.scan_limit)
         markets = await self._prioritize_known_gaps(markets, cfg)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -611,8 +611,12 @@ resolution_lens:
   # 'resolution_lens_kalshi' (its own graduation cells; can't dilute the proven
   # Poly lens). Pre-registered kill: <5 signals in 2wk or negative paper
   # realized -> flip back to false.
-  kalshi_enabled: true     # spike STARTED 2026-06-25 — 2wk paper measurement
-  kalshi_min_liquidity: 300.0
+  # Spike clock RESTARTED 2026-07-03: the instrument was disconnected until
+  # now (empty descriptions -> rules-text fix; long-dated-only discovery ->
+  # close-window merge; 300 floor vs underreporting bulk liquidity field ->
+  # 50, matching cross_venue). Don't judge the pre-07-03 silence.
+  kalshi_enabled: true
+  kalshi_min_liquidity: 50.0
   min_gap_score: 0.4       # lens-judged headline/criteria divergence floor
   high_conf_gap_score: 0.7 # >= this -> HIGH confidence (clears divergence filter)
   min_edge: 0.08           # |strict fair - market| floor

--- a/config/settings.py
+++ b/config/settings.py
@@ -762,7 +762,12 @@ class ResolutionLensConfig(BaseModel):
     # the hypothesis that Kalshi's CFTC-legalistic resolution criteria carry
     # fine-print mispricing. Kalshi's book is thinner, so it gets its own floor.
     kalshi_enabled: bool = False
-    kalshi_min_liquidity: float = 300.0
+    # Kalshi's bulk liquidity field underreports badly (top-of-book only, often
+    # 0 even on active econ ladders) — 300 starved the spike to zero verdicts
+    # (2026-07-03 funnel: 14/218 candidates cleared it, none also in-window).
+    # 50 matches the cross_venue floor; safe for a paper spike that holds to
+    # resolution, where illiquidity can't block an exit.
+    kalshi_min_liquidity: float = 50.0
 
 
 class GraduationConfig(BaseModel):

--- a/tests/test_resolution_lens.py
+++ b/tests/test_resolution_lens.py
@@ -861,3 +861,69 @@ def test_budget_exhaustion_never_strikes_or_caches():
         assert v is not None and v[1] == 0.8
 
     asyncio.run(run())
+
+
+def test_kalshi_instance_merges_close_window_slice():
+    """Kalshi's generic discovery surfaces mostly ultra-long-dated novelty
+    markets, so the DB-backed lexical scan starves the Kalshi lens (funnel
+    audit: zero candidates passed all gates). When the venue's discovery
+    exposes get_markets_by_close_window, the lens must merge that near-dated
+    tradeable slice (trigger-filtered, deduped) into its scan — and a
+    discovery without the method (Polymarket) stays a no-op."""
+    async def run():
+        from auramaur.strategy.resolution_lens import ResolutionLensPillar
+
+        db = Database(":memory:")
+        await db.connect()
+        settings = _settings()
+        calibration = MagicMock(); calibration.record_prediction = AsyncMock()
+
+        in_window = _market(
+            mid="KXTEST-26AUG-T5", liquidity=350.0, days_out=20.0,
+            question="Will the BLS officially confirm CPI above 5 percent?")
+        in_window.exchange = "kalshi"
+        no_trigger = _market(mid="KXNOPE", liquidity=350.0, days_out=20.0,
+                             question="Higher temperature in NYC?")
+        no_trigger.exchange = "kalshi"
+
+        discovery = MagicMock()
+        discovery.get_markets = AsyncMock(return_value=[])
+        discovery.get_markets_by_close_window = AsyncMock(
+            return_value=[in_window, no_trigger])
+
+        pillar = ResolutionLensPillar(
+            db=db, settings=settings, discovery=discovery,
+            exchange=_exchange(), risk_manager=_risk(),
+            pnl_tracker=PnLTracker(db, settings), calibration=calibration,
+            analyzer=_analyzer(), exchange_name="kalshi",
+            source_tag="resolution_lens_kalshi",
+        )
+        entered = await pillar.run_once()
+
+        # The close-window fetch was used with the lens's resolution window...
+        assert discovery.get_markets_by_close_window.await_count == 1
+        args = discovery.get_markets_by_close_window.await_args
+        assert args.args[1] > args.args[0] > 0  # (min_ts, max_ts) sane
+        # ...the trigger-bearing in-window market traded; the no-trigger one
+        # was filtered before any LLM call.
+        assert entered == 1
+        sig = await db.fetchone(
+            "SELECT market_id FROM signals WHERE strategy_source='resolution_lens_kalshi'")
+        assert sig is not None and sig["market_id"] == "KXTEST-26AUG-T5"
+        row = await db.fetchone(
+            "SELECT 1 FROM lens_verdicts WHERE market_id='KXNOPE'")
+        assert row is None
+
+        # A discovery WITHOUT the method degrades to the plain scan (no-op).
+        class _NoWindow:
+            async def get_markets(self, limit=300):
+                return []
+        poly = ResolutionLensPillar(
+            db=db, settings=settings, discovery=_NoWindow(),
+            exchange=_exchange(), risk_manager=_risk(),
+            pnl_tracker=PnLTracker(db, settings), calibration=calibration,
+            analyzer=_analyzer(),
+        )
+        assert await poly._close_window_candidates() == []
+
+    asyncio.run(run())


### PR DESCRIPTION
The Kalshi lens spike stayed at zero verdicts even after the rules-text fix (#253). Funnel audit: of its trigger-matching candidates in the markets table, almost none fall inside the lens's 12h–90d resolution window, and none also clear the liquidity floor — because the generic /events discovery fills the table with ultra-long-dated novelty markets. Same discovery bias that starved informed_flow (#244).

- The lens now merges a live `get_markets_by_close_window` fetch into its scan when the venue's discovery exposes it (no-op for Polymarket), trigger-filtered and deduped against DB candidates.
- Kalshi lens liquidity floor 300 → 50 (matching cross_venue): the bulk liquidity field is top-of-book only and underreports badly; a paper spike that holds to resolution can't be blocked from exiting by illiquidity.
- The spike's 2-week clock restarts from this fix — the instrument was disconnected until now, so the earlier silence is not evidence.

Tests: close-window merge (trigger filter, dedup, window bounds, no-op without the method). Full suite green (1020), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)