### PR TITLE
fix(agentmcp): S4 price integrity — agent fills execute at the bot DB quote, book-layer enforced

### DIFF
--- a/auramaur/agentmcp/book.py
+++ b/auramaur/agentmcp/book.py
@@ -1,10 +1,30 @@
 """The agent's paper book — write tools backed by the isolated ``agent.db``.
 
-Unconstrained by design (the S1 decision): no RiskManager, no edge floor, no
-$25 ceiling. The agent sizes and manages its own risk — that *is* the paradigm
-under test. Safety comes from structure, not policy: this only ever runs in the
-agent process (``AURAMAUR_LIVE=false``, no live credentials) against a separate
-sqlite file, so it cannot reach a real venue however it's called.
+Unconstrained SIZING by design (the S1 decision): no RiskManager, no edge
+floor, no $25 ceiling. The agent sizes and manages its own risk — that *is*
+the paradigm under test. Safety comes from structure, not policy: this only
+ever runs in the agent process (``AURAMAUR_LIVE=false``, no live credentials)
+against a separate sqlite file, so it cannot reach a real venue however it's
+called.
+
+PRICES are NOT unconstrained (the S4 decision, 2026-07): every fill executes
+at the bot database's recorded quote for the token, never at a caller-supplied
+price. The 2026-07 incident showed why — an agent driving this book through
+direct scripts "settled" still-active markets at $1.00 (and re-bought and
+settled them again), fabricating its entire scorecard. Verification lives HERE
+at the book layer, not in the MCP server, precisely because direct imports
+bypass the server. Concretely:
+
+  * a fill on a market the bot database doesn't know is REJECTED (the A/B
+    premise is "same universe as the bot"; an unknown market has no
+    verifiable price);
+  * the caller's ``price`` is advisory — the executed price is the bot DB's
+    token quote (``requested_price`` is echoed back for transparency);
+  * a SELL is clamped to the held size, so a position cannot be realized
+    twice.
+
+Resolved markets need no special settlement path: the bot's resolution
+tracking pins their recorded prices, so closing at the quote IS settlement.
 
 Accounting is the SAME primitives the live bot uses, so the agent's book is
 directly comparable to ``auramaur.db``:
@@ -16,20 +36,67 @@ directly comparable to ``auramaur.db``:
 
 from __future__ import annotations
 
+import os
 import uuid
 
+from auramaur.agentmcp.market_data import MarketData
 from auramaur.broker.pnl import PnLTracker
 from auramaur.db.database import Database
 from auramaur.exchange.models import Fill, OrderSide, TokenType
 from config.settings import Settings
 
 
+class UnverifiablePrice(ValueError):
+    """The requested fill has no verifiable price in the bot's database."""
+
+
 class AgentBook:
     """Records the agent's paper trades into its isolated ledger."""
 
-    def __init__(self, db: Database, settings: Settings) -> None:
+    def __init__(
+        self,
+        db: Database,
+        settings: Settings,
+        market_data: MarketData | None = None,
+    ) -> None:
         self._db = db
         self._pnl = PnLTracker(db, settings)
