### PR TITLE
feat(long_horizon): Kalshi instance + decay-harvest exits

### DIFF
--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -44,10 +44,13 @@ class StrategyTaskMixin:
             await asyncio.sleep(interval)
 
     async def _task_long_horizon(self) -> None:
-        """Periodic long-horizon favorite-underpricing scan (paper-forced)."""
+        """Periodic long-horizon favorite-underpricing scan (paper-forced).
+        Runs the Polymarket instance and, when configured and composed, a
+        second Kalshi instance (long_horizon_kalshi — its own ladder cell,
+        politics_intl admitted; see the pillar docstring)."""
         from auramaur.strategy.long_horizon import LongHorizonPillar
 
-        pillar = LongHorizonPillar(
+        pillars = [LongHorizonPillar(
             db=self._components.db,
             settings=self.settings,
             discovery=self._components.discovery,
@@ -55,15 +58,33 @@ class StrategyTaskMixin:
             risk_manager=self._components.risk_manager,
             pnl_tracker=self._components.pnl_tracker,
             calibration=self._components.calibration,
-        )
+        )]
+        if self.settings.long_horizon.kalshi_enabled:
+            kalshi_discovery = (self._components.discoveries or {}).get("kalshi")
+            kalshi_exchange = (self._components.exchanges or {}).get("kalshi")
+            if kalshi_discovery is not None and kalshi_exchange is not None:
+                pillars.append(LongHorizonPillar(
+                    db=self._components.db,
+                    settings=self.settings,
+                    discovery=kalshi_discovery,
+                    exchange=kalshi_exchange,
+                    risk_manager=self._components.risk_manager,
+                    pnl_tracker=self._components.pnl_tracker,
+                    calibration=self._components.calibration,
+                    venue="kalshi",
+                ))
+            else:
+                log.info("long_horizon.kalshi_not_composed")
         interval = max(60, self.settings.long_horizon.interval_seconds)
         while self._running:
             if await self._check_kill_switch():
                 return
-            try:
-                await pillar.run_once()
-            except Exception as e:
-                log.error("long_horizon.cycle_error", error=str(e))
+            for pillar in pillars:
+                try:
+                    await pillar.run_once()
+                except Exception as e:
+                    log.error("long_horizon.cycle_error", venue=pillar._venue,
+                              error=str(e))
             await asyncio.sleep(interval)
 
     async def _task_agent_trader(self) -> None:

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -36,7 +36,15 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
-from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.exchange.models import (
+    Confidence,
+    Market,
+    Order,
+    OrderSide,
+    OrderType,
+    Signal,
+    TokenType,
+)
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.strategy.protocols import ExecutionMode
 
@@ -54,14 +62,27 @@ def calibrated_fair(price: float, slope: float) -> float:
 
 
 class LongHorizonPillar:
-    """Periodic long-horizon favored-side scanner for Polymarket."""
+    """Periodic long-horizon favored-side scanner.
+
+    Runs per venue: the classic Polymarket instance, and (when
+    ``kalshi_enabled``) a second instance over Kalshi attributed to
+    ``long_horizon_kalshi`` — its own graduation cell, so the venue earns
+    live status on its own ledger (the resolution_lens_kalshi idiom). The
+    Kalshi cell also ADMITS politics_intl: the live evidence for the slope
+    edge on Kalshi is precisely long-tenor geopolitical persistence (the
+    2026-04→07 live book: fear-fade ladders and status-quo favorites carried
+    the whole gain), and the research the pillar is built on found the slope
+    strongest in politics. These are persistence trades on the market's own
+    price, not forecasts — the no-politics-forecasting rule is about
+    forecasts.
+    """
 
     # Uniform Strategy contract (see strategy/protocols.py).
     name = "long_horizon"
     execution_mode = ExecutionMode.GATEWAY_SINGLE
 
     def __init__(self, db, settings, discovery, exchange, risk_manager,
-                 pnl_tracker, calibration) -> None:
+                 pnl_tracker, calibration, *, venue: str = "polymarket") -> None:
         self._db = db
         self._settings = settings
         self._discovery = discovery
@@ -69,8 +90,10 @@ class LongHorizonPillar:
         self._risk = risk_manager
         self._pnl = pnl_tracker
         self._calibration = calibration
