### PR TITLE
fix(edge): Signal.edge contract (absolute points) + router edge-basis clamp + relative-edge producer fix

### DIFF
--- a/auramaur/broker/router.py
+++ b/auramaur/broker/router.py
@@ -129,6 +129,22 @@ class SmartOrderRouter:
                     f"no asks on the book for {market.id} — dead or one-sided market"
                 )
             ask = book.best_ask
+            # Signal.edge is documented as ABSOLUTE points (see the model),
+            # so subtracting crossing costs in points below is sound — but a
+            # producer that slips back to a relative figure would inflate the
+            # budget exactly on cheap markets where thin books park asks at
+            # multiples of fair value. Clamp the edge basis to the gap the
+            # signal's own fair value implies for the token being bought; for
+            # conforming producers the fair-implied gap is >= the (fee-
+            # adjusted) edge, so this is a no-op.
+            fair_token = (
+                signal.claude_prob
+                if base_order.token == TokenType.YES
+                else 1.0 - signal.claude_prob
+            )
+            edge_pct = min(
+                edge_pct, max(0.0, (fair_token - base_order.price) * 100.0)
+            )
             cross_cost_pts = (ask - base_order.price) * 100.0
             realizable_edge = edge_pct - cross_cost_pts
             if realizable_edge < min_edge_pct:
@@ -137,18 +153,9 @@ class SmartOrderRouter:
                     f"{min_edge_pct:.2f}% (ref {base_order.price:.2f}, ask {ask:.2f})"
                 )
             # Cents cap: never chase more than entry_max_cross_cents above
