### PR TITLE
fix(term_structure): seed-and-search family assembly — volume scans cannot see ladders

### DIFF
--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -228,6 +228,12 @@ class TermStructurePillar:
     # ------------------------------------------------------------------
 
     async def _families(self, cfg) -> list[tuple[str, list[Market]]]:
+        """Seed-and-search family assembly. A volume-ranked dated scan cannot
+        see ladders — deep strikes are low-volume by construction, so the
+        top-of-volume slice yields lone members (observed: 73 eligible, 10
+        ladder members, ZERO complete families; the same wall long_horizon hit
+        with its first scan). Any parseable 'by <date>' hit is treated as a
+        SEED, and the family's siblings are fetched live via text search."""
         now = datetime.now(timezone.utc)
         emin = (now + timedelta(days=cfg.min_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
         emax = (now + timedelta(days=cfg.max_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -243,17 +249,46 @@ class TermStructurePillar:
         except TypeError:
             raw = await self._discovery.get_markets(limit=cfg.scan_limit)
 
-        groups: dict[str, list[Market]] = {}
+        groups: dict[str, dict[str, Market]] = {}
+        seed_volume: dict[str, float] = {}
         for m in raw:
             if not self._eligible(m, cfg):
                 continue
             fam = family_key(m.question)
             if fam is None or parse_deadline(m.question) is None:
                 continue
-            groups.setdefault(fam, []).append(m)
+            groups.setdefault(fam, {})[m.id] = m
+            seed_volume[fam] = seed_volume.get(fam, 0.0) + m.volume
+
+        # Complete incomplete families by live sibling search, highest-volume
+        # seeds first, bounded to max_families searches per cycle.
+        searcher = getattr(self._discovery, "search_markets", None)
+        if searcher is not None:
+            searched = 0
+            for fam in sorted(groups, key=lambda f: -seed_volume[f]):
+                if len(groups[fam]) >= cfg.min_strikes:
+                    continue  # scan already delivered the ladder
+                if searched >= cfg.max_families:
+                    break
+                searched += 1
+                try:
+                    siblings = await searcher(fam, limit=20)
+                    for s in siblings or []:
+                        if family_key(s.question) != fam:
+                            continue
+                        if parse_deadline(s.question) is None:
+                            continue
+                        if not self._eligible(s, cfg):
+                            continue
+                        groups[fam][s.id] = s
+                except Exception as e:
+                    log.debug("term_structure.sibling_search_failed",
+                              family=fam, error=str(e))
+                    continue
 
         out: list[tuple[str, list[Market]]] = []
-        for fam, strikes in groups.items():
+        for fam, by_id in groups.items():
+            strikes = list(by_id.values())
             if len(strikes) < cfg.min_strikes:
                 continue
             strikes.sort(key=lambda m: parse_deadline(m.question))

--- a/tests/test_term_structure.py
+++ b/tests/test_term_structure.py
@@ -100,6 +100,7 @@ async def _pillar(tmp_path, markets, llm_reply: str):
     await db.connect()
     discovery = MagicMock()
     discovery.get_markets = AsyncMock(return_value=markets)
+    discovery.search_markets = AsyncMock(return_value=[])
     risk = MagicMock()
     decision = MagicMock()
     decision.approved = True
@@ -218,5 +219,36 @@ async def test_families_below_min_strikes_ignored(tmp_path):
     try:
         assert await pillar.run_once() == 0
         pillar._call_model.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_seed_and_search_completes_a_family(tmp_path):
+    """A volume-ranked scan yields lone ladder members (deep strikes are
+    low-volume); a single seed must trigger a live sibling search that
+    completes the family."""
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.70}, {"market_id": "c", "prob": 0.72}]}')
+    seed_only = [_strike("a", 5, 0.10)]  # scan sees ONE strike
+    pillar, db, _ = await _pillar(tmp_path, seed_only, reply)
+    pillar._settings.term_structure.min_strikes = 3
+    full = _ladder()
+    pillar._discovery.search_markets = AsyncMock(return_value=full + [
+        # noise the merge must reject: wrong family / no deadline
+        Market(id="x", question="Unrelated by July 9, 2026?",
+               outcome_yes_price=0.5, outcome_no_price=0.5, liquidity=5000,
+               volume=100, active=True, exchange="polymarket"),
+        Market(id="y", question="Event happening soon?", outcome_yes_price=0.5,
+               outcome_no_price=0.5, liquidity=5000, volume=100, active=True,
+               exchange="polymarket"),
+    ])
+    try:
+        entered = await pillar.run_once()
+        assert entered == 2
+        pillar._discovery.search_markets.assert_awaited_once()
+        sigs = {r["market_id"] for r in await db.fetchall(
+            "SELECT market_id FROM signals")}
+        assert sigs == {"a", "b"}
     finally:
         await db.close()


### PR DESCRIPTION
First live cycle found ZERO families while 70+ exist: deep ladder strikes
are low-volume by construction, so the top-of-volume dated scan yields lone
members (73 eligible -> 10 ladder members -> 0 complete families; the same
wall long_horizon hit with its first scan). Any parseable 'by <date>' hit
now acts as a SEED: the family's siblings are fetched live via the
public-search endpoint (dedup by id, same family key, parseable deadline,
standard eligibility), bounded to max_families searches per cycle,
highest-volume seeds first. Scans that already deliver a complete ladder
skip the search.

Assisted-by: Claude (Anthropic)
