### PR TITLE
chore(graduation): headroom on the unproven-spray breadth cap

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -134,6 +134,13 @@ graduation:
   cache_seconds: 300
   # Structural/two-sided strategies bypass the ladder.
   exempt_strategies: ["arbitrage", "market_maker", "order_monitor"]
+  # Unproven-spray breadth cap (open PAPER positions across ALL cells before
+  # new unproven entries are skipped). Raised from the 100 default after the
+  # Kalshi paper-book restoration legitimately re-added a large block of open
+  # positions overnight and froze every unproven cell (including a pillar on
+  # its first day). Still a hard ceiling — exploration concentrates, it just
+  # doesn't get starved by bookkeeping repairs.
+  max_unproven_positions: 175
 
 intervals:
   market_scan_seconds: 300


### PR DESCRIPTION
The cap counts open paper positions across ALL cells; the Kalshi paper-book
restoration legitimately re-added a large block of open positions overnight,
pushing breadth past the cap and freezing every unproven cell — including a
pillar on its first day. Raise the ceiling so exploration is not starved by
a bookkeeping repair; it remains a hard cap.

Assisted-by: Claude (Anthropic)
