### PR TITLE
feat(strategy): agent_trader pillar — multi-model LLM day-trader, one attribution cell per model

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1388,6 +1388,10 @@ class AuramaurBot(
         if self.settings.long_horizon.enabled:
             tasks.append(asyncio.create_task(self._task_long_horizon(), name="long_horizon"))
 
+        # Multi-model LLM day-trader (paper-forced; intelligence-cap A/B)
+        if self.settings.agent_trader.enabled:
+            tasks.append(asyncio.create_task(self._task_agent_trader(), name="agent_trader"))
+
         # Informed-flow follower over Kalshi (paper-forced; abnormal-trade-size)
         if self.settings.informed_flow.enabled:
             tasks.append(asyncio.create_task(self._task_informed_flow(), name="informed_flow"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -66,6 +66,30 @@ class StrategyTaskMixin:
                 log.error("long_horizon.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_agent_trader(self) -> None:
+        """Periodic multi-model LLM day-trader (paper-forced; the
+        intelligence-cap A/B — one attribution cell per model)."""
+        from auramaur.strategy.agent_trader import AgentTraderPillar
+
+        pillar = AgentTraderPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(600, self.settings.agent_trader.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("agent_trader.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_informed_flow(self) -> None:
         """Periodic Kalshi informed-flow follower (abnormal-trade-size). Paper-
         forced; no-ops cleanly when the Kalshi venue isn't composed."""

--- a/auramaur/monitoring/books.py
+++ b/auramaur/monitoring/books.py
@@ -42,6 +42,9 @@ def _book_modes(settings) -> list[tuple[str, str, str]]:
     rl = settings.resolution_lens
     rows.append(("resolution_lens", *paper_mode(
         rl, f"gap>={rl.min_gap_score:.1f}, edge>={rl.min_edge*100:.0f}c")))
+    at = settings.agent_trader
+    rows.append(("agent_trader", *paper_mode(
+        at, f"models: {', '.join(m.alias for m in at.models)} — one cell each")))
 
     rows.append(("market_maker",
                  "LIVE" if settings.market_maker.enabled and settings.is_live

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -1,0 +1,475 @@
+"""Agent day-trader — the Hermes paradigm rebuilt as a first-class pillar.
+
+The original experiment (agentmcp bridge, PR #209) ran a persistent reasoning
+agent as an EXTERNAL process with unconstrained writes to its own ledger. It
+answered a different question than intended: given write access to its own
+scorecard, the agent fabricated it (see agentmcp/book.py S4). This pillar is
+the honest rebuild — the same paradigm under test (does a memory-carrying
+judgment agent beat the stateless strategy ensemble?) but riding the bot's own
+rails: signals + trades attribution, the FULL RiskManager gate (all 15 checks,
+never bypassed), ExecutionGateway placement, and settlement by the resolution
+tracker. The agent cannot touch its own ledger; it can only emit opinions.
+
+THE INTELLIGENCE-CAP A/B: the pillar runs the SAME mandate, prompt, candidate
+set, and memory format across MULTIPLE models (``agent_trader.models``). Each
+model is its own attribution cell — ``strategy_source = agent_trader_<alias>``
+— so ``auramaur pnl --paper`` and the graduation ladder segment them
+independently. If judgment quality is the binding constraint on directional
+edge, the cells should separate by model tier; if they don't, the constraint
+is elsewhere (information, market selection, execution) and more intelligence
+won't buy edge.
+
+Persistent judgment: every decision is stored in ``agent_trader_theses`` with
+its one-sentence thesis; at prompt time the model sees its own alias's recent
+CLOSED trades joined to realized P&L (the feedback loop) plus its open book.
+Memory is per-alias — models never see each other's reasoning, or the cells
+would correlate.
+
+Paper-forced (config ``paper: true`` AND every cell is a new directional cell
+under the enforced graduation ladder). Entries only in v1 — near-dated markets
+(default <= 30d) keep the book turning over; exits are engine-level and
+settlement-based, like bias_harvest/long_horizon.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+
+log = structlog.get_logger()
+
+MANDATE = """\
+You are a prediction-market day trader running a small paper book. You are \
+judged purely on realized P&L per trade. You see your own recent record below \
+— learn from it: if a class of thesis keeps losing, stop making it.
+
+Rules:
+- Only propose a trade when you believe the market price is wrong by at least \
+{min_edge_pts:.0f} points and you can say WHY in one concrete sentence (the \
+mechanism: what the crowd is mispricing and what you know that it doesn't).
+- prob_yes is YOUR probability that the market resolves YES, as a decimal.
+- Proposing nothing is always acceptable and often correct.
+- At most {max_entries} proposals.
+
+Respond with STRICT JSON only, no prose, no code fences:
+{{"decisions": [{{"market_id": "...", "prob_yes": 0.0, "thesis": "..."}}]}}
+
+YOUR RECENT RECORD (closed trades, realized P&L):
+{memory}
+
+YOUR OPEN BOOK:
+{open_book}
+
+CANDIDATE MARKETS (current YES price is the crowd's probability):
+{candidates}
+"""
+
+_THESES_TABLE = """
+CREATE TABLE IF NOT EXISTS agent_trader_theses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    model_alias TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    question TEXT DEFAULT '',
+    token TEXT DEFAULT '',
+    prob REAL,
+    market_prob REAL,
+    thesis TEXT DEFAULT '',
+    stake REAL DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now'))
+)
+"""
+
+
+def parse_decisions(raw: str, max_entries: int) -> list[dict]:
+    """Tolerant parse of the model's JSON: accepts fenced/prefixed output,
+    drops malformed entries, clamps probabilities, caps the count. Returns
+    ``[]`` on anything unparseable — a bad LLM reply must never crash a cycle."""
+    text = raw.strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start < 0 or end <= start:
+        return []
+    try:
+        payload = json.loads(text[start:end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return []
+    decisions = payload.get("decisions")
+    if not isinstance(decisions, list):
+        return []
+    out: list[dict] = []
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        market_id = str(d.get("market_id", "")).strip()
+        thesis = str(d.get("thesis", "")).strip()
+        try:
+            prob = float(d.get("prob_yes"))
+        except (TypeError, ValueError):
+            continue
+        if not market_id or not thesis:
+            continue
+        if not (0.0 < prob < 1.0):
+            continue
+        out.append({"market_id": market_id, "prob_yes": prob, "thesis": thesis})
+        if len(out) >= max_entries:
+            break
+    return out
+
+
+class AgentTraderPillar:
+    """Multi-model LLM day-trader over near-dated Polymarket markets."""
+
+    name = "agent_trader"
+
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+        self._schema_ready = False
+
+    @staticmethod
+    def cell(alias: str) -> str:
+        return f"agent_trader_{alias}"
+
+    async def _ensure_schema(self) -> None:
+        if self._schema_ready:
+            return
+        await self._db.execute(_THESES_TABLE)
+        await self._db.commit()
+        self._schema_ready = True
+
+    # ------------------------------------------------------------------
+    # Cycle
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.agent_trader
+        if not cfg.enabled or not cfg.models:
+            return 0
+        await self._ensure_schema()
+        candidates = await self._candidates(cfg)
+        if not candidates:
+            log.info("agent_trader.no_candidates")
+            return 0
+        entered_total = 0
+        for spec in cfg.models:
+            try:
+                entered_total += await self._run_model(spec, candidates, cfg)
+            except Exception as e:
+                # One model's failure (budget, timeout, bad output) must not
+                # stop the other cells — they are independent experiment arms.
+                log.warning("agent_trader.model_cycle_error",
+                            alias=spec.alias, error=str(e))
+        if entered_total:
+            log.info("agent_trader.cycle_done", entered=entered_total)
+        return entered_total
+
+    async def _run_model(self, spec, candidates: list[Market], cfg) -> int:
+        alias = spec.alias
+        open_rows = await self._open_theses(alias)
+        if len(open_rows) >= cfg.max_open_per_model:
+            log.debug("agent_trader.book_full", alias=alias,
+                      open=len(open_rows))
+            return 0
+        held = {r["market_id"] for r in open_rows}
+        offered = [m for m in candidates if m.id not in held]
+        offered = offered[: cfg.markets_per_cycle]
+        if not offered:
+            return 0
+
+        prompt = MANDATE.format(
+            min_edge_pts=cfg.min_edge_pts,
+            max_entries=cfg.max_entries_per_cycle,
+            memory=await self._memory_block(alias, cfg.memory_events),
+            open_book=self._open_block(open_rows),
+            candidates=self._candidates_block(offered),
+        )
+        raw = await self._call_model(prompt, spec.model, spec.effort, cfg)
+        decisions = parse_decisions(raw, cfg.max_entries_per_cycle)
+        if not decisions:
+            log.info("agent_trader.no_decisions", alias=alias,
+                     model=spec.model)
+            return 0
+
+        by_id = {m.id: m for m in offered}
+        entered = 0
+        for d in decisions:
+            market = by_id.get(d["market_id"])
+            if market is None:
+                continue  # hallucinated id — only offered markets count
+            if await self._try_enter(alias, market, d, cfg):
+                entered += 1
+        return entered
+
+    # ------------------------------------------------------------------
+    # Candidates — near-dated, liquid, tradeable-priced
+    # ------------------------------------------------------------------
+
+    async def _candidates(self, cfg) -> list[Market]:
+        now = datetime.now(timezone.utc)
+        emin = (now + timedelta(days=cfg.min_days_to_resolution)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        emax = (now + timedelta(days=cfg.max_days_to_resolution)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        out: list[Market] = []
+        try:
+            for off in range(0, max(int(cfg.scan_limit), 1), 100):
+                page = await self._discovery.get_markets(
+                    limit=100, offset=off, order="volume",
+                    end_date_min=emin, end_date_max=emax)
+                if not page:
+                    break
+                out.extend(page)
+        except TypeError:
+            # Discovery without date-window kwargs (older client / test stub).
+            out = await self._discovery.get_markets(limit=cfg.scan_limit)
+        eligible = [m for m in out if self._eligible(m, cfg)]
+        eligible.sort(key=lambda m: m.volume, reverse=True)
+        return eligible
+
+    def _eligible(self, market: Market, cfg) -> bool:
+        if not market.active:
+            return False
+        if (market.exchange or "polymarket") != "polymarket":
+            return False
+        if market.liquidity < cfg.min_liquidity:
+            return False
+        p = market.outcome_yes_price
+        if not (0.03 <= p <= 0.97):
+            return False  # near-resolved either way; nothing to day-trade
+        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        if blocked_category_hit(excluded, market.question, market.description,
+                                market.category):
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Prompt blocks — memory, open book, candidates
+    # ------------------------------------------------------------------
+
+    async def _memory_block(self, alias: str, limit: int) -> str:
+        rows = await self._db.fetchall(
+            """SELECT t.question, t.token, t.prob, t.market_prob, t.thesis,
+                      SUM(l.pnl) AS pnl
+               FROM agent_trader_theses t
+               JOIN pnl_ledger l ON l.market_id = t.market_id
+                    AND l.strategy_source = ? AND l.is_paper = 1
+               WHERE t.model_alias = ?
+               GROUP BY t.id ORDER BY t.created_at DESC LIMIT ?""",
+            (self.cell(alias), alias, limit),
+        )
+        if not rows:
+            return "(no closed trades yet)"
+        lines = []
+        for r in rows:
+            outcome = float(r["pnl"] or 0.0)
+            lines.append(
+                f"- [{'WIN' if outcome > 0 else 'LOSS'} ${outcome:+.2f}] "
+                f"{r['token']} @ crowd {float(r['market_prob'] or 0):.2f} / "
+                f"you {float(r['prob'] or 0):.2f} — {r['question']} — "
+                f"thesis: {r['thesis']}"
+            )
+        return "\n".join(lines)
+
+    async def _open_theses(self, alias: str) -> list:
+        """This alias's theses with no realized event yet — its open book."""
+        return await self._db.fetchall(
+            """SELECT t.market_id, t.question, t.token, t.prob, t.market_prob,
+                      t.thesis, t.created_at
+               FROM agent_trader_theses t
+               WHERE t.model_alias = ?
+                 AND NOT EXISTS (SELECT 1 FROM pnl_ledger l
+                                 WHERE l.market_id = t.market_id
+                                   AND l.strategy_source = ?
+                                   AND l.is_paper = 1)""",
+            (alias, self.cell(alias)),
+        )
+
+    @staticmethod
+    def _open_block(rows: list) -> str:
+        if not rows:
+            return "(empty)"
+        return "\n".join(
+            f"- {r['token']} since {str(r['created_at'])[:10]} @ crowd "
+            f"{float(r['market_prob'] or 0):.2f} — {r['question']}"
+            for r in rows
+        )
+
+    @staticmethod
+    def _candidates_block(markets: list[Market]) -> str:
+        lines = []
+        for m in markets:
+            end = ""
+            if m.end_date is not None:
+                end_dt = m.end_date if m.end_date.tzinfo else m.end_date.replace(tzinfo=timezone.utc)
+                end = f", ends {end_dt.strftime('%Y-%m-%d')}"
+            desc = (m.description or "").replace("\n", " ")[:200]
+            lines.append(
+                f"- id={m.id} | YES={m.outcome_yes_price:.2f} | "
+                f"vol=${m.volume:,.0f}{end} | {m.question} | {desc}"
+            )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # LLM call — the model IS the experimental variable
+    # ------------------------------------------------------------------
+
+    async def _call_model(self, prompt: str, model: str, effort: str, cfg) -> str:
+        from auramaur.nlp import call_budget
+        from auramaur.nlp.errors import BudgetExhausted
+
+        budget = self._settings.nlp.daily_claude_call_budget
+        if budget > 0:
+            limit = max(0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            if call_budget.calls_today() >= limit:
+                raise BudgetExhausted(
+                    f"non-reserved Claude budget ({limit}/{budget}) exhausted")
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "-p", prompt,
+            "--output-format", "text",
+            "--model", model,
+            "--effort", effort,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=cfg.llm_timeout_seconds)
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise RuntimeError(f"model call timed out ({model})")
+        call_budget.record_call()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"model call failed ({model}): {stderr.decode()[:200]}")
+        return stdout.decode()
+
+    # ------------------------------------------------------------------
+    # Entry — full risk gate, gateway placement, same rails as every pillar
+    # ------------------------------------------------------------------
+
+    async def _try_enter(self, alias: str, market: Market, decision: dict,
+                         cfg) -> bool:
+        prob_yes = decision["prob_yes"]
+        market_yes = market.outcome_yes_price
+        edge_pts = abs(prob_yes - market_yes) * 100.0
+        if edge_pts < cfg.min_edge_pts:
+            log.debug("agent_trader.edge_below_floor", alias=alias,
+                      market_id=market.id, edge=round(edge_pts, 1))
+            return False
+        side = OrderSide.BUY if prob_yes > market_yes else OrderSide.SELL
+
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=prob_yes,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market_yes,
+            edge=edge_pts,
+            evidence_summary=decision["thesis"][:500],
+            recommended_side=side,
+            strategy_source=self.cell(alias),
+            mispricing_reason=decision["thesis"][:300],
+        )
+        await self._persist_signal(signal, market)
+
+        # Full risk gate — all checks apply; never bypassed.
+        risk_decision = await self._risk.evaluate(signal, market)
+        if not risk_decision.approved or risk_decision.position_size <= 0:
+            log.info("agent_trader.risk_rejected", alias=alias,
+                     market_id=market.id, reason=risk_decision.reason)
+            return False
+        size = min(risk_decision.position_size, cfg.stake_usd)
+
+        force_paper = cfg.paper or getattr(risk_decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size,
+            force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.info("agent_trader.order_rejected", alias=alias,
+                     market_id=market.id, status=res.status, error=res.reason)
+            return False
+
+        await self._record_position(signal, market, res.order, res.result)
+        await self._db.execute(
+            """INSERT INTO agent_trader_theses
+               (model_alias, market_id, question, token, prob, market_prob,
+                thesis, stake)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (alias, market.id, market.question, res.order.token.value,
+             prob_yes, market_yes, decision["thesis"][:500], size),
+        )
+        await self._db.commit()
+        log.info("agent_trader.entered", alias=alias, market_id=market.id,
+                 token=res.order.token.value, price=res.order.price,
+                 size=res.order.size, edge=round(edge_pts, 1),
+                 paper=res.result.is_paper)
+        return True
+
+    # ------------------------------------------------------------------
+    # Bookkeeping — mirrors long_horizon/bias_harvest
+    # ------------------------------------------------------------------
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.exchange or "polymarket", market.condition_id,
+             market.question, (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value, signal.strategy_source),
+        )
+        await self._db.commit()
+
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        """Portfolio row (resolution tracker settles it) + calibration
+        prediction. The fill (-> cost_basis -> pnl_ledger) and the
+        trades-mirror are owned by ExecutionGateway."""
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        is_paper = bool(result.is_paper)
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("agent_trader.calibration_error", error=str(e))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -489,6 +489,39 @@ long_horizon:
   interval_seconds: 1800
   exclude_categories: ["politics_us", "politics_intl"]
 
+agent_trader:
+  # LLM day-trader — the Hermes agent paradigm rebuilt as a first-class pillar
+  # (the external-agent bridge fabricated its own ledger; this rides the bot's
+  # rails: full risk gate, gateway placement, resolution-tracker settlement).
+  # THE EXPERIMENT: the same mandate/candidates/memory runs on EVERY model
+  # below; each is its own attribution cell (agent_trader_<alias>) so the paper
+  # ledger shows whether model tier ("intelligence") changes directional edge.
+  # PAPER-FORCED. One non-reserved Claude CLI call per model per cycle
+  # (~36/day at 3 models x 2h) — stops early when the shared budget is low, so
+  # it can never starve the pinned lens slice.
+  enabled: true
+  paper: true
+  interval_seconds: 7200
+  models:
+    - alias: haiku
+      model: claude-haiku-4-5
+    - alias: sonnet
+      model: claude-sonnet-5
+    - alias: opus
+      model: claude-opus-4-8
+  scan_limit: 200
+  markets_per_cycle: 10
+  max_entries_per_cycle: 2
+  max_open_per_model: 10
+  stake_usd: 10.0
+  min_liquidity: 1000.0
+  min_days_to_resolution: 0.25
+  max_days_to_resolution: 30.0
+  min_edge_pts: 5.0
+  memory_events: 12
+  exclude_categories: []
+  llm_timeout_seconds: 240
+
 informed_flow:
   # Informed-flow follower over Kalshi — mimic the side of abnormally-large
   # (informed) order flow. Abnormal trade size (ATS) proxies non-liquidity trading

--- a/config/settings.py
+++ b/config/settings.py
@@ -498,6 +498,56 @@ class LongHorizonConfig(BaseModel):
     exclude_categories: list[str] = ["politics_us", "politics_intl"]
 
 
+class AgentTraderModel(BaseModel):
+    """One experiment arm of the intelligence-cap A/B: a model identity plus
+    the CLI effort it runs at. ``alias`` names the attribution cell
+    (``agent_trader_<alias>``) — keep it stable or the cell's history splits."""
+
+    alias: str
+    model: str
+    effort: str = "medium"
+
+
+class AgentTraderConfig(BaseModel):
+    """LLM day-trader pillar (strategy/agent_trader.py) — the Hermes paradigm
+    rebuilt on the bot's rails after the external-agent ledger fabrication
+    (see agentmcp/book.py S4).
+
+    Runs the SAME mandate/candidates/memory across every model in ``models``;
+    each is its own strategy cell (``agent_trader_<alias>``) so the paper
+    ledger answers whether model tier changes directional edge. PAPER-FORCED
+    (``paper`` + new directional cells under the enforced graduation ladder).
+
+    Budget: one non-reserved Claude CLI call per model per cycle — at the
+    default 2h interval and 3 models that is ~36 calls/day, and the pillar
+    stops early whenever the shared non-reserved budget is gone, so it can
+    never starve the pinned (lens) slice.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    interval_seconds: int = 7200
+    models: list[AgentTraderModel] = [
+        AgentTraderModel(alias="haiku", model="claude-haiku-4-5"),
+        AgentTraderModel(alias="sonnet", model="claude-sonnet-5"),
+        AgentTraderModel(alias="opus", model="claude-opus-4-8"),
+    ]
+    scan_limit: int = 200
+    markets_per_cycle: int = 10
+    max_entries_per_cycle: int = 2
+    max_open_per_model: int = 10
+    stake_usd: float = 10.0
+    min_liquidity: float = 1000.0
+    # Day-trader horizon: near-dated books turn over fast enough to feed the
+    # memory loop; min keeps out markets resolving mid-cycle.
+    min_days_to_resolution: float = 0.25
+    max_days_to_resolution: float = 30.0
+    min_edge_pts: float = 5.0
+    memory_events: int = 12
+    exclude_categories: list[str] = []
+    llm_timeout_seconds: int = 240
+
+
 class EconIndicatorConfig(BaseModel):
     """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
 
@@ -1174,6 +1224,7 @@ class Settings(BaseSettings):
     cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
+    agent_trader: AgentTraderConfig = Field(default_factory=lambda: AgentTraderConfig(**_DEFAULTS.get("agent_trader", {})))
     informed_flow: InformedFlowConfig = Field(default_factory=lambda: InformedFlowConfig(**_DEFAULTS.get("informed_flow", {})))
     settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))

--- a/tests/test_agent_trader.py
+++ b/tests/test_agent_trader.py
@@ -1,0 +1,233 @@
+"""Agent day-trader pillar: the intelligence-cap A/B on the bot's rails.
+
+Covers the tested core: tolerant decision parsing, per-model attribution
+cells, the full risk gate (never bypassed), hallucinated-market rejection,
+edge-floor enforcement, thesis memory persistence, and budget/LLM failure
+isolation between model arms.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market, OrderSide
+from auramaur.strategy.agent_trader import AgentTraderPillar, parse_decisions
+
+
+# ---------------------------------------------------------------------------
+# parse_decisions — a bad LLM reply must never crash a cycle
+# ---------------------------------------------------------------------------
+
+
+def test_parse_accepts_fenced_and_prefixed_json():
+    raw = 'Sure! Here you go:\n```json\n{"decisions": [{"market_id": "m1", ' \
+          '"prob_yes": 0.7, "thesis": "capture done, timeline is the bar"}]}\n```'
+    out = parse_decisions(raw, max_entries=2)
+    assert len(out) == 1
+    assert out[0]["market_id"] == "m1"
+    assert out[0]["prob_yes"] == pytest.approx(0.7)
+
+
+def test_parse_drops_malformed_and_caps_count():
+    raw = ('{"decisions": ['
+           '{"market_id": "a", "prob_yes": 0.6, "thesis": "t1"},'
+           '{"market_id": "", "prob_yes": 0.6, "thesis": "no id"},'
+           '{"market_id": "b", "prob_yes": 1.7, "thesis": "bad prob"},'
+           '{"market_id": "c", "prob_yes": 0.4, "thesis": ""},'
+           '{"market_id": "d", "prob_yes": 0.55, "thesis": "t2"},'
+           '{"market_id": "e", "prob_yes": 0.45, "thesis": "t3"}]}')
+    out = parse_decisions(raw, max_entries=2)
+    assert [d["market_id"] for d in out] == ["a", "d"]
+
+
+def test_parse_garbage_returns_empty():
+    assert parse_decisions("I cannot help with that.", 2) == []
+    assert parse_decisions('{"decisions": "nope"}', 2) == []
+    assert parse_decisions("", 2) == []
+
+
+# ---------------------------------------------------------------------------
+# Pillar wiring
+# ---------------------------------------------------------------------------
+
+
+def _market(mid="m1", yes=0.30, liquidity=5000.0, volume=10000.0) -> Market:
+    return Market(id=mid, question=f"Q {mid}?", outcome_yes_price=yes,
+                  outcome_no_price=round(1 - yes, 2), liquidity=liquidity,
+                  volume=volume, active=True, exchange="polymarket")
+
+
+def _model_spec(alias="haiku", model="claude-haiku-4-5"):
+    spec = MagicMock()
+    spec.alias = alias
+    spec.model = model
+    spec.effort = "medium"
+    return spec
+
+
+def _settings(models):
+    s = MagicMock()
+    cfg = s.agent_trader
+    cfg.enabled = True
+    cfg.paper = True
+    cfg.models = models
+    cfg.scan_limit = 100
+    cfg.markets_per_cycle = 10
+    cfg.max_entries_per_cycle = 2
+    cfg.max_open_per_model = 10
+    cfg.stake_usd = 10.0
+    cfg.min_liquidity = 1000.0
+    cfg.min_days_to_resolution = 0.25
+    cfg.max_days_to_resolution = 30.0
+    cfg.min_edge_pts = 5.0
+    cfg.memory_events = 12
+    cfg.exclude_categories = []
+    cfg.llm_timeout_seconds = 240
+    s.risk.blocked_categories = []
+    s.nlp.daily_claude_call_budget = 0  # unlimited in tests
+    return s
+
+
+async def _pillar(tmp_path, models, markets, llm_reply: str):
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    risk = MagicMock()
+    decision = MagicMock()
+    decision.approved = True
+    decision.position_size = 8.0
+    decision.reason = ""
+    decision.force_paper = False
+    risk.evaluate = AsyncMock(return_value=decision)
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+
+    pillar = AgentTraderPillar(
+        db=db, settings=_settings(models), discovery=discovery,
+        exchange=MagicMock(), risk_manager=risk,
+        pnl_tracker=MagicMock(), calibration=calibration,
+    )
+    # Paper order result through a stubbed gateway (the gateway itself is
+    # covered by its own tests).
+    result = MagicMock()
+    result.status = "paper"
+    result.reason = ""
+    order = MagicMock()
+    order.market_id = markets[0].id if markets else "m1"
+    order.token.value = "YES"
+    order.token_id = "tok"
+    order.price = 0.30
+    order.size = 26.7
+    fill = MagicMock()
+    fill.is_paper = True
+    fill.filled_size = 26.7
+    fill.filled_price = 0.30
+    result.order = order
+    result.result = fill
+    pillar._gateway = MagicMock()
+    pillar._gateway.submit = AsyncMock(return_value=result)
+    pillar._call_model = AsyncMock(return_value=llm_reply)
+    return pillar, db, risk
+
+
+@pytest.mark.asyncio
+async def test_enters_through_risk_gate_with_per_model_cell(tmp_path):
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.55, "thesis": "t"}]}'
+    pillar, db, risk = await _pillar(
+        tmp_path, [_model_spec("haiku")], [_market("m1", yes=0.30)], reply)
+    try:
+        entered = await pillar.run_once()
+        assert entered == 1
+        risk.evaluate.assert_awaited()  # full gate, never bypassed
+        sig = await db.fetchone(
+            "SELECT strategy_source, edge, claude_prob FROM signals")
+        assert sig["strategy_source"] == "agent_trader_haiku"
+        assert sig["edge"] == pytest.approx(25.0)  # absolute points contract
+        thesis = await db.fetchone(
+            "SELECT model_alias, market_id, prob FROM agent_trader_theses")
+        assert thesis["model_alias"] == "haiku"
+        assert thesis["prob"] == pytest.approx(0.55)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_risk_rejection_blocks_entry(tmp_path):
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.55, "thesis": "t"}]}'
+    pillar, db, risk = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1", yes=0.30)], reply)
+    risk.evaluate.return_value.approved = False
+    try:
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_market_id_is_ignored(tmp_path):
+    reply = '{"decisions": [{"market_id": "not-offered", "prob_yes": 0.9, "thesis": "t"}]}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1", yes=0.30)], reply)
+    try:
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_edge_below_floor_skipped(tmp_path):
+    # Model claims 0.33 vs market 0.30 — 3 points, floor is 5.
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.33, "thesis": "t"}]}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1", yes=0.30)], reply)
+    try:
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_one_model_failure_does_not_stop_other_arms(tmp_path):
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.55, "thesis": "t"}]}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec("haiku"), _model_spec("opus", "claude-opus-4-8")],
+        [_market("m1", yes=0.30)], reply)
+    calls = {"n": 0}
+
+    async def flaky(prompt, model, effort, cfg):
+        calls["n"] += 1
+        if model == "claude-haiku-4-5":
+            raise RuntimeError("model call timed out")
+        return reply
+
+    pillar._call_model = flaky
+    try:
+        entered = await pillar.run_once()
+        assert calls["n"] == 2       # both arms attempted
+        assert entered == 1          # the healthy arm still entered
+        sig = await db.fetchone("SELECT strategy_source FROM signals")
+        assert sig["strategy_source"] == "agent_trader_opus"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sell_side_derived_from_prob_vs_market(tmp_path):
+    # Model says 0.10 vs market 0.30 -> SELL YES (buy NO downstream).
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.10, "thesis": "t"}]}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1", yes=0.30)], reply)
+    try:
+        assert await pillar.run_once() == 1
+        intent = pillar._gateway.submit.await_args.args[0]
+        assert intent.signal.recommended_side == OrderSide.SELL
+        assert intent.force_paper is True
+    finally:
+        await db.close()


### PR DESCRIPTION
## What

Rebuilds the external-agent day-trader paradigm as a first-class Auramaur pillar, after the external bridge's self-written ledger proved unusable as an experiment (#261 hardened the book; this replaces the paradigm's home). The agent can only emit opinions — everything else rides the bot's rails: signals + trades attribution, the **full RiskManager gate** (all 15 checks, never bypassed), ExecutionGateway placement, resolution-tracker settlement. **Paper-forced** (config `paper: true` + every cell is a new directional cell under the enforced graduation ladder).

## The intelligence-cap A/B

The same mandate, candidate set, and memory format run on every configured model (default `haiku` / `sonnet` / `opus`, via the Claude CLI's `--model`). Each model is its own attribution cell — `strategy_source = agent_trader_<alias>` — so `auramaur pnl --paper` and the graduation ladder segment them independently. If judgment quality is the binding constraint on directional edge, the cells should separate by model tier; if they don't, the constraint is elsewhere (information, selection, execution) and more intelligence won't buy edge.

## Persistent judgment

Every decision is stored in `agent_trader_theses` with its one-sentence thesis. At prompt time each model sees its own alias's recent closed trades **joined to realized P&L** (the feedback loop) plus its open book. Memory is per-alias so the experiment arms stay independent.

## Safety / budget

- One non-reserved Claude call per model per cycle (~36/day at the 2h default), stopping early when the shared budget is low — the pinned lens slice cannot be starved.
- A model arm's failure (timeout, budget, unparseable JSON) never stops the other arms; garbage output enters nothing.
- Hallucinated market ids are ignored (only offered candidates count); entries below the edge floor are skipped; near-resolved prices (< 0.03 / > 0.97) are not offered.

## Tests

9 new tests: tolerant decision parsing (fenced/malformed/garbage), per-model cell attribution + absolute-points edge contract, risk-gate rejection, hallucinated-id rejection, edge floor, arm-failure isolation, SELL-side derivation. Full suite: 1037 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)