### PR TITLE
fix(long_horizon): Kalshi-scoped liquidity floor + multi-year tenor window

### DIFF
--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -145,7 +145,9 @@ class LongHorizonPillar:
         from datetime import timedelta
         now = datetime.now(timezone.utc)
         emin = (now + timedelta(days=cfg.min_days_to_resolution)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        emax = (now + timedelta(days=cfg.max_days_to_resolution)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        max_days = (cfg.kalshi_max_days_to_resolution if self._venue == "kalshi"
+                    else cfg.max_days_to_resolution)
+        emax = (now + timedelta(days=max_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
         out: list[Market] = []
         try:
             for off in range(0, max(int(cfg.scan_limit), 1), 100):
@@ -183,7 +185,9 @@ class LongHorizonPillar:
             return False
         if (market.exchange or "polymarket") != self._venue:
             return False  # each instance owns exactly its venue's book
-        if market.liquidity < cfg.min_liquidity:
+        min_liq = (cfg.kalshi_min_liquidity if self._venue == "kalshi"
+                   else cfg.min_liquidity)
+        if market.liquidity < min_liq:
             return False
         # Classify before the block (mislabel-safe, like bias_harvest/the gateway):
         # exclude the global block AND politics (the paper's effect is strongest
@@ -204,8 +208,10 @@ class LongHorizonPillar:
         days_left = (end - datetime.now(timezone.utc)).total_seconds() / 86400.0
         if days_left < cfg.min_days_to_resolution:
             return False  # not a LONG-horizon market — no underconfidence edge
-        if days_left > cfg.max_days_to_resolution:
-            return False  # capital lock-up cap
+        max_days = (cfg.kalshi_max_days_to_resolution if self._venue == "kalshi"
+                    else cfg.max_days_to_resolution)
+        if days_left > max_days:
+            return False  # capital lock-up cap (decay harvest funds the kalshi tenor)
         return True
 
     async def _already_entered_or_held(self, market_id: str) -> bool:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -511,6 +511,12 @@ long_horizon:
   # trades on the market's own price, not forecasts. US politics stays out.
   kalshi_enabled: true
   kalshi_exclude_categories: ["politics_us"]
+  # Kalshi bulk liquidity underreports (lens precedent: floor 300->50); the
+  # Poly floor rejected 98% of far-dated Kalshi markets. Multi-year tenors
+  # admitted — the persistence winners resolve 2028-2035 and the decay
+  # harvest keeps capital velocity acceptable.
+  kalshi_min_liquidity: 50.0
+  kalshi_max_days_to_resolution: 1460.0
   # Decay harvest: exit once the favored side captured this fraction of its
   # entry->$1 distance — realizes the front-loaded premium on a weeks clock
   # (graduation-ladder compatible) and recycles locked capital. 0 disables.

--- a/config/settings.py
+++ b/config/settings.py
@@ -516,6 +516,14 @@ class LongHorizonConfig(BaseModel):
     # forecast.
     kalshi_enabled: bool = False
     kalshi_exclude_categories: list[str] = ["politics_us"]
+    # Kalshi's bulk liquidity field UNDERREPORTS (the lens hit the same wall:
+    # floor 300 -> 50); the Polymarket floor rejected 98% of far-dated Kalshi
+    # markets. And the persistence lane on Kalshi lives at MULTI-YEAR tenors
+    # (the live-book winners resolve 2028-2035) — the 365d lock-up cap that
+    # protects the Poly instance would exclude the entire lane; the decay
+    # harvest is what makes long tenor affordable.
+    kalshi_min_liquidity: float = 50.0
+    kalshi_max_days_to_resolution: float = 1460.0
     # Decay harvest: exit once the side has captured this fraction of the
     # entry->$1 distance. 0 disables. Realizes the front-loaded premium on a
     # weeks clock (ladder-compatible) instead of waiting years for resolution.


### PR DESCRIPTION
First visible cycle (post the #283 funnel logging) showed the Kalshi
instance scanning hundreds of markets with ZERO in-band — two Polymarket
assumptions killed everything:

- liquidity floor: Kalshi's bulk liquidity field underreports (the lens
  hit the identical wall, floor 300->50); the Poly floor rejected ~98% of
  far-dated Kalshi markets. kalshi_min_liquidity: 50.

- tenor cap: the persistence lane on Kalshi lives at MULTI-YEAR tenors
  (the live-book evidence resolves 2028-2035), entirely beyond the 365d
  lock-up cap that protects the Poly instance. The decay harvest is what
  makes long tenor affordable, so the Kalshi window opens to
  kalshi_max_days_to_resolution: 1460.

Assisted-by: Claude (Anthropic)
