### PR TITLE
feat(agent_trader): Gemini arms (3.1 flash/pro + 3.5 flash) — cost-metered cross-provider A/B

### DIFF
--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -88,6 +88,16 @@ CREATE TABLE IF NOT EXISTS agent_trader_declines (
 )
 """
 
+_COSTS_TABLE = """
+CREATE TABLE IF NOT EXISTS agent_trader_costs (
+    day TEXT NOT NULL,
+    model_alias TEXT NOT NULL,
+    calls INTEGER NOT NULL DEFAULT 0,
+    usd REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (day, model_alias)
+)
+"""
+
 _THESES_TABLE = """
 CREATE TABLE IF NOT EXISTS agent_trader_theses (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -170,6 +180,7 @@ class AgentTraderPillar:
             return
         await self._db.execute(_THESES_TABLE)
         await self._db.execute(_DECLINES_TABLE)
+        await self._db.execute(_COSTS_TABLE)
         try:
             # Upgrade a pre-`entered` table in place (rows so far all entered).
             await self._db.execute(
@@ -251,7 +262,10 @@ class AgentTraderPillar:
             open_book=self._open_block(open_rows),
             candidates=self._candidates_block(offered),
         )
-        raw = await self._call_model(prompt, spec.model, spec.effort, cfg)
+        if getattr(spec, "provider", "claude") == "gemini":
+            raw = await self._call_gemini(prompt, spec, cfg)
+        else:
+            raw = await self._call_model(prompt, spec.model, spec.effort, cfg)
         decisions = parse_decisions(raw, cfg.max_entries_per_cycle)
 
         # The model actually saw and passed on these — remember the pass for
@@ -444,6 +458,77 @@ class AgentTraderPillar:
             raise RuntimeError(
                 f"model call failed ({model}): {stderr.decode()[:200]}")
         return stdout.decode()
+
+    # ------------------------------------------------------------------
+    # Gemini arms — paid REST API, own daily ceiling, metered cost
+    # ------------------------------------------------------------------
+
+    async def _gemini_calls_today(self) -> int:
+        row = await self._db.fetchone(
+            """SELECT COALESCE(SUM(calls), 0) AS n FROM agent_trader_costs
+               WHERE day = date('now')""")
+        return int(row["n"]) if row else 0
+
+    async def _record_gemini_cost(self, alias: str, usd: float) -> None:
+        await self._db.execute(
+            """INSERT INTO agent_trader_costs (day, model_alias, calls, usd)
+               VALUES (date('now'), ?, 1, ?)
+               ON CONFLICT(day, model_alias) DO UPDATE SET
+                   calls = calls + 1, usd = usd + excluded.usd""",
+            (alias, usd))
+        await self._db.commit()
+
+    async def _gemini_request(self, url: str, body: dict, timeout_s: int) -> dict:
+        """One POST to the Gemini REST API (separate method so tests stub it)."""
+        import aiohttp
+        async with aiohttp.ClientSession() as s:
+            async with s.post(url, json=body,
+                              timeout=aiohttp.ClientTimeout(total=timeout_s)) as r:
+                return await r.json()
+
+    async def _call_gemini(self, prompt: str, spec, cfg) -> str:
+        """A Gemini arm's read. PAID per token (unlike the Claude arms on the
+        Max+ plan), so: (a) its own daily ceiling, independent of the Claude
+        paced pool; (b) every call's token usage is metered into
+        agent_trader_costs at configured $/Mtok — the arm's record is judged
+        net of its own intelligence bill (operator's cost-inclusive rule).
+        Google-Search grounding is enabled for research parity with the
+        Claude arms' WebSearch; no JSON response mime (grounding conflicts),
+        the tolerant parse_decisions handles prose-wrapped JSON."""
+        key = self._settings.gemini_api_key
+        if not key:
+            raise RuntimeError("gemini arm: no GEMINI_API_KEY configured")
+        limit = int(getattr(cfg, "gemini_daily_call_limit", 0))
+        if limit > 0 and await self._gemini_calls_today() >= limit:
+            raise RuntimeError(
+                f"gemini daily call limit ({limit}) exhausted")
+        url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
+               f"{spec.model}:generateContent?key={key}")
+        body = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "tools": [{"google_search": {}}],
+            "generationConfig": {"temperature": 0.3, "maxOutputTokens": 2048},
+        }
+        data = await self._gemini_request(url, body, int(cfg.llm_timeout_seconds))
+        try:
+            parts = data["candidates"][0]["content"]["parts"]
+            text = "".join(p.get("text", "") for p in parts).strip()
+        except (KeyError, IndexError, TypeError):
+            raise RuntimeError(
+                f"gemini reply unparseable ({spec.model}): "
+                f"{str(data)[:160]}")
+        usage = data.get("usageMetadata", {}) or {}
+        prices = (getattr(cfg, "gemini_price_per_mtok", {}) or {}).get(
+            spec.model, [0.0, 0.0])
+        usd = (float(usage.get("promptTokenCount", 0)) * float(prices[0])
+               + float(usage.get("candidatesTokenCount", 0)) * float(prices[1])
+               ) / 1e6
+        await self._record_gemini_cost(spec.alias, usd)
+        log.info("agent_trader.gemini_call", alias=spec.alias,
+                 model=spec.model, usd=round(usd, 5),
+                 in_tok=usage.get("promptTokenCount", 0),
+                 out_tok=usage.get("candidatesTokenCount", 0))
+        return text
 
     # ------------------------------------------------------------------
     # Entry — full risk gate, gateway placement, same rails as every pillar

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -581,6 +581,9 @@ agent_trader:
     - alias: gflash
       model: gemini-3.1-flash-preview
       provider: gemini
