### PR TITLE
fix(cash): balance-API failure serves the last good reading + MM cash-reserve floor

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -50,6 +50,9 @@ class PositionSyncer:
         self._exchange = exchange
         self._paper = paper
         self._pnl = pnl
+        # Last good spendable-balance reading, served when the balance API
+        # throws transiently (a failed probe is not a zero balance).
+        self._last_balance: float = 0.0
 
     # ------------------------------------------------------------------
     # Public API
@@ -233,14 +236,21 @@ class PositionSyncer:
             )
             gross = int(resp.get("balance", 0)) / 1e6 if isinstance(resp, dict) else 0.0
         except Exception as e:
+            # A transient API failure is NOT a zero balance. Returning 0.0
+            # here stomped the monitor's cash to $0 (false LOW CASH alarm,
+            # observed 2026-07-17 while the venue held real spendable cash)
+            # and could wrongly gate entries. Serve the last good reading —
+            # sizing against slightly-stale cash is bounded by the submit-time
+            # guard, which re-checks against the venue anyway.
             log.error("sync.balance.error", error=str(e))
-            return 0.0
+            return self._last_balance
 
         reserved = 0.0
         reserve_fn = getattr(self._exchange, "_reserved_buy_collateral_from_open_orders", None)
         if reserve_fn is not None:
             reserved = reserve_fn() or 0.0
         available = max(0.0, gross - reserved)
+        self._last_balance = available
         log.info("sync.balance.computed", available=round(available, 2),
                  gross=round(gross, 2), reserved=round(reserved, 2))
         return available

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -281,6 +281,21 @@ class MarketMaker:
 
     async def _quote_market(self, market: Market) -> tuple[dict | None, str | None]:
         """Fetch order book, compute quotes, and place two-sided order for a market."""
+        # Cash reserve floor: MM is graduation-exempt and quotes continuously,
+        # so by default it absorbs EVERY free live dollar as inventory — a
+        # $200 float deposited for directional entries was fully claimed by MM
+        # fills within a week (2026-07). New quote pairs are skipped while
+        # spendable cash sits at/below the reserve; exits and cancels are
+        # never gated, so inventory still unwinds back to cash.
+        reserve = float(getattr(self._settings.market_maker, "cash_reserve_usd", 0.0))
+        if reserve > 0 and self._settings.is_live:
+            probe = getattr(self._exchange, "_free_collateral_usd", None)
+            free = await probe() if probe is not None else None
+            if free is not None and free <= reserve:
+                log.info("market_maker.reserve_floor", free=round(free, 2),
+                         reserve=reserve, market_id=market.id)
+                return None, "cash_reserve_floor"
+
         # Fetch YES order book to determine BBO
         book = await self._exchange.get_order_book(market.clob_token_yes)
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -393,6 +393,10 @@ market_maker:
   quote_size: 10.0          # tokens per side
   max_inventory: 50.0       # max directional exposure per market
   max_markets: 5            # max simultaneous MM markets
+  # No NEW quote pairs while spendable live cash <= this floor (exits and
+  # cancels never gated). MM is the only always-live cell, so without a
+  # floor it auto-claims every free dollar as inventory working capital.
+  cash_reserve_usd: 50.0
   refresh_seconds: 30       # re-quote frequency
   # Per-op watchdog: a stuck Polymarket call (no timeout) hung the whole MM loop
   # twice on 2026-06-30 (silent 12-24 min). Bound each quote op so a stuck call is

--- a/config/settings.py
+++ b/config/settings.py
@@ -336,6 +336,11 @@ class MarketMakerConfig(BaseModel):
     quote_size: float = 10.0  # tokens per side
     max_inventory: float = 50.0  # max directional exposure per market
     max_markets: int = 5  # max simultaneous MM markets
+    # Live-cash floor MM must leave untouched: no NEW quote pairs while
+    # spendable collateral <= this (exits/cancels never gated). Stops MM —
+    # the only always-live cell — from auto-claiming every deposited dollar
+    # as inventory working capital.
+    cash_reserve_usd: float = 50.0
     refresh_seconds: int = 30  # re-quote frequency
     # Per-operation watchdog: a single Polymarket call (orderbook fetch, quote
     # placement) that stalls without a timeout will hang the WHOLE MM loop