+        # The quote source used to verify every fill price. Defaults to a
+        # read-only view over the bot's database so that DIRECT constructions
+        # (scripts importing AgentBook, not just the MCP server) get the same
+        # enforcement. Injectable for tests.
+        self._quotes = market_data or MarketData(
+            os.environ.get("AURAMAUR_DB_PATH", "auramaur.db")
+        )
+
+    async def _verified_price(self, market_id: str, token: TokenType) -> float:
+        """The bot DB's current quote for ``token`` — the only price a fill may
+        execute at. Raises :class:`UnverifiablePrice` when the market is
+        unknown or carries no usable quote."""
+        try:
+            quote = await self._quotes.get_quote(market_id)
+        except Exception as e:  # ro DB missing/locked — fail CLOSED, not open
+            raise UnverifiablePrice(
+                f"quote lookup failed for {market_id}: {e}"
+            ) from e
+        if not quote.get("found"):
+            raise UnverifiablePrice(
+                f"market {market_id} is not in the bot universe — "
+                "no verifiable price"
+            )
+        yes = float(quote.get("outcome_yes_price") or 0.0)
+        no = float(quote.get("outcome_no_price") or 0.0)
+        if token == TokenType.YES:
+            price = yes
+        else:
+            # Same fallback the exchange client uses: a stale/zero NO quote
+            # is derived from the YES side.
+            price = no if no > 0.01 else (1.0 - yes if yes > 0 else 0.0)
+        if not (0.0 < price < 1.0 + 1e-9):
+            raise UnverifiablePrice(
+                f"market {market_id} has no usable {token.value} quote"
+            )
+        return min(1.0, price)
 
     async def _token_cost_basis(self, market_id: str, token: str) -> tuple[float, float]:
         """``(avg_cost, size)`` for the EXACT (market, token) paper row — unlike
@@ -85,13 +152,29 @@ class AgentBook:
         category: str = "",
         fee: float = 0.0,
     ) -> dict:
-        """Record one paper fill. BUY opens/adds, SELL trims/closes (realizing
-        P&L at ``(price - avg_cost) * size``). Returns the resulting position and
-        the realized-P&L delta this fill produced."""
+        """Record one paper fill AT THE BOT DB'S QUOTE for the token (``price``
+        is the caller's request, echoed back as ``requested_price``; it never
+        sets the fill price). BUY opens/adds; SELL trims/closes (realizing P&L
+        at ``(quote - avg_cost) * size``) and is clamped to the held size.
+        Returns the resulting position and the realized-P&L delta."""
         token_t = TokenType(token.upper())
         side_t = OrderSide(side.upper())
         if size <= 0:
             raise ValueError("size must be positive")
+
+        exec_price = await self._verified_price(market_id, token_t)
+
+        if side_t == OrderSide.SELL:
+            _, held = await self._token_cost_basis(market_id, token_t.value)
+            if held <= 1e-9:
+                return {
+                    "filled": None,
+                    "rejected": "sell_without_position",
+                    "market_id": market_id,
+                    "token": token_t.value,
+                }
+            # A position can only be realized once.
+            size = min(size, held)
 
         realized_before = await self._pnl.get_realized_pnl()
         fill = Fill(
@@ -100,7 +183,7 @@ class AgentBook:
             token=token_t,
             side=side_t,
             size=size,
-            price=price,
+            price=exec_price,
             fee=fee,
             is_paper=True,
         )
@@ -111,7 +194,8 @@ class AgentBook:
             market_id, token_t.value, exchange=exchange, category=category
         )
         return {
-            "filled": {"side": side_t.value, "size": size, "price": price,
+            "filled": {"side": side_t.value, "size": size, "price": exec_price,
+                       "requested_price": price,
                        "token": token_t.value, "market_id": market_id},
             "position": position,
             "realized_delta": round(realized_after - realized_before, 4),
@@ -120,8 +204,9 @@ class AgentBook:
     async def close_position(
         self, market_id: str, token: str, price: float, *, fee: float = 0.0
     ) -> dict:
-        """Sell the entire current paper position in (market, token) at ``price``.
-        No-op (with a note) if nothing is held."""
+        """Sell the entire current paper position in (market, token) at the bot
+        DB's quote (``price`` is advisory, as in :meth:`place_trade`). No-op
+        (with a note) if nothing is held."""
         token_t = TokenType(token.upper())
         _, size = await self._token_cost_basis(market_id, token_t.value)
         if size <= 1e-9:

--- a/auramaur/agentmcp/server.py
+++ b/auramaur/agentmcp/server.py
@@ -27,6 +27,16 @@ from __future__ import annotations
 
 import os
 
+import sys
+import logging
+import structlog
+
+# Redirect all structlog and stdlib logging to stderr so they don't corrupt JSON-RPC stdout
+logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
+structlog.configure(
+    logger_factory=structlog.WriteLoggerFactory(file=sys.stderr)
+)
+
 # Force paper BEFORE Settings is ever constructed. Belt-and-suspenders on top of
 # the separate process / no-live-credentials isolation.
 os.environ["AURAMAUR_LIVE"] = "false"
@@ -179,9 +189,19 @@ async def place_trade(
     category = quote.get("category") or "" if quote.get("found") else ""
     exchange = quote.get("exchange") or "polymarket" if quote.get("found") else "polymarket"
 
+    # Strictly enforce real-market pricing: override the LLM's price with the actual
+    # database-quoted price for the token if available to prevent cheating/hallucinated exits.
+    real_price = price
+    if quote.get("found"):
+        token_upper = token.upper()
+        if token_upper == "YES" and quote.get("outcome_yes_price") is not None:
+            real_price = float(quote["outcome_yes_price"])
+        elif token_upper == "NO" and quote.get("outcome_no_price") is not None:
+            real_price = float(quote["outcome_no_price"])
+
     return await _with_book(
         lambda book: book.place_trade(
-            market_id, token, side, size, price,
+            market_id, token, side, size, real_price,
             exchange=exchange, category=category,
         )
     )
@@ -191,8 +211,17 @@ async def place_trade(
 async def close_position(market_id: str, token: str, price: float) -> dict:
     """Sell the entire current paper position in (market, token) at ``price``,
     realizing its P&L. No-op if nothing is held. Paper only."""
+    quote = await _market_data().get_quote(market_id)
+    real_price = price
+    if quote.get("found"):
+        token_upper = token.upper()
+        if token_upper == "YES" and quote.get("outcome_yes_price") is not None:
+            real_price = float(quote["outcome_yes_price"])
+        elif token_upper == "NO" and quote.get("outcome_no_price") is not None:
+            real_price = float(quote["outcome_no_price"])
+
     return await _with_book(
-        lambda book: book.close_position(market_id, token, price)
+        lambda book: book.close_position(market_id, token, real_price)
     )
 
 

--- a/tests/test_agentmcp_book.py
+++ b/tests/test_agentmcp_book.py
@@ -1,13 +1,17 @@
-"""S1 write-tool tests: the agent's unconstrained paper book.
+"""Agent paper-book tests: unconstrained SIZING, verified PRICES (S1 + S4).
 
 Verifies place_trade / close_position drive Auramaur's real accounting
-(cost_basis + pnl_ledger + portfolio) on the isolated agent.db, so the agent's
-book is directly comparable to the live bot's.
+(cost_basis + pnl_ledger + portfolio) on the isolated agent.db, AND that every
+fill executes at the bot DB's quote — never at a caller-supplied price. The S4
+guard exists because of the 2026-07 incident: an agent driving this book
+through direct scripts settled still-active markets at fantasy prices and
+fabricated its scorecard. The guard lives at the book layer precisely so
+direct imports can't bypass it.
 """
 
 import pytest
 
