### PR TITLE
feat(ops): launchd KeepAlive supervision + launchd-aware restart script

### DIFF
--- a/scripts/launchd/is.auramaur.bot.plist.example
+++ b/scripts/launchd/is.auramaur.bot.plist.example
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>is.auramaur.bot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOURUSER/Auramaur/.venv/bin/auramaur</string>
+        <string>run</string>
+        <string>--hybrid</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOURUSER/Auramaur</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AURAMAUR_LIVE</key>
+        <string>true</string>
+        <!-- The bot spawns `claude` subprocesses (Max+ CLI) and needs the
+             venv + ~/.local/bin on PATH; launchd's default PATH is bare. -->
+        <key>PATH</key>
+        <string>/Users/YOURUSER/Auramaur/.venv/bin:/Users/YOURUSER/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Keep the bot alive ONLY while the kill switch is absent: a crash or
+         reboot auto-restarts it; creating ./KILL_SWITCH lets it exit (the bot
+         halts itself on the switch) and launchd will NOT resurrect it until
+         the file is removed. The switch is now a launchd-level control too. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>PathState</key>
+        <dict>
+            <key>/Users/YOURUSER/Auramaur/KILL_SWITCH</key>
+            <false/>
+        </dict>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/Auramaur/logs/run_live_launchd.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/Auramaur/logs/run_live_launchd.out</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/scripts/restart_live.sh
+++ b/scripts/restart_live.sh
@@ -9,6 +9,12 @@
 # This script stops every running bot first, waits for the lock holder to
 # exit, launches exactly one instance, and FAILS LOUDLY if the new bot came
 # up on a fallback database.
+#
+# LAUNCHD MODE (2026-07-12): when the is.auramaur.bot LaunchAgent is loaded,
+# the bot is supervised by launchd (KeepAlive; auto-restart on crash/reboot;
+# KILL_SWITCH suspends it). A manual kill+nohup here would RACE launchd's
+# respawn into the dual-instance trap, so in that mode this script restarts
+# via `launchctl kickstart -k` and verifies against the launchd log instead.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -18,6 +24,41 @@ if [ -f ./KILL_SWITCH ]; then
     exit 1
 fi
 
+LAUNCHD_LABEL="is.auramaur.bot"
+LAUNCHD_LOG="logs/run_live_launchd.out"
+
+verify_startup() {
+    # $1 = log file to watch; $2 = optional PID to liveness-check (legacy mode)
+    local log="$1" pid="${2:-}"
+    for _ in $(seq 1 60); do
+        grep -q 'strategy books' "$log" 2>/dev/null && break
+        if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+            echo "Bot exited during startup — tail of ${log}:" >&2
+            tail -20 "$log" >&2
+            return 1
+        fi
+        sleep 2
+    done
+    if grep -q 'Instance: auramaur_' "$log"; then
+        echo "FALLBACK DB DETECTED — the primary auramaur.db was still locked." >&2
+        echo "Stopping the wrong-book instance. Re-run once the lock holder exits." >&2
+        if [ -n "$pid" ]; then kill -TERM "$pid"; fi
+        return 1
+    fi
+    grep -E 'Build:|Mode:' "$log" | head -2
+    echo "OK: single instance on the primary database."
+}
+
+# ---- launchd-supervised path -------------------------------------------
+if launchctl print "gui/$(id -u)/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+    echo "launchd mode: kickstarting ${LAUNCHD_LABEL}"
+    : > "$LAUNCHD_LOG"   # truncate so the verification reads THIS boot
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}"
+    verify_startup "$LAUNCHD_LOG"
+    exit $?
+fi
+
+# ---- legacy nohup path (LaunchAgent not loaded) ------------------------
 # 1. Stop every running bot instance gracefully (SIGTERM -> shutdown path
 #    cancels resting orders and releases the DB flock).
 pids=$(pgrep -f 'auramaur run' || true)
@@ -44,20 +85,4 @@ echo "Launched PID ${pid}, log: ${log}"
 
 # 3. Verify it came up on the PRIMARY database. The banner prints an
 #    "Instance: auramaur_N.db" line only on lock-contention fallback.
-for _ in $(seq 1 60); do
-    grep -q 'strategy books' "$log" 2>/dev/null && break
-    if ! kill -0 "$pid" 2>/dev/null; then
-        echo "Bot exited during startup — tail of ${log}:" >&2
-        tail -20 "$log" >&2
-        exit 1
-    fi
-    sleep 2
-done
-if grep -q 'Instance: auramaur_' "$log"; then
-    echo "FALLBACK DB DETECTED — the primary auramaur.db was still locked." >&2
-    echo "Stopping the wrong-book instance. Re-run once the lock holder exits." >&2
-    kill -TERM "$pid"
-    exit 1
-fi
-grep -E 'Build:|Mode:' "$log" | head -2
-echo "OK: single instance on the primary database."
+verify_startup "$log" "$pid"


### PR DESCRIPTION
The bot now runs under a user LaunchAgent (example plist included; install
to ~/Library/LaunchAgents and bootstrap): auto-start on login, auto-restart
on crash (verified with kill -9 -> respawn on the primary DB), and the
KILL_SWITCH doubles as a launchd-level control — KeepAlive is conditioned
on the switch file being ABSENT, so creating it lets the bot halt itself
without launchd resurrecting it, and removing it brings the bot back.

restart_live.sh is launchd-aware: when the agent is loaded it restarts via
`launchctl kickstart -k` and verifies the fixed launchd log — a manual
kill+nohup would RACE launchd's respawn straight into the dual-instance /
fallback-DB trap this script exists to prevent. The legacy nohup path
remains for hosts without the agent. The plist sets PATH explicitly
(launchd's default is bare) so the Claude CLI subprocesses keep resolving.

Assisted-by: Claude (Anthropic)
