### PR TITLE
fix(ledger): token-scoped entry-strategy attribution — credit the side's own opener

### DIFF
--- a/auramaur/broker/ledger.py
+++ b/auramaur/broker/ledger.py
@@ -31,6 +31,27 @@ log = structlog.get_logger()
 # pairs have no row in ``markets``).
 _KRAKEN_QUOTES = ("USDC", "USDT", "ZUSD", "USD", "EUR", "ZEUR")
 
+# Token-scoped entry-strategy resolution: credit the strategy that opened
+# THIS side of the market. Market-level attribution (below) credits every
+# realization on a market to its earliest entrant — with 40+ markets carrying
+# trades from 2+ strategies, one strategy's win on the OPPOSITE token landed
+# in another's cell (observed: an llm NO win booked into an agent arm's cell
+# because the arm's YES entry was 3 minutes earlier). trades has no token
+# column, so the token comes from the paired fill (same order_id), scoped to
+# the realization's mode. Same-token stacking by multiple strategies still
+# collapses to the earliest entrant — cost_basis is genuinely merged there.
+_TOKEN_ENTRY_STRATEGY_SQL = """
+    SELECT t.strategy_source FROM trades t
+    JOIN fills f ON f.order_id = t.order_id
+    WHERE f.market_id = ?
+      AND UPPER(f.token) = UPPER(?)
+      AND f.is_paper = ?
+      AND t.strategy_source IS NOT NULL
+      AND t.strategy_source != 'order_monitor'
+      AND t.strategy_source != ''
+    ORDER BY f.timestamp ASC LIMIT 1
+"""
+
 # Entry-strategy resolution — same semantics as
 # auramaur.monitoring.attribution._entry_strategy_expr: credit the strategy
 # that DECIDED to open the position (earliest non-order_monitor trade, then
@@ -68,8 +89,16 @@ def _looks_like_us_ticker(market_id: str) -> bool:
     return market_id.isupper() and market_id.isalpha() and 1 <= len(market_id) <= 5
 
 
-async def _market_context(db: Database, market_id: str) -> tuple[str, str, str]:
-    """Resolve ``(venue, category, strategy_source)`` for a realization."""
+async def _market_context(
+    db: Database, market_id: str, token: str = "", is_paper: bool | None = None,
+) -> tuple[str, str, str]:
+    """Resolve ``(venue, category, strategy_source)`` for a realization.
+
+    When the realization's ``token`` and mode are known (they always are on
+    the ledger write path), the strategy is resolved for THAT side of the
+    market first; the market-level earliest-entrant lookup is the fallback
+    for legacy rows without a paired fill (kraken pairs, manual fills).
+    """
     row = await db.fetchone(
         "SELECT exchange, category FROM markets WHERE id = ?", (market_id,)
     )
@@ -88,11 +117,19 @@ async def _market_context(db: Database, market_id: str) -> tuple[str, str, str]:
     else:
         venue, category = "", ""
 
-    srow = await db.fetchone(
-        f"SELECT {_ENTRY_STRATEGY_SQL} AS src",
-        (market_id, market_id, market_id),
-    )
-    strategy = (srow["src"] if srow else "") or ""
+    strategy = ""
+    if token and is_paper is not None:
+        srow = await db.fetchone(
+            _TOKEN_ENTRY_STRATEGY_SQL,
+            (market_id, token, 1 if is_paper else 0),
+        )
+        strategy = (srow["strategy_source"] if srow else "") or ""
+    if not strategy:
+        srow = await db.fetchone(
+            f"SELECT {_ENTRY_STRATEGY_SQL} AS src",
+            (market_id, market_id, market_id),
+        )
+        strategy = (srow["src"] if srow else "") or ""
     return venue, category, strategy
 
 
