### PR TITLE
fix(router): re-derive size at the crossed price + absolute-points gate on the cents-cap waiver

### DIFF
--- a/auramaur/broker/router.py
+++ b/auramaur/broker/router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import structlog
 
 from auramaur.exchange.models import (
@@ -57,8 +59,12 @@ class SmartOrderRouter:
         3. BUY entries are taker-or-skip: price at the best ask when the
            realizable edge (edge minus cross cost) clears the minimum-edge
            floor and the ask is within ``entry_max_cross_cents`` of the
-           reference price (the cents cap is waived above 40% edge);
-           otherwise raise :class:`UnmarketableSignal`.
+           reference price (the cents cap is waived above 40% edge, but
+           only when the fair value for the bought token also clears the
+           ask by the minimum-edge floor in absolute points); otherwise
+           raise :class:`UnmarketableSignal`. The token count is re-derived
+           from the dollar intent at the crossed price so the notional
+           can't inflate when the ask sits above the reference.
         4. SELL orders keep the passive path (limit one tick inside the
            book, market-order fallbacks) — exits must get out, and "no
            fill" is not an acceptable outcome for them.
@@ -131,9 +137,23 @@ class SmartOrderRouter:
                     f"{min_edge_pct:.2f}% (ref {base_order.price:.2f}, ask {ask:.2f})"
                 )
             # Cents cap: never chase more than entry_max_cross_cents above
