### PR TITLE
feat(coinbase): read-only shadow comparator for the Kraken paper trial (Codex suggestion, reviewed)

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -637,7 +637,17 @@ class AuramaurBot(
         from auramaur.monitoring.display import console
 
         client = KrakenSpotClient(self.settings)
-        pillar = KrakenPillar(self.settings, client, bot=self, console=console)
+        coinbase_client = None
+        comparator = None
+        if self.settings.coinbase.paper_enabled:
+            from auramaur.exchange.coinbase import CoinbasePublicClient
+            from auramaur.treasury.coinbase_paper import CoinbasePaperBook
+            coinbase_client = CoinbasePublicClient()
+            comparator = CoinbasePaperBook(
+                self.settings, coinbase_client, self._components.get("db"))
+        pillar = KrakenPillar(
+            self.settings, client, bot=self, console=console,
+            paper_comparator=comparator)
         interval = self.settings.kraken.treasury_interval_seconds
         try:
             while self._running:
@@ -647,6 +657,8 @@ class AuramaurBot(
                 await asyncio.sleep(interval)
         finally:
             await client.close()
+            if coinbase_client is not None:
+                await coinbase_client.close()
 
     async def _task_momentum_coupling(self) -> None:
         """Fast path: spot->prediction momentum-coupling pillar (gated, detect-only).

--- a/auramaur/broker/ledger.py
+++ b/auramaur/broker/ledger.py
@@ -105,6 +105,8 @@ async def _market_context(
     if row is not None:
         venue = row["exchange"] or ""
         category = row["category"] or ""
+    elif market_id.startswith("coinbase:"):
+        return "coinbase", "coinbase_spot", "coinbase_paper"
     elif _looks_like_kraken_pair(market_id):
         # Kraken directional book: market_id is the spot pair, no markets row.
         # 'kraken_spot' matches the calibration category used for its signals.

--- a/auramaur/exchange/coinbase.py
+++ b/auramaur/exchange/coinbase.py
@@ -1,0 +1,48 @@
+"""Read-only Coinbase public market data for the spot paper comparator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import aiohttp
+
+
+@dataclass(frozen=True)
+class CoinbaseQuote:
+    bid: float
+    ask: float
+
+
+class CoinbasePublicClient:
+    """Tiny unauthenticated adapter; deliberately has no order-placement API."""
+
+    _API = "https://api.exchange.coinbase.com"
+
+    def __init__(self) -> None:
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=15),
+                headers={"User-Agent": "auramaur-coinbase-paper/1.0"},
+            )
+        return self._session
+
+    async def get_quote(self, product_id: str) -> CoinbaseQuote | None:
+        session = await self._get_session()
+        async with session.get(f"{self._API}/products/{product_id}/ticker") as response:
+            if response.status != 200:
+                return None
+            data = await response.json()
+        try:
+            bid, ask = float(data["bid"]), float(data["ask"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if bid <= 0 or ask <= 0 or bid > ask:
+            return None
+        return CoinbaseQuote(bid=bid, ask=ask)
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()

--- a/auramaur/treasury/coinbase_paper.py
+++ b/auramaur/treasury/coinbase_paper.py
@@ -1,0 +1,55 @@
+"""Coinbase shadow fills for the Kraken directional paper book."""
+
+from __future__ import annotations
+
+import structlog
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.exchange.models import Fill, OrderSide, TokenType
+
+log = structlog.get_logger()
+
+
+class CoinbasePaperBook:
+    """Price identical decisions on Coinbase without credentials or execution."""
+
+    _PRODUCTS = {
+        "XBTUSDC": "BTC-USDC",
+        "ETHUSDC": "ETH-USDC",
+        "SOLUSDC": "SOL-USDC",
+    }
+
+    def __init__(self, settings, client, db) -> None:
+        self._settings = settings
+        self._client = client
+        self._pnl = PnLTracker(db, settings)
+
+    async def record_shadow_fill(self, pair: str, side: OrderSide, qty: float) -> None:
+        product = self._PRODUCTS.get(pair)
+        if product is None or qty <= 0:
+            return
+        try:
+            quote = await self._client.get_quote(product)
+        except Exception as exc:  # noqa: BLE001 — comparator must not break Kraken
+            log.warning("coinbase.paper.quote_error", pair=pair, error=str(exc)[:120])
+            return
+        if quote is None:
+            log.warning("coinbase.paper.quote_unavailable", pair=pair, product=product)
+            return
+        price = quote.ask if side == OrderSide.BUY else quote.bid
+        notional = qty * price
+        fee_pct = self._settings.coinbase.paper_fee_pct / 100.0
+        fill = Fill(
+            order_id=f"coinbase-paper-{pair}",
+            market_id=f"coinbase:{product}",
+            token_id=product,
+            side=side,
+            token=TokenType.YES,
+            size=qty,
+            price=price,
+            fee=notional * fee_pct,
+            is_paper=True,
+        )
+        await self._pnl.record_fill(fill)
+        log.info("coinbase.paper.fill", pair=pair, product=product,
+                 side=side.value, price=price, qty=round(qty, 10), fee=fill.fee)

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -29,11 +29,13 @@ log = structlog.get_logger()
 
 
 class KrakenPillar:
-    def __init__(self, settings, kraken_client, bot=None, console=None):
+    def __init__(self, settings, kraken_client, bot=None, console=None,
+                 paper_comparator=None):
         self._s = settings
         self._k = kraken_client
         self._bot = bot          # for _last_known_cash
         self._console = console
+        self._paper_comparator = paper_comparator
         # Open directional longs: pair -> entry-price proxy. Reconciled from
         # actual Kraken balances each cycle (see _reconcile_positions), so it
         # survives restarts instead of silently over-allocating.
@@ -704,6 +706,9 @@ class KrakenPillar:
                     # the fill; paper books a simulated one at the est price.
                     fill_price = await self._record_directional_fill(
                         pair, OrderSide.SELL, res, price, vol, paper=effective_paper)
+                    if effective_paper and self._paper_comparator is not None:
+                        await self._paper_comparator.record_shadow_fill(
+                            pair, OrderSide.SELL, vol)
                 # Only forget the position once the sell is real. In paper mode
                 # nothing executes, so simulate the close unconditionally; in live
                 # mode require a confirmed fill — otherwise a sell that never
@@ -801,6 +806,9 @@ class KrakenPillar:
                     # simulated fill at the current price.
                     fill_price = await self._record_directional_fill(
                         pair, OrderSide.BUY, res, price, vol, paper=effective_paper)
+                    if effective_paper and self._paper_comparator is not None:
+                        await self._paper_comparator.record_shadow_fill(
+                            pair, OrderSide.BUY, vol)
                     if effective_paper:
                         self._dir_long[pair] = price          # paper: simulate the entry
                     elif fill_price is not None:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -333,6 +333,12 @@ kraken:
   directional_conviction_budget_enabled: false
   directional_conviction_min_mult: 0.34
 
+# Read-only venue comparator for the Kraken paper decisions. It fetches public
+# bid/ask quotes and records shadow fills; there are no credentials or order API.
+coinbase:
+  paper_enabled: true
+  paper_fee_pct: 0.60
+
 transfers:
   # Cross-venue fund movement (Kraken -> Polymarket, Polygon USDC only).
   # Requires BOTH this and the AURAMAUR_ENABLE_TRANSFERS env gate, plus the

--- a/config/settings.py
+++ b/config/settings.py
@@ -1116,6 +1116,13 @@ class KrakenConfig(BaseModel):
     directional_conviction_min_mult: float = 0.34  # floor on the budget multiplier
 
 
+class CoinbaseConfig(BaseModel):
+    """Read-only Coinbase shadow book; live execution is intentionally absent."""
+
+    paper_enabled: bool = False
+    paper_fee_pct: float = 0.60
+
+
 class TransfersConfig(BaseModel):
     """Cross-venue fund movement (Kraken <-> Polymarket, Polygon USDC only).
 
@@ -1316,6 +1323,7 @@ class Settings(BaseSettings):
     ibkr: IBKRConfig = Field(default_factory=lambda: IBKRConfig(**_DEFAULTS.get("ibkr", {})))
     cryptodotcom: CryptoComConfig = Field(default_factory=lambda: CryptoComConfig(**_DEFAULTS.get("cryptodotcom", {})))
     kraken: KrakenConfig = Field(default_factory=lambda: KrakenConfig(**_DEFAULTS.get("kraken", {})))
+    coinbase: CoinbaseConfig = Field(default_factory=lambda: CoinbaseConfig(**_DEFAULTS.get("coinbase", {})))
     transfers: TransfersConfig = Field(default_factory=lambda: TransfersConfig(**_DEFAULTS.get("transfers", {})))
     ensemble: EnsembleConfig = Field(default_factory=lambda: EnsembleConfig(**_DEFAULTS.get("ensemble", {})))
     llm_ensemble: LLMEnsembleConfig = Field(default_factory=lambda: LLMEnsembleConfig(**_DEFAULTS.get("llm_ensemble", {})))

--- a/tests/test_coinbase_paper.py
+++ b/tests/test_coinbase_paper.py
@@ -1,0 +1,51 @@
+"""Coinbase read-only shadow book tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.coinbase import CoinbaseQuote
+from auramaur.exchange.models import OrderSide
+from auramaur.treasury.coinbase_paper import CoinbasePaperBook
+from config.settings import Settings
+
+
+class FakeCoinbase:
+    async def get_quote(self, product):
+        assert product == "BTC-USDC"
+        return CoinbaseQuote(bid=99.0, ask=101.0)
+
+
+@pytest.mark.asyncio
+async def test_shadow_book_uses_ask_bid_and_keeps_separate_attribution():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    book = CoinbasePaperBook(settings, FakeCoinbase(), db)
+
+    await book.record_shadow_fill("XBTUSDC", OrderSide.BUY, 0.1)
+    await book.record_shadow_fill("XBTUSDC", OrderSide.SELL, 0.1)
+
+    fills = await db.fetchall(
+        "SELECT market_id, side, price, fee, is_paper FROM fills ORDER BY id")
+    assert [(r["side"], r["price"]) for r in fills] == [("BUY", 101.0), ("SELL", 99.0)]
+    assert all(r["market_id"] == "coinbase:BTC-USDC" for r in fills)
+    assert all(r["is_paper"] == 1 for r in fills)
+    assert fills[0]["fee"] == pytest.approx(10.1 * 0.006)
+
+    ledger = await db.fetchone(
+        "SELECT venue, category, strategy_source, pnl FROM pnl_ledger")
+    assert dict(ledger) | {} == {
+        "venue": "coinbase", "category": "coinbase_spot",
+        "strategy_source": "coinbase_paper",
+        "pnl": pytest.approx((99.0 - 101.0) * 0.1 - 9.9 * 0.006),
+    }
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_pair_is_ignored_without_market_call():
+    client = SimpleNamespace(get_quote=None)
+    book = CoinbasePaperBook(Settings(), client, None)
+    await book.record_shadow_fill("DOGEUSDC", OrderSide.BUY, 10.0)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -151,6 +151,7 @@ def test_yaml_defaults_safe():
     assert kraken["directional_liquidate_orphans"] is False
     assert 0 < kraken["directional_budget_usd"] <= 2 * kraken["max_order_usd"]
     assert kraken["directional_pairs"] == ["XBTUSDC", "ETHUSDC", "SOLUSDC"]
+    assert raw["coinbase"]["paper_enabled"] is True
 
 
 def test_hf_token_exported_to_environ(monkeypatch):


### PR DESCRIPTION
Every paper fill the Kraken directional trial records is simultaneously
re-priced against Coinbase's public book (buy at ask, sell at bid) with
Coinbase's taker fee, and booked to its own ledger cell via a market-id
namespace the ledger resolves to a dedicated venue/category/strategy.
Same decisions, second venue, worse fee tier — a direct measurement of
how much of any future Kraken paper edge is venue-dependent, which is
the fee-floor question that killed both this book's live run and the
independent replication.

Review notes: the client is read-only BY CONSTRUCTION — no credentials,
no order-placement API exists to misuse (capability absence over policy,
the lesson of this month's agent incidents). Comparator failures cannot
break the Kraken cycle (guarded, quote-unavailable no-ops). Shadow fills
draw bounded headroom from the shared paper wallet (mirror of the
two-order Kraken ceiling — immaterial, same precedent as Kraken's own
paper fills). Config pinned in test_settings alongside the Kraken trial
profile. Known nit: the aiohttp session is not explicitly closed on
shutdown (harmless under supervised restarts).

Suggested-by: Codex
Assisted-by: Claude (Anthropic)