@@ -114,7 +151,8 @@ async def record_ledger_event(
     Never raises — a ledger failure must not break order/settlement flow.
     """
     try:
-        venue, category, strategy = await _market_context(db, market_id)
+        venue, category, strategy = await _market_context(
+            db, market_id, token=token, is_paper=is_paper)
         if realized_at is None:
             await db.execute(
                 """INSERT OR IGNORE INTO pnl_ledger

--- a/tests/test_ledger_token_attribution.py
+++ b/tests/test_ledger_token_attribution.py
@@ -1,0 +1,107 @@
+"""Ledger attribution is token-scoped: credit the strategy that opened THIS
+side of the market, not whoever touched the market first on any side.
+
+Market-level earliest-entrant attribution booked one strategy's win on the
+OPPOSITE token into another strategy's cell whenever two strategies traded
+the same market (40+ such markets existed). The token comes from the fill
+paired to the trade by order_id; the market-level lookup remains as the
+fallback for realizations without a paired fill.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from auramaur.broker.ledger import record_ledger_event
+from auramaur.db.database import Database
+
+
+async def _seed_trade_and_fill(db, *, market_id, order_id, token, strategy,
+                               ts, is_paper=1, side="BUY"):
+    await db.execute(
+        """INSERT INTO trades (market_id, timestamp, side, size, price,
+           is_paper, order_id, status, exchange, strategy_source)
+           VALUES (?, ?, ?, 10, 0.5, ?, ?, 'filled', 'polymarket', ?)""",
+        (market_id, ts, side, is_paper, order_id, strategy),
+    )
+    await db.execute(
+        """INSERT INTO fills (order_id, market_id, token_id, side, token,
+           size, price, fee, is_paper, timestamp)
+           VALUES (?, ?, 'tok', ?, ?, 10, 0.5, 0, ?, ?)""",
+        (order_id, market_id, side, token, is_paper, ts),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_opposite_tokens_attribute_to_their_own_strategies(tmp_path):
+    """The incident shape: arm buys YES, the llm engine buys NO minutes later
+    on the same market. Each side's realization credits its own strategy."""
+    db = Database(str(tmp_path / "t.db"))
+    await db.connect()
+    try:
+        await _seed_trade_and_fill(
+            db, market_id="m1", order_id="o-yes", token="YES",
+            strategy="agent_trader_haiku", ts="2026-07-06 05:25:33")
+        await _seed_trade_and_fill(
+            db, market_id="m1", order_id="o-no", token="NO",
+            strategy="llm", ts="2026-07-06 05:28:01")
+
+        await record_ledger_event(
+            db, market_id="m1", kind="settlement", token="YES", qty=10,
+            pnl=-5.0, fees=0, is_paper=True, source_ref="s:yes")
+        await record_ledger_event(
+            db, market_id="m1", kind="settlement", token="NO", qty=10,
+            pnl=5.0, fees=0, is_paper=True, source_ref="s:no")
+
+        rows = {r["token"]: r["strategy_source"] for r in await db.fetchall(
+            "SELECT token, strategy_source FROM pnl_ledger")}
+        assert rows["YES"] == "agent_trader_haiku"
+        assert rows["NO"] == "llm"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_mode_scoped_lookup(tmp_path):
+    """A paper realization must not inherit the strategy of a LIVE fill on
+    the same (market, token)."""
+    db = Database(str(tmp_path / "t.db"))
+    await db.connect()
+    try:
+        await _seed_trade_and_fill(
+            db, market_id="m1", order_id="o-live", token="YES",
+            strategy="market_maker", ts="2026-07-01 00:00:00", is_paper=0)
+        await _seed_trade_and_fill(
+            db, market_id="m1", order_id="o-paper", token="YES",
+            strategy="bias_harvest", ts="2026-07-02 00:00:00", is_paper=1)
+
+        await record_ledger_event(
+            db, market_id="m1", kind="settlement", token="YES", qty=10,
+            pnl=1.0, fees=0, is_paper=True, source_ref="s:p")
+        row = await db.fetchone("SELECT strategy_source FROM pnl_ledger")
+        assert row["strategy_source"] == "bias_harvest"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_market_level_without_paired_fill(tmp_path):
+    """A trade with no matching fill (legacy rows) still resolves via the
+    market-level earliest-entrant lookup."""
+    db = Database(str(tmp_path / "t.db"))
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, exchange, strategy_source)
+               VALUES ('m1', '2026-07-01 00:00:00', 'BUY', 10, 0.5, 1,
+                       'legacy-1', 'filled', 'polymarket', 'long_horizon')""")
+        await db.commit()
+        await record_ledger_event(
+            db, market_id="m1", kind="settlement", token="YES", qty=10,
+            pnl=2.0, fees=0, is_paper=True, source_ref="s:1")
+        row = await db.fetchone("SELECT strategy_source FROM pnl_ledger")
+        assert row["strategy_source"] == "long_horizon"
+    finally:
+        await db.close()


### PR DESCRIPTION
Market-level earliest-entrant attribution credited EVERY realization on a
market to whichever strategy traded it first, on any side. With 40+ markets
carrying trades from two or more strategies, one strategy's win on the
OPPOSITE token landed in another's cell (observed: an engine NO win booked
into an agent arm's cell because the arm's YES entry was minutes earlier).

The write path now resolves the entry strategy per (market, token, mode)
via the fill paired to the trade by order_id — trades itself has no token
column — and falls back to the market-level lookup only when no paired
fill exists (kraken pairs, legacy/manual rows). Same-token stacking by
multiple strategies still collapses to the earliest entrant: cost_basis is
genuinely merged there and no per-strategy split exists to recover.

Assisted-by: Claude (Anthropic)
