### PR TITLE
fix(kalshi): remove the paper purge — it was shredding the live Kalshi paper books

### DIFF
--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -958,23 +958,16 @@ class KalshiClient:
                          AND market_id IN (SELECT id FROM markets WHERE exchange = 'kalshi')"""
                 )
 
-            # Purge orphaned PAPER Kalshi rows. The paper trader is
-            # exchange-agnostic and never writes Kalshi positions, so any
-            # is_paper=1 Kalshi row is a legacy orphan (a one-time 2026-06-07
-            # snapshot carrying pre-#119 inverted marks). Paper rows are never
-            # re-marked, so they linger frozen forever and leak into unfiltered
-            # risk reads (risk/portfolio.py `SELECT * FROM portfolio`), inflating
-            # category exposure / position count with fiction. This live sync is
-            # the sole authoritative Kalshi source — drop the paper book. (If
-            # paper-Kalshi trading is ever reintroduced, revisit this.)
-            await db.execute(
-                "DELETE FROM portfolio WHERE exchange = 'kalshi' AND is_paper = 1"
-            )
-            await db.execute(
-                """DELETE FROM cost_basis
-                   WHERE is_paper = 1
-                     AND market_id IN (SELECT id FROM markets WHERE exchange = 'kalshi')"""
-            )
+            # NOTE (history): a paper-Kalshi purge lived here 2026-06→07 (#131)
+            # under the assumption that "the paper trader never writes Kalshi
+            # positions". That became false when the Kalshi PAPER strategies
+            # shipped (informed_flow #230/#231, the Kalshi lens #257,
+            # econ_indicator) — the purge then silently shredded every Kalshi
+            # paper book on each live sync: fills accrued but cost_basis and
+            # portfolio rows vanished within minutes, so nothing ever settled
+            # into the ledger and those cells' records were structurally
+            # impossible. The purge is REMOVED; the legacy 2026-06-07 orphan
+            # snapshot it targeted was already gone after a month of purges.
 
             await db.commit()
             if synced > 0:

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -171,30 +171,33 @@ class TestKalshiLivePositionAccounting:
             await db.close()
 
     @pytest.mark.asyncio
-    async def test_sync_positions_purges_orphaned_paper_kalshi_rows(self):
-        """Legacy is_paper=1 Kalshi rows (the paper trader never writes Kalshi)
-        are orphans with frozen, side-inverted marks that leak into unfiltered
-        risk reads. A live sync must purge them from portfolio and cost_basis."""
+    async def test_sync_positions_preserves_paper_kalshi_rows(self):
+        """The live sync must NOT touch is_paper=1 Kalshi rows. A purge lived
+        here while nothing traded Kalshi on paper; once the Kalshi paper
+        strategies shipped (informed_flow, the Kalshi lens, econ_indicator) it
+        silently shredded their books on every sync — fills accrued but
+        positions and cost basis vanished, so nothing ever settled into the
+        ledger and those cells' records were structurally impossible."""
         db = Database(":memory:")
         await db.connect()
         try:
-            # Seed a stale orphaned paper Kalshi position + cost basis.
+            # Seed a PAPER Kalshi position + cost basis (a live pillar's book).
             await db.execute(
                 """INSERT INTO portfolio
                    (market_id, exchange, side, size, avg_price, current_price,
                     unrealized_pnl, category, token, token_id, is_paper, updated_at)
-                   VALUES ('KXSTALE', 'kalshi', 'BUY', 100, 0.80, 0.10,
-                           -70.0, 'other', 'NO', 'KXSTALE', 1, '2026-01-01 00:00:00')"""
+                   VALUES ('KXPAPER', 'kalshi', 'BUY', 27, 0.37, 0.37,
+                           0.0, 'economics', 'YES', 'KXPAPER', 1, datetime('now'))"""
             )
             await db.execute(
                 """INSERT INTO markets (id, exchange, question, category, active,
                    outcome_yes_price, outcome_no_price, last_updated)
-                   VALUES ('KXSTALE', 'kalshi', 'Stale?', 'other', 1, 0.9, 0.1, datetime('now'))"""
+                   VALUES ('KXPAPER', 'kalshi', 'Paper?', 'economics', 1, 0.37, 0.63, datetime('now'))"""
             )
             await db.execute(
                 """INSERT INTO cost_basis
                    (market_id, token, token_id, size, avg_cost, total_cost, is_paper, updated_at)
-                   VALUES ('KXSTALE', 'NO', 'KXSTALE', 100, 0.80, 80.0, 1, '2026-01-01 00:00:00')"""
+                   VALUES ('KXPAPER', 'YES', 'KXPAPER', 27, 0.37, 9.99, 1, datetime('now'))"""
             )
             await db.commit()
 
@@ -216,11 +219,11 @@ class TestKalshiLivePositionAccounting:
 
             await client.sync_positions(db)
 
-            # Orphaned paper row purged from both tables.
+            # Paper book untouched by the LIVE sync.
             assert await db.fetchone(
-                "SELECT 1 FROM portfolio WHERE market_id='KXSTALE' AND is_paper=1") is None
+                "SELECT 1 FROM portfolio WHERE market_id='KXPAPER' AND is_paper=1") is not None
             assert await db.fetchone(
-                "SELECT 1 FROM cost_basis WHERE market_id='KXSTALE' AND is_paper=1") is None
+                "SELECT 1 FROM cost_basis WHERE market_id='KXPAPER' AND is_paper=1") is not None
             # Live position still synced.
             assert await db.fetchone(
                 "SELECT 1 FROM portfolio WHERE market_id='KXLIVE' AND is_paper=0") is not None


### PR DESCRIPTION
The live position sync deleted ALL is_paper=1 Kalshi portfolio and
cost_basis rows on every pass, from an era when nothing traded Kalshi on
paper (the purge targeted a one-time 2026-06 orphan snapshot with inverted
marks, and carried an explicit "revisit if paper-Kalshi trading is ever
reintroduced" note). Paper-Kalshi trading WAS reintroduced — informed_flow,
the Kalshi resolution-lens cell, econ_indicator — and the purge silently
destroyed their books within minutes of every entry: fills accrued, but
positions and cost basis vanished, so nothing ever settled into the ledger
and those cells produced no record at all. Their silence was structural,
not evidence about the strategies.

The purge is removed (the legacy orphans it targeted are long gone after a
month of purging); the test that pinned the purge now pins the opposite:
a live sync must not touch the paper book.

Assisted-by: Claude (Anthropic)
