### PR TITLE
chore(observability): cycle-visibility sweep — every scanner logs every cycle

### DIFF
--- a/auramaur/monitoring/hydro_market_watch.py
+++ b/auramaur/monitoring/hydro_market_watch.py
@@ -94,6 +94,5 @@ class HydroMarketWatcher:
                 log.info("hydro_watch.new_market", venue=venue, market_id=m.id,
                          question=(m.question or "")[:80])
                 new += 1
-        if new:
-            log.info("hydro_watch.cycle_done", new=new)
+        log.info("hydro_watch.cycle", new=new)
         return new

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -208,8 +208,7 @@ class AgentTraderPillar:
                 # stop the other cells — they are independent experiment arms.
                 log.warning("agent_trader.model_cycle_error",
                             alias=spec.alias, error=str(e))
-        if entered_total:
-            log.info("agent_trader.cycle_done", entered=entered_total)
+        log.info("agent_trader.cycle", arms=len(cfg.models), entered=entered_total)
         return entered_total
 
     async def _run_model(self, spec, candidates: list[Market], cfg) -> int:

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -130,8 +130,7 @@ class BiasHarvestPillar:
                     entered += 1
             except Exception as e:
                 log.error("bias_harvest.entry_error", market_id=market.id, error=str(e))
-        if entered:
-            log.info("bias_harvest.cycle_done", entered=entered)
+        log.info("bias_harvest.cycle", scanned=len(markets), entered=entered)
         return entered
 
     # ------------------------------------------------------------------

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -358,6 +358,5 @@ class CrossVenueArbPillar:
                     entered += 1
             except Exception as e:
                 log.error("cross_venue.entry_error", a=a.id, b=b.id, error=str(e))
-        if entered:
-            log.info("cross_venue.cycle_done", entered=entered)
+        log.info("cross_venue.cycle", pairs=len(pairs), entered=entered)
         return entered

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -489,8 +489,7 @@ class EntailmentArbPillar:
             except Exception as e:
                 log.error("entailment.entry_error", a=implier.id, b=implied.id,
                           error=str(e))
-        if placed:
-            log.info("entailment.cycle_done", pairs=placed)
+        log.info("entailment.cycle", candidates=len(candidates), placed=placed)
         return placed
 
     # -- execution --------------------------------------------------------

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -86,8 +86,7 @@ class InformedFlowPillar:
                     entered += 1
             except Exception as e:
                 log.error("informed_flow.entry_error", market_id=market.id, error=str(e))
-        if entered:
-            log.info("informed_flow.cycle_done", entered=entered)
+        log.info("informed_flow.cycle", scanned=len(markets), entered=entered)
         return entered
 
     # ------------------------------------------------------------------

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -109,8 +109,7 @@ class OddLotTenderPillar:
                     and verdict["confidence"] >= cfg.llm_min_confidence):
                 found += 1
                 await self._on_opportunity(f, verdict)
-        if analyzed:
-            log.info("oddlot.cycle_done", analyzed=analyzed, opportunities=found)
+        log.info("oddlot.cycle", analyzed=analyzed, opportunities=found)
         return found
 
     async def _audit_filing(self, f) -> dict | None:

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -218,9 +218,8 @@ class TermStructurePillar:
             except Exception as e:
                 log.warning("term_structure.family_error", family=fam,
                             error=str(e))
-        if entered:
-            log.info("term_structure.cycle_done", entered=entered,
-                     families=len(families), reads=calls)
+        log.info("term_structure.cycle", families=len(families), reads=calls,
+                 entered=entered)
         return entered
 
     # ------------------------------------------------------------------

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -263,8 +263,8 @@ class VolAnchorPillar:
                 continue
             if await self._try_enter(market, fair, sigma, realized, kind, cfg):
                 entered += 1
-        if priced:
-            log.info("vol_anchor.cycle_done", priced=priced, entered=entered)
+        log.info("vol_anchor.cycle", candidates=len(candidates), priced=priced,
+                 entered=entered)
         return entered
 
     async def _candidates(self, cfg) -> list[tuple[str, str, float, datetime, Market]]:


### PR DESCRIPTION
Systematic audit of the "running invisibly" bug class after its third
occurrence (settlement_arb #246, long_horizon #283, and the Kalshi paper
books whose quiet records turned out to be structural #269): NINE periodic
scanners guarded their only cycle-level log behind `if entered` — a quiet
log was indistinguishable from a dead task, a starved funnel, or a
misconfigured venue, and diagnosis required shipping a logging patch first
every single time.

All scanners now log one line per cycle with their funnel counts
(scanned/candidates/pairs -> entered/placed/priced), unconditionally:
bias_harvest, informed_flow, entailment_arb, cross_venue_arb,
oddlot_tender, vol_anchor, term_structure, agent_trader, hydro_watch.
Already-visible loops (settlement_arb, resolution_lens, long_horizon,
market_maker heartbeat, intraday_drift, engine cycles) are unchanged.

One line per pillar per interval (~30-120min) is negligible log volume
against never again mistaking silence for health.

Assisted-by: Claude (Anthropic)
