### PR TITLE
feat(ops): host-migration kit — phased script + checklist

### DIFF
--- a/docs/MIGRATION_HOST.md
+++ b/docs/MIGRATION_HOST.md
@@ -1,0 +1,88 @@
+# Host migration checklist
+
+Moving the bot to a new machine (e.g. laptop replacement). The companion
+script `scripts/migrate_host.sh` mechanizes each phase; this file is the
+authority on the gates between phases.
+
+**The one invariant: never two live bots.** The live venue account is
+shared state — two instances double every risk cap and race each other's
+orders (the 2026-07 dual-instance incident, across machines this time).
+The cutover sequence below is ordered so there is no moment where both
+hosts can trade.
+
+Terminology: OLD = the machine currently running the bot; NEW = the target.
+
+---
+
+## Phase 1 — stage the NEW host (safe anytime; zero risk to the live bot)
+
+On NEW:
+
+1. Install prerequisites: git, Python 3.11+, the Claude CLI
+   (`~/.local/bin/claude`), and log the CLI in interactively
+   (`claude` → `/login`) against the Max+ account.
+2. `git clone` the repo, `python -m venv .venv`, `pip install -e .`
+   (or the project's documented install).
+3. Power settings — the bot must survive lid-closed/idle:
+   `sudo pmset -c sleep 0 && sudo pmset -c disablesleep 1` (AC power),
+   or run under `caffeinate -i`.
+4. **Paper shakedown** (no live credentials on the machine yet):
+   `scripts/migrate_host.sh stage` runs the checks, then start the bot
+   WITHOUT any `.env` — the env gate stays closed, everything paper-routes.
+   Let it run ≥ a few hours.
+
+Gate to Phase 2 — on NEW, all true:
+- [ ] bot cycles complete on both venues (scan lines in the log)
+- [ ] an LLM call succeeded (`llm.routed` / a lens or arm event in
+      `auramaur.log`) — proves the Claude CLI + PATH work
+- [ ] no `Instance: auramaur_N.db` fallback line in the startup banner
+- [ ] machine survived a lid-close/idle period without the process dying
+
+## Phase 2 — cutover (one sitting, ~1 hour; do NOT split across days)
+
+1. On OLD: `scripts/migrate_host.sh freeze`
+   — creates `KILL_SWITCH` (bot halts; launchd will not resurrect),
+   waits for the process to exit, then `launchctl bootout`s the agent.
+   From this moment NOTHING trades until Phase 2 completes.
+2. On NEW: `scripts/migrate_host.sh pull olduser@oldhost:/path/to/Auramaur`
+   — rsyncs the private state (see the PRIVATE_STATE list in the script:
+   DB + WAL, `.env`, `config/defaults.local.yaml`, logs/, incident
+   backups). The repo itself came from git, not rsync.
+3. On NEW: install the LaunchAgent —
+   `scripts/migrate_host.sh install-agent` (templates the versioned
+   example plist with this user's paths, bootstraps it).
+4. On NEW: `scripts/migrate_host.sh verify`
+   — single instance, primary DB, live mode banner, LLM call, recent
+   heartbeat, and NO kill switch present.
+
+Gate to Phase 3 — on NEW, all true:
+- [ ] `verify` passes clean
+- [ ] first live-mode heartbeat shows the expected cash/positions
+      (compare against the venue UI)
+- [ ] a full trading cycle completed without `database is locked` storms
+
+Rollback (if NEW misbehaves): `bootout` the agent on NEW, remove
+`KILL_SWITCH` on OLD, re-bootstrap the agent on OLD. The DB on OLD is
+still authoritative until Phase 3 — nothing on NEW has diverged unless
+the NEW bot traded; if it did, rsync the DB BACK before restarting OLD.
+
+## Phase 3 — decommission OLD (before hand-back)
+
+On OLD: `scripts/migrate_host.sh decommission`
+— after an interactive confirmation it: bootouts + deletes the
+LaunchAgent, securely removes `.env` (Polygon private key + venue API
+keys — the real hazard on a returned machine), removes the DBs/WAL,
+logs, local config, `~/.claude` credentials, and the repo checkout.
+Also remember, outside this repo's scope:
+
+- [ ] Straummaur: stop its recorder, rsync `~/Straummaur/data` to NEW,
+      restart the recorder there (it is vol_anchor's calibration feed)
+- [ ] Hermes: `~/.hermes` and the (unloaded) `ai.hermes.gateway.plist`
+      if still present
+- [ ] any shell profiles/keychains holding venue or exchange secrets
+
+---
+
+Post-migration watch (first 48h on NEW): the standard daily check plus
+`launchctl print gui/$UID/is.auramaur.bot` (runs count should stay flat),
+and one deliberate `kill -9` + respawn test once, off-hours.

--- a/scripts/migrate_host.sh
+++ b/scripts/migrate_host.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Host-migration helper — see docs/MIGRATION_HOST.md for the phase gates.
+#
+#   stage                      (NEW) preflight checks for the paper shakedown
+#   freeze                     (OLD) kill-switch + bootout: nothing trades
+#   pull  user@oldhost:/path   (NEW) rsync private state from the frozen OLD
+#   install-agent              (NEW) template + bootstrap the LaunchAgent
+#   verify                     (NEW) post-cutover health gate
+#   decommission               (OLD) wipe secrets/state before hand-back
+#
+# The one invariant: NEVER two live bots. `pull` refuses to run unless the
+# source is frozen (KILL_SWITCH present on OLD).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_DIR="$(pwd)"
+LABEL="is.auramaur.bot"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+UID_N="$(id -u)"
+
+# Private state that git does NOT carry — everything the new host needs
+# beyond the checkout. Deliberately explicit, not a glob of the repo root.
+PRIVATE_STATE=(
+    "auramaur.db"
+    "auramaur.db-wal"
+    "auramaur.db-shm"
+    ".env"
+    "config/defaults.local.yaml"
+    "logs/"
+    "agent_db_backup_20260705.db"
+)
+
+say()  { printf '\n== %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+cmd_stage() {
+    say "stage: preflight for the paper shakedown (run on NEW)"
+    command -v git >/dev/null || fail "git missing"
+    .venv/bin/python -c 'import sys; assert sys.version_info >= (3,11)' \
+        2>/dev/null || fail "no .venv with Python 3.11+ (python -m venv .venv; pip install -e .)"
+    command -v claude >/dev/null || fail "claude CLI not on PATH (install + /login first)"
+    claude -p "reply with exactly OK" --output-format text 2>/dev/null | grep -q OK \
+        || fail "claude CLI call failed — not logged in?"
+    [ -f .env ] && fail ".env present — stage phase must run WITHOUT live credentials"
+    pmset -g 2>/dev/null | grep -qE ' sleep\s+0' \
+        || echo "WARN: system sleep is enabled — set 'pmset -c sleep 0' or run under caffeinate"
+    echo "stage preflight OK. Start the bot (paper: no .env) and watch it for a few hours."
+    echo "Gate checklist: docs/MIGRATION_HOST.md Phase 1."
+}
+
+cmd_freeze() {
+    say "freeze: halting the bot on THIS host (run on OLD)"
+    touch KILL_SWITCH
+    echo "KILL_SWITCH created — waiting for the bot to halt itself..."
+    for _ in $(seq 1 60); do
+        pgrep -f 'auramaur run' >/dev/null || break
+        sleep 2
+    done
+    pgrep -f 'auramaur run' >/dev/null && fail "bot still running after 120s — investigate before proceeding"
+    if launchctl print "gui/${UID_N}/${LABEL}" >/dev/null 2>&1; then
+        launchctl bootout "gui/${UID_N}/${LABEL}"
+        echo "LaunchAgent booted out."
+    fi
+    echo "FROZEN. Nothing trades until the new host completes 'verify'."
+    echo "Leave KILL_SWITCH in place — it is the rollback anchor."
+}
+
+cmd_pull() {
+    local src="${1:-}"
+    [ -n "$src" ] || fail "usage: migrate_host.sh pull user@oldhost:/path/to/Auramaur"
+    say "pull: syncing private state from ${src} (run on NEW)"
+    # Refuse unless the source is frozen — the never-two-live-bots gate.
+    local host="${src%%:*}" path="${src#*:}"
+    ssh "$host" "test -f '${path}/KILL_SWITCH'" \
+        || fail "source is NOT frozen (no KILL_SWITCH at ${src}) — run 'freeze' on OLD first"
+    ssh "$host" "! pgrep -f 'auramaur run' >/dev/null" \
+        || fail "a bot process is still running on the source host"
+    for item in "${PRIVATE_STATE[@]}"; do
+        rsync -a --info=progress2 "${src}/${item}" "./$(dirname "$item")/" \
+            || echo "WARN: ${item} missing on source (ok if it never existed)"
+    done
+    # The kill switch must NOT travel: the new host starts armed.
+    rm -f KILL_SWITCH
+    sqlite3 auramaur.db "PRAGMA integrity_check;" | grep -qx ok \
+        || fail "pulled auramaur.db fails integrity_check"
+    echo "pull complete; DB integrity OK."
+}
+
+cmd_install_agent() {
+    say "install-agent: templating + bootstrapping the LaunchAgent (run on NEW)"
+    sed "s|/Users/YOURUSER|$HOME|g" scripts/launchd/is.auramaur.bot.plist.example > "$PLIST"
+    plutil -lint "$PLIST" >/dev/null || fail "templated plist fails lint"
+    launchctl bootout "gui/${UID_N}/${LABEL}" 2>/dev/null || true
+    launchctl bootstrap "gui/${UID_N}" "$PLIST"
+    echo "LaunchAgent bootstrapped. The bot should be starting now."
+}
+
+cmd_verify() {
+    say "verify: post-cutover health gate (run on NEW)"
+    [ -f KILL_SWITCH ] && fail "KILL_SWITCH present on the NEW host — remove it deliberately"
+    launchctl print "gui/${UID_N}/${LABEL}" 2>/dev/null | grep -q 'state = running' \
+        || fail "LaunchAgent not running"
+    [ "$(pgrep -f 'auramaur run' | wc -l | tr -d ' ')" = "1" ] \
+        || fail "expected exactly 1 bot process"
+    local log="logs/run_live_launchd.out"
+    for _ in $(seq 1 60); do
+        grep -q 'strategy books' "$log" 2>/dev/null && break
+        sleep 2
+    done
+    grep -q 'strategy books' "$log" || fail "startup banner never appeared in ${log}"
+    grep -q 'Instance: auramaur_' "$log" && fail "FALLBACK DB — primary auramaur.db was locked"
+    grep -qE 'Mode: LIVE' "$log" || echo "WARN: not in LIVE mode — is .env in place?"
+    grep -E 'Build:|Mode:' "$log" | head -2
+    echo "verify OK. Watch the first full cycle + compare cash/positions to the venue UI."
+}
+
+cmd_decommission() {
+    say "decommission: wiping secrets/state on THIS host (run on OLD, LAST)"
+    echo "This deletes .env (private keys!), DBs, logs, local config,"
+    echo "~/.claude credentials, the LaunchAgent, and this checkout."
+    read -r -p "Type the hostname of THIS machine to confirm: " ans
+    [ "$ans" = "$(hostname)" ] || fail "confirmation mismatch — aborted"
+    pgrep -f 'auramaur run' >/dev/null && fail "bot still running — freeze first"
+    launchctl bootout "gui/${UID_N}/${LABEL}" 2>/dev/null || true
+    rm -f "$PLIST"
+    rm -P .env 2>/dev/null || rm -f .env
+    rm -f auramaur*.db auramaur*.db-wal auramaur*.db-shm agent*.db
+    rm -rf logs data
+    rm -f config/defaults.local.yaml
+    echo "Repo-local state wiped. Now, manually:"
+    echo "  - rm -rf ~/.claude (CLI credentials) when done using Claude here"
+    echo "  - handle Straummaur + ~/.hermes (see MIGRATION_HOST.md Phase 3)"
+    echo "  - finally: rm -rf ${REPO_DIR}"
+}
+
+case "${1:-}" in
+    stage)          cmd_stage ;;
+    freeze)         cmd_freeze ;;
+    pull)           shift; cmd_pull "$@" ;;
+    install-agent)  cmd_install_agent ;;
+    verify)         cmd_verify ;;
+    decommission)   cmd_decommission ;;
+    *) grep '^#' "$0" | sed -n '2,12p'; exit 1 ;;
+esac


### PR DESCRIPTION
Moving the bot between machines has one hard invariant: NEVER two live
bots (shared venue account; the dual-instance incident, across hosts).
The kit encodes it: `pull` refuses to sync unless the source host is
frozen (KILL_SWITCH present + no bot process, checked over ssh), and the
kill switch deliberately does not travel to the new host.

Phases (docs/MIGRATION_HOST.md holds the gates):
  stage        (NEW) preflight — venv, Claude CLI login proven by a real
               call, no .env (paper shakedown runs without credentials)
  freeze       (OLD) kill-switch halt + launchd bootout; rollback anchor
  pull         (NEW) rsync the explicit private-state list (DB+WAL, .env,
               local config, logs) + DB integrity_check
  install-agent(NEW) template the versioned plist example + bootstrap
  verify       (NEW) single instance / primary DB / LIVE banner gate
  decommission (OLD) interactive-confirmed wipe of keys, DBs, agent,
               credentials before hardware hand-back

verify was exercised against the running production host.

Assisted-by: Claude (Anthropic)