+    - alias: g35flash
+      model: gemini-3.5-flash
+      provider: gemini
     - alias: gpro
       model: gemini-3.1-pro-preview
       provider: gemini
@@ -600,6 +603,7 @@ agent_trader:
   gemini_daily_call_limit: 30   # across all gemini arms; independent of the Claude pool
   gemini_price_per_mtok:        # $/1M tokens [input, output] — update from the rate card
     gemini-3.1-flash-preview: [0.30, 2.50]
+    gemini-3.5-flash: [0.50, 3.50]
     gemini-3.1-pro-preview: [2.00, 12.00]
 
 term_structure:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -574,6 +574,16 @@ agent_trader:
       model: claude-sonnet-5
     - alias: opus
       model: claude-opus-4-8
+    # Gemini arms — cross-provider tier comparison. PAID API (unlike the
+    # Claude arms on the plan): own daily ceiling below, and every call's
+    # token usage is metered into agent_trader_costs so each arm's record
+    # is judged NET of its own intelligence bill.
+    - alias: gflash
+      model: gemini-3.1-flash-preview
+      provider: gemini
+    - alias: gpro
+      model: gemini-3.1-pro-preview
+      provider: gemini
   scan_limit: 200
   markets_per_cycle: 10
   max_entries_per_cycle: 2
@@ -587,6 +597,10 @@ agent_trader:
   exclude_categories: []
   llm_timeout_seconds: 420   # room for WebSearch rounds
   decline_ttl_hours: 24.0    # a pass keeps the market off the arm's slate this long
+  gemini_daily_call_limit: 30   # across all gemini arms; independent of the Claude pool
+  gemini_price_per_mtok:        # $/1M tokens [input, output] — update from the rate card
+    gemini-3.1-flash-preview: [0.30, 2.50]
+    gemini-3.1-pro-preview: [2.00, 12.00]
 
 term_structure:
   # Deadline-ladder curve reader — the reading edge, amortized: ONE LLM read

