### PR TITLE
fix(agent_analyzer): depth agent runs from a neutral cwd — the memory channel is writable

### DIFF
--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import tempfile
 from pathlib import Path
 
 import structlog
@@ -335,6 +336,16 @@ class AgentAnalyzer:
         Tool access is restricted to WebSearch + WebFetch only — no file
         system, no code execution.  Cost is bounded by --max-turns and
         the daily call budget enforced by _check_budget().
+
+        Runs from a NEUTRAL cwd (same treatment as agent_trader /
+        term_structure): from the repo root, `claude -p` loads CLAUDE.md and
+        the project auto-memory — and the auto-memory channel is WRITABLE, so
+        a trading call can append unreviewed beliefs to the context that
+        seeds every future session and its own future calls (observed
+        2026-07-09: a 02:28 depth-agent cycle wrote its market analysis into
+        the operator's memory index — the world-model-poisoning shape, via
+        memory). The agent's sanctioned state is world_model.json, passed
+        explicitly in the prompt; it needs nothing from the ambient context.
         """
         cmd = [
             "claude", "-p", prompt,
@@ -361,6 +372,7 @@ class AgentAnalyzer:
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    cwd=tempfile.gettempdir(),
                 )
                 stdout, stderr = await asyncio.wait_for(
                     proc.communicate(), timeout=self._timeout_seconds,

--- a/tests/test_agent_analyzer_isolation.py
+++ b/tests/test_agent_analyzer_isolation.py
@@ -1,0 +1,51 @@
+"""Depth-agent CLI isolation: neutral cwd + restricted tools.
+
+From the repo root, `claude -p` loads CLAUDE.md and the project auto-memory —
+and the auto-memory channel is WRITABLE, so a trading call can append
+unreviewed beliefs to the context that seeds every future session and its own
+future calls (observed 2026-07-09: an overnight depth-agent cycle wrote its
+market analysis into the operator's memory index). The subprocess must run
+from the system temp dir with only WebSearch/WebFetch enabled; the agent's
+sanctioned state is world_model.json, passed explicitly in the prompt.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+import auramaur.strategy.agent_analyzer as aa
+from auramaur.strategy.agent_analyzer import AgentAnalyzer
+
+
+@pytest.mark.asyncio
+async def test_cli_call_neutral_cwd_and_restricted_tools(monkeypatch):
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(aa.asyncio, "create_subprocess_exec", fake_exec)
+
+    settings = MagicMock()
+    settings.nlp.model = "claude-opus-4-8"
+    settings.nlp.effort_tool_use = "medium"
+    settings.nlp.daily_claude_call_budget = 0  # unlimited: skip budget gate
+    analyzer = AgentAnalyzer(settings=settings, db=MagicMock())
+
+    out = await analyzer._call_claude_agent("prompt")
+    assert out == "ok"
+    cmd = captured["cmd"]
+    assert captured["kwargs"]["cwd"] == tempfile.gettempdir()
+    assert "--allowedTools" in cmd
+    assert cmd[cmd.index("--allowedTools") + 1] == "WebSearch,WebFetch"


### PR DESCRIPTION
From the repo root, `claude -p` loads CLAUDE.md and the project auto-memory,
and the auto-memory channel is WRITABLE: an overnight depth-agent cycle was
found appending its own market analysis to the operator's memory index — an
unattended trading subprocess writing unreviewed beliefs into the context
that seeds every future session and its own future calls (the world-model-
poisoning shape, via memory). Same neutral-cwd treatment as agent_trader and
term_structure; the agent's sanctioned state is world_model.json, which the
PARENT process reads/writes (bot cwd unchanged) and injects as prompt text,
so nothing is lost. The lens keeps its ambient context per the standing
measured-A/B decision — reading is a known tradeoff there; writing is not.

Assisted-by: Claude (Anthropic)