+        self._venue = venue
+        self._tag = "long_horizon" if venue == "polymarket" else f"long_horizon_{venue}"
         self._gateway = ExecutionGateway(
-            router=None, exchange=exchange, exchange_name="polymarket",
+            router=None, exchange=exchange, exchange_name=venue,
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
 
@@ -82,6 +105,10 @@ class LongHorizonPillar:
         cfg = self._settings.long_horizon
         if not cfg.enabled:
             return 0
+        try:
+            await self._harvest_decay(cfg)
+        except Exception as e:
+            log.error("long_horizon.harvest_error", error=str(e))
         open_count = await self._open_position_count()
         if open_count >= cfg.max_open:
             log.debug("long_horizon.book_full", open=open_count, cap=cfg.max_open)
@@ -148,14 +175,16 @@ class LongHorizonPillar:
         cfg = self._settings.long_horizon
         if not market.active:
             return False
-        if (market.exchange or "polymarket") != "polymarket":
-            return False  # v1: Polymarket only (0% fees — the edge clears cleanly)
+        if (market.exchange or "polymarket") != self._venue:
+            return False  # each instance owns exactly its venue's book
         if market.liquidity < cfg.min_liquidity:
             return False
         # Classify before the block (mislabel-safe, like bias_harvest/the gateway):
         # exclude the global block AND politics (the paper's effect is strongest
         # there but it's the bot's no-edge zone — we test generalization elsewhere).
-        excluded = set(self._settings.risk.blocked_categories) | set(cfg.exclude_categories)
+        venue_excludes = (cfg.kalshi_exclude_categories if self._venue == "kalshi"
+                          else cfg.exclude_categories)
+        excluded = set(self._settings.risk.blocked_categories) | set(venue_excludes)
         hit = blocked_category_hit(excluded, market.question, market.description,
                                    market.category)
         if hit:
@@ -175,8 +204,8 @@ class LongHorizonPillar:
 
     async def _already_entered_or_held(self, market_id: str) -> bool:
         row = await self._db.fetchone(
-            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = 'long_horizon' LIMIT 1",
-            (market_id,),
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = ? LIMIT 1",
+            (market_id, self._tag),
         )
         if row is not None:
             return True  # one shot per market, ever
@@ -190,7 +219,8 @@ class LongHorizonPillar:
             """SELECT COUNT(*) AS n FROM portfolio p
                WHERE EXISTS (SELECT 1 FROM signals s
                              WHERE s.market_id = p.market_id
-                               AND s.strategy_source = 'long_horizon')""",
+                               AND s.strategy_source = ?)""",
+            (self._tag,),
         )
         return int(row["n"]) if row else 0
 
@@ -213,7 +243,7 @@ class LongHorizonPillar:
                 f"(+{edge_fav * 100:.1f}pts); no forecast claimed."
             ),
             recommended_side=OrderSide.BUY if fav_is_yes else OrderSide.SELL,
-            strategy_source="long_horizon",
+            strategy_source=self._tag,
             # Names the structural gap so the name-the-gap divergence gate passes:
             # the divergence IS the thesis (published calibration slope), not an
             # unexplained model disagreement.
@@ -263,6 +293,73 @@ class LongHorizonPillar:
         return True
 
     # ------------------------------------------------------------------
+    # Decay harvest — realize the front-loaded premium, don't wait for the bell
+    # ------------------------------------------------------------------
+
+    async def _harvest_decay(self, cfg) -> int:
+        """Exit positions whose side has captured >= ``take_profit_capture`` of
+        the entry->$1 distance.
+
+        The slope/persistence premium decays FRONT-LOADED (the scare recedes,
+        the milestone slips) — holding the last cents to a multi-year
+        resolution is bad capital velocity, and worse: a cell whose events
+        only realize at resolution can never accrue the graduation ladder's
+        20-events-in-90-days record. Harvesting the decay converts marks into
+        honest realized ledger events on a weeks clock, recycles the locked
+        capital, and keeps the strategy judgeable. Marks must be FRESH
+        (stale-active rows freeze prices; the #80 lesson) — positions whose
+        market row hasn't updated recently are skipped, not exited."""
+        capture_floor = float(getattr(cfg, "take_profit_capture", 0.0))
+        if capture_floor <= 0:
+            return 0
+        rows = await self._db.fetchall(
+            """SELECT p.market_id, p.token, p.token_id, p.size, p.avg_price,
+                      p.is_paper, m.outcome_yes_price, m.clob_token_yes,
+                      m.clob_token_no
+               FROM portfolio p JOIN markets m ON m.id = p.market_id
+               WHERE p.size > 0 AND p.exchange = ?
+                 AND m.last_updated >= datetime('now', '-1 day')
+                 AND EXISTS (SELECT 1 FROM signals s
+                             WHERE s.market_id = p.market_id
+                               AND s.strategy_source = ?)""",
+            (self._venue, self._tag))
+        exited = 0
+        for r in rows:
+            token = (r["token"] or "YES").upper()
+            p_yes = float(r["outcome_yes_price"] or 0.0)
+            if not (0.0 < p_yes < 1.0):
+                continue
+            mark = p_yes if token == "YES" else 1.0 - p_yes
+            entry = float(r["avg_price"] or 0.0)
+            if entry <= 0 or entry >= 1.0 or mark <= entry:
+                continue
+            captured = (mark - entry) / (1.0 - entry)
+            if captured < capture_floor:
+                continue
+            token_id = r["token_id"] or (
+                r["clob_token_yes"] if token == "YES" else r["clob_token_no"]) or ""
+            order = Order(
+                market_id=r["market_id"],
+                exchange=self._venue,
+                token_id=token_id,
+                side=OrderSide.SELL,
+                token=TokenType(token),
+                size=float(r["size"]),
+                price=max(0.01, min(0.99, round(mark, 2))),
+                order_type=OrderType.LIMIT,
+                dry_run=bool(r["is_paper"]) or not self._settings.is_live,
+                source="exit",
+            )
+            res = await self._gateway.submit_exit(
+                order, exchange=self._exchange, exchange_name=self._venue)
+            if res.status in ("filled", "paper", "partial", "pending"):
+                exited += 1
+                log.info("long_horizon.decay_harvested", market_id=r["market_id"],
+                         tag=self._tag, entry=entry, mark=round(mark, 2),
+                         captured=round(captured, 2), paper=bool(r["is_paper"]))
+        return exited
+
+    # ------------------------------------------------------------------
     # Bookkeeping — same rails as bias_harvest / the engine
     # ------------------------------------------------------------------
 
@@ -281,10 +378,10 @@ class LongHorizonPillar:
         await self._db.execute(
             """INSERT INTO signals (market_id, claude_prob, claude_confidence,
                market_prob, edge, evidence_summary, action, strategy_source)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 'long_horizon')""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
              signal.market_prob, signal.edge, signal.evidence_summary,
-             signal.recommended_side.value),
+             signal.recommended_side.value, self._tag),
         )
         await self._db.commit()
 
@@ -300,13 +397,13 @@ class LongHorizonPillar:
             """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
                current_price, unrealized_pnl, category, token, token_id,
                is_paper, updated_at)
-               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
+               VALUES (?, ?, 'BUY', ?, ?, ?, 0, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
                    size = excluded.size,
                    avg_price = excluded.avg_price,
                    current_price = excluded.current_price,
                    updated_at = excluded.updated_at""",
-            (order.market_id, fill_size, fill_price, fill_price,
+            (order.market_id, self._venue, fill_size, fill_price, fill_price,
              market.category or "", order.token.value, order.token_id,
              1 if is_paper else 0),
         )

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -505,6 +505,16 @@ long_horizon:
   max_days_to_resolution: 365.0   # was 180 — the >180d bucket is the largest candidate pool
   interval_seconds: 1800
   exclude_categories: ["politics_us", "politics_intl"]
+  # Kalshi instance — long_horizon_kalshi cell, paper-first on its own ledger.
+  # Admits politics_intl: the live Kalshi book's gains are long-tenor
+  # geopolitical PERSISTENCE (fear-fade ladders, status-quo favorites) — slope
+  # trades on the market's own price, not forecasts. US politics stays out.
+  kalshi_enabled: true
+  kalshi_exclude_categories: ["politics_us"]
+  # Decay harvest: exit once the favored side captured this fraction of its
+  # entry->$1 distance — realizes the front-loaded premium on a weeks clock
+  # (graduation-ladder compatible) and recycles locked capital. 0 disables.
+  take_profit_capture: 0.6
 
 agent_trader:
   # LLM day-trader — the Hermes agent paradigm rebuilt as a first-class pillar

--- a/config/settings.py
+++ b/config/settings.py
@@ -510,6 +510,16 @@ class LongHorizonConfig(BaseModel):
     # where the bot has no edge — so we test generalization elsewhere. Checked on
     # top of risk.blocked_categories, against the CLASSIFIED category.
     exclude_categories: list[str] = ["politics_us", "politics_intl"]
+    # Kalshi instance (long_horizon_kalshi cell, paper-first on its own ledger).
+    # Its exclusions ADMIT politics_intl: the live Kalshi evidence for the slope
+    # edge is long-tenor geopolitical persistence — a price-slope trade, not a
+    # forecast.
+    kalshi_enabled: bool = False
+    kalshi_exclude_categories: list[str] = ["politics_us"]
+    # Decay harvest: exit once the side has captured this fraction of the
+    # entry->$1 distance. 0 disables. Realizes the front-loaded premium on a
+    # weeks clock (ladder-compatible) instead of waiting years for resolution.
+    take_profit_capture: float = 0.6
 
 
 class AgentTraderModel(BaseModel):

--- a/tests/test_long_horizon.py
+++ b/tests/test_long_horizon.py
@@ -268,3 +268,133 @@ def test_scan_long_dated_paginates_and_uses_date_window():
         assert "end_date_min" in kw and "end_date_max" in kw and kw["order"] == "liquidity"
         await db.close()
     asyncio.run(run())
+
+
+# ----------------------------------------------------------------------
+# Kalshi instance + decay harvest (2026-07)
+# ----------------------------------------------------------------------
+
+
+def _kalshi_pillar(db, settings, markets, exchange=None, risk=None):
+    discovery = MagicMock()
+    discovery.get_markets = AsyncMock(return_value=markets)
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+    return LongHorizonPillar(
+        db=db, settings=settings, discovery=discovery,
+        exchange=exchange or _exchange(), risk_manager=risk or _risk(),
+        pnl_tracker=PnLTracker(db, settings), calibration=calibration,
+        venue="kalshi",
+    )
+
+
+async def test_kalshi_instance_owns_tag_venue_and_admits_politics_intl():
+    """The Kalshi instance writes long_horizon_kalshi signals and a kalshi
+    portfolio row, ADMITS politics_intl (the live-book evidence category),
+    and rejects Polymarket markets (each instance owns exactly its venue)."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings = _settings()
+        markets = [
+            _market("KX1", yes=0.75, category="politics_intl", exchange="kalshi"),
+            _market("p1", yes=0.75, category="tech", exchange="polymarket"),
+        ]
+        pillar = _kalshi_pillar(db, settings, markets)
+        entered = await pillar.run_once()
+        assert entered == 1
+        sig = await db.fetchone("SELECT market_id, strategy_source FROM signals")
+        assert sig["market_id"] == "KX1"
+        assert sig["strategy_source"] == "long_horizon_kalshi"
+        port = await db.fetchone(
+            "SELECT exchange FROM portfolio WHERE market_id='KX1'")
+        assert port["exchange"] == "kalshi"
+    finally:
+        await db.close()
+
+
+async def test_poly_instance_still_excludes_politics():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings = _settings()
+        pillar, _ = _pillar(db, settings, [
+            _market("p2", yes=0.75, category="politics_intl")])
+        assert await pillar.run_once() == 0
+    finally:
+        await db.close()
+
+
+async def _seed_position(db, *, market_id, tag, venue, token, size, avg,
+                         yes_price, fresh=True):
+    await db.execute(
+        """INSERT INTO markets (id, exchange, question, category, active,
+           outcome_yes_price, outcome_no_price, last_updated, created_at)
+           VALUES (?, ?, 'q?', 'tech', 1, ?, ?, ?, datetime('now'))""",
+        (market_id, venue, yes_price, round(1 - yes_price, 2),
+         "now" if fresh else "2026-01-01 00:00:00"))
+    if fresh:
+        await db.execute(
+            "UPDATE markets SET last_updated = datetime('now') WHERE id = ?",
+            (market_id,))
+    await db.execute(
+        """INSERT INTO signals (market_id, claude_prob, claude_confidence,
+           market_prob, edge, evidence_summary, action, strategy_source)
+           VALUES (?, 0.8, 'MEDIUM', 0.7, 8.0, 'e', 'BUY', ?)""",
+        (market_id, tag))
+    await db.execute(
+        """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+           current_price, unrealized_pnl, category, token, token_id, is_paper,
+           updated_at)
+           VALUES (?, ?, 'BUY', ?, ?, ?, 0, 'tech', ?, 'tok', 1, datetime('now'))""",
+        (market_id, venue, size, avg, avg, token))
+    # The BUY's cost basis — what the harvest's SELL realizes against.
+    await db.execute(
+        """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost,
+           total_cost, realized_pnl, is_paper, updated_at)
+           VALUES (?, ?, 'tok', ?, ?, ?, 0, 1, datetime('now'))""",
+        (market_id, token, size, avg, size * avg))
+    await db.commit()
+
+
+async def test_decay_harvest_exits_captured_position_and_realizes():
+    """A NO position entered at 0.66 with the market now at YES=0.06 (mark
+    0.94) has captured (0.94-0.66)/(1-0.66) = 82% >= 60% -> exit fires, and
+    the sell realizes a ledger event attributed to the ENTRY cell (the
+    token-scoped #268 lookup) — graduation events on a weeks clock."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings = _settings()
+        pillar = _kalshi_pillar(db, settings, [])
+        await _seed_position(db, market_id="KXH", tag="long_horizon_kalshi",
+                             venue="kalshi", token="NO", size=30, avg=0.66,
+                             yes_price=0.06)
+        exited = await pillar._harvest_decay(settings.long_horizon)
+        assert exited == 1
+        row = await db.fetchone(
+            "SELECT strategy_source, pnl FROM pnl_ledger WHERE market_id='KXH'")
+        assert row is not None
+        assert row["pnl"] > 0
+    finally:
+        await db.close()
+
+
+async def test_decay_harvest_skips_below_floor_and_stale_marks():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        settings = _settings()
+        pillar = _kalshi_pillar(db, settings, [])
+        # Captured only 26% (< 60%) -> hold.
+        await _seed_position(db, market_id="KXLOW", tag="long_horizon_kalshi",
+                             venue="kalshi", token="NO", size=30, avg=0.66,
+                             yes_price=0.25)
+        # Fully captured but the mark is STALE (frozen row) -> skip, not exit.
+        await _seed_position(db, market_id="KXSTALE", tag="long_horizon_kalshi",
+                             venue="kalshi", token="NO", size=30, avg=0.66,
+                             yes_price=0.02, fresh=False)
+        assert await pillar._harvest_decay(settings.long_horizon) == 0
+        assert await db.fetchone("SELECT 1 FROM pnl_ledger") is None
+    finally:
+        await db.close()


### PR DESCRIPTION
Extends the slope pillar to the venue where its thesis has live evidence:
the 2026-04..07 live Kalshi book's gains are concentrated in long-tenor
PERSISTENCE positions (fear-fade ladders, status-quo favorites bought
against exciting-change pricing) — the published slope edge, strongest in
politics, expressed as price-slope trades rather than forecasts.

- Venue-parameterized pillar: a second instance runs over Kalshi when
  kalshi_enabled, attributed long_horizon_kalshi (its own graduation cell,
  the resolution_lens_kalshi idiom). The Kalshi cell ADMITS politics_intl
  (kalshi_exclude_categories keeps politics_us out); the Polymarket
  instance's exclusions are unchanged.

- Decay harvest (both venues): exit once the held side has captured
  take_profit_capture (default 0.6) of its entry->$1 distance. The premium
  this pillar trades decays FRONT-LOADED, so waiting for multi-year
  resolutions is bad capital velocity — and structurally ungraduatable
  (a cell whose events realize in years can never accrue 20 events in the
  ladder's 90-day window). Harvest exits realize honest ledger events on a
  weeks clock, attributed to the entry cell via the token-scoped lookup.
  Marks must be fresh (stale-active rows are skipped, never exited on).

Assisted-by: Claude (Anthropic)
