### PR TITLE
feat(vol_anchor): Deribit IV term structure as the sigma source

### DIFF
--- a/auramaur/data_sources/deribit_iv.py
+++ b/auramaur/data_sources/deribit_iv.py
@@ -1,0 +1,165 @@
+"""Deribit implied-volatility term structure — vol_anchor's market sigma.
+
+vol_anchor's original sigma was an ESTIMATE: recent realized vol blended
+toward a calibrated long-run anchor. Deribit publishes the market-clearing
+implied-vol surface for the same underlyings (the deepest crypto vol venue),
+free and unauthenticated. Reading ATM IV per expiry off the option book and
+interpolating to a market's horizon replaces the estimate with the price
+professionals actually clear at — and turns the pillar's edge claim into a
+directly measurable spread: prediction-market implied vol vs Deribit IV.
+
+Read-only by construction: one public GET per currency, no credentials, no
+order API in this module. Failure of any kind returns None and the pillar
+falls back to the calibrated blend (the pre-Deribit behavior), logging which
+source priced each market so records stay interpretable.
+
+Term-structure math: per expiry, take the strike nearest the index (ATM) and
+average the closest call/put mark IVs; interpolate between tenors LINEARLY IN
+TOTAL VARIANCE (w = sigma^2 * T, the standard no-arbitrage-friendly scheme);
+clamp flat outside the quoted range.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import aiohttp
+import structlog
+
+log = structlog.get_logger()
+
+_API = "https://www.deribit.com/api/v2"
+
+# "ETH-26SEP26-1600-C" -> (expiry, strike, kind)
+_INSTRUMENT_RE = re.compile(
+    r"^[A-Z]+-(\d{1,2})([A-Z]{3})(\d{2})-(\d+(?:d\d+)?)-([CP])$")
+
+_MONTHS = {m: i + 1 for i, m in enumerate(
+    ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+     "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"])}
+
+
+def parse_instrument(name: str) -> tuple[datetime, float, str] | None:
+    """(expiry_utc, strike, 'C'|'P') from a Deribit option name, else None."""
+    m = _INSTRUMENT_RE.match(name or "")
+    if not m:
+        return None
+    day, mon, yy, strike_s, kind = m.groups()
+    month = _MONTHS.get(mon)
+    if month is None:
+        return None
+    try:
+        expiry = datetime(2000 + int(yy), month, int(day), 8, 0,
+                          tzinfo=timezone.utc)  # Deribit expires 08:00 UTC
+        strike = float(strike_s.replace("d", "."))
+    except ValueError:
+        return None
+    return expiry, strike, kind
+
+
+def atm_term_structure(
+    summaries: list[dict], index_price: float, now: datetime,
+) -> list[tuple[float, float]]:
+    """[(t_years, sigma)] sorted by tenor, from a book summary list.
+
+    Per expiry: the strike nearest the index; sigma = mean of that strike's
+    call/put mark_iv (single side accepted). Entries without a usable
+    mark_iv are skipped. Tenors under ~12h are dropped (expiry-noise IVs).
+    """
+    by_expiry: dict[datetime, dict[float, list[float]]] = {}
+    for s in summaries:
+        parsed = parse_instrument(s.get("instrument_name", ""))
+        iv = s.get("mark_iv")
+        if parsed is None or iv is None or iv <= 0:
+            continue
+        expiry, strike, _kind = parsed
+        by_expiry.setdefault(expiry, {}).setdefault(strike, []).append(
+            float(iv) / 100.0)
+
+    out: list[tuple[float, float]] = []
+    for expiry, strikes in by_expiry.items():
+        t_years = (expiry - now).total_seconds() / (365.0 * 86400.0)
+        if t_years < 0.5 / 365.0:
+            continue
+        atm_strike = min(strikes, key=lambda k: abs(k - index_price))
+        ivs = strikes[atm_strike]
+        out.append((t_years, sum(ivs) / len(ivs)))
+    out.sort()
+    return out
+
+
+def interp_sigma(term: list[tuple[float, float]], t_years: float) -> float | None:
+    """Sigma at t_years — linear in total variance between quoted tenors,
+    flat-clamped outside the range. None on an empty structure."""
+    if not term or t_years <= 0:
+        return None
+    if t_years <= term[0][0]:
+        return term[0][1]
+    if t_years >= term[-1][0]:
+        return term[-1][1]
+    for (t0, s0), (t1, s1) in zip(term, term[1:]):
+        if t0 <= t_years <= t1:
+            w0, w1 = s0 * s0 * t0, s1 * s1 * t1
+            w = w0 + (w1 - w0) * (t_years - t0) / (t1 - t0)
+            return (w / t_years) ** 0.5
+    return term[-1][1]
+
+
+@dataclass
+class _Cached:
+    at: float
+    term: list[tuple[float, float]]
+
+
+class DeribitIVSource:
+    """ATM IV term structures per currency, cached with a TTL."""
+
+    def __init__(self, currencies: dict[str, str], ttl_seconds: float = 1800.0,
+                 timeout_s: float = 20.0) -> None:
+        self._currencies = currencies      # coingecko id -> deribit currency
+        self._ttl = ttl_seconds
+        self._timeout = timeout_s
+        self._cache: dict[str, _Cached] = {}
+
+    async def _fetch_json(self, url: str) -> dict:
+        async with aiohttp.ClientSession() as s:
+            async with s.get(url, timeout=aiohttp.ClientTimeout(
+                    total=self._timeout)) as r:
+                r.raise_for_status()
+                return await r.json()
+
+    async def _term_for_currency(self, ccy: str) -> list[tuple[float, float]]:
+        cached = self._cache.get(ccy)
+        if cached and (time.monotonic() - cached.at) < self._ttl:
+            return cached.term
+        idx = await self._fetch_json(
+            f"{_API}/public/get_index_price?index_name={ccy.lower()}_usd")
+        index_price = float(idx["result"]["index_price"])
+        book = await self._fetch_json(
+            f"{_API}/public/get_book_summary_by_currency"
+            f"?currency={ccy}&kind=option")
+        term = atm_term_structure(
+            book["result"], index_price, datetime.now(timezone.utc))
+        self._cache[ccy] = _Cached(time.monotonic(), term)
+        log.info("deribit_iv.term_refreshed", currency=ccy,
+                 tenors=len(term),
+                 near=round(term[0][1], 3) if term else None,
+                 far=round(term[-1][1], 3) if term else None)
+        return term
+
+    async def term_sigma(self, cg_id: str, t_years: float) -> float | None:
+        """Market IV at the horizon, or None (asset uncovered / API down /
+        empty structure) — the caller falls back to its estimate."""
+        ccy = self._currencies.get(cg_id)
+        if ccy is None:
+            return None
+        try:
+            term = await self._term_for_currency(ccy)
+        except Exception as e:
+            log.warning("deribit_iv.fetch_failed", currency=ccy,
+                        error=f"{type(e).__name__}: {e}"[:160])
+            return None
+        return interp_sigma(term, t_years)

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -43,6 +43,7 @@ import aiohttp
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.data_sources.deribit_iv import DeribitIVSource
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 
@@ -174,6 +175,10 @@ class VolAnchorPillar:
             router=None, exchange=exchange, exchange_name="polymarket",
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
+        va = settings.vol_anchor
+        self._iv_source = (DeribitIVSource(
+            dict(va.deribit_currencies), ttl_seconds=va.deribit_ttl_seconds)
+            if getattr(va, "sigma_source", "blend") == "deribit_iv" else None)
 
     # ------------------------------------------------------------------
     # Market data — spot + realized vol, fetched fresh each cycle
@@ -243,7 +248,15 @@ class VolAnchorPillar:
             anchor = cfg.long_run_vol.get(cg_id, 0.0)
             if anchor <= 0:
                 continue
-            sigma = blended_sigma(realized, anchor, t_years, cfg.tau_years)
+            sigma = None
+            sigma_src = "blend"
+            if self._iv_source is not None:
+                sigma = await self._iv_source.term_sigma(cg_id, t_years)
+                if sigma is not None:
+                    sigma_src = "deribit_iv"
+            if sigma is None:
+                # Fallback = the calibrated estimate (pre-Deribit behavior).
+                sigma = blended_sigma(realized, anchor, t_years, cfg.tau_years)
             if kind in ("touch_up", "touch_down"):
                 fair = touch_prob(spot, strike, sigma, t_years)
             elif kind == "above":
@@ -254,7 +267,8 @@ class VolAnchorPillar:
             edge_pts = abs(fair - market.outcome_yes_price) * 100.0
             log.info("vol_anchor.priced", market_id=market.id, asset=cg_id,
                      kind=kind, strike=strike, spot=round(spot, 2),
-                     sigma=round(sigma, 3), realized=round(realized, 3),
+                     sigma=round(sigma, 3), sigma_src=sigma_src,
+                     realized=round(realized, 3),
                      fair=round(fair, 3), market=market.outcome_yes_price,
                      edge=round(edge_pts, 1))
             if edge_pts < cfg.min_edge_pts:

--- a/config/settings.py
+++ b/config/settings.py
@@ -665,6 +665,15 @@ class VolAnchorConfig(BaseModel):
     # vol-literature slow component. A 4-day market prices off the tape;
     # anything beyond ~6 weeks prices mostly off the anchor.
     tau_years: float = 0.05
+    # Sigma source: 'deribit_iv' prices off Deribit's ATM implied-vol term
+    # structure (the market-clearing surface; read-only public API) with the
+    # calibrated blend as automatic per-asset fallback; 'blend' uses the
+    # estimate alone. The priced log carries sigma_src either way.
+    sigma_source: str = "deribit_iv"
+    deribit_currencies: dict[str, str] = {
+        "bitcoin": "BTC", "ethereum": "ETH", "solana": "SOL",
+    }
+    deribit_ttl_seconds: float = 1800.0
     # Long-run annualized vol anchors, by coingecko id: 1y realized vol,
     # calibrated 2026-07-09 (year of daily closes, cross-checked against
     # ~30d of recorded tick data).

--- a/tests/test_deribit_iv.py
+++ b/tests/test_deribit_iv.py
@@ -1,0 +1,101 @@
+"""Deribit IV source: instrument parsing, ATM term structure, total-variance
+interpolation, and the pillar's source-then-fallback behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.data_sources.deribit_iv import (
+    DeribitIVSource,
+    atm_term_structure,
+    interp_sigma,
+    parse_instrument,
+)
+
+NOW = datetime(2026, 7, 18, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_instrument_variants():
+    exp, strike, kind = parse_instrument("ETH-26SEP26-1600-C")
+    assert (exp.year, exp.month, exp.day, exp.hour) == (2026, 9, 26, 8)
+    assert (strike, kind) == (1600.0, "C")
+    assert parse_instrument("BTC-2JAN27-100000-P")[1] == 100000.0
+    assert parse_instrument("ETH_USDC-PERPETUAL") is None
+    assert parse_instrument("") is None
+
+
+def _summ(name, iv):
+    return {"instrument_name": name, "mark_iv": iv}
+
+
+def test_atm_term_structure_picks_nearest_strike_and_averages():
+    rows = [
+        _summ("ETH-25JUL26-1800-C", 50.0), _summ("ETH-25JUL26-1800-P", 54.0),
+        _summ("ETH-25JUL26-2400-C", 80.0),   # far strike ignored for ATM
+        _summ("ETH-25SEP26-1900-C", 62.0),
+        _summ("ETH-25SEP26-1900-P", None),   # missing IV skipped
+        _summ("ETH-18JUL26-1800-C", 95.0),   # ~0.3d tenor -> dropped? 18JUL 08:00 vs NOW 18JUL 00:00 = 8h < 12h -> dropped
+    ]
+    term = atm_term_structure(rows, index_price=1841.0, now=NOW)
+    assert len(term) == 2
+    t0, s0 = term[0]
+    assert s0 == pytest.approx(0.52)         # mean(50, 54)/100
+    assert term[1][1] == pytest.approx(0.62)
+
+
+def test_interp_linear_in_total_variance_and_clamps():
+    term = [(0.1, 0.50), (0.5, 0.70)]
+    # Below/above range clamps flat.
+    assert interp_sigma(term, 0.01) == pytest.approx(0.50)
+    assert interp_sigma(term, 2.0) == pytest.approx(0.70)
+    # Midpoint in total variance: w = 0.025 + (0.245-0.025)*0.5 = 0.135 at t=0.3
+    assert interp_sigma(term, 0.3) == pytest.approx((0.135 / 0.3) ** 0.5)
+    assert interp_sigma([], 0.3) is None
+
+
+@pytest.mark.asyncio
+async def test_source_uncovered_asset_and_failure_return_none():
+    src = DeribitIVSource({"ethereum": "ETH"})
+    assert await src.term_sigma("dogecoin", 0.3) is None   # uncovered
+    src._fetch_json = AsyncMock(side_effect=RuntimeError("down"))
+    assert await src.term_sigma("ethereum", 0.3) is None   # API failure
+
+
+@pytest.mark.asyncio
+async def test_source_caches_within_ttl():
+    src = DeribitIVSource({"ethereum": "ETH"}, ttl_seconds=3600)
+    calls = {"n": 0}
+
+    async def fake(url):
+        calls["n"] += 1
+        if "index_price" in url:
+            return {"result": {"index_price": 1841.0}}
+        return {"result": [_summ("ETH-25SEP26-1900-C", 62.0)]}
+
+    src._fetch_json = fake
+    s1 = await src.term_sigma("ethereum", 0.2)
+    s2 = await src.term_sigma("ethereum", 0.2)
+    assert s1 == s2 == pytest.approx(0.62)
+    assert calls["n"] == 2                    # one index + one book, then cache
+
+
+@pytest.mark.asyncio
+async def test_pillar_uses_iv_then_falls_back(tmp_path):
+    from tests.test_vol_anchor import _market, _pillar, _future
+
+    m = _market("m1", f"Will Ethereum reach $3,000 by {_future(175)}?", 0.10)
+    pillar, db, _ = await _pillar(tmp_path, [m])
+    try:
+        # IV source present and answering -> deribit sigma drives pricing.
+        pillar._iv_source = DeribitIVSource({"ethereum": "ETH"})
+        pillar._iv_source.term_sigma = AsyncMock(return_value=0.80)
+        assert await pillar.run_once() == 1    # sigma 0.80 -> fair well above crowd
+        # Source answering None -> the calibrated blend takes over (no crash).
+        pillar._iv_source.term_sigma = AsyncMock(return_value=None)
+        n2 = await pillar.run_once()
+        assert n2 == 0                         # market now claimed; no error path
+    finally:
+        await db.close()


### PR DESCRIPTION
Market-clearing ATM implied vol per expiry, interpolated in total variance to each market's horizon; calibrated blend stays as automatic fallback; sigma_src logged on every priced event. Read-only public API, no credentials. Live smoke-tested against the real surface. 🤖 Generated with [Claude Code](https://claude.com/claude-code)