--- a/tests/test_balance_failopen_mm_reserve.py
+++ b/tests/test_balance_failopen_mm_reserve.py
@@ -1,0 +1,94 @@
+"""Balance fail-open + the MM cash-reserve floor.
+
+1. A transient balance-API failure is NOT a zero balance: _get_live_balance
+   must serve the last good reading instead of 0.0 (returning 0 stomped the
+   monitor's cash to $0 — a false LOW CASH alarm against a funded venue
+   account — and could wrongly gate entries).
+2. MM must not place NEW quote pairs while spendable live cash sits at or
+   below its reserve floor — without the floor, the only always-live cell
+   auto-claims every deposited dollar as inventory working capital.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.broker.sync import PositionSyncer
+
+
+def _syncer(gross_usd_6dp: int | Exception) -> PositionSyncer:
+    s = PositionSyncer.__new__(PositionSyncer)
+    s._settings = MagicMock()
+    s._settings.is_live = True
+    s._last_balance = 0.0
+    exchange = MagicMock()
+    exchange._init_clob_client = MagicMock()
+    client = MagicMock()
+    if isinstance(gross_usd_6dp, Exception):
+        client.get_balance_allowance = MagicMock(side_effect=gross_usd_6dp)
+    else:
+        client.get_balance_allowance = MagicMock(
+            return_value={"balance": gross_usd_6dp})
+    exchange._clob_client = client
+    exchange._reserved_buy_collateral_from_open_orders = MagicMock(return_value=0.0)
+    s._exchange = exchange
+    return s
+
+
+@pytest.mark.asyncio
+async def test_balance_error_serves_last_good_reading():
+    s = _syncer(138_520_000)  # $138.52
+    assert await s._get_live_balance() == pytest.approx(138.52)
+    # API starts throwing — the last good reading is served, not 0.0.
+    s._exchange._clob_client.get_balance_allowance = MagicMock(
+        side_effect=RuntimeError("Request exception!"))
+    assert await s._get_live_balance() == pytest.approx(138.52)
+
+
+@pytest.mark.asyncio
+async def test_balance_error_before_any_reading_is_zero():
+    s = _syncer(RuntimeError("down"))
+    # No good reading yet — 0.0 is the only honest floor.
+    assert await s._get_live_balance() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# MM reserve floor
+# ---------------------------------------------------------------------------
+
+
+def _mm(free: float | None, reserve: float):
+    from auramaur.strategy.market_maker import MarketMaker
+
+    mm = MarketMaker.__new__(MarketMaker)
+    mm._settings = MagicMock()
+    mm._settings.is_live = True
+    mm._settings.market_maker.cash_reserve_usd = reserve
+    mm._exchange = MagicMock()
+    mm._exchange._free_collateral_usd = AsyncMock(return_value=free)
+    # get_order_book must not be reached when the floor blocks.
+    mm._exchange.get_order_book = AsyncMock(
+        side_effect=AssertionError("quote path reached past the reserve floor"))
+    return mm
+
+
+@pytest.mark.asyncio
+async def test_mm_skips_new_quotes_at_reserve_floor():
+    mm = _mm(free=42.0, reserve=50.0)
+    result, reason = await mm._quote_market(MagicMock())
+    assert result is None
+    assert reason == "cash_reserve_floor"
+
+
+@pytest.mark.asyncio
+async def test_mm_quotes_above_reserve_and_fails_open_on_probe_error():
+
+    for free in (120.0, None):  # ample cash / probe unavailable -> proceed
+        mm = _mm(free=free, reserve=50.0)
+        # Past the floor the quote path runs; stub it to observe passage.
+        mm._exchange.get_order_book = AsyncMock(
+            return_value=MagicMock(bids=[], asks=[]))
+        result, reason = await mm._quote_market(MagicMock())
+        assert reason == "empty_book"  # i.e. we got PAST the floor


### PR DESCRIPTION
Two coupled fixes from a false LOW CASH incident:

1. _get_live_balance returned 0.0 on a transient balance-API exception,
   stomping the monitor's cash to $0 against a funded venue account (the
   false alarm briefly rewrote a capital-policy verdict) and potentially
   gating entries off a phantom zero. The error path now serves the last
   good reading; 0.0 only before any successful probe. Sizing against a
   slightly-stale balance is bounded by the submit-time guard, which
   re-checks the venue.

2. market_maker.cash_reserve_usd (default 50): MM is the only always-live
   cell and quotes continuously, so it absorbed an entire deposited float
   as inventory working capital within a week. New quote pairs are now
   skipped while spendable collateral sits at or below the floor; exits
   and cancels are never gated, so inventory still unwinds to cash. The
   probe failing open (None) proceeds — availability over strictness, as
   elsewhere in the money path.

Assisted-by: Claude (Anthropic)
