### PR TITLE
feat(budget): peak-window pacing envelope on the non-reserved Claude pool

### DIFF
--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -141,8 +141,10 @@ class ClaudeAnalyzer:
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
-            limit = budget if reserved else max(
-                0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            # Non-reserved callers get the PACED limit (peak-window envelope,
+            # see call_budget.paced_limit); reserved callers the full budget.
+            limit = budget if reserved else call_budget.non_reserved_limit(
+                self._settings)
             if call_budget.calls_today() >= limit:
                 from auramaur.nlp.errors import BudgetExhausted
                 raise BudgetExhausted(

--- a/auramaur/nlp/call_budget.py
+++ b/auramaur/nlp/call_budget.py
@@ -90,6 +90,50 @@ def calls_today() -> int:
         return _mem_calls if _mem_day == today else 0
 
 
+def paced_limit(base_limit: int, *, peak_start_hour: int, peak_end_hour: int,
+                offpeak_share: float, now_hour: int | None = None) -> int:
+    """Time-shaped ceiling on the NON-RESERVED budget.
+
+    The daily counter resets at midnight (UTC on this host), but the bot's
+    opportunity flow peaks 12-22 UTC (measured: signals/entries cluster at
+    14-17 UTC — US econ prints land 12:30 UTC, then US market hours), and
+    under greedy consumption the pool was documented exhausted by ~13:36 UTC
+    — dead exactly when the flow arrives. Before the peak window opens,
+    non-reserved callers may spend at most ``offpeak_share`` of the pool;
+    inside and after it, the full pool. The reserved (pinned) slice is
+    untouched — the proven edges were never subject to this limit.
+
+    Pure function (``now_hour`` injectable for tests). Hours are UTC.
+    ``offpeak_share >= 1`` or an empty window disables pacing.
+    """
+    if base_limit <= 0:
+        return base_limit
+    share = max(0.0, min(1.0, offpeak_share))
+    if share >= 1.0 or peak_start_hour >= peak_end_hour:
+        return base_limit
+    if now_hour is None:
+        from datetime import datetime, timezone
+        now_hour = datetime.now(timezone.utc).hour
+    if now_hour < peak_start_hour:
+        return int(base_limit * share)
+    return base_limit
+
+
+def non_reserved_limit(settings) -> int:
+    """The shared non-reserved ceiling every unpinned caller checks against:
+    (budget - pinned reserve), paced by the peak-window envelope. Returns 0
+    when the budget is fully reserved; a non-positive configured budget means
+    unlimited (callers already special-case budget <= 0)."""
+    nlp = settings.nlp
+    base = max(0, nlp.daily_claude_call_budget - nlp.claude_reserve_for_pinned)
+    return paced_limit(
+        base,
+        peak_start_hour=nlp.budget_peak_start_hour_utc,
+        peak_end_hour=nlp.budget_peak_end_hour_utc,
+        offpeak_share=nlp.budget_offpeak_share,
+    )
+
+
 def record_call() -> int:
     """Count one successful Claude call; returns today's new total."""
     global _mem_calls, _mem_day

--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -237,13 +237,20 @@ class AgentAnalyzer:
         self._timeout_seconds: int = 600  # 10 minutes for thorough analysis
 
     def _check_budget(self) -> None:
-        """Enforce daily Claude call budget. Raises BudgetExhausted if spent."""
+        """Enforce the daily Claude call budget. Raises BudgetExhausted if
+        spent. The depth agent is an unpinned bulk consumer, so it checks the
+        PACED non-reserved limit (peak-window envelope + pinned reserve) —
+        previously it checked the FULL budget, so it could eat into the lens's
+        reserved slice on top of ignoring pacing."""
         from auramaur.nlp import call_budget
         from auramaur.nlp.errors import BudgetExhausted
         budget = self.settings.nlp.daily_claude_call_budget
-        if budget > 0 and call_budget.calls_today() >= budget:
+        if budget <= 0:
+            return
+        limit = call_budget.non_reserved_limit(self.settings)
+        if call_budget.calls_today() >= limit:
             raise BudgetExhausted(
-                f"Daily agent call budget ({budget}) exhausted"
+                f"Daily agent call budget ({limit}/{budget}, paced) exhausted"
             )
 
     async def analyze_markets(

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -416,10 +416,10 @@ class AgentTraderPillar:
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
-            limit = max(0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            limit = call_budget.non_reserved_limit(self._settings)
             if call_budget.calls_today() >= limit:
                 raise BudgetExhausted(
-                    f"non-reserved Claude budget ({limit}/{budget}) exhausted")
+                    f"non-reserved Claude budget ({limit}/{budget}, paced) exhausted")
         # cwd MUST be neutral: `claude -p` loads CLAUDE.md and the project
         # memory from its working directory, and run from the repo root the
         # arms were caught citing the operator's own market analyses ("your

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -377,10 +377,10 @@ class TermStructurePillar:
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
-            limit = max(0, budget - self._settings.nlp.claude_reserve_for_pinned)
+            limit = call_budget.non_reserved_limit(self._settings)
             if call_budget.calls_today() >= limit:
                 raise BudgetExhausted(
-                    f"non-reserved Claude budget ({limit}/{budget}) exhausted")
+                    f"non-reserved Claude budget ({limit}/{budget}, paced) exhausted")
         # Neutral cwd: `claude -p` loads CLAUDE.md + project memory from its
         # working directory (see agent_trader / the context-leak note).
         proc = await asyncio.create_subprocess_exec(

--- a/config/settings.py
+++ b/config/settings.py
@@ -241,6 +241,15 @@ class NLPConfig(BaseModel):
     # at budget - reserve; pinned callers can spend up to the full budget, so a
     # bulk consumer can never starve the money-making calls.
     claude_reserve_for_pinned: int = 25
+    # Pacing envelope on the NON-RESERVED pool (call_budget.paced_limit). The
+    # counter resets at midnight UTC but opportunity flow peaks 12-22 UTC
+    # (measured; US prints land 12:30 UTC), and greedy consumption exhausted
+    # the pool by early afternoon — dead when the flow arrives. Before
+    # peak_start only offpeak_share of the pool may be spent; inside/after
+    # the window the remainder unlocks. offpeak_share: 1.0 disables.
+    budget_peak_start_hour_utc: int = 12
+    budget_peak_end_hour_utc: int = 22
+    budget_offpeak_share: float = 0.4
 
     # Tool-use analyzer — refines strategic-batch results on top-edge markets
     # by letting Claude Code drive its own web_search / web_fetch. "auto"

--- a/tests/test_call_budget.py
+++ b/tests/test_call_budget.py
@@ -58,3 +58,61 @@ def test_sqlite_failure_degrades_to_memory(tmp_path):
     assert (n1, n2) == (1, 2)
     assert call_budget.calls_today() == 2
     assert call_budget._mem_day == date.today().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Pacing envelope — the non-reserved pool is time-shaped toward the peak
+# window (measured flow peaks 12-22 UTC; greedy consumption used to exhaust
+# the pool by ~13:36 UTC, dead exactly when the flow arrives).
+# ---------------------------------------------------------------------------
+
+
+def test_paced_limit_offpeak_ration_and_peak_unlock():
+    kw = dict(peak_start_hour=12, peak_end_hour=22, offpeak_share=0.4)
+    # Overnight: only the ration is spendable.
+    assert call_budget.paced_limit(150, now_hour=0, **kw) == 60
+    assert call_budget.paced_limit(150, now_hour=11, **kw) == 60
+    # Inside and after the window: the full pool.
+    assert call_budget.paced_limit(150, now_hour=12, **kw) == 150
+    assert call_budget.paced_limit(150, now_hour=17, **kw) == 150
+    assert call_budget.paced_limit(150, now_hour=23, **kw) == 150
+
+
+def test_paced_limit_disable_switches():
+    # share >= 1 disables pacing entirely.
+    assert call_budget.paced_limit(
+        150, peak_start_hour=12, peak_end_hour=22, offpeak_share=1.0,
+        now_hour=3) == 150
+    # Degenerate window disables pacing.
+    assert call_budget.paced_limit(
+        150, peak_start_hour=22, peak_end_hour=12, offpeak_share=0.4,
+        now_hour=3) == 150
+    # Non-positive base passes through (callers special-case budget <= 0).
+    assert call_budget.paced_limit(
+        0, peak_start_hour=12, peak_end_hour=22, offpeak_share=0.4,
+        now_hour=3) == 0
+
+
+def test_non_reserved_limit_subtracts_reserve_then_paces(monkeypatch):
+    from unittest.mock import MagicMock
+
+    s = MagicMock()
+    s.nlp.daily_claude_call_budget = 175
+    s.nlp.claude_reserve_for_pinned = 25
+    s.nlp.budget_peak_start_hour_utc = 12
+    s.nlp.budget_peak_end_hour_utc = 22
+    s.nlp.budget_offpeak_share = 0.4
+
+    import auramaur.nlp.call_budget as cb
+
+    real = cb.paced_limit
+    captured = {}
+
+    def spy(base_limit, **kwargs):
+        captured["base"] = base_limit
+        return real(base_limit, **kwargs)
+
+    monkeypatch.setattr(cb, "paced_limit", spy)
+    limit = cb.non_reserved_limit(s)
+    assert captured["base"] == 150          # reserve subtracted first
+    assert limit in (60, 150)               # paced by wall clock

--- a/tests/test_claude_retry.py
+++ b/tests/test_claude_retry.py
@@ -16,6 +16,10 @@ def settings():
     s.nlp.claude_reserve_for_pinned = 0
     s.nlp.skip_second_opinion = False
     s.nlp.cache_ttl_breaking_seconds = 900
+    # Pacing disabled: these tests exercise retries, not the envelope.
+    s.nlp.budget_peak_start_hour_utc = 12
+    s.nlp.budget_peak_end_hour_utc = 22
+    s.nlp.budget_offpeak_share = 1.0
     return s
 
 


### PR DESCRIPTION
The daily counter resets at midnight (UTC on this host) but the bot's
opportunity flow peaks 12-22 UTC (measured over 14 days: signals and
entries cluster 14-17 UTC; US economic prints land 12:30 UTC). Under
greedy consumption the non-reserved pool was documented exhausted by
early afternoon — dead exactly when the flow arrives, and dead for the
CPI-print morning that two pillars exist to trade.

call_budget.paced_limit: before the peak window opens, non-reserved
callers may spend at most offpeak_share (default 0.4) of the pool; inside
and after the window the remainder unlocks. Pure function, injectable
clock, disable via share >= 1. non_reserved_limit composes reserve
subtraction + pacing so every unpinned call site checks one number.

Applied at all four unpinned call sites (analyzer CLI path, agent_trader
arms, term_structure curve reads, depth agent). The depth agent's check
previously compared against the FULL budget — it could eat into the
lens's pinned reserve on top of ignoring pacing; now fixed. Reserved
(pin_claude) callers are untouched at every site.

Assisted-by: Claude (Anthropic)
