### PR TITLE
fix(agent_trader): rotate arm order per cycle so contested markets don't always go to the same arm

### DIFF
--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -150,6 +150,7 @@ class AgentTraderPillar:
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
         self._schema_ready = False
+        self._cycle_n = 0
 
     @staticmethod
     def cell(alias: str) -> str:
@@ -182,7 +183,14 @@ class AgentTraderPillar:
             log.info("agent_trader.no_candidates")
             return 0
         entered_total = 0
-        for spec in cfg.models:
+        # Rotate which arm runs first each cycle. Arms run sequentially and a
+        # market is claimed by the first entrant, so a fixed order hands every
+        # contested market to the same arm — the later arms' cells fill up
+        # with leftovers (observed: one arm claim-blocked 3x in a night).
+        start = self._cycle_n % len(cfg.models)
+        self._cycle_n += 1
+        rotated = list(cfg.models[start:]) + list(cfg.models[:start])
+        for spec in rotated:
             try:
                 entered_total += await self._run_model(spec, candidates, cfg)
             except Exception as e:

--- a/tests/test_agent_trader.py
+++ b/tests/test_agent_trader.py
@@ -219,6 +219,36 @@ async def test_one_model_failure_does_not_stop_other_arms(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_arm_order_rotates_per_cycle(tmp_path):
+    """Arms run sequentially and first entrant claims the market, so a fixed
+    order hands every contested market to the same arm. The starting arm must
+    rotate each cycle."""
+    reply = '{"decisions": []}'
+    pillar, db, _ = await _pillar(
+        tmp_path,
+        [_model_spec("haiku"), _model_spec("sonnet", "claude-sonnet-5"),
+         _model_spec("opus", "claude-opus-4-8")],
+        [_market("m1")], reply)
+    order: list[str] = []
+
+    async def record(prompt, model, effort, cfg):
+        order.append(model)
+        return reply
+
+    pillar._call_model = record
+    try:
+        await pillar.run_once()
+        await pillar.run_once()
+        await pillar.run_once()
+        assert order[0] == "claude-haiku-4-5"
+        assert order[3] == "claude-sonnet-5"   # cycle 2 starts one later
+        assert order[6] == "claude-opus-4-8"   # cycle 3 starts two later
+        assert len(set(order[:3])) == 3        # every arm still runs each cycle
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_second_arm_blocked_on_claimed_market_records_prediction(tmp_path):
     """Settlement attribution is market-level earliest-entrant-wins, so once
     one arm (or any strategy) has a trade on a market, another arm must NOT


### PR DESCRIPTION
Arms run sequentially within a cycle and the first entrant claims the
market (one position per market, #264). With a fixed order, whenever two
arms independently like the same market the earlier-run arm always wins
the claim — the later arms' cells systematically fill with leftovers
(observed: the last-configured arm claim-blocked three times in one
night). The starting arm now rotates round-robin each cycle; every arm
still runs every cycle.

Assisted-by: Claude (Anthropic)
