### PR TITLE
fix(agent_trader): isolate arm context (neutral cwd) + enable research tools

### DIFF
--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import tempfile
 from datetime import datetime, timedelta, timezone
 
 import structlog
@@ -45,12 +46,19 @@ from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 
 log = structlog.get_logger()
 
+# The arms may research the open web (same precedent as agent_analyzer) —
+# real evidence-gathering, identical for every arm, no bot-opinion leakage.
+_ALLOWED_TOOLS = "WebSearch,WebFetch"
+
 MANDATE = """\
 You are a prediction-market day trader running a small paper book. You are \
 judged purely on realized P&L per trade. You see your own recent record below \
 — learn from it: if a class of thesis keeps losing, stop making it.
 
 Rules:
+- You may use WebSearch/WebFetch to check current facts (prices, dates, \
+announcements, standings) before deciding. Base decisions ONLY on the market \
+data below plus your own research — you have no other context.
 - Only propose a trade when you believe the market price is wrong by at least \
 {min_edge_pts:.0f} points and you can say WHY in one concrete sentence (the \
 mechanism: what the crowd is mispricing and what you know that it doesn't).
@@ -337,13 +345,19 @@ class AgentTraderPillar:
             if call_budget.calls_today() >= limit:
                 raise BudgetExhausted(
                     f"non-reserved Claude budget ({limit}/{budget}) exhausted")
+        # cwd MUST be neutral: `claude -p` loads CLAUDE.md and the project
+        # memory from its working directory, and run from the repo root the
+        # arms were caught citing the operator's own market analyses ("your
+        # prior CPI work") — contaminating the A/B and correlating the arms.
         proc = await asyncio.create_subprocess_exec(
             "claude", "-p", prompt,
             "--output-format", "text",
             "--model", model,
             "--effort", effort,
+            "--allowedTools", _ALLOWED_TOOLS,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=tempfile.gettempdir(),
         )
         try:
             stdout, stderr = await asyncio.wait_for(

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -520,7 +520,7 @@ agent_trader:
   min_edge_pts: 5.0
   memory_events: 12
   exclude_categories: []
-  llm_timeout_seconds: 240
+  llm_timeout_seconds: 420   # room for WebSearch rounds
 
 informed_flow:
   # Informed-flow follower over Kalshi — mimic the side of abnormally-large

--- a/config/settings.py
+++ b/config/settings.py
@@ -545,7 +545,8 @@ class AgentTraderConfig(BaseModel):
     min_edge_pts: float = 5.0
     memory_events: int = 12
     exclude_categories: list[str] = []
-    llm_timeout_seconds: int = 240
+    # Generous: the arms may run WebSearch rounds before answering.
+    llm_timeout_seconds: int = 420
 
 
 class EconIndicatorConfig(BaseModel):

--- a/tests/test_agent_trader.py
+++ b/tests/test_agent_trader.py
@@ -219,6 +219,46 @@ async def test_one_model_failure_does_not_stop_other_arms(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_cli_call_isolated_and_tool_enabled(tmp_path, monkeypatch):
+    """The subprocess must run from a NEUTRAL cwd (claude -p loads CLAUDE.md
+    and project memory from its working directory — run from the repo root the
+    arms cited the operator's own analyses, contaminating the A/B) and with
+    the research tools enabled."""
+    import tempfile as _tempfile
+
+    import auramaur.strategy.agent_trader as at
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b'{"decisions": []}', b""
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(at.asyncio, "create_subprocess_exec", fake_exec)
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1")], "")
+    pillar._call_model = AgentTraderPillar._call_model.__get__(pillar)
+    try:
+        cfg = pillar._settings.agent_trader
+        out = await pillar._call_model("prompt", "claude-haiku-4-5", "medium", cfg)
+        assert out == '{"decisions": []}'
+        cmd = captured["cmd"]
+        assert "--allowedTools" in cmd
+        assert cmd[cmd.index("--allowedTools") + 1] == "WebSearch,WebFetch"
+        assert "--model" in cmd and "claude-haiku-4-5" in cmd
+        assert captured["kwargs"]["cwd"] == _tempfile.gettempdir()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_sell_side_derived_from_prob_vs_market(tmp_path):
     # Model says 0.10 vs market 0.30 -> SELL YES (buy NO downstream).
     reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.10, "thesis": "t"}]}'


### PR DESCRIPTION
First-cycle probe caught an arm citing the operator's own market analyses —
`claude -p` loads CLAUDE.md and the project memory from its working
directory, so running from the repo root leaked accumulated operator context
into every arm: it confounds the intelligence-cap A/B (arm skill vs operator
memory) and correlates the arms. The subprocess now runs from the system
temp dir, so no project context loads.

The same probe showed why all arms declined to trade: they had nothing but
prices to reason from. Arms now get WebSearch/WebFetch on the CLI call (same
tool allowlist as agent_analyzer) — real evidence-gathering, identical for
every arm, no bot-opinion leakage — with the mandate updated to say research
is allowed and the timeout raised to fit search rounds.

Assisted-by: Claude (Anthropic)
