### PR TITLE
chore(strategy): mid-month evaluation — wind down two cells, scale the strongest

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -453,7 +453,13 @@ econ_indicator:
   # FRED history (random-walk nowcast + change-vol, sigma floored), trade bins
   # the crowd misprices. Directional -> PAPER-FORCED until the ledger +
   # calibration prove it; edge must clear the Kalshi taker fee on top of min_edge.
-  enabled: true
+  # WOUND DOWN 2026-07-15: first honestly-recorded settlement wave (post the
+  # paper-book restoration) came back clearly negative, and the known model
+  # deficiency is the cause — the random-walk YoY nowcast ignores base
+  # effects, so it fights the crowd exactly when the crowd is right (the
+  # divergence guard kept blocking its own best-rated trades). Re-enable
+  # only WITH the base-effects nowcast (the deferred Phase-B item).
+  enabled: false
   paper: true
   series: []             # empty = all registered (KXCPIYOY, KXU3, KXPAYROLLS)
   stake_usd: 10.0
@@ -545,8 +551,12 @@ term_structure:
   effort: medium
   scan_limit: 300
   min_strikes: 3
-  max_families: 12
-  families_per_cycle: 3
+  # Throughput raised 2026-07-15 (12->16 families, 3->5 fresh reads/cycle):
+  # the pillar's early ledger is the strongest of the new cells and its
+  # marginal cost is low (curves cached 24h; reads ride the paced
+  # non-reserved pool, never the pinned lens slice).
+  max_families: 16
+  families_per_cycle: 5
   curve_ttl_hours: 24.0
   max_entries_per_family: 2
   stake_usd: 10.0
@@ -750,7 +760,12 @@ bias_harvest:
   # paper: false (still behind the three live gates).
   enabled: true
   paper: true
-  band_lo: 0.60
+  # band_lo 0.90 = deep band only (the proven cell). The 0.60-0.90 regimes
+  # (bias_harvest_wide) were WOUND DOWN 2026-07-15: their own graduation-cell
+  # paper ledger came back clearly negative with a low win rate at adequate
+  # sample — the tail losses eat the wide-band harvest, exactly the failure
+  # the isolation was built to catch. Reversible: band_lo back to 0.60.
+  band_lo: 0.90
   band_hi: 0.97
   # claude_prob = favored price + uplift (the measured band gap is +4..+6pts).
   # MUST stay < 0.05 or the divergence filter blocks entries at MEDIUM conf.

--- a/config/settings.py
+++ b/config/settings.py
@@ -580,8 +580,8 @@ class TermStructureConfig(BaseModel):
     effort: str = "medium"
     scan_limit: int = 300
     min_strikes: int = 3
-    max_families: int = 12
-    families_per_cycle: int = 3   # fresh LLM reads per cycle (cached fams free)
+    max_families: int = 16
+    families_per_cycle: int = 5   # fresh LLM reads per cycle (cached fams free)
     curve_ttl_hours: float = 24.0
     max_entries_per_family: int = 2
     stake_usd: float = 10.0


### PR DESCRIPTION
Verdicts from the graduation-cell paper ledgers (records post the Kalshi
paper-book restoration, so honestly measured):

- bias_harvest wide regimes (0.60-0.90 bands): wound down via band_lo 0.90.
  The isolated bias_harvest_wide cell is clearly negative with a low win
  rate at adequate sample — tail losses eat the wide-band harvest, the
  exact failure the cell isolation was built to catch. The proven deep
  band (0.90-0.97) is untouched. Reversible: band_lo back to 0.60.

- econ_indicator: disabled pending the deferred base-effects YoY nowcast.
  Its first honestly-recorded settlement wave is clearly negative and the
  mechanism is the known model deficiency (random-walk nowcast fights the
  crowd exactly when the crowd is right; the divergence guard was blocking
  its own best-rated signals all week). Not condemned — parked until the
  Phase-B nowcast lands.

- term_structure: throughput raised (families 12->16, fresh reads 3->5).
  Strongest early ledger of the new cells; marginal cost is low (24h curve
  cache; rides the paced non-reserved pool, never the pinned lens slice).

(weather_temp was separately closed per its pre-registered 07-16 check —
that flag lives in the untracked local config where its re-open lived.)

Assisted-by: Claude (Anthropic)