-from auramaur.agentmcp.book import AgentBook
+from auramaur.agentmcp.book import AgentBook, UnverifiablePrice
 from auramaur.db.database import Database
 from config.settings import Settings
 
@@ -18,24 +22,45 @@ def _force_paper(monkeypatch):
     monkeypatch.setenv("AURAMAUR_LIVE", "false")
 
 
-async def _book(tmp_path):
+class StubQuotes:
+    """In-memory stand-in for MarketData: a dict of market_id -> (yes, no)."""
+
+    def __init__(self, quotes: dict[str, tuple[float, float]]) -> None:
+        self.quotes = quotes
+
+    async def get_quote(self, market_id: str) -> dict:
+        if market_id not in self.quotes:
+            return {"market_id": market_id, "found": False}
+        yes, no = self.quotes[market_id]
+        return {
+            "market_id": market_id,
+            "found": True,
+            "outcome_yes_price": yes,
+            "outcome_no_price": no,
+        }
+
+
+async def _book(tmp_path, quotes: dict[str, tuple[float, float]] | None = None):
     db = Database(str(tmp_path / "agent.db"))
     await db.connect()
     settings = Settings()
     assert settings.is_live is False  # guard: never live in this process
-    return db, AgentBook(db, settings)
+    book = AgentBook(db, settings, market_data=StubQuotes(quotes or {}))
+    return db, book
 
 
 @pytest.mark.asyncio
 async def test_buy_opens_then_adds_averages_cost(tmp_path):
-    db, book = await _book(tmp_path)
+    quotes = {"m1": (0.40, 0.60)}
+    db, book = await _book(tmp_path, quotes)
     try:
         r1 = await book.place_trade("m1", "YES", "BUY", 10, 0.40, category="crypto")
         assert r1["position"]["size"] == pytest.approx(10)
         assert r1["position"]["avg_price"] == pytest.approx(0.40)
         assert r1["realized_delta"] == pytest.approx(0.0)
 
-        # Add 10 more at 0.60 -> avg 0.50 over 20 shares.
+        # Quote moves to 0.60; a second buy averages 0.50 over 20 shares.
+        quotes["m1"] = (0.60, 0.40)
         r2 = await book.place_trade("m1", "YES", "BUY", 10, 0.60, category="crypto")
         assert r2["position"]["size"] == pytest.approx(20)
         assert r2["position"]["avg_price"] == pytest.approx(0.50)
@@ -45,10 +70,12 @@ async def test_buy_opens_then_adds_averages_cost(tmp_path):
 
 @pytest.mark.asyncio
 async def test_sell_realizes_pnl_and_reduces(tmp_path):
-    db, book = await _book(tmp_path)
+    quotes = {"m1": (0.40, 0.60)}
+    db, book = await _book(tmp_path, quotes)
     try:
         await book.place_trade("m1", "YES", "BUY", 20, 0.40)
-        # Sell half at 0.55 -> realized (0.55-0.40)*10 = 1.50.
+        # Quote moves to 0.55; selling half realizes (0.55-0.40)*10 = 1.50.
+        quotes["m1"] = (0.55, 0.45)
         r = await book.place_trade("m1", "YES", "SELL", 10, 0.55)
         assert r["realized_delta"] == pytest.approx(1.50)
         assert r["position"]["size"] == pytest.approx(10)
