### PR TITLE
fix(agent_trader): low-tier Gemini arm model id (3.1-flash-lite)

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -579,7 +579,7 @@ agent_trader:
     # token usage is metered into agent_trader_costs so each arm's record
     # is judged NET of its own intelligence bill.
     - alias: gflash
-      model: gemini-3.1-flash-preview
+      model: gemini-3.1-flash-lite
       provider: gemini
     - alias: g35flash
       model: gemini-3.5-flash
@@ -602,7 +602,7 @@ agent_trader:
   decline_ttl_hours: 24.0    # a pass keeps the market off the arm's slate this long
   gemini_daily_call_limit: 30   # across all gemini arms; independent of the Claude pool
   gemini_price_per_mtok:        # $/1M tokens [input, output] — update from the rate card
-    gemini-3.1-flash-preview: [0.30, 2.50]
+    gemini-3.1-flash-lite: [0.10, 0.40]
     gemini-3.5-flash: [0.50, 3.50]
     gemini-3.1-pro-preview: [2.00, 12.00]
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -569,7 +569,7 @@ class AgentTraderConfig(BaseModel):
         AgentTraderModel(alias="haiku", model="claude-haiku-4-5"),
         AgentTraderModel(alias="sonnet", model="claude-sonnet-5"),
         AgentTraderModel(alias="opus", model="claude-opus-4-8"),
-        AgentTraderModel(alias="gflash", model="gemini-3.1-flash-preview",
+        AgentTraderModel(alias="gflash", model="gemini-3.1-flash-lite",
                          provider="gemini"),
         AgentTraderModel(alias="g35flash", model="gemini-3.5-flash",
                          provider="gemini"),
@@ -582,7 +582,7 @@ class AgentTraderConfig(BaseModel):
     # update from the current rate card.
     gemini_daily_call_limit: int = 30
     gemini_price_per_mtok: dict[str, list[float]] = {
-        "gemini-3.1-flash-preview": [0.30, 2.50],
+        "gemini-3.1-flash-lite": [0.10, 0.40],
         "gemini-3.5-flash": [0.50, 3.50],
         "gemini-3.1-pro-preview": [2.00, 12.00],
     }


### PR DESCRIPTION
The configured low-tier id 404'd; the live models list shows the 3.1 flash tier as flash-lite. Alias unchanged (cell had no history — its only cycle was the 404). Price map updated to the lite tier. 🤖 Generated with [Claude Code](https://claude.com/claude-code)