### PR TITLE
feat(strategy): term_structure pillar — price a deadline ladder off one reading

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1392,6 +1392,10 @@ class AuramaurBot(
         if self.settings.agent_trader.enabled:
             tasks.append(asyncio.create_task(self._task_agent_trader(), name="agent_trader"))
 
+        # Deadline-ladder curve reader (paper-forced; amortized reading edge)
+        if self.settings.term_structure.enabled:
+            tasks.append(asyncio.create_task(self._task_term_structure(), name="term_structure"))
+
         # Informed-flow follower over Kalshi (paper-forced; abnormal-trade-size)
         if self.settings.informed_flow.enabled:
             tasks.append(asyncio.create_task(self._task_informed_flow(), name="informed_flow"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -90,6 +90,30 @@ class StrategyTaskMixin:
                 log.error("agent_trader.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_term_structure(self) -> None:
+        """Periodic deadline-ladder curve reader (paper-forced; one LLM read
+        prices a whole family of strikes)."""
+        from auramaur.strategy.term_structure import TermStructurePillar
+
+        pillar = TermStructurePillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(600, self.settings.term_structure.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("term_structure.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_informed_flow(self) -> None:
         """Periodic Kalshi informed-flow follower (abnormal-trade-size). Paper-
         forced; no-ops cleanly when the Kalshi venue isn't composed."""

--- a/auramaur/monitoring/books.py
+++ b/auramaur/monitoring/books.py
@@ -45,6 +45,9 @@ def _book_modes(settings) -> list[tuple[str, str, str]]:
     at = settings.agent_trader
     rows.append(("agent_trader", *paper_mode(
         at, f"models: {', '.join(m.alias for m in at.models)} — one cell each")))
+    ts = settings.term_structure
+    rows.append(("term_structure", *paper_mode(
+        ts, f">={ts.min_strikes} strikes, curve/24h, edge>={ts.min_edge_pts:.0f}pts")))
 
     rows.append(("market_maker",
                  "LIVE" if settings.market_maker.enabled and settings.is_live

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -1,0 +1,497 @@
+"""Term-structure pillar — price a deadline ladder off ONE reading of the event.
+
+Deadline families ("X by July 10?", "X by July 17?", … — 70+ active families,
+some with 13 strikes spanning 1c-90c) are priced strike-by-strike by the
+crowd, independently. But the strikes share one underlying question: WHEN, if
+ever, does the event happen. This pillar reads the family once — rules plus
+current evidence, one LLM call — into an event-time curve (P(event by each
+listed deadline)), then prices EVERY strike off that curve and trades the
+largest gaps. One call amortizes across the whole ladder, which is the direct
+answer to the budget-throughput constraint that starves per-market readers
+(the lens); and a curve fit is structurally immune to the "right story,
+wrong strike" failure observed in the per-market reads.
+
+The reading-edge thesis this operationalizes: an LLM can out-READ the crowd —
+resolution rules, registers, deadlines, term structure — not out-forecast it.
+The curve is a timeline judgment anchored on the family's own resolution
+criteria, not a world-model prophecy.
+
+Deterministic sanity comes free: within a family, P(by T1) <= P(by T2) for
+T1 < T2. Violations are logged (entailment_arb owns trading them); the model
+curve itself is isotonic-clamped so a noisy read can't emit an impossible
+curve.
+
+Data hygiene (why candidates come from live discovery, not the markets
+table): stored end_date is NULL or wrong for many ladder strikes and
+resolved markets freeze active=1, so families are built from the dated
+discovery scan and the deadline is parsed from the QUESTION TEXT.
+
+Rides the standard rails: signals + trades attribution, full RiskManager
+gate, ExecutionGateway placement, resolution-tracker settlement. PAPER-FORCED
+(new directional cell under the enforced graduation ladder). One position per
+market bot-wide (settlement attribution is market-scoped for same-token
+stacks; see agent_trader for the same rule and rationale).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+
+log = structlog.get_logger()
+
+_MONTHS = {m.lower(): i + 1 for i, m in enumerate(
+    ["January", "February", "March", "April", "May", "June", "July",
+     "August", "September", "October", "November", "December"])}
+
+# "... by July 10, 2026?" / "... by July 10?" / "... by end of 2026?"
+_BY_DATE_RE = re.compile(
+    r"\bby\s+([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s*(\d{4}))?\s*\??\s*$",
+    re.IGNORECASE,
+)
+
+CURVE_PROMPT = """\
+You are pricing a prediction-market DEADLINE LADDER: the same event with \
+multiple "by <date>" strikes. Read the resolution criteria and research the \
+current state of the event (you may use WebSearch/WebFetch), then give YOUR \
+probability that the event happens by EACH deadline.
+
+Anchor on the RESOLUTION CRITERIA, not the headline: what exactly must occur, \
+per the rules text, for YES. Probabilities must be non-decreasing with later \
+deadlines. Base your read ONLY on the material below plus your own research.
+
+Respond with STRICT JSON only, no prose, no code fences:
+{{"thesis": "one sentence: the timeline mechanism the crowd misprices", \
+"curve": [{{"market_id": "...", "prob": 0.0}}]}}
+Include every strike listed below in "curve".
+
+EVENT FAMILY: {family}
+
+RESOLUTION CRITERIA (from the longest-dated strike):
+{rules}
+
+STRIKES (deadline | current market price = crowd's probability):
+{strikes}
+"""
+
+_CURVES_TABLE = """
+CREATE TABLE IF NOT EXISTS term_structure_curves (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    family TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    deadline TEXT DEFAULT '',
+    model_prob REAL,
+    market_prob REAL,
+    thesis TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now'))
+)
+"""
+
+
+def parse_deadline(question: str) -> datetime | None:
+    """Deadline from the question tail ('… by July 10, 2026?'). The stored
+    end_date is unreliable for ladder strikes (NULL/wrong), so the question
+    text is the source of truth."""
+    m = _BY_DATE_RE.search(question or "")
+    if not m:
+        return None
+    month = _MONTHS.get(m.group(1).lower())
+    if month is None:
+        return None
+    day = int(m.group(2))
+    year = int(m.group(3)) if m.group(3) else datetime.now(timezone.utc).year
+    try:
+        return datetime(year, month, day, tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def family_key(question: str) -> str | None:
+    """Normalized family identity: the question up to its ' by <date>' tail."""
+    m = _BY_DATE_RE.search(question or "")
+    if not m:
+        return None
+    return question[: m.start()].strip().lower()
+
+
+def parse_curve(raw: str, strikes: list[Market]) -> tuple[str, dict[str, float]]:
+    """(thesis, {market_id: prob}) from the model reply — tolerant of fences
+    and prose, isotonic-clamped in deadline order so an impossible curve
+    (P(by T1) > P(by T2)) can never be emitted. Returns ({}, {}) shape on
+    garbage; a bad reply must never crash a cycle."""
+    text = raw.strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start < 0 or end <= start:
+        return "", {}
+    try:
+        payload = json.loads(text[start:end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return "", {}
+    entries = payload.get("curve")
+    if not isinstance(entries, list):
+        return "", {}
+    probs: dict[str, float] = {}
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        mid = str(e.get("market_id", "")).strip()
+        try:
+            p = float(e.get("prob"))
+        except (TypeError, ValueError):
+            continue
+        if mid and 0.0 <= p <= 1.0:
+            probs[mid] = p
+    # Isotonic clamp in deadline order: running max.
+    running = 0.0
+    for mkt in strikes:  # strikes arrive deadline-sorted
+        if mkt.id in probs:
+            running = max(running, probs[mkt.id])
+            probs[mkt.id] = running
+    thesis = str(payload.get("thesis", "")).strip()
+    return thesis, probs
+
+
+class TermStructurePillar:
+    """Deadline-ladder curve reader over Polymarket."""
+
+    name = "term_structure"
+
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+        self._schema_ready = False
+
+    async def _ensure_schema(self) -> None:
+        if self._schema_ready:
+            return
+        await self._db.execute(_CURVES_TABLE)
+        await self._db.commit()
+        self._schema_ready = True
+
+    # ------------------------------------------------------------------
+    # Cycle
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.term_structure
+        if not cfg.enabled:
+            return 0
+        await self._ensure_schema()
+        families = await self._families(cfg)
+        if not families:
+            log.info("term_structure.no_families")
+            return 0
+        entered = 0
+        calls = 0
+        for fam, strikes in families:
+            try:
+                curve = await self._cached_curve(fam, cfg)
+                if curve is None:
+                    if calls >= cfg.families_per_cycle:
+                        continue  # fresh reads capped; cached fams still trade
+                    calls += 1
+                    curve = await self._read_family(fam, strikes, cfg)
+                if not curve:
+                    continue
+                thesis, probs = curve
+                entered += await self._trade_curve(fam, strikes, thesis,
+                                                   probs, cfg)
+            except Exception as e:
+                log.warning("term_structure.family_error", family=fam,
+                            error=str(e))
+        if entered:
+            log.info("term_structure.cycle_done", entered=entered,
+                     families=len(families), reads=calls)
+        return entered
+
+    # ------------------------------------------------------------------
+    # Families — live discovery, question-text deadlines
+    # ------------------------------------------------------------------
+
+    async def _families(self, cfg) -> list[tuple[str, list[Market]]]:
+        now = datetime.now(timezone.utc)
+        emin = (now + timedelta(days=cfg.min_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        emax = (now + timedelta(days=cfg.max_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        raw: list[Market] = []
+        try:
+            for off in range(0, max(int(cfg.scan_limit), 1), 100):
+                page = await self._discovery.get_markets(
+                    limit=100, offset=off, order="volume",
+                    end_date_min=emin, end_date_max=emax)
+                if not page:
+                    break
+                raw.extend(page)
+        except TypeError:
+            raw = await self._discovery.get_markets(limit=cfg.scan_limit)
+
+        groups: dict[str, list[Market]] = {}
+        for m in raw:
+            if not self._eligible(m, cfg):
+                continue
+            fam = family_key(m.question)
+            if fam is None or parse_deadline(m.question) is None:
+                continue
+            groups.setdefault(fam, []).append(m)
+
+        out: list[tuple[str, list[Market]]] = []
+        for fam, strikes in groups.items():
+            if len(strikes) < cfg.min_strikes:
+                continue
+            strikes.sort(key=lambda m: parse_deadline(m.question))
+            self._log_monotonicity(fam, strikes)
+            out.append((fam, strikes))
+        # Widest ladders first — the most opinion per read.
+        out.sort(key=lambda fs: (len(fs[1]), sum(m.volume for m in fs[1])),
+                 reverse=True)
+        return out[: cfg.max_families]
+
+    def _eligible(self, market: Market, cfg) -> bool:
+        if not market.active:
+            return False
+        if (market.exchange or "polymarket") != "polymarket":
+            return False
+        if market.liquidity < cfg.min_liquidity:
+            return False
+        if not (0.02 <= market.outcome_yes_price <= 0.98):
+            return False
+        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        if blocked_category_hit(excluded, market.question, market.description,
+                                market.category):
+            return False
+        return True
+
+    @staticmethod
+    def _log_monotonicity(fam: str, strikes: list[Market]) -> None:
+        """P(by T1) <= P(by T2) must hold; a violation is model-free signal
+        for entailment_arb — here it is only surfaced, not traded."""
+        prev = 0.0
+        for m in strikes:
+            if m.outcome_yes_price < prev - 0.03:  # tolerance for spread noise
+                log.info("term_structure.monotonicity_violation",
+                         family=fam, market_id=m.id,
+                         price=m.outcome_yes_price, earlier_strike=prev)
+            prev = max(prev, m.outcome_yes_price)
+
+    # ------------------------------------------------------------------
+    # Curve read — one LLM call per family, cached
+    # ------------------------------------------------------------------
+
+    async def _cached_curve(self, fam: str, cfg) -> tuple[str, dict[str, float]] | None:
+        rows = await self._db.fetchall(
+            """SELECT market_id, model_prob, thesis FROM term_structure_curves
+               WHERE family = ? AND created_at > datetime('now', ?)""",
+            (fam, f"-{float(cfg.curve_ttl_hours)} hours"),
+        )
+        if not rows:
+            return None
+        probs = {r["market_id"]: float(r["model_prob"]) for r in rows}
+        return (rows[0]["thesis"] or "", probs)
+
+    async def _read_family(self, fam: str, strikes: list[Market],
+                           cfg) -> tuple[str, dict[str, float]] | None:
+        rules = (strikes[-1].description or strikes[-1].question)[:1500]
+        lines = []
+        for m in strikes:
+            d = parse_deadline(m.question)
+            lines.append(f"- market_id={m.id} | by {d.strftime('%Y-%m-%d')} | "
+                         f"price {m.outcome_yes_price:.2f}")
+        prompt = CURVE_PROMPT.format(
+            family=strikes[-1].question, rules=rules, strikes="\n".join(lines))
+        raw = await self._call_model(prompt, cfg)
+        thesis, probs = parse_curve(raw, strikes)
+        if not probs:
+            log.info("term_structure.unparseable_curve", family=fam)
+            return None
+        for m in strikes:
+            if m.id in probs:
+                d = parse_deadline(m.question)
+                await self._db.execute(
+                    """INSERT INTO term_structure_curves
+                       (family, market_id, deadline, model_prob, market_prob, thesis)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (fam, m.id, d.strftime("%Y-%m-%d"), probs[m.id],
+                     m.outcome_yes_price, thesis[:400]),
+                )
+        await self._db.commit()
+        log.info("term_structure.curve_read", family=fam,
+                 strikes=len(probs))
+        return thesis, probs
+
+    async def _call_model(self, prompt: str, cfg) -> str:
+        from auramaur.nlp import call_budget
+        from auramaur.nlp.errors import BudgetExhausted
+
+        budget = self._settings.nlp.daily_claude_call_budget
+        if budget > 0:
+            limit = max(0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            if call_budget.calls_today() >= limit:
+                raise BudgetExhausted(
+                    f"non-reserved Claude budget ({limit}/{budget}) exhausted")
+        # Neutral cwd: `claude -p` loads CLAUDE.md + project memory from its
+        # working directory (see agent_trader / the context-leak note).
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "-p", prompt,
+            "--output-format", "text",
+            "--model", cfg.model,
+            "--effort", cfg.effort,
+            "--allowedTools", "WebSearch,WebFetch",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=tempfile.gettempdir(),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=cfg.llm_timeout_seconds)
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise RuntimeError("curve read timed out")
+        call_budget.record_call()
+        if proc.returncode != 0:
+            raise RuntimeError(f"curve read failed: {stderr.decode()[:200]}")
+        return stdout.decode()
+
+    # ------------------------------------------------------------------
+    # Trading the curve — standard rails per strike
+    # ------------------------------------------------------------------
+
+    async def _trade_curve(self, fam: str, strikes: list[Market], thesis: str,
+                           probs: dict[str, float], cfg) -> int:
+        entered = 0
+        gaps = []
+        for m in strikes:
+            if m.id not in probs:
+                continue
+            gap = abs(probs[m.id] - m.outcome_yes_price) * 100.0
+            if gap >= cfg.min_edge_pts:
+                gaps.append((gap, m))
+        gaps.sort(reverse=True, key=lambda g: g[0])
+        for gap, market in gaps:
+            if entered >= cfg.max_entries_per_family:
+                break
+            # Claimed markets don't consume an entry slot — the cap applies
+            # to entries actually made, largest gaps first.
+            if await self._market_claimed(market.id):
+                continue
+            if await self._try_enter(market, probs[market.id], thesis, cfg):
+                entered += 1
+        return entered
+
+    async def _market_claimed(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM trades WHERE market_id = ? LIMIT 1", (market_id,))
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,))
+        return row is not None
+
+    async def _try_enter(self, market: Market, prob_yes: float, thesis: str,
+                         cfg) -> bool:
+        market_yes = market.outcome_yes_price
+        side = OrderSide.BUY if prob_yes > market_yes else OrderSide.SELL
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=prob_yes,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market_yes,
+            edge=abs(prob_yes - market_yes) * 100.0,
+            evidence_summary=thesis[:500],
+            recommended_side=side,
+            strategy_source="term_structure",
+            mispricing_reason=(
+                f"term-structure: {thesis[:250]}" if thesis else
+                "term-structure: strike mispriced vs family event-time curve"),
+        )
+        await self._persist_signal(signal, market)
+
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("term_structure.risk_rejected", market_id=market.id,
+                     reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size,
+            force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.info("term_structure.order_rejected", market_id=market.id,
+                     status=res.status, error=res.reason)
+            return False
+        await self._record_position(signal, market, res.order, res.result)
+        log.info("term_structure.entered", market_id=market.id,
+                 token=res.order.token.value, price=res.order.price,
+                 size=res.order.size, model_prob=round(prob_yes, 2),
+                 paper=res.result.is_paper)
+        return True
+
+    # ------------------------------------------------------------------
+    # Bookkeeping — same rails as the other pillars
+    # ------------------------------------------------------------------
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.exchange or "polymarket", market.condition_id,
+             market.question, (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'term_structure')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value),
+        )
+        await self._db.commit()
+
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if result.is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("term_structure.calibration_error", error=str(e))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -523,6 +523,33 @@ agent_trader:
   llm_timeout_seconds: 420   # room for WebSearch rounds
   decline_ttl_hours: 24.0    # a pass keeps the market off the arm's slate this long
 
+term_structure:
+  # Deadline-ladder curve reader — the reading edge, amortized: ONE LLM read
+  # per family ("X by <date>" ladders, 70+ active with 3-13 strikes) into an
+  # event-time curve, then every strike is priced off it. Curves cached 24h;
+  # steady-state spends calls only on new/expired families. Deadlines parsed
+  # from QUESTION TEXT (stored end_date is unreliable for ladder strikes).
+  # PAPER-FORCED, own graduation cell. Monotonicity violations are logged for
+  # entailment_arb, not traded here.
+  enabled: true
+  paper: true
+  interval_seconds: 7200
+  model: claude-opus-4-8
+  effort: medium
+  scan_limit: 300
+  min_strikes: 3
+  max_families: 12
+  families_per_cycle: 3
+  curve_ttl_hours: 24.0
+  max_entries_per_family: 2
+  stake_usd: 10.0
+  min_liquidity: 1000.0
+  min_days: 0.25
+  max_days: 90.0
+  min_edge_pts: 8.0
+  llm_timeout_seconds: 420
+  exclude_categories: []
+
 informed_flow:
   # Informed-flow follower over Kalshi — mimic the side of abnormally-large
   # (informed) order flow. Abnormal trade size (ATS) proxies non-liquidity trading

--- a/config/settings.py
+++ b/config/settings.py
@@ -553,6 +553,37 @@ class AgentTraderConfig(BaseModel):
     decline_ttl_hours: float = 24.0
 
 
+class TermStructureConfig(BaseModel):
+    """Deadline-ladder curve reader (strategy/term_structure.py).
+
+    One LLM read per FAMILY (same event, multiple 'by <date>' strikes) into an
+    event-time curve, then every strike is priced off that curve — one call
+    amortizes across up to a dozen markets, attacking the budget-throughput
+    constraint that starves per-market readers. PAPER-FORCED new directional
+    cell. Curves are cached ``curve_ttl_hours`` so steady-state spends calls
+    only on new/expired families.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    interval_seconds: int = 7200
+    model: str = "claude-opus-4-8"
+    effort: str = "medium"
+    scan_limit: int = 300
+    min_strikes: int = 3
+    max_families: int = 12
+    families_per_cycle: int = 3   # fresh LLM reads per cycle (cached fams free)
+    curve_ttl_hours: float = 24.0
+    max_entries_per_family: int = 2
+    stake_usd: float = 10.0
+    min_liquidity: float = 1000.0
+    min_days: float = 0.25
+    max_days: float = 90.0
+    min_edge_pts: float = 8.0
+    llm_timeout_seconds: int = 420
+    exclude_categories: list[str] = []
+
+
 class EconIndicatorConfig(BaseModel):
     """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
 
@@ -1230,6 +1261,7 @@ class Settings(BaseSettings):
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
     agent_trader: AgentTraderConfig = Field(default_factory=lambda: AgentTraderConfig(**_DEFAULTS.get("agent_trader", {})))
+    term_structure: TermStructureConfig = Field(default_factory=lambda: TermStructureConfig(**_DEFAULTS.get("term_structure", {})))
     informed_flow: InformedFlowConfig = Field(default_factory=lambda: InformedFlowConfig(**_DEFAULTS.get("informed_flow", {})))
     settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))

--- a/tests/test_term_structure.py
+++ b/tests/test_term_structure.py
@@ -1,0 +1,222 @@
+"""Term-structure pillar: deadline parsing, family grouping, curve parsing
+with isotonic clamping, cache amortization, and the standard-rails entry path
+(risk gate, market claim, per-family entry cap)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.strategy.term_structure import (
+    TermStructurePillar,
+    family_key,
+    parse_curve,
+    parse_deadline,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_parse_deadline_variants():
+    assert parse_deadline("US x Iran diplomatic meeting by July 10, 2026?") == \
+        datetime(2026, 7, 10, tzinfo=timezone.utc)
+    assert parse_deadline("GPT-5.6 released by August 5?").month == 8
+    assert parse_deadline("Will X happen by July 32, 2026?") is None  # bad day
+    assert parse_deadline("Will X happen this year?") is None
+    assert parse_deadline("") is None
+
+
+def test_family_key_strips_deadline_and_normalizes():
+    a = family_key("US x Iran diplomatic meeting by July 10, 2026?")
+    b = family_key("US x Iran diplomatic meeting by July 17, 2026?")
+    assert a == b == "us x iran diplomatic meeting"
+    assert family_key("No deadline here?") is None
+
+
+def _strike(mid: str, day: int, yes: float) -> Market:
+    return Market(id=mid, question=f"Event by July {day}, 2026?",
+                  outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+                  liquidity=5000.0, volume=10000.0, active=True,
+                  exchange="polymarket")
+
+
+def test_parse_curve_isotonic_clamp():
+    """A noisy read with P(by T1) > P(by T2) is clamped to non-decreasing."""
+    strikes = [_strike("a", 5, 0.2), _strike("b", 15, 0.4), _strike("c", 25, 0.6)]
+    raw = '{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.5},' \
+          '{"market_id": "b", "prob": 0.3}, {"market_id": "c", "prob": 0.9}]}'
+    thesis, probs = parse_curve(raw, strikes)
+    assert thesis == "t"
+    assert probs["a"] == pytest.approx(0.5)
+    assert probs["b"] == pytest.approx(0.5)  # clamped up to running max
+    assert probs["c"] == pytest.approx(0.9)
+
+
+def test_parse_curve_garbage_is_empty():
+    strikes = [_strike("a", 5, 0.2)]
+    assert parse_curve("cannot help", strikes) == ("", {})
+    assert parse_curve('{"curve": "nope"}', strikes) == ("", {})
+
+
+# ---------------------------------------------------------------------------
+# Pillar wiring
+# ---------------------------------------------------------------------------
+
+
+def _settings():
+    s = MagicMock()
+    cfg = s.term_structure
+    cfg.enabled = True
+    cfg.paper = True
+    cfg.model = "claude-opus-4-8"
+    cfg.effort = "medium"
+    cfg.scan_limit = 100
+    cfg.min_strikes = 3
+    cfg.max_families = 12
+    cfg.families_per_cycle = 3
+    cfg.curve_ttl_hours = 24.0
+    cfg.max_entries_per_family = 2
+    cfg.stake_usd = 10.0
+    cfg.min_liquidity = 1000.0
+    cfg.min_days = 0.25
+    cfg.max_days = 90.0
+    cfg.min_edge_pts = 8.0
+    cfg.llm_timeout_seconds = 420
+    cfg.exclude_categories = []
+    s.risk.blocked_categories = []
+    s.nlp.daily_claude_call_budget = 0
+    return s
+
+
+async def _pillar(tmp_path, markets, llm_reply: str):
+    db = Database(str(tmp_path / "t.db"))
+    await db.connect()
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    risk = MagicMock()
+    decision = MagicMock()
+    decision.approved = True
+    decision.position_size = 8.0
+    decision.reason = ""
+    decision.force_paper = False
+    risk.evaluate = AsyncMock(return_value=decision)
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+    pillar = TermStructurePillar(
+        db=db, settings=_settings(), discovery=discovery, exchange=MagicMock(),
+        risk_manager=risk, pnl_tracker=MagicMock(), calibration=calibration)
+
+    result = MagicMock()
+    result.status = "paper"
+    result.reason = ""
+    order = MagicMock()
+    order.token.value = "YES"
+    order.token_id = "tok"
+    order.price = 0.30
+    order.size = 33.3
+    fill = MagicMock()
+    fill.is_paper = True
+    fill.filled_size = 33.3
+    fill.filled_price = 0.30
+
+    def _submit_side_effect(intent):
+        order.market_id = intent.market.id
+        result.order = order
+        result.result = fill
+        return result
+
+    pillar._gateway = MagicMock()
+    pillar._gateway.submit = AsyncMock(side_effect=_submit_side_effect)
+    pillar._call_model = AsyncMock(return_value=llm_reply)
+    return pillar, db, risk
+
+
+def _ladder():
+    return [_strike("a", 5, 0.10), _strike("b", 15, 0.30), _strike("c", 25, 0.50)]
+
+
+@pytest.mark.asyncio
+async def test_one_read_trades_multiple_strikes(tmp_path):
+    """One curve read produces entries across the family — capped by
+    max_entries_per_family, largest gaps first."""
+    reply = ('{"thesis": "timeline says sooner", "curve": ['
+             '{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.70},'
+             '{"market_id": "c", "prob": 0.72}]}')
+    pillar, db, risk = await _pillar(tmp_path, _ladder(), reply)
+    try:
+        entered = await pillar.run_once()
+        assert entered == 2                        # cap, not 3
+        assert pillar._call_model.await_count == 1  # ONE read for the family
+        sigs = await db.fetchall(
+            "SELECT market_id, edge FROM signals ORDER BY edge DESC")
+        assert {r["market_id"] for r in sigs} == {"b", "a"}  # gaps 40, 30 (c=22)
+        assert risk.evaluate.await_count == 2      # full gate per entry
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_cached_curve_spends_no_call(tmp_path):
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.70}, {"market_id": "c", "prob": 0.72}]}')
+    pillar, db, _ = await _pillar(tmp_path, _ladder(), reply)
+    try:
+        await pillar.run_once()
+        assert pillar._call_model.await_count == 1
+        await pillar.run_once()                    # curve cached, markets claimed
+        assert pillar._call_model.await_count == 1  # no second read
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_small_gaps_enter_nothing(tmp_path):
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.12},'
+             '{"market_id": "b", "prob": 0.33}, {"market_id": "c", "prob": 0.54}]}')
+    pillar, db, _ = await _pillar(tmp_path, _ladder(), reply)
+    try:
+        assert await pillar.run_once() == 0        # all gaps < 8 pts
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_claimed_market_skipped(tmp_path):
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.70}, {"market_id": "c", "prob": 0.72}]}')
+    pillar, db, _ = await _pillar(tmp_path, _ladder(), reply)
+    try:
+        await db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, exchange, strategy_source)
+               VALUES ('b', datetime('now'), 'BUY', 10, 0.3, 1, 'x', 'paper',
+                       'polymarket', 'llm')""")
+        await db.commit()
+        entered = await pillar.run_once()
+        # b is claimed -> the two entries come from the remaining strikes.
+        sigs = {r["market_id"] for r in await db.fetchall(
+            "SELECT market_id FROM signals")}
+        assert "b" not in sigs
+        assert entered == 2 and sigs == {"a", "c"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_families_below_min_strikes_ignored(tmp_path):
+    pillar, db, _ = await _pillar(
+        tmp_path, [_strike("a", 5, 0.10), _strike("b", 15, 0.30)], "")
+    try:
+        assert await pillar.run_once() == 0
+        pillar._call_model.assert_not_awaited()
+    finally:
+        await db.close()


### PR DESCRIPTION
Deadline families ("X by <date>" with 3+ strikes; 70+ active, up to 13
strikes spanning 1c-90c) are priced strike-by-strike by the crowd, but share
one underlying question: WHEN, if ever. The pillar reads a family ONCE (rules
+ current evidence, WebSearch-enabled, one LLM call) into an event-time
curve, then prices EVERY strike off that curve and enters the largest gaps —
one call amortized across the whole ladder, attacking the budget-throughput
constraint that starves per-market readers. A curve fit is structurally
immune to the right-story-wrong-strike failure observed in per-market reads.

Mechanics: families built from live dated discovery with deadlines parsed
from QUESTION TEXT (stored end_date is NULL/wrong for many strikes and
resolved rows freeze active=1); model curves isotonic-clamped so an
impossible curve (P by T1 > P by T2) cannot be emitted; observed price
monotonicity violations are logged for entailment_arb, not traded; curves
cached 24h so steady-state spends calls only on new/expired families;
claimed markets skipped without consuming the per-family entry cap.

Standard rails: signals + trades attribution, full RiskManager gate,
ExecutionGateway placement, resolution-tracker settlement, calibration
predictions. PAPER-FORCED, own graduation cell, neutral-cwd subprocess
(context-leak hygiene), budget-guarded against the pinned lens slice.

Assisted-by: Claude (Anthropic)