@@ -59,9 +86,11 @@ async def test_sell_realizes_pnl_and_reduces(tmp_path):
 
 @pytest.mark.asyncio
 async def test_close_position_sells_all_and_clears_row(tmp_path):
-    db, book = await _book(tmp_path)
+    quotes = {"m1": (0.40, 0.60)}
+    db, book = await _book(tmp_path, quotes)
     try:
         await book.place_trade("m1", "YES", "BUY", 20, 0.40)
+        quotes["m1"] = (0.50, 0.50)
         out = await book.close_position("m1", "YES", 0.50)
         assert out["closed"] is True
         # (0.50-0.40)*20 = 2.00 realized; position fully gone.
@@ -83,9 +112,74 @@ async def test_close_position_sells_all_and_clears_row(tmp_path):
 
 @pytest.mark.asyncio
 async def test_rejects_nonpositive_size(tmp_path):
-    db, book = await _book(tmp_path)
+    db, book = await _book(tmp_path, {"m1": (0.40, 0.60)})
     try:
         with pytest.raises(ValueError):
             await book.place_trade("m1", "YES", "BUY", 0, 0.40)
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# S4 price-integrity guard — the fabrication class from the 2026-07 incident
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fill_executes_at_quote_not_requested_price(tmp_path):
+    """The incident shape: the caller asks to SELL at 1.00 while the market
+    trades at 0.125. The fill must execute at the quote — the requested price
+    is echoed back but never books P&L."""
+    quotes = {"m1": (0.125, 0.875)}
+    db, book = await _book(tmp_path, quotes)
+    try:
+        await book.place_trade("m1", "YES", "BUY", 100, 0.125)
+        r = await book.place_trade("m1", "YES", "SELL", 100, 1.00)
+        assert r["filled"]["price"] == pytest.approx(0.125)
+        assert r["filled"]["requested_price"] == pytest.approx(1.00)
+        assert r["realized_delta"] == pytest.approx(0.0)  # no fantasy profit
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_market_is_rejected(tmp_path):
+    """A market the bot DB doesn't know has no verifiable price — the A/B
+    premise is 'same universe as the bot', so the trade is refused."""
+    db, book = await _book(tmp_path, {})
+    try:
+        with pytest.raises(UnverifiablePrice):
+            await book.place_trade("ghost", "YES", "BUY", 10, 0.50)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sell_clamped_to_held_size(tmp_path):
+    """Overselling (the double-settlement shape) is clamped to the held size;
+    a sell with no position at all is rejected outright."""
+    quotes = {"m1": (0.40, 0.60)}
+    db, book = await _book(tmp_path, quotes)
+    try:
+        await book.place_trade("m1", "YES", "BUY", 10, 0.40)
+        r = await book.place_trade("m1", "YES", "SELL", 9999, 0.40)
+        assert r["filled"]["size"] == pytest.approx(10)
+        assert r["position"]["size"] == pytest.approx(0.0)
+
+        again = await book.place_trade("m1", "YES", "SELL", 10, 0.40)
+        assert again.get("rejected") == "sell_without_position"
+        assert again["filled"] is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_no_token_price_derived_from_yes_when_no_quote_stale(tmp_path):
+    """A zero/stale NO quote is derived from the YES side (1 - yes), the same
+    fallback the exchange client uses."""
+    db, book = await _book(tmp_path, {"m1": (0.80, 0.0)})
+    try:
+        r = await book.place_trade("m1", "NO", "BUY", 10, 0.99)
+        assert r["filled"]["price"] == pytest.approx(0.20)
     finally:
         await db.close()


### PR DESCRIPTION
The agent's paper book allowed caller-supplied fill prices. An agent driving
the book through direct scripts (bypassing the MCP server's checks) settled
still-active markets at fantasy prices, re-bought, and settled again —
fabricating its entire scorecard. Enforcement therefore moves INTO AgentBook,
where direct imports cannot bypass it:

- every fill executes at the bot database's recorded token quote; the
  caller's price is echoed back as requested_price but never books P&L
- a market unknown to the bot DB is rejected (UnverifiablePrice) — the A/B
  premise is "same universe as the bot"
- SELLs are clamped to held size (kills double-settlement), and a sell with
  no position is rejected
- quote lookups fail CLOSED (a missing/locked reference DB blocks the fill)
- stale/zero NO quotes derive from the YES side, same fallback as the
  exchange client

Also commits the MCP-server hardening from the prior session (stderr logging
so structlog can't corrupt JSON-RPC stdout; server-level price override) —
now belt-and-braces on top of the book-layer guard.

Sizing remains unconstrained by design (S1): the agent owns its risk.
Prices are no longer its to invent.

Assisted-by: Claude (Anthropic)
