### PR TITLE
fix(lens): verdict cache-write failure is non-fatal + tracebacks on cycle errors

### DIFF
--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -299,7 +299,7 @@ class StrategyTaskMixin:
             try:
                 await pillar.run_once()
             except Exception as e:
-                log.error("lens.cycle_error", error=str(e))
+                log.error("lens.cycle_error", error=str(e), exc_info=True)
             await asyncio.sleep(interval)
 
     async def _task_resolution_lens_kalshi(self) -> None:
@@ -339,7 +339,9 @@ class StrategyTaskMixin:
             try:
                 await pillar.run_once()
             except Exception as e:
-                log.error("lens.kalshi_cycle_error", error=str(e))
+                # exc_info: 'database is locked' with no stack burned an
+                # evening of diagnosis — always capture where a cycle died.
+                log.error("lens.kalshi_cycle_error", error=str(e), exc_info=True)
             await asyncio.sleep(interval)
 
     async def _task_oddlot_tender(self) -> None:

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -274,13 +274,22 @@ class ResolutionLensPillar:
                 return None
             log.warning("lens.verdict_gave_up", market_id=m.id, error=str(e))
             fair, score, mech = m.outcome_yes_price, 0.0, "none"
-        await self._db.execute(
-            """INSERT OR REPLACE INTO lens_verdicts
-               (market_id, fair_prob, gap_score, mechanism, verified)
-               VALUES (?, ?, ?, ?, -1)""",
-            (m.id, fair, score, mech),
-        )
-        await self._db.commit()
+        try:
+            await self._db.execute(
+                """INSERT OR REPLACE INTO lens_verdicts
+                   (market_id, fair_prob, gap_score, mechanism, verified)
+                   VALUES (?, ?, ?, ?, -1)""",
+                (m.id, fair, score, mech),
+            )
+            await self._db.commit()
+        except Exception as e:
+            # A failed CACHE write must not kill the cycle or waste the LLM
+            # call that just succeeded — the verdict is valid right now, it
+            # just won't be cached (recomputed next cycle). Observed:
+            # transient 'database is locked' killed every Kalshi cycle at its
+            # first verdict write (2026-07-03), zeroing the spike.
+            log.warning("lens.verdict_cache_write_failed", market_id=m.id,
+                        error=str(e))
         return fair, score, mech, -1
 
     async def _verify_mechanism(self, m: Market, fair: float, mechanism: str) -> bool:


### PR DESCRIPTION
Every Kalshi lens cycle since #257 died with `database is locked` at its first verdict write — discarding the LLM call that had just succeeded and keeping the spike at zero. A failed **cache** write doesn't invalidate the verdict (it's valid this cycle, just recomputed next time), so the write is now best-effort with a warning. Both lens cycle-error handlers now log full tracebacks so the next lock has a stack instead of a bare string.

Suite green (1020), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)