--- a/config/settings.py
+++ b/config/settings.py
@@ -571,6 +571,8 @@ class AgentTraderConfig(BaseModel):
         AgentTraderModel(alias="opus", model="claude-opus-4-8"),
         AgentTraderModel(alias="gflash", model="gemini-3.1-flash-preview",
                          provider="gemini"),
+        AgentTraderModel(alias="g35flash", model="gemini-3.5-flash",
+                         provider="gemini"),
         AgentTraderModel(alias="gpro", model="gemini-3.1-pro-preview",
                          provider="gemini"),
     ]
@@ -581,6 +583,7 @@ class AgentTraderConfig(BaseModel):
     gemini_daily_call_limit: int = 30
     gemini_price_per_mtok: dict[str, list[float]] = {
         "gemini-3.1-flash-preview": [0.30, 2.50],
+        "gemini-3.5-flash": [0.50, 3.50],
         "gemini-3.1-pro-preview": [2.00, 12.00],
     }
     scan_limit: int = 200

--- a/config/settings.py
+++ b/config/settings.py
@@ -533,11 +533,17 @@ class LongHorizonConfig(BaseModel):
 class AgentTraderModel(BaseModel):
     """One experiment arm of the intelligence-cap A/B: a model identity plus
     the CLI effort it runs at. ``alias`` names the attribution cell
-    (``agent_trader_<alias>``) — keep it stable or the cell's history splits."""
+    (``agent_trader_<alias>``) — keep it stable or the cell's history splits.
+
+    ``provider``: 'claude' arms run through the Max+ CLI (zero marginal
+    cost); 'gemini' arms call the REST API (PAID per token — their usage is
+    metered into agent_trader_costs so each arm's record can be judged net
+    of its own intelligence bill; the operator's cost-inclusive rule)."""
 
     alias: str
     model: str
     effort: str = "medium"
+    provider: str = "claude"  # 'claude' | 'gemini'
 
 
 class AgentTraderConfig(BaseModel):
@@ -563,7 +569,20 @@ class AgentTraderConfig(BaseModel):
         AgentTraderModel(alias="haiku", model="claude-haiku-4-5"),
         AgentTraderModel(alias="sonnet", model="claude-sonnet-5"),
         AgentTraderModel(alias="opus", model="claude-opus-4-8"),
+        AgentTraderModel(alias="gflash", model="gemini-3.1-flash-preview",
+                         provider="gemini"),
+        AgentTraderModel(alias="gpro", model="gemini-3.1-pro-preview",
+                         provider="gemini"),
     ]
+    # Gemini arms: daily REST-call ceiling across all gemini arms (paid API,
+    # independent of the Claude paced pool) and per-model $/1M-token prices
+    # [input, output] for the cost meter. Prices are config, not gospel —
+    # update from the current rate card.
+    gemini_daily_call_limit: int = 30
+    gemini_price_per_mtok: dict[str, list[float]] = {
+        "gemini-3.1-flash-preview": [0.30, 2.50],
+        "gemini-3.1-pro-preview": [2.00, 12.00],
+    }
     scan_limit: int = 200
     markets_per_cycle: int = 10
     max_entries_per_cycle: int = 2

--- a/tests/test_agent_trader.py
+++ b/tests/test_agent_trader.py
@@ -392,3 +392,97 @@ async def test_sell_side_derived_from_prob_vs_market(tmp_path):
         assert intent.force_paper is True
     finally:
         await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Gemini arms — paid provider, metered cost, own daily ceiling