-            # the reference price. Very high edges (>40%) may waive the cap,
-            # but only when the model's fair value for the token being bought
-            # clears the ask by the minimum-edge floor in ABSOLUTE points.
-            # signal.edge is relative to fair value, so on cheap markets a
-            # few points of gap reads as a huge percentage — exactly where
-            # thin books park asks at multiples of fair value; a relative
-            # threshold alone would waive the cap into those asks.
-            fair_token = (
-                signal.claude_prob
-                if base_order.token == TokenType.YES
-                else 1.0 - signal.claude_prob
-            )
+            # the reference price. Very high edges (>40 points) may waive the
+            # cap, but only when fair value for the token being bought also
+            # clears the ASK itself by the minimum-edge floor.
             waive_cents_cap = (
                 edge_pct > 40.0
                 and (fair_token - ask) * 100.0 >= min_edge_pct

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -337,6 +337,13 @@ class Signal(BaseModel):
     claude_prob: float
     claude_confidence: Confidence
     market_prob: float
+    # Edge contract: ABSOLUTE percentage points between fair value and the
+    # market price (fee-adjusted where the producer knows the fee), i.e.
+    # roughly (claude_prob - market_prob) * 100. NOT relative to fair value:
+    # the router subtracts crossing costs in points from this number, and a
+    # relative figure on a cheap market reads as a huge edge exactly where
+    # thin books park asks at multiples of fair value. The router also clamps
+    # this against the fair-implied gap as a backstop.
     edge: float
     second_opinion_prob: float | None = None
     divergence: float | None = None

--- a/auramaur/strategy/technical.py
+++ b/auramaur/strategy/technical.py
@@ -79,7 +79,11 @@ class TechnicalAnalyzer:
 
         # Oversold (Price < Mean) -> Buy YES
         if deviation < -self.mean_rev_threshold:
-            edge = abs(deviation) * 100
+            # deviation (relative to the mean) is the TRIGGER; the emitted
+            # edge follows the Signal.edge contract: absolute points between
+            # fair value (the mean) and the current price. A relative figure
+            # here overstated the edge on cheap markets by 1/price.
+            edge = abs(avg_price - current_price) * 100
             return Signal(
                 market_id=market.id,
                 market_question=market.question,
@@ -95,7 +99,7 @@ class TechnicalAnalyzer:
 
         # Overbought (Price > Mean) -> Buy NO (Sell YES)
         if deviation > self.mean_rev_threshold:
-            edge = deviation * 100
+            edge = abs(current_price - avg_price) * 100
             return Signal(
                 market_id=market.id,
                 market_question=market.question,
@@ -125,11 +129,15 @@ class TechnicalAnalyzer:
         if total_move >= (self.min_move_pct / 100.0):
             # Check if trend is consistent (last 3 points are increasing)
             if history[-1] > history[-2] > history[-3]:
-                edge = total_move * 100
+                # total_move (relative) is the TRIGGER; the emitted edge is
+                # absolute points to the continuation target (Signal.edge
+                # contract).
+                fair = min(0.99, current_price + 0.05)  # Expect continuation
+                edge = (fair - current_price) * 100
                 return Signal(
                     market_id=market.id,
                     market_question=market.question,
-                    claude_prob=min(0.99, current_price + 0.05),  # Expect continuation
+                    claude_prob=fair,
                     claude_confidence=Confidence.LOW,
                     market_prob=current_price,
                     edge=edge,
@@ -143,11 +151,12 @@ class TechnicalAnalyzer:
         if total_move <= -(self.min_move_pct / 100.0):
             # Check if trend is consistent (last 3 points are decreasing)
             if history[-1] < history[-2] < history[-3]:
-                edge = abs(total_move) * 100
+                fair = max(0.01, current_price - 0.05)
+                edge = (current_price - fair) * 100
                 return Signal(
                     market_id=market.id,
                     market_question=market.question,
-                    claude_prob=max(0.01, current_price - 0.05),
+                    claude_prob=fair,
                     claude_confidence=Confidence.LOW,
                     market_prob=current_price,
                     edge=edge,

--- a/tests/test_router_crossing.py
+++ b/tests/test_router_crossing.py
@@ -198,9 +198,12 @@ async def test_takes_price_improvement_when_ask_below_reference():
 async def test_high_urgency_prices_at_real_ask():
     """edge > 40 used to submit at the stale reference price, which just
     rested on the book until the TTL reaper killed it. It must price at the
-    actual ask to be marketable (cents cap waived above 40% edge)."""
+    actual ask to be marketable (cents cap waived above 40 points of edge,
+    with fair value clearing the ask). The signal is coherent: fair 0.95 vs
+    reference 0.40 implies the 55-point edge it claims."""
     router = _router(_book(0.40, 0.55), base_price=0.40)
-    order = await router.route(_signal(edge=56.8), Market(id="m1", question="Q?"), 10.0, False)
+    order = await router.route(
+        _signal(edge=55.0, claude_prob=0.95), Market(id="m1", question="Q?"), 10.0, False)
     assert order is not None
     assert order.order_type == OrderType.LIMIT
     assert order.price == 0.55
@@ -218,15 +221,15 @@ async def test_high_urgency_still_skips_below_floor():
 
 
 @pytest.mark.asyncio
-async def test_waiver_needs_absolute_edge_at_the_ask():
-    """signal.edge is RELATIVE to fair value, so a few points of gap on a
-    cheap market reads as a huge percentage — the old >40% waiver then let
-    the router pay a dead-book ask at a multiple of fair value. The waiver
-    must also require fair value to clear the ASK by the min-edge floor in
-    absolute points: fair 0.13 vs ask 0.42 fails that, so the cents cap
-    holds and the entry is skipped."""
+async def test_relative_edge_clamped_to_fair_implied_gap():
+    """A producer that emits a RELATIVE edge (a few points of gap on a cheap
+    market reads as a huge percentage) used to both clear the floor and waive
+    the cents cap, letting the router pay a dead-book ask at a multiple of
+    fair value. The edge basis is now clamped to the gap the signal's own
+    fair value implies (fair 0.13 vs reference 0.08 = 5 points, not 47), so
+    crossing to a 0.42 ask fails the min-edge floor outright."""
     router = _router(_book(0.05, 0.42), base_price=0.08)
-    with pytest.raises(UnmarketableSignal, match="above"):
+    with pytest.raises(UnmarketableSignal, match="edge at the ask"):
         await router.route(
             _signal(edge=47.0, claude_prob=0.13, market_prob=0.08),
             Market(id="m1", question="Q?"), 10.0, False,


### PR DESCRIPTION
## Problem

Follow-up to #259. `realizable_edge = signal.edge - cross_cost_pts` mixes units *if* a producer emits a relative edge. Auditing the producers: the llm cycle, agent analyzer, entailment, bias harvest and the arb paths all emit **absolute points** (`(fair − market) × 100`, fee-adjusted where the producer knows the fee) — so the subtraction was sound for them — but the contract was never written down, and `technical.py` emitted a **relative** deviation. On cheap markets a relative figure reads as a huge edge exactly where thin books park asks at multiples of fair value, letting an entry both clear the min-edge floor and (pre-#259) waive the cents cap.

## Fix

- **Contract**: `Signal.edge` is now documented on the model as absolute percentage points.
- **Backstop in the router**: the edge basis is clamped to the gap implied by the signal's own fair value for the bought token (`claude_prob`, or `1 − claude_prob` for NO) over the reference price. For conforming producers this is a no-op (fair-implied gap ≥ fee-adjusted edge). A rogue relative edge can no longer clear the floor or reach the >40 waiver past what fair value supports; incoherent signals (fair below reference on a BUY) clamp to zero and skip.
- **Producer fix**: `technical.py` (disabled in config) now emits absolute-point edges; the relative deviation/move stays as the trigger condition only.

## Tests

- `test_relative_edge_clamped_to_fair_implied_gap` (replaces the #259 waiver-denial test — the clamp now blocks the same shape one gate earlier, at the min-edge floor).
- High-urgency waiver test updated to a coherent signal (fair implies the claimed edge).
- Full suite: 1024 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)