### PR TITLE
feat(agent_trader): TTL'd decline memory — a pass keeps the market off the arm's slate

### DIFF
--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -79,6 +79,15 @@ CANDIDATE MARKETS (current YES price is the crowd's probability):
 {candidates}
 """
 
+_DECLINES_TABLE = """
+CREATE TABLE IF NOT EXISTS agent_trader_declines (
+    model_alias TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    declined_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (model_alias, market_id)
+)
+"""
+
 _THESES_TABLE = """
 CREATE TABLE IF NOT EXISTS agent_trader_theses (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -160,6 +169,7 @@ class AgentTraderPillar:
         if self._schema_ready:
             return
         await self._db.execute(_THESES_TABLE)
+        await self._db.execute(_DECLINES_TABLE)
         try:
             # Upgrade a pre-`entered` table in place (rows so far all entered).
             await self._db.execute(
@@ -213,10 +223,23 @@ class AgentTraderPillar:
             "SELECT DISTINCT market_id FROM agent_trader_theses WHERE model_alias = ?",
             (alias,),
         )
-        # Skip anything this alias already holds OR has already opined on
-        # (a prediction-only thesis on a claimed market is recorded once,
-        # not re-elicited every cycle).
-        seen = {r["market_id"] for r in seen_rows} | {r["market_id"] for r in open_rows}
+        declined_rows = await self._db.fetchall(
+            """SELECT market_id FROM agent_trader_declines
+               WHERE model_alias = ?
+                 AND declined_at > datetime('now', ?)""",
+            (alias, f"-{float(cfg.decline_ttl_hours)} hours"),
+        )
+        # Skip anything this alias already holds, has already opined on (a
+        # prediction-only thesis is recorded once, not re-elicited), or
+        # DECLINED within the TTL — without the decline memory, the same
+        # unseen top-of-volume markets were re-offered every cycle and each
+        # arm burned a call re-rejecting them. After the TTL the market is
+        # offered again (prices move; a stale no is not a permanent no).
+        seen = (
+            {r["market_id"] for r in seen_rows}
+            | {r["market_id"] for r in open_rows}
+            | {r["market_id"] for r in declined_rows}
+        )
         offered = [m for m in candidates if m.id not in seen]
         offered = offered[: cfg.markets_per_cycle]
         if not offered:
@@ -231,6 +254,22 @@ class AgentTraderPillar:
         )
         raw = await self._call_model(prompt, spec.model, spec.effort, cfg)
         decisions = parse_decisions(raw, cfg.max_entries_per_cycle)
+
+        # The model actually saw and passed on these — remember the pass for
+        # decline_ttl_hours. Only after a SUCCESSFUL call: a budget/timeout
+        # failure means the markets were never evaluated.
+        decided_ids = {d["market_id"] for d in decisions}
+        passed = [m.id for m in offered if m.id not in decided_ids]
+        if passed:
+            await self._db.executemany(
+                """INSERT INTO agent_trader_declines (model_alias, market_id, declined_at)
+                   VALUES (?, ?, datetime('now'))
+                   ON CONFLICT(model_alias, market_id) DO UPDATE SET
+                       declined_at = excluded.declined_at""",
+                [(alias, mid) for mid in passed],
+            )
+            await self._db.commit()
+
         if not decisions:
             log.info("agent_trader.no_decisions", alias=alias,
                      model=spec.model)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -521,6 +521,7 @@ agent_trader:
   memory_events: 12
   exclude_categories: []
   llm_timeout_seconds: 420   # room for WebSearch rounds
+  decline_ttl_hours: 24.0    # a pass keeps the market off the arm's slate this long
 
 informed_flow:
   # Informed-flow follower over Kalshi — mimic the side of abnormally-large

--- a/config/settings.py
+++ b/config/settings.py
@@ -547,6 +547,10 @@ class AgentTraderConfig(BaseModel):
     exclude_categories: list[str] = []
     # Generous: the arms may run WebSearch rounds before answering.
     llm_timeout_seconds: int = 420
+    # How long a pass on an offered market keeps it out of that arm's
+    # candidate slate (prevents burning calls re-declining the same markets
+    # every cycle; after the TTL prices have moved enough to re-ask).
+    decline_ttl_hours: float = 24.0
 
 
 class EconIndicatorConfig(BaseModel):

--- a/tests/test_agent_trader.py
+++ b/tests/test_agent_trader.py
@@ -86,6 +86,7 @@ def _settings(models):
     cfg.memory_events = 12
     cfg.exclude_categories = []
     cfg.llm_timeout_seconds = 240
+    cfg.decline_ttl_hours = 24.0
     s.risk.blocked_categories = []
     s.nlp.daily_claude_call_budget = 0  # unlimited in tests
     return s
@@ -214,6 +215,56 @@ async def test_one_model_failure_does_not_stop_other_arms(tmp_path):
         assert entered == 1          # the healthy arm still entered
         sig = await db.fetchone("SELECT strategy_source FROM signals")
         assert sig["strategy_source"] == "agent_trader_opus"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_declined_market_not_reoffered_within_ttl(tmp_path):
+    """A market the arm passed on is remembered for decline_ttl_hours — the
+    old behavior re-offered the same unseen markets every cycle and burned a
+    call re-declining them."""
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1")], '{"decisions": []}')
+    calls = {"n": 0}
+
+    async def counting(prompt, model, effort, cfg):
+        calls["n"] += 1
+        return '{"decisions": []}'
+
+    pillar._call_model = counting
+    try:
+        await pillar.run_once()
+        assert calls["n"] == 1
+        row = await db.fetchone(
+            "SELECT model_alias FROM agent_trader_declines WHERE market_id='m1'")
+        assert row["model_alias"] == "haiku"
+        # Same slate next cycle -> nothing to offer -> no call burned.
+        await pillar.run_once()
+        assert calls["n"] == 1
+
+        # After the TTL the market is offered again.
+        await db.execute(
+            "UPDATE agent_trader_declines SET declined_at = datetime('now', '-25 hours')")
+        await db.commit()
+        await pillar.run_once()
+        assert calls["n"] == 2
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_decided_market_is_not_declined(tmp_path):
+    """A market the arm traded goes to theses, not to the decline table."""
+    reply = '{"decisions": [{"market_id": "m1", "prob_yes": 0.55, "thesis": "t"}]}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec()], [_market("m1", yes=0.30), _market("m2", yes=0.50)],
+        reply)
+    try:
+        assert await pillar.run_once() == 1
+        declined = await db.fetchall(
+            "SELECT market_id FROM agent_trader_declines")
+        assert [r["market_id"] for r in declined] == ["m2"]
     finally:
         await db.close()
 


### PR DESCRIPTION
Declined markets never entered an arm's seen-set, so every cycle re-offered
the same unseen top-of-volume markets and each arm burned a Claude call
re-rejecting them (~a third of the pillar's daily budget after a few days
of accumulated passes). A pass is now recorded per (arm, market) and keeps
the market off that arm's slate for decline_ttl_hours (default 24h — prices
move; a stale no is not a permanent no). Declines are only recorded after a
SUCCESSFUL model call; a budget/timeout failure never marks markets the arm
never evaluated.

Assisted-by: Claude (Anthropic)