+# ---------------------------------------------------------------------------
+
+
+def _gemini_spec(alias="gpro", model="gemini-3.1-pro-preview"):
+    spec = MagicMock()
+    spec.alias = alias
+    spec.model = model
+    spec.effort = "medium"
+    spec.provider = "gemini"
+    return spec
+
+
+def _gemini_cfg(pillar):
+    cfg = pillar._settings.agent_trader
+    cfg.gemini_daily_call_limit = 30
+    cfg.gemini_price_per_mtok = {"gemini-3.1-pro-preview": [2.0, 12.0]}
+    pillar._settings.gemini_api_key = "k"
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_gemini_arm_routes_meters_cost_and_enters(tmp_path):
+    """A gemini-provider arm uses the REST path (not the Claude CLI), its
+    token usage is metered into agent_trader_costs at configured prices, and
+    its decisions trade through the same rails/attribution."""
+    reply = {"candidates": [{"content": {"parts": [
+                {"text": '{"decisions": [{"market_id": "m1", "prob_yes": 0.55, "thesis": "t"}]}'}]}}],
+             "usageMetadata": {"promptTokenCount": 1000, "candidatesTokenCount": 500}}
+    pillar, db, _ = await _pillar(
+        tmp_path, [_gemini_spec()], [_market("m1", yes=0.30)], "")
+    _gemini_cfg(pillar)
+    pillar._call_model = AsyncMock(side_effect=AssertionError("claude path used for gemini arm"))
+    pillar._gemini_request = AsyncMock(return_value=reply)
+    try:
+        assert await pillar.run_once() == 1
+        sig = await db.fetchone("SELECT strategy_source FROM signals")
+        assert sig["strategy_source"] == "agent_trader_gpro"
+        cost = await db.fetchone(
+            "SELECT calls, usd FROM agent_trader_costs WHERE model_alias='gpro'")
+        # 1000*2.0/1e6 + 500*12.0/1e6 = 0.002 + 0.006 = 0.008
+        assert cost["calls"] == 1
+        assert cost["usd"] == pytest.approx(0.008)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_gemini_daily_ceiling_blocks_without_stopping_claude_arms(tmp_path):
+    """The gemini ceiling is independent of the Claude pool: an exhausted
+    gemini budget errors that arm's cycle (isolated) while claude arms run."""
+    reply = '{"decisions": []}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_gemini_spec(), _model_spec("haiku")],
+        [_market("m1", yes=0.30)], reply)
+    cfg = _gemini_cfg(pillar)
+    cfg.gemini_daily_call_limit = 1
+    # Pre-burn the day's single gemini call.
+    await pillar._ensure_schema()
+    await pillar._record_gemini_cost("gpro", 0.001)
+    claude_calls = {"n": 0}
+
+    async def claude_ok(prompt, model, effort, c):
+        claude_calls["n"] += 1
+        return reply
+
+    pillar._call_model = claude_ok
+    pillar._gemini_request = AsyncMock(
+        side_effect=AssertionError("request made past the ceiling"))
+    try:
+        await pillar.run_once()
+        assert claude_calls["n"] == 1          # claude arm unaffected
+        row = await db.fetchone(
+            "SELECT SUM(calls) AS n FROM agent_trader_costs")
+        assert row["n"] == 1                   # no new gemini call
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_claude_arms_unaffected_by_provider_field_default(tmp_path):
+    """Back-compat: arms without an explicit provider run the Claude path."""
+    reply = '{"decisions": []}'
+    pillar, db, _ = await _pillar(
+        tmp_path, [_model_spec("haiku")], [_market("m1")], reply)
+    pillar._gemini_request = AsyncMock(
+        side_effect=AssertionError("gemini path used for claude arm"))
+    try:
+        await pillar.run_once()
+    finally:
+        await db.close()


### PR DESCRIPTION
Re-lands the Gemini arms (the prior branch was accidentally rooted on the
quarantine branch and got reverted with it) on a verified-main base, plus a
third Gemini arm per operator request.

Six arms total: three Claude tiers (Max+ CLI, zero marginal cost) and three
Gemini tiers (paid REST API). Gemini calls are metered per (day, arm) at
configured $/Mtok into agent_trader_costs — records judged NET of each
arm's intelligence bill — with an independent daily ceiling and
Google-Search grounding for research parity. Arm failures stay isolated;
provider-less arms default to the Claude path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)