-            # the reference price. Very high edges (>40%) waive the cap —
-            # the proportional floor above still bounds them.
-            if edge_pct <= 40.0 and (ask - base_order.price) > max_cross + 1e-9:
+            # the reference price. Very high edges (>40%) may waive the cap,
+            # but only when the model's fair value for the token being bought
+            # clears the ask by the minimum-edge floor in ABSOLUTE points.
+            # signal.edge is relative to fair value, so on cheap markets a
+            # few points of gap reads as a huge percentage — exactly where
+            # thin books park asks at multiples of fair value; a relative
+            # threshold alone would waive the cap into those asks.
+            fair_token = (
+                signal.claude_prob
+                if base_order.token == TokenType.YES
+                else 1.0 - signal.claude_prob
+            )
+            waive_cents_cap = (
+                edge_pct > 40.0
+                and (fair_token - ask) * 100.0 >= min_edge_pct
+            )
+            if not waive_cents_cap and (ask - base_order.price) > max_cross + 1e-9:
                 raise UnmarketableSignal(
                     f"ask {ask:.2f} is {round((ask - base_order.price) * 100)}c above "
                     f"reference {base_order.price:.2f} (cap {round(max_cross * 100)}c)"
@@ -141,6 +161,35 @@ class SmartOrderRouter:
             crossed_to_ask = True
             order_type = OrderType.LIMIT
             limit_price = max(0.01, min(0.99, round(ask, 2)))
+
+            # The token count was derived at the REFERENCE price; the fill
+            # happens at limit_price. Re-derive it from the original dollar
+            # intent so the notional can't silently inflate by
+            # limit/reference when crossing up (shrink-only: a cheaper fill
+            # keeps the token count and simply spends less). Applied again
+            # after depth-aware sweep pricing, which can lift the limit.
+            intended_dollars = base_order.size * base_order.price
+
+            def _rederived_size(current: float, price: float) -> float:
+                if price <= base_order.price + 1e-9 or price <= 0:
+                    return current
+                resized = round(intended_dollars / price, 2)
+                # Venue minimums (5 tokens / $1 notional), same floor as
+                # prepare_order; the bump never exceeds the pre-cross size.
+                resized = max(resized, max(5.0, math.ceil(100.0 / price) / 100))
+                return min(current, resized)
+
+            new_size = _rederived_size(base_order.size, limit_price)
+            if new_size < base_order.size - 1e-9:
+                log.info(
+                    "router.size_rederived_at_cross",
+                    market_id=market.id,
+                    reference=base_order.price,
+                    limit_price=limit_price,
+                    original_size=round(base_order.size, 2),
+                    resized=round(new_size, 2),
+                )
+                base_order = base_order.model_copy(update={"size": new_size})
 
             # Depth-aware sizing: the gate above only proved the BEST ask clears
             # the floor. For the FULL size we walk the asks up to the slippage
@@ -159,8 +208,8 @@ class SmartOrderRouter:
                 # Highest price that still leaves >= min_edge after slippage.
                 edge_budget_pts = max(0.0, edge_pct - min_edge_pct)
                 price_cap = base_order.price + edge_budget_pts / 100.0
-                # Honor the cents cap too (waived above 40% edge, mirroring above).
-                if edge_pct <= 40.0:
+                # Honor the cents cap too (same waiver as above).
+                if not waive_cents_cap:
                     price_cap = min(price_cap, base_order.price + max_cross)
                 price_cap = max(price_cap, ask)  # always at least take the best ask
                 price_cap = min(0.99, price_cap)
@@ -192,6 +241,11 @@ class SmartOrderRouter:
                 # matching means the effective fill is the VWAP (<= the limit).
                 if sweep_price > 0:
                     limit_price = max(0.01, min(0.99, round(sweep_price, 2)))
+                    # Sweep pricing can lift the limit past the best ask —
+                    # re-derive the size at the price we will actually pay.
+                    resized = _rederived_size(base_order.size, limit_price)
+                    if resized < base_order.size - 1e-9:
+                        base_order = base_order.model_copy(update={"size": resized})
                 cross_cost_pts = (vwap - base_order.price) * 100.0 if vwap else cross_cost_pts
                 realizable_edge = edge_pct - cross_cost_pts
 

--- a/tests/test_router_crossing.py
+++ b/tests/test_router_crossing.py
@@ -42,7 +42,8 @@ def _settings(max_cross_cents: int = 4, min_edge_pct: float = 2.5) -> MagicMock:
 
 
 def _router(book: OrderBook, base_price: float, settings=None,
-            side: OrderSide = OrderSide.BUY) -> SmartOrderRouter:
+            side: OrderSide = OrderSide.BUY,
+            token: TokenType = TokenType.YES) -> SmartOrderRouter:
     exchange = MagicMock()
     exchange.prepare_order = MagicMock(
         return_value=Order(
@@ -50,7 +51,7 @@ def _router(book: OrderBook, base_price: float, settings=None,
             exchange="polymarket",
             token_id="tok",
             side=side,
-            token=TokenType.YES,
+            token=token,
             size=10.0,
             price=base_price,
             dry_run=True,
@@ -60,12 +61,12 @@ def _router(book: OrderBook, base_price: float, settings=None,
     return SmartOrderRouter(settings if settings is not None else _settings(), exchange)
 
 
-def _signal(edge: float) -> Signal:
+def _signal(edge: float, claude_prob: float = 0.6, market_prob: float = 0.45) -> Signal:
     return Signal(
         market_id="m1",
-        claude_prob=0.6,
+        claude_prob=claude_prob,
         claude_confidence="HIGH",
-        market_prob=0.45,
+        market_prob=market_prob,
         edge=edge,
     )
 
@@ -172,8 +173,12 @@ async def test_depth_sweep_prices_at_marginal_level():
                            settings=_depth_settings(max_cross_cents=10, cap_frac=1.0, min_fill=0.5))
     order = await router.route(_signal(edge=12.0), Market(id="m1", question="Q?"), 40.0, False)
     assert order is not None
-    assert order.size == 40.0          # capacity ample (cap_frac 1.0)
     assert order.price == 0.55         # marginal sweep level, not the 0.50 ask
+    # Size is re-derived from the dollar intent (40 tokens * 0.49 reference)
+    # at each price lift: 19.6 / 0.50 = 39.2 at the ask, then 19.6 / 0.55 =
+    # 35.64 at the sweep price — the notional stays at the intent instead of
+    # inflating with the limit.
+    assert order.size == 35.64
 
 
 @pytest.mark.asyncio
@@ -186,6 +191,7 @@ async def test_takes_price_improvement_when_ask_below_reference():
     assert order.order_type == OrderType.LIMIT
     assert order.price == 0.20
     assert order.post_only is False
+    assert order.size == 10.0  # cheaper fill keeps the token count (shrink-only)
 
 
 @pytest.mark.asyncio
@@ -209,6 +215,59 @@ async def test_high_urgency_still_skips_below_floor():
     router = _router(_book(0.10, 0.90), base_price=0.20)
     with pytest.raises(UnmarketableSignal, match="edge at the ask"):
         await router.route(_signal(edge=42.5), Market(id="m1", question="Q?"), 10.0, False)
+
+
+@pytest.mark.asyncio
+async def test_waiver_needs_absolute_edge_at_the_ask():
+    """signal.edge is RELATIVE to fair value, so a few points of gap on a
+    cheap market reads as a huge percentage — the old >40% waiver then let
+    the router pay a dead-book ask at a multiple of fair value. The waiver
+    must also require fair value to clear the ASK by the min-edge floor in
+    absolute points: fair 0.13 vs ask 0.42 fails that, so the cents cap
+    holds and the entry is skipped."""
+    router = _router(_book(0.05, 0.42), base_price=0.08)
+    with pytest.raises(UnmarketableSignal, match="above"):
+        await router.route(
+            _signal(edge=47.0, claude_prob=0.13, market_prob=0.08),
+            Market(id="m1", question="Q?"), 10.0, False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_waiver_holds_when_fair_clears_ask():
+    """A genuine high-conviction entry still waives the cents cap: fair 0.90
+    clears the 0.50 ask by far more than the floor. The size is re-derived
+    at the crossed price (10 tokens * 0.40 ref = $4 intent -> 8 at 0.50)."""
+    router = _router(_book(0.40, 0.50), base_price=0.40)
+    order = await router.route(
+        _signal(edge=55.0, claude_prob=0.90), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.price == 0.50
+    assert order.size == 8.0
+
+
+@pytest.mark.asyncio
+async def test_waiver_uses_no_token_fair_value():
+    """When the bought token is NO, the waiver measures fair = 1 - claude_prob
+    against the NO ask."""
+    router = _router(_book(0.40, 0.50), base_price=0.40, token=TokenType.NO)
+    order = await router.route(
+        _signal(edge=55.0, claude_prob=0.10), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.price == 0.50
+    assert order.size == 8.0
+
+
+@pytest.mark.asyncio
+async def test_cross_rederives_size_from_dollar_intent():
+    """Crossing up re-derives the token count from the dollar intent at the
+    limit price: 10 tokens sized at 0.22 ($2.20) become 9.17 at the 0.24 ask
+    instead of 10 tokens costing $2.40."""
+    router = _router(_book(0.20, 0.24), base_price=0.22)
+    order = await router.route(_signal(edge=10.0), Market(id="m1", question="Q?"), 10.0, False)
+    assert order is not None
+    assert order.price == 0.24
+    assert order.size == 9.17
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A BUY entry could cross into a thin book far above its sizing price at an inflated notional. Two stacked holes:

1. **Size was never re-derived after crossing.** `prepare_order` computes the token count at the reference price; the router then updates `order.price` to the best ask (or the depth-aware sweep price) but keeps the count, so the actual notional inflates by `limit/reference`. On a post-crash dead book the ask can sit at a multiple of the reference, turning a capped-dollar intent into a multiple of it in a single order.

2. **The cents-cap waiver used relative edge.** `entry_max_cross_cents` was waived when `edge > 40%`, but `signal.edge` is relative to fair value — on cheap markets a small absolute gap reads as a huge percentage, which is exactly where dead books live. The waiver could therefore authorize paying an ask far above the model's own fair value.

The #212 gateway stake cap bounds the blast radius of (1) since it checks the crossed notional, but sub-cap inflation was still live.

## Fix

- After crossing (and again after depth-aware sweep pricing lifts the limit), re-derive the token count from the original dollar intent at the price actually paid. Shrink-only: a cheaper fill keeps the count and simply spends less. Venue minimums (5 tokens / $1 notional) are re-applied with the same floor as `prepare_order`.
- The >40% waiver now also requires the fair value of the **bought token** (`claude_prob`, or `1 - claude_prob` for NO) to clear the **ask** by `risk.min_edge_pct` in absolute points. The depth-aware `price_cap` honors the same waiver flag instead of duplicating the old condition.

## Tests

- New: waiver denied when fair value doesn't clear the ask (the incident shape); waiver granted on genuine high-conviction entries (YES and NO token fair-value branches); size re-derivation at the ask; shrink-only on price improvement.
- Updated: depth-sweep test expectations now reflect dollar-intent sizing at each price lift.
- Full suite: 1024 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)