### PR TITLE
feat(strategy): vol_anchor pillar — deterministic GBM pricing of crypto threshold markets

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1396,6 +1396,10 @@ class AuramaurBot(
         if self.settings.term_structure.enabled:
             tasks.append(asyncio.create_task(self._task_term_structure(), name="term_structure"))
 
+        # Vol-anchored crypto threshold pricing (paper-forced; deterministic)
+        if self.settings.vol_anchor.enabled:
+            tasks.append(asyncio.create_task(self._task_vol_anchor(), name="vol_anchor"))
+
         # Informed-flow follower over Kalshi (paper-forced; abnormal-trade-size)
         if self.settings.informed_flow.enabled:
             tasks.append(asyncio.create_task(self._task_informed_flow(), name="informed_flow"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -114,6 +114,30 @@ class StrategyTaskMixin:
                 log.error("term_structure.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_vol_anchor(self) -> None:
+        """Periodic deterministic vol-anchored crypto threshold pricing
+        (paper-forced; zero LLM cost)."""
+        from auramaur.strategy.vol_anchor import VolAnchorPillar
+
+        pillar = VolAnchorPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(600, self.settings.vol_anchor.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("vol_anchor.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_informed_flow(self) -> None:
         """Periodic Kalshi informed-flow follower (abnormal-trade-size). Paper-
         forced; no-ops cleanly when the Kalshi venue isn't composed."""

--- a/auramaur/monitoring/books.py
+++ b/auramaur/monitoring/books.py
@@ -48,6 +48,9 @@ def _book_modes(settings) -> list[tuple[str, str, str]]:
     ts = settings.term_structure
     rows.append(("term_structure", *paper_mode(
         ts, f">={ts.min_strikes} strikes, curve/24h, edge>={ts.min_edge_pts:.0f}pts")))
+    va = settings.vol_anchor
+    rows.append(("vol_anchor", *paper_mode(
+        va, f"GBM thresholds, tau {va.tau_years:.2f}y, edge>={va.min_edge_pts:.0f}pts")))
 
     rows.append(("market_maker",
                  "LIVE" if settings.market_maker.enabled and settings.is_live

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -1,0 +1,415 @@
+"""Vol-anchor pillar — deterministic GBM pricing of crypto threshold markets.
+
+The edge (observed 2026-07-09, ETH): crowd prices for threshold markets at
+DIFFERENT horizons back out to the SAME implied volatility — a flat vol term
+structure anchored on the current tape (a 4-day and a 6-month ETH market both
+implied sigma ~52% during an unusually calm week). Volatility mean-reverts;
+from a depressed tape the long-horizon expectation belongs above the recent
+realized, and from an elevated tape below it. So long-dated touch/threshold
+markets are systematically mispriced whenever recent realized vol sits far
+from the long-run anchor: buy long-dated touch when the tape is calm, fade it
+when the tape is wild.
+
+This is the reading edge in its cheapest form — no LLM anywhere. Inputs are
+spot and daily closes (CoinGecko, free endpoints), a strike and deadline
+parsed from the question text, and two closed-form GBM probabilities under
+the martingale convention (E[S_T] = S0, log-drift -sigma^2/2 — the
+finance-standard "driftless"; deliberately conservative for touch-up vs the
+zero-log-drift reflection). Directional drift views are OUT of scope: the
+edge claim is vol anchoring, not price forecasting, and drift is where
+forecasting would sneak back in.
+
+Sigma blends recent realized toward a per-asset long-run anchor with horizon:
+    sigma(T) = anchor + (realized - anchor) * exp(-T / tau)
+so a 4-day market prices off the tape (as it should) and a 6-month market
+prices mostly off the anchor — exactly the term structure the crowd flattens.
+
+Candidates come from LIVE discovery only. The markets table freezes resolved
+rows at active=1 with stale prices — a stale-DB scan of this family showed
+strike-monotonicity "violations" that evaporated against live quotes.
+
+Rides the standard rails: signals + trades attribution, the full RiskManager
+gate, ExecutionGateway placement, resolution-tracker settlement, calibration.
+PAPER-FORCED, own graduation cell, one position per market bot-wide.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timedelta, timezone
+
+import aiohttp
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+
+log = structlog.get_logger()
+
+_COINGECKO = "https://api.coingecko.com/api/v3"
+
+# Asset detection: question keyword -> coingecko id. Crypto only in v1 —
+# commodities ("WTI", "Silver") have different vol dynamics and no clean
+# spot/anchor source here.
+_ASSETS = {
+    "bitcoin": "bitcoin", "btc": "bitcoin",
+    "ethereum": "ethereum", "eth": "ethereum",
+    "solana": "solana", "sol": "solana",
+    "xrp": "ripple",
+    "dogecoin": "dogecoin", "doge": "dogecoin",
+}
+
+_MONTHS = {m.lower(): i + 1 for i, m in enumerate(
+    ["January", "February", "March", "April", "May", "June", "July",
+     "August", "September", "October", "November", "December"])}
+
+_STRIKE = r"\$([0-9][0-9,]*(?:\.[0-9]+)?)"
+_DATE = r"([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s*(\d{4}))?"
+
+# kind: 'touch_up' / 'touch_down' / 'above' / 'below'
+_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("touch_up", re.compile(
+        rf"\b(?:reach|hit)\s+{_STRIKE}.*\bby\s+{_DATE}\s*\??\s*$", re.I)),
+    ("touch_down", re.compile(
+        rf"\b(?:dip|fall|drop)\s+to\s+{_STRIKE}.*\bby\s+{_DATE}\s*\??\s*$", re.I)),
+    ("above", re.compile(
+        rf"\bbe\s+above\s+{_STRIKE}\s+on\s+{_DATE}\s*\??\s*$", re.I)),
+    ("below", re.compile(
+        rf"\bbe\s+below\s+{_STRIKE}\s+on\s+{_DATE}\s*\??\s*$", re.I)),
+]
+
+
+def _phi(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def touch_prob(spot: float, barrier: float, sigma: float, t_years: float) -> float:
+    """P(barrier is touched within T) under GBM with the martingale
+    convention (log-drift mu = -sigma^2/2). Standard first-passage formula:
+    P = Phi((mu*T - b)/(s√T)) + exp(2*mu*b/s^2) * Phi((-mu*T - b)/(s√T)),
+    with b = |ln(barrier/spot)| and the sign of mu flipped for a downward
+    barrier (by GBM symmetry in log space)."""
+    if spot <= 0 or barrier <= 0 or sigma <= 0 or t_years <= 0:
+        return 0.0
+    b = math.log(barrier / spot)
+    mu = -0.5 * sigma * sigma
+    if b == 0:
+        return 1.0
+    if b < 0:  # downward barrier: reflect
+        b, mu = -b, -mu
+    st = sigma * math.sqrt(t_years)
+    p = _phi((mu * t_years - b) / st) + \
+        math.exp(2.0 * mu * b / (sigma * sigma)) * _phi((-mu * t_years - b) / st)
+    return min(1.0, max(0.0, p))
+
+
+def terminal_above_prob(spot: float, strike: float, sigma: float,
+                        t_years: float) -> float:
+    """P(S_T > strike) under the same martingale GBM."""
+    if spot <= 0 or strike <= 0 or sigma <= 0 or t_years <= 0:
+        return 0.0
+    st = sigma * math.sqrt(t_years)
+    d = (math.log(spot / strike) - 0.5 * sigma * sigma * t_years) / st
+    return min(1.0, max(0.0, _phi(d)))
+
+
+def blended_sigma(realized: float, anchor: float, t_years: float,
+                  tau_years: float) -> float:
+    """Horizon-dependent vol: the tape for short T, the long-run anchor for
+    long T — the mean-reverting term structure the crowd flattens."""
+    w = math.exp(-t_years / max(tau_years, 1e-6))
+    return anchor + (realized - anchor) * w
+
+
+def parse_threshold(question: str) -> tuple[str, float, datetime] | None:
+    """(kind, strike, deadline) from the question text, or None. Only
+    unambiguous phrasings are traded."""
+    q = (question or "").strip()
+    for kind, pat in _PATTERNS:
+        m = pat.search(q)
+        if not m:
+            continue
+        try:
+            strike = float(m.group(1).replace(",", ""))
+        except ValueError:
+            continue
+        month = _MONTHS.get(m.group(2).lower())
+        if month is None:
+            continue
+        day = int(m.group(3))
+        year = int(m.group(4)) if m.group(4) else datetime.now(timezone.utc).year
+        try:
+            deadline = datetime(year, month, day, tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        return kind, strike, deadline
+    return None
+
+
+def detect_asset(question: str) -> str | None:
+    ql = (question or "").lower()
+    for kw, cg_id in _ASSETS.items():
+        if re.search(rf"\b{kw}\b", ql):
+            return cg_id
+    return None
+
+
+class VolAnchorPillar:
+    """Deterministic vol-anchored threshold pricing over Polymarket crypto."""
+
+    name = "vol_anchor"
+
+    def __init__(self, db, settings, discovery, exchange, risk_manager,
+                 pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._gateway = ExecutionGateway(
+            router=None, exchange=exchange, exchange_name="polymarket",
+            settings=settings, db=db, pnl_tracker=pnl_tracker,
+        )
+
+    # ------------------------------------------------------------------
+    # Market data — spot + realized vol, fetched fresh each cycle
+    # ------------------------------------------------------------------
+
+    async def _asset_state(self, cg_id: str, cfg) -> tuple[float, float] | None:
+        """(spot, realized_vol_annualized) or None. Fail CLOSED: no fresh
+        data, no trades on that asset this cycle."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{_COINGECKO}/coins/{cg_id}/market_chart",
+                    params={"vs_currency": "usd",
+                            "days": str(int(cfg.realized_window_days)),
+                            "interval": "daily"},
+                    timeout=aiohttp.ClientTimeout(total=20),
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+        except Exception as e:
+            log.warning("vol_anchor.price_fetch_failed", asset=cg_id,
+                        error=str(e)[:120])
+            return None
+        closes = [p[1] for p in (data.get("prices") or []) if p and p[1]]
+        if len(closes) < 10:
+            return None
+        rets = [math.log(closes[i] / closes[i - 1])
+                for i in range(1, len(closes)) if closes[i - 1] > 0]
+        n = len(rets)
+        mean = sum(rets) / n
+        var = sum((r - mean) ** 2 for r in rets) / max(n - 1, 1)
+        realized = math.sqrt(var * 365.0)
+        return closes[-1], realized
+
+    # ------------------------------------------------------------------
+    # Cycle
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.vol_anchor
+        if not cfg.enabled:
+            return 0
+        candidates = await self._candidates(cfg)
+        if not candidates:
+            log.info("vol_anchor.no_candidates")
+            return 0
+
+        # One data fetch per asset per cycle.
+        state: dict[str, tuple[float, float]] = {}
+        for cg_id in {a for a, _, _, _, _ in candidates}:
+            s = await self._asset_state(cg_id, cfg)
+            if s is not None:
+                state[cg_id] = s
+
+        now = datetime.now(timezone.utc)
+        entered = 0
+        priced = 0
+        for cg_id, kind, strike, deadline, market in candidates:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            if cg_id not in state:
+                continue
+            spot, realized = state[cg_id]
+            t_years = (deadline - now).total_seconds() / (365.0 * 86400.0)
+            if t_years <= 0:
+                continue
+            anchor = cfg.long_run_vol.get(cg_id, 0.0)
+            if anchor <= 0:
+                continue
+            sigma = blended_sigma(realized, anchor, t_years, cfg.tau_years)
+            if kind in ("touch_up", "touch_down"):
+                fair = touch_prob(spot, strike, sigma, t_years)
+            elif kind == "above":
+                fair = terminal_above_prob(spot, strike, sigma, t_years)
+            else:  # below
+                fair = 1.0 - terminal_above_prob(spot, strike, sigma, t_years)
+            priced += 1
+            edge_pts = abs(fair - market.outcome_yes_price) * 100.0
+            log.info("vol_anchor.priced", market_id=market.id, asset=cg_id,
+                     kind=kind, strike=strike, spot=round(spot, 2),
+                     sigma=round(sigma, 3), realized=round(realized, 3),
+                     fair=round(fair, 3), market=market.outcome_yes_price,
+                     edge=round(edge_pts, 1))
+            if edge_pts < cfg.min_edge_pts:
+                continue
+            if await self._market_claimed(market.id):
+                continue
+            if await self._try_enter(market, fair, sigma, realized, kind, cfg):
+                entered += 1
+        if priced:
+            log.info("vol_anchor.cycle_done", priced=priced, entered=entered)
+        return entered
+
+    async def _candidates(self, cfg) -> list[tuple[str, str, float, datetime, Market]]:
+        now = datetime.now(timezone.utc)
+        emin = (now + timedelta(days=cfg.min_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        emax = (now + timedelta(days=cfg.max_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        raw: list[Market] = []
+        try:
+            for off in range(0, max(int(cfg.scan_limit), 1), 100):
+                page = await self._discovery.get_markets(
+                    limit=100, offset=off, order="volume",
+                    end_date_min=emin, end_date_max=emax)
+                if not page:
+                    break
+                raw.extend(page)
+        except TypeError:
+            raw = await self._discovery.get_markets(limit=cfg.scan_limit)
+
+        out = []
+        for m in raw:
+            if not self._eligible(m, cfg):
+                continue
+            asset = detect_asset(m.question)
+            if asset is None:
+                continue
+            parsed = parse_threshold(m.question)
+            if parsed is None:
+                continue
+            kind, strike, deadline = parsed
+            out.append((asset, kind, strike, deadline, m))
+        return out
+
+    def _eligible(self, market: Market, cfg) -> bool:
+        if not market.active:
+            return False
+        if (market.exchange or "polymarket") != "polymarket":
+            return False
+        if market.liquidity < cfg.min_liquidity:
+            return False
+        if not (0.02 <= market.outcome_yes_price <= 0.98):
+            return False
+        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        if blocked_category_hit(excluded, market.question, market.description,
+                                market.category):
+            return False
+        return True
+
+    async def _market_claimed(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM trades WHERE market_id = ? LIMIT 1", (market_id,))
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1", (market_id,))
+        return row is not None
+
+    async def _try_enter(self, market: Market, fair: float, sigma: float,
+                         realized: float, kind: str, cfg) -> bool:
+        market_yes = market.outcome_yes_price
+        side = OrderSide.BUY if fair > market_yes else OrderSide.SELL
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=min(0.99, max(0.01, fair)),
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market_yes,
+            edge=abs(fair - market_yes) * 100.0,
+            evidence_summary=(
+                f"Vol-anchor {kind}: blended sigma {sigma:.2f} (realized "
+                f"{realized:.2f} mean-reverted to anchor) -> GBM fair "
+                f"{fair:.2f} vs market {market_yes:.2f}; no drift view."),
+            recommended_side=side,
+            strategy_source="vol_anchor",
+            mispricing_reason=(
+                "structural: crowd prices all horizons off recent realized "
+                "vol (flat implied term structure); mean-reversion says "
+                "long-dated thresholds are mispriced when the tape is "
+                "calm/wild"),
+        )
+        await self._persist_signal(signal, market)
+
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            log.info("vol_anchor.risk_rejected", market_id=market.id,
+                     reason=decision.reason)
+            return False
+        size = min(decision.position_size, cfg.stake_usd)
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await self._gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size,
+            force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.info("vol_anchor.order_rejected", market_id=market.id,
+                     status=res.status, error=res.reason)
+            return False
+        await self._record_position(signal, market, res.order, res.result)
+        log.info("vol_anchor.entered", market_id=market.id,
+                 token=res.order.token.value, price=res.order.price,
+                 size=res.order.size, fair=round(fair, 3),
+                 paper=res.result.is_paper)
+        return True
+
+    async def _persist_signal(self, signal: Signal, market: Market) -> None:
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question,
+               description, category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (market.id, market.exchange or "polymarket", market.condition_id,
+             market.question, (market.description or "")[:500],
+             ensure_category(market.question, market.description, market.category),
+             market.outcome_yes_price, market.outcome_no_price,
+             market.volume, market.liquidity),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+               market_prob, edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'vol_anchor')""",
+            (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+             signal.market_prob, signal.edge, signal.evidence_summary,
+             signal.recommended_side.value),
+        )
+        await self._db.commit()
+
+    async def _record_position(self, signal: Signal, market: Market,
+                               order, result) -> None:
+        fill_size = result.filled_size if result.filled_size > 0 else order.size
+        fill_price = result.filled_price if result.filled_price > 0 else order.price
+        await self._db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, fill_size, fill_price, fill_price,
+             market.category or "", order.token.value, order.token_id,
+             1 if result.is_paper else 0),
+        )
+        await self._db.commit()
+        try:
+            await self._calibration.record_prediction(
+                order.market_id, signal.claude_prob, market.category or "")
+        except Exception as e:
+            log.debug("vol_anchor.calibration_error", error=str(e))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -557,6 +557,34 @@ term_structure:
   llm_timeout_seconds: 420
   exclude_categories: []
 
+vol_anchor:
+  # Deterministic vol-anchored crypto threshold pricing. Crowd threshold
+  # prices imply a FLAT vol term structure (a 4-day and a 6-month ETH market
+  # both implied sigma ~52% on a calm tape, 2026-07-09); vol mean-reverts, so
+  # long-dated touch markets are mispriced when the tape is calm/wild.
+  # Closed-form GBM (martingale convention, NO drift view), spot + realized
+  # vol from CoinGecko, candidates from LIVE discovery only (stale-DB prices
+  # faked strike-arb in this family). Zero LLM budget. PAPER-FORCED.
+  enabled: true
+  paper: true
+  interval_seconds: 3600
+  scan_limit: 300
+  min_liquidity: 1000.0
+  min_days: 1.0
+  max_days: 240.0
+  min_edge_pts: 8.0
+  stake_usd: 10.0
+  max_entries_per_cycle: 3
+  realized_window_days: 30
+  tau_years: 0.25
+  long_run_vol:
+    bitcoin: 0.50
+    ethereum: 0.70
+    solana: 0.90
+    ripple: 0.85
+    dogecoin: 0.95
+  exclude_categories: []
+
 informed_flow:
   # Informed-flow follower over Kalshi — mimic the side of abnormally-large
   # (informed) order flow. Abnormal trade size (ATS) proxies non-liquidity trading

--- a/config/settings.py
+++ b/config/settings.py
@@ -584,6 +584,38 @@ class TermStructureConfig(BaseModel):
     exclude_categories: list[str] = []
 
 
+class VolAnchorConfig(BaseModel):
+    """Deterministic vol-anchored crypto threshold pricing (strategy/vol_anchor.py).
+
+    Edge: crowd threshold prices back out to a FLAT implied-vol term structure
+    anchored on the recent tape; vol mean-reverts, so long-dated touch markets
+    are mispriced whenever recent realized sits far from the long-run anchor.
+    Zero LLM cost (spot/closes from CoinGecko + closed-form GBM, martingale
+    convention, no drift view). PAPER-FORCED, own graduation cell.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    interval_seconds: int = 3600
+    scan_limit: int = 300
+    min_liquidity: float = 1000.0
+    min_days: float = 1.0
+    max_days: float = 240.0
+    min_edge_pts: float = 8.0
+    stake_usd: float = 10.0
+    max_entries_per_cycle: int = 3
+    realized_window_days: int = 30
+    # Mean-reversion horizon for the sigma blend (years). ~90d: a 4-day market
+    # prices off the tape, a 6-month market mostly off the anchor.
+    tau_years: float = 0.25
+    # Long-run annualized vol anchors, by coingecko id. Conservative.
+    long_run_vol: dict[str, float] = {
+        "bitcoin": 0.50, "ethereum": 0.70, "solana": 0.90,
+        "ripple": 0.85, "dogecoin": 0.95,
+    }
+    exclude_categories: list[str] = []
+
+
 class EconIndicatorConfig(BaseModel):
     """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
 
@@ -1262,6 +1294,7 @@ class Settings(BaseSettings):
     long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
     agent_trader: AgentTraderConfig = Field(default_factory=lambda: AgentTraderConfig(**_DEFAULTS.get("agent_trader", {})))
     term_structure: TermStructureConfig = Field(default_factory=lambda: TermStructureConfig(**_DEFAULTS.get("term_structure", {})))
+    vol_anchor: VolAnchorConfig = Field(default_factory=lambda: VolAnchorConfig(**_DEFAULTS.get("vol_anchor", {})))
     informed_flow: InformedFlowConfig = Field(default_factory=lambda: InformedFlowConfig(**_DEFAULTS.get("informed_flow", {})))
     settlement_arb: SettlementArbConfig = Field(default_factory=lambda: SettlementArbConfig(**_DEFAULTS.get("settlement_arb", {})))
     weather_temp: WeatherTempConfig = Field(default_factory=lambda: WeatherTempConfig(**_DEFAULTS.get("weather_temp", {})))

--- a/tests/test_vol_anchor.py
+++ b/tests/test_vol_anchor.py
@@ -1,0 +1,252 @@
+"""Vol-anchor pillar: GBM formula pins, question parsing, the sigma blend,
+and the standard-rails entry path (risk gate, claim rule, edge floor,
+fail-closed data)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.strategy.vol_anchor import (
+    VolAnchorPillar,
+    blended_sigma,
+    detect_asset,
+    parse_threshold,
+    terminal_above_prob,
+    touch_prob,
+)
+
+
+# ---------------------------------------------------------------------------
+# Formulas — pinned to the 2026-07-09 ETH verification numbers
+# ---------------------------------------------------------------------------
+
+
+def test_touch_prob_pinned_to_eth_case():
+    """ETH spot 1734.54, barrier 3000, T=0.48y — martingale convention.
+    sigma 0.65 -> ~0.168, sigma 0.70 -> ~0.193 (the depth agent's 0.16-0.19)."""
+    assert touch_prob(1734.54, 3000, 0.65, 0.48) == pytest.approx(0.168, abs=0.01)
+    assert touch_prob(1734.54, 3000, 0.70, 0.48) == pytest.approx(0.193, abs=0.01)
+
+
+def test_touch_prob_monotone_in_sigma_and_t():
+    p = [touch_prob(100, 150, s, 0.5) for s in (0.4, 0.6, 0.8)]
+    assert p[0] < p[1] < p[2]
+    q = [touch_prob(100, 150, 0.6, t) for t in (0.1, 0.5, 1.0)]
+    assert q[0] < q[1] < q[2]
+
+
+def test_touch_prob_downward_barrier_symmetric_shape():
+    down = touch_prob(100, 70, 0.6, 0.5)
+    assert 0.0 < down < 1.0
+    # Already through the barrier region: degenerate inputs return sane values.
+    assert touch_prob(100, 100, 0.6, 0.5) == 1.0
+    assert touch_prob(0, 100, 0.6, 0.5) == 0.0
+
+
+def test_terminal_above_pinned_to_eth_case():
+    """ETH 4-day: spot 1734.54 > 1600, T=4/365. sigma 0.55 -> ~0.92
+    (matches crowd 0.92-0.93 at implied sigma ~52-55)."""
+    assert terminal_above_prob(1734.54, 1600, 0.55, 4 / 365) == \
+        pytest.approx(0.92, abs=0.015)
+    # Touch dominates terminal for the same upward strike.
+    assert touch_prob(100, 120, 0.6, 0.3) > terminal_above_prob(100, 120, 0.6, 0.3)
+
+
+def test_blended_sigma_term_structure():
+    """Short horizon ~ the tape; long horizon ~ the anchor — the term
+    structure the crowd flattens."""
+    near = blended_sigma(0.52, 0.70, 4 / 365, 0.25)
+    far = blended_sigma(0.52, 0.70, 0.48, 0.25)
+    assert near == pytest.approx(0.52, abs=0.01)
+    assert far > 0.66  # mostly anchor
+    assert near < far
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_threshold_variants():
+    kind, strike, dl = parse_threshold("Will Bitcoin reach $130,000 by December 31, 2026?")
+    assert (kind, strike) == ("touch_up", 130000.0)
+    assert dl == datetime(2026, 12, 31, tzinfo=timezone.utc)
+
+    kind, strike, _ = parse_threshold("Will Ethereum be above $1,600 on July 13?")
+    assert (kind, strike) == ("above", 1600.0)
+
+    kind, strike, _ = parse_threshold("Will the price of Bitcoin be below $60,000 on July 20, 2026?")
+    assert (kind, strike) == ("below", 60000.0)
+
+    kind, strike, _ = parse_threshold("Will Solana dip to $80 by August 15, 2026?")
+    assert (kind, strike) == ("touch_down", 80.0)
+
+    assert parse_threshold("Will Bitcoin be volatile this month?") is None
+    assert parse_threshold("") is None
+
+
+def test_detect_asset():
+    assert detect_asset("Will Bitcoin reach $130,000 by...") == "bitcoin"
+    assert detect_asset("Will the price of Ethereum be above...") == "ethereum"
+    assert detect_asset("Will XRP dip to $1 by...") == "ripple"
+    assert detect_asset("Will WTI Crude Oil hit (HIGH) $80 in July?") is None
+    assert detect_asset("Will Tether depeg?") is None
+
+
+# ---------------------------------------------------------------------------
+# Pillar wiring
+# ---------------------------------------------------------------------------
+
+
+def _future(days: int) -> str:
+    d = datetime.now(timezone.utc) + timedelta(days=days)
+    return f"{d.strftime('%B')} {d.day}, {d.year}"
+
+
+def _market(mid: str, question: str, yes: float) -> Market:
+    return Market(id=mid, question=question, outcome_yes_price=yes,
+                  outcome_no_price=round(1 - yes, 2), liquidity=5000.0,
+                  volume=10000.0, active=True, exchange="polymarket")
+
+
+def _settings():
+    s = MagicMock()
+    cfg = s.vol_anchor
+    cfg.enabled = True
+    cfg.paper = True
+    cfg.interval_seconds = 3600
+    cfg.scan_limit = 100
+    cfg.min_liquidity = 1000.0
+    cfg.min_days = 1.0
+    cfg.max_days = 240.0
+    cfg.min_edge_pts = 8.0
+    cfg.stake_usd = 10.0
+    cfg.max_entries_per_cycle = 3
+    cfg.realized_window_days = 30
+    cfg.tau_years = 0.25
+    cfg.long_run_vol = {"bitcoin": 0.50, "ethereum": 0.70}
+    cfg.exclude_categories = []
+    s.risk.blocked_categories = []
+    return s
+
+
+async def _pillar(tmp_path, markets, spot=1734.54, realized=0.52):
+    db = Database(str(tmp_path / "t.db"))
+    await db.connect()
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    risk = MagicMock()
+    decision = MagicMock()
+    decision.approved = True
+    decision.position_size = 8.0
+    decision.reason = ""
+    decision.force_paper = False
+    risk.evaluate = AsyncMock(return_value=decision)
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+    pillar = VolAnchorPillar(
+        db=db, settings=_settings(), discovery=discovery, exchange=MagicMock(),
+        risk_manager=risk, pnl_tracker=MagicMock(), calibration=calibration)
+    pillar._asset_state = AsyncMock(return_value=(spot, realized))
+
+    result = MagicMock()
+    result.status = "paper"
+    result.reason = ""
+    order = MagicMock()
+    order.token.value = "YES"
+    order.token_id = "tok"
+    order.price = 0.13
+    order.size = 76.9
+    fill = MagicMock()
+    fill.is_paper = True
+    fill.filled_size = 76.9
+    fill.filled_price = 0.13
+
+    def _submit(intent):
+        order.market_id = intent.market.id
+        result.order = order
+        result.result = fill
+        return result
+
+    pillar._gateway = MagicMock()
+    pillar._gateway.submit = AsyncMock(side_effect=_submit)
+    return pillar, db, risk
+
+
+@pytest.mark.asyncio
+async def test_enters_underpriced_long_dated_touch(tmp_path):
+    """The ETH shape: calm tape (realized 0.52), anchor 0.70 -> blended sigma
+    ~0.67 at ~6mo -> fair ~0.18 vs crowd 0.09 -> ~9 pt edge -> entry.
+    (Crowd 0.10 is edge 7.97 — correctly under the 8.0 floor; see
+    test_small_edge_skipped for the near-fair case.)"""
+    m = _market("m1", f"Will Ethereum reach $3,000 by {_future(175)}?", 0.09)
+    pillar, db, risk = await _pillar(tmp_path, [m])
+    try:
+        assert await pillar.run_once() == 1
+        risk.evaluate.assert_awaited_once()
+        sig = await db.fetchone(
+            "SELECT strategy_source, claude_prob, market_prob FROM signals")
+        assert sig["strategy_source"] == "vol_anchor"
+        assert sig["claude_prob"] > sig["market_prob"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_small_edge_skipped(tmp_path):
+    """Crowd already near fair -> below the 8pt floor -> no entry."""
+    m = _market("m1", f"Will Ethereum reach $3,000 by {_future(175)}?", 0.16)
+    pillar, db, _ = await _pillar(tmp_path, [m])
+    try:
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_no_data_fails_closed(tmp_path):
+    m = _market("m1", f"Will Ethereum reach $3,000 by {_future(175)}?", 0.10)
+    pillar, db, _ = await _pillar(tmp_path, [m])
+    pillar._asset_state = AsyncMock(return_value=None)
+    try:
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_claimed_market_skipped(tmp_path):
+    m = _market("m1", f"Will Ethereum reach $3,000 by {_future(175)}?", 0.10)
+    pillar, db, _ = await _pillar(tmp_path, [m])
+    try:
+        await db.execute(
+            """INSERT INTO trades (market_id, timestamp, side, size, price,
+               is_paper, order_id, status, exchange, strategy_source)
+               VALUES ('m1', datetime('now'), 'BUY', 10, 0.1, 1, 'x', 'paper',
+                       'polymarket', 'llm')""")
+        await db.commit()
+        assert await pillar.run_once() == 0
+        pillar._gateway.submit.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_non_crypto_and_unparseable_ignored(tmp_path):
+    ms = [
+        _market("m1", f"Will WTI Crude Oil hit (HIGH) $80 by {_future(20)}?", 0.15),
+        _market("m2", "Will Bitcoin be volatile in July?", 0.50),
+    ]
+    pillar, db, _ = await _pillar(tmp_path, ms)
+    try:
+        assert await pillar.run_once() == 0
+        pillar._asset_state.assert_not_awaited()  # nothing to price at all
+    finally:
+        await db.close()


### PR DESCRIPTION
Crowd prices for threshold markets at different horizons back out to the
SAME implied volatility — a flat vol term structure anchored on the current
tape (a 4-day and a 6-month market on one asset both implied ~52% during a
calm week). Volatility mean-reverts, so long-dated touch/threshold markets
are systematically mispriced whenever recent realized vol sits far from the
long-run anchor: buy long-dated touch when the tape is calm, fade it when
the tape is wild.

Zero LLM cost: spot + daily closes from CoinGecko (fail-closed), strike and
deadline parsed from question text (touch-up/touch-down/above/below;
unambiguous phrasings only, crypto only), closed-form GBM under the
martingale convention (no drift view — drift is where forecasting would
sneak back in), and a horizon-blended sigma
    sigma(T) = anchor + (realized - anchor) * exp(-T/tau)
so short-dated markets price off the tape and long-dated off the anchor —
the term structure the crowd flattens. Candidates from LIVE discovery only:
a stale-DB scan of this family faked strike-monotonicity arbs that
evaporated against live quotes.

Standard rails: signals + trades attribution, full RiskManager gate,
ExecutionGateway placement, resolution-tracker settlement, calibration.
PAPER-FORCED, own graduation cell, one position per market bot-wide.
Formula pins in tests anchor the implementation to independently verified
values.

Assisted-by: Claude (Anthropic)
