### PR TITLE
fix(ibkr): harden multi-asset paper validation

### DIFF
--- a/auramaur/cli/diagnostics.py
+++ b/auramaur/cli/diagnostics.py
@@ -156,18 +156,23 @@ def ibkr_etf_preflight():
 
 
 @main.command("ibkr-multiasset-preflight")
-def ibkr_multiasset_preflight():
+@click.option("--book", "book_names", multiple=True,
+              type=click.Choice(("global_etf", "fx", "futures",
+                                 "international_equity", "options", "bonds")))
+def ibkr_multiasset_preflight(book_names):
     """Verify contract resolution, data, isolation, and schema for six books."""
     import sys
 
     async def _run() -> int:
         from auramaur.monitoring.ibkr_multiasset_preflight import preflight
+        from auramaur.exchange.ibkr_instruments import IBKRBook
 
         settings = Settings()
         db = Database()
         await db.connect()
         try:
-            report = await preflight(settings, db)
+            books = tuple(IBKRBook(name) for name in book_names) or None
+            report = await preflight(settings, db, books=books)
         finally:
             await db.close()
         colour = {"OK": "green", "WARN": "yellow", "BLOCK": "red"}

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -109,6 +109,8 @@ class Database:
             await self._migrate_v22_to_v23()
         if from_version < 24:
             await self._migrate_v23_to_v24()
+        if from_version < 25:
+            await self._migrate_v24_to_v25()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -573,12 +575,33 @@ class Database:
             try:
                 await self._db.execute(
                     f"ALTER TABLE {table} ADD COLUMN price_source TEXT "
-                    "NOT NULL DEFAULT 'ibkr'")
-            except Exception:
-                pass
+                    "NOT NULL DEFAULT 'ibkr_unknown'")
+            except aiosqlite.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        for table in ("ibkr_paper_positions", "ibkr_paper_fills"):
+            columns = await self.fetchall(f"PRAGMA table_info({table})")
+            if "price_source" not in {row["name"] for row in columns}:
+                raise RuntimeError(f"migration did not add {table}.price_source")
         await self._db.execute("UPDATE schema_version SET version = 24")
         await self._db.commit()
         log.info("database.migrated", from_version=23, to_version=24)
+
+    async def _migrate_v24_to_v25(self) -> None:
+        """Persist enough instrument identity to manage catalog orphans."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE ibkr_paper_positions ADD COLUMN "
+                "instrument_spec_json TEXT NOT NULL DEFAULT ''")
+        except aiosqlite.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
+        columns = await self.fetchall("PRAGMA table_info(ibkr_paper_positions)")
+        if "instrument_spec_json" not in {row["name"] for row in columns}:
+            raise RuntimeError("migration did not add instrument_spec_json")
+        await self._db.execute("UPDATE schema_version SET version = 25")
+        await self._db.commit()
+        log.info("database.migrated", from_version=24, to_version=25)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -518,7 +518,8 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_positions (
     avg_cost REAL NOT NULL,
     current_price REAL,
     unrealized_pnl_usd REAL NOT NULL DEFAULT 0,
-    price_source TEXT NOT NULL DEFAULT 'ibkr',
+    price_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
+    instrument_spec_json TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (book, instrument_key)
@@ -536,7 +537,7 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_fills (
     currency TEXT NOT NULL,
     fx_to_usd REAL NOT NULL DEFAULT 1,
     commission_usd REAL NOT NULL DEFAULT 0,
-    price_source TEXT NOT NULL DEFAULT 'ibkr',
+    price_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
     fill_ref TEXT NOT NULL UNIQUE,
     filled_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/auramaur/exchange/ibkr_instruments.py
+++ b/auramaur/exchange/ibkr_instruments.py
@@ -152,7 +152,7 @@ BONDS = tuple(
         ("UST_5Y", "government", "US Treasury near 5-year maturity", "UST:5Y"),
         ("UST_10Y", "government", "US Treasury near 10-year maturity", "UST:10Y"),
         ("UST_30Y", "government", "US Treasury near 30-year maturity", "UST:30Y"),
-        ("IG_CORP_5Y", "corporate", "Investment-grade corporate near 5-year maturity", "CORP:IG:5Y"),
+        ("CORP_5Y", "corporate", "US corporate bond near 5-year maturity", "CORP:5Y"),
     )
 )
 

--- a/auramaur/exchange/ibkr_instruments.py
+++ b/auramaur/exchange/ibkr_instruments.py
@@ -7,7 +7,7 @@ options, and bonds require discovery before a quoteable contract exists.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 
 
@@ -40,6 +40,7 @@ class InstrumentSpec:
     description: str
     primary_exchange: str = ""
     multiplier: float = 1.0
+    contract_multiplier: float = 0.0
     paper_capital_per_unit_usd: float = 0.0
     calendar: str = "US_EQUITY"
     # Discovery policies are resolved by the read-only client at runtime.
@@ -103,10 +104,18 @@ FUTURES = tuple(
         ("ZN", "ZN", "CBOT", "USD", "rates", "10-year US Treasury note", 1000, 3000),
         ("MCL", "MCL", "NYMEX", "USD", "energy", "Micro WTI crude oil", 100, 1500),
         ("MGC", "MGC", "COMEX", "USD", "metals", "Micro Gold", 10, 2000),
-        ("SIL", "SIL", "COMEX", "USD", "metals", "Micro Silver", 1000, 3000),
+        ("SIC", "SIC", "COMEX", "USD", "metals", "100-ounce Silver", 100, 1000),
         ("ZC", "ZC", "CBOT", "USD", "agriculture", "Corn", 50, 2500),
         ("ZW", "ZW", "CBOT", "USD", "agriculture", "Wheat", 50, 3000),
     )
+)
+
+# IBKR qualifies grains with the physical 5,000-bushel contract multiplier and
+# priceMagnifier=100. P&L per displayed price point is therefore $50.
+FUTURES = tuple(
+    replace(spec, contract_multiplier=5000.0)
+    if spec.key in {"ZC", "ZW"} else spec
+    for spec in FUTURES
 )
 
 INTERNATIONAL_EQUITIES = (

--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -169,6 +169,11 @@ class IBKRReadOnlyMarketData:
         ticker = (await self._ib.reqTickersAsync(underlying))[0]
         spot = float(ticker.marketPrice())
         if not math.isfinite(spot) or spot <= 0:
+            bars = await self._ib.reqHistoricalDataAsync(
+                underlying, endDateTime="", durationStr="5 D",
+                barSizeSetting="1 day", whatToShow="TRADES", useRTH=True)
+            spot = float(bars[-1].close) if bars else float("nan")
+        if not math.isfinite(spot) or spot <= 0:
             raise LookupError(f"no underlying price for {spec.key}")
         chains = await self._ib.reqSecDefOptParamsAsync(
             underlying.symbol, "", underlying.secType, underlying.conId)
@@ -218,7 +223,7 @@ class IBKRReadOnlyMarketData:
         subscription = ScannerSubscription(
             instrument="BOND" if corporate else "BOND.GOVT",
             locationCode="BOND.US" if corporate else "BOND.GOVT.US",
-            scanCode="LOW_BOND_ASK_YIELD_ALL" if corporate else "HIGH_BOND_ASK_YIELD_ALL",
+            scanCode="BOND_CUSIP_AZ" if corporate else "HIGH_BOND_ASK_YIELD_ALL",
             numberOfRows=50,
         )
         rows = await self._ib.reqScannerDataAsync(
@@ -359,6 +364,8 @@ class IBKRReadOnlyMarketData:
         ticker = (await self._ib.reqTickersAsync(underlying))[0]
         spot = float(ticker.marketPrice())
         closes = [float(bar.close) for bar in bars if float(bar.close or 0) > 0]
+        if (not math.isfinite(spot) or spot <= 0) and closes:
+            spot = closes[-1]
         if not math.isfinite(spot) or spot <= 0 or len(closes) < 21:
             return None
         returns = [math.log(b / a) for a, b in zip(closes, closes[1:])]

--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -7,11 +7,13 @@ simulator.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 import math
 import time
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import structlog
 
@@ -35,38 +37,46 @@ class MarketDataQuote:
 class IBKRReadOnlyMarketData:
     """Resolve contracts and acquire BBO/history through a read-only socket."""
 
-    def __init__(self, settings):
+    def __init__(self, settings, *, client_id: int | None = None):
         self._settings = settings
+        self._client_id = client_id
         self.readonly = True
         self._ib = None
         self._connected = False
         self._cooldown_until = 0.0
+        self._connect_lock = asyncio.Lock()
         self._contracts: dict[str, tuple[Any, float | None]] = {}
+        self._trading_hours: dict[int, tuple[str, str, float]] = {}
 
     async def _ensure_connected(self) -> None:
         if self._connected and self._ib is not None:
             return
-        if time.monotonic() < self._cooldown_until:
-            raise ConnectionError("IBKR multi-asset connection on cooldown")
-        from ib_async import IB
+        async with self._connect_lock:
+            if self._connected and self._ib is not None:
+                return
+            if time.monotonic() < self._cooldown_until:
+                raise ConnectionError("IBKR multi-asset connection on cooldown")
+            from ib_async import IB
 
-        cfg = self._settings.ibkr
-        try:
-            self._ib = IB()
-            await self._ib.connectAsync(
-                host=cfg.host,
-                port=cfg.etf_quote_port,
-                clientId=cfg.multiasset_client_id,
-                readonly=True,
-            )
-            self._ib.reqMarketDataType(cfg.market_data_type)
-            self._connected = True
-            log.info("ibkr_multiasset.connected", port=cfg.etf_quote_port,
-                     client_id=cfg.multiasset_client_id, readonly=True)
-        except Exception:
-            self._ib = None
-            self._cooldown_until = time.monotonic() + 300
-            raise
+            cfg = self._settings.ibkr
+            try:
+                self._ib = IB()
+                await self._ib.connectAsync(
+                    host=cfg.host,
+                    port=cfg.etf_quote_port,
+                    clientId=(self._client_id if self._client_id is not None
+                              else cfg.multiasset_client_id),
+                    readonly=True,
+                )
+                self._ib.reqMarketDataType(cfg.market_data_type)
+                self._connected = True
+                log.info("ibkr_multiasset.connected", port=cfg.etf_quote_port,
+                         client_id=(self._client_id if self._client_id is not None
+                                    else cfg.multiasset_client_id), readonly=True)
+            except Exception:
+                self._ib = None
+                self._cooldown_until = time.monotonic() + 300
+                raise
 
     async def close(self) -> None:
         if self._ib is not None:
@@ -127,6 +137,14 @@ class IBKRReadOnlyMarketData:
         candidates = []
         for detail in details or []:
             contract = detail.contract
+            try:
+                contract_multiplier = float(getattr(contract, "multiplier", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            expected_multiplier = spec.contract_multiplier or spec.multiplier
+            if contract_multiplier and not math.isclose(
+                    contract_multiplier, expected_multiplier, rel_tol=0, abs_tol=1e-9):
+                continue
             raw = str(getattr(contract, "lastTradeDateOrContractMonth", ""))[:8]
             try:
                 expiry = datetime.strptime(raw, "%Y%m%d").date()
@@ -224,11 +242,60 @@ class IBKRReadOnlyMarketData:
 
     async def get_quote_by_con_id(self, spec: InstrumentSpec, con_id: int):
         """Mark a held derivative using the exact contract originally filled."""
+        contract = await self._contract_by_con_id(spec, con_id)
+        return await self._quote_contract(spec, contract)
+
+    async def _contract_by_con_id(self, spec: InstrumentSpec, con_id: int):
         from ib_async import Contract
         await self._ensure_connected()
-        contract = await self._qualify_one(
-            Contract(conId=con_id, exchange=spec.exchange))
-        return await self._quote_contract(spec, contract)
+        cache_key = f"conid:{con_id}"
+        cached = self._contracts.get(cache_key)
+        if cached is not None:
+            return cached[0]
+        contract = await self._qualify_one(Contract(conId=con_id, exchange=spec.exchange))
+        self._contracts[cache_key] = (contract, None)
+        return contract
+
+    async def is_market_open(self, spec: InstrumentSpec, *, con_id: int = 0,
+                             now: datetime | None = None) -> bool:
+        """Use IBKR's dated liquid-hours schedule, including holidays and breaks."""
+        contract = (await self._contract_by_con_id(spec, con_id)
+                    if con_id else await self.resolve(spec))
+        contract_id = int(getattr(contract, "conId", 0))
+        cached = self._trading_hours.get(contract_id)
+        if cached is None or time.monotonic() >= cached[2]:
+            details = await self._ib.reqContractDetailsAsync(contract)
+            if not details:
+                return False
+            detail = details[0]
+            hours = str(getattr(detail, "liquidHours", "")
+                        or getattr(detail, "tradingHours", ""))
+            zone = str(getattr(detail, "timeZoneId", "") or "UTC")
+            cached = (hours, zone, time.monotonic()
+                      + self._settings.ibkr.multiasset_contract_cache_seconds)
+            self._trading_hours[contract_id] = cached
+        hours, zone_name, _ = cached
+        try:
+            zone = ZoneInfo(zone_name)
+        except ZoneInfoNotFoundError:
+            log.warning("ibkr_multiasset.unknown_timezone", key=spec.key, zone=zone_name)
+            return False
+        local_now = (now or datetime.now(timezone.utc)).astimezone(zone)
+        for day in hours.split(";"):
+            if not day or day.endswith(":CLOSED"):
+                continue
+            for session in day.split(","):
+                start_text, separator, end_text = session.partition("-")
+                if not separator:
+                    continue
+                try:
+                    start = datetime.strptime(start_text, "%Y%m%d:%H%M").replace(tzinfo=zone)
+                    end = datetime.strptime(end_text, "%Y%m%d:%H%M").replace(tzinfo=zone)
+                except ValueError:
+                    continue
+                if start <= local_now < end:
+                    return True
+        return False
 
     async def _quote_contract(self, spec: InstrumentSpec, contract):
         try:
@@ -244,14 +311,21 @@ class IBKRReadOnlyMarketData:
             timestamp = tick_time.timestamp()
             if not math.isfinite(timestamp):
                 return None
-            multiplier = float(getattr(contract, "multiplier", "") or spec.multiplier)
+            multiplier = spec.multiplier
             return MarketDataQuote(spec.key, bid, ask, timestamp,
                                    int(getattr(contract, "conId", 0)),
                                    spec.currency, multiplier)
         except Exception as exc:  # noqa: BLE001
+            if self._is_pacing_error(exc):
+                raise
             log.warning("ibkr_multiasset.quote_error", key=spec.key,
                         error=str(exc)[:160])
             return await self._synthetic_option_quote(spec, contract)
+
+    @staticmethod
+    def _is_pacing_error(exc: Exception) -> bool:
+        text = str(exc).lower()
+        return any(marker in text for marker in ("pacing", "error 162", "error 420"))
 
     @staticmethod
     def _normal_cdf(value: float) -> float:
@@ -303,6 +377,15 @@ class IBKRReadOnlyMarketData:
 
     async def get_daily_bars(self, spec: InstrumentSpec, duration: str = "3 M"):
         contract = await self.resolve(spec)
+        return await self._daily_bars_contract(spec, contract, duration)
+
+    async def get_daily_bars_by_con_id(self, spec: InstrumentSpec, con_id: int,
+                                       duration: str = "3 M"):
+        """History for the exact contract held, never a newly rolled discovery."""
+        contract = await self._contract_by_con_id(spec, con_id)
+        return await self._daily_bars_contract(spec, contract, duration)
+
+    async def _daily_bars_contract(self, spec: InstrumentSpec, contract, duration: str):
         what = "MIDPOINT" if spec.kind in {ContractKind.FOREX, ContractKind.BOND} else "TRADES"
         bars = await self._ib.reqHistoricalDataAsync(
             contract, endDateTime="", durationStr=duration,
@@ -315,7 +398,6 @@ class IBKRReadOnlyMarketData:
             if close > 0 and math.isfinite(close):
                 out.append((day[:10], close))
         if not out and spec.kind is ContractKind.OPTION:
-            contract = await self.resolve(spec)
             _, underlying_bars = await self._underlying_history(spec.symbol)
             expiry = datetime.strptime(
                 contract.lastTradeDateOrContractMonth[:8], "%Y%m%d").date()

--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -31,7 +31,7 @@ class MarketDataQuote:
     con_id: int
     currency: str
     multiplier: float
-    source: str = "ibkr"
+    source: str = "ibkr_live"
 
 
 class IBKRReadOnlyMarketData:
@@ -49,11 +49,12 @@ class IBKRReadOnlyMarketData:
         self._trading_hours: dict[int, tuple[str, str, float]] = {}
 
     async def _ensure_connected(self) -> None:
-        if self._connected and self._ib is not None:
+        if self._connection_alive():
             return
         async with self._connect_lock:
-            if self._connected and self._ib is not None:
+            if self._connection_alive():
                 return
+            self._connected = False
             if time.monotonic() < self._cooldown_until:
                 raise ConnectionError("IBKR multi-asset connection on cooldown")
             from ib_async import IB
@@ -61,6 +62,9 @@ class IBKRReadOnlyMarketData:
             cfg = self._settings.ibkr
             try:
                 self._ib = IB()
+                disconnected = getattr(self._ib, "disconnectedEvent", None)
+                if disconnected is not None:
+                    disconnected += self._on_disconnected
                 await self._ib.connectAsync(
                     host=cfg.host,
                     port=cfg.etf_quote_port,
@@ -77,6 +81,17 @@ class IBKRReadOnlyMarketData:
                 self._ib = None
                 self._cooldown_until = time.monotonic() + 300
                 raise
+
+    def _connection_alive(self) -> bool:
+        if not self._connected or self._ib is None:
+            return False
+        probe = getattr(self._ib, "isConnected", None)
+        return bool(probe()) if callable(probe) else True
+
+    def _on_disconnected(self, *_args: object) -> None:
+        self._connected = False
+        self._contracts.clear()
+        self._trading_hours.clear()
 
     async def close(self) -> None:
         if self._ib is not None:
@@ -317,9 +332,16 @@ class IBKRReadOnlyMarketData:
             if not math.isfinite(timestamp):
                 return None
             multiplier = spec.multiplier
+            market_data_type = int(getattr(ticker, "marketDataType", 0) or 0)
+            source = {
+                1: "ibkr_live",
+                2: "ibkr_frozen",
+                3: "ibkr_delayed",
+                4: "ibkr_delayed_frozen",
+            }.get(market_data_type, "ibkr_unknown")
             return MarketDataQuote(spec.key, bid, ask, timestamp,
                                    int(getattr(contract, "conId", 0)),
-                                   spec.currency, multiplier)
+                                   spec.currency, multiplier, source)
         except Exception as exc:  # noqa: BLE001
             if self._is_pacing_error(exc):
                 raise

--- a/auramaur/monitoring/books.py
+++ b/auramaur/monitoring/books.py
@@ -155,8 +155,10 @@ async def gather_books(db) -> list[dict]:
         }
 
     ibkr_rows = await db.fetchall(
-        """SELECT l.book, COUNT(*) AS n, SUM(l.pnl_usd) AS pnl,
-                  SUM(CASE WHEN l.pnl_usd > 0 THEN 1 ELSE 0 END) AS wins,
+        """SELECT l.book,
+                  SUM(CASE WHEN l.kind = 'trade' THEN 1 ELSE 0 END) AS n,
+                  SUM(l.pnl_usd) AS pnl,
+                  SUM(CASE WHEN l.kind = 'trade' AND l.pnl_usd > 0 THEN 1 ELSE 0 END) AS wins,
                   (SELECT COUNT(*) FROM ibkr_paper_positions p
                     WHERE p.book = l.book) AS open_n
              FROM ibkr_paper_ledger l GROUP BY l.book""")

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -66,8 +66,8 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                 age = time.time() - float(quote.timestamp)
                 if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
                     return f"{spec.key}: stale BBO ({age:.0f}s old)", None, None
-                source = getattr(quote, "source", "ibkr")
-                if source != "ibkr":
+                source = getattr(quote, "source", "ibkr_unknown")
+                if source != "ibkr_live":
                     return f"{spec.key}: non-executable {source} quote", source, None
                 return None, source, None
             except Exception as exc:  # noqa: BLE001

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -105,12 +105,21 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         if not book_cfg.enabled:
             add(book.value, "WARN", "book disabled")
             continue
+        disabled = set(cfg.multiasset_disabled_instruments)
+        universe = tuple(spec for spec in BY_BOOK[book] if spec.key not in disabled)
+        skipped = [spec.key for spec in BY_BOOK[book] if spec.key in disabled]
+        if skipped:
+            add(f"{book.value}:coverage", "WARN",
+                "entitlement-gated: " + ", ".join(skipped))
+        if not universe:
+            add(book.value, "BLOCK", "no enabled instruments")
+            continue
         log.info("ibkr_multiasset.preflight_book_start", book=book.value,
-                 instruments=len(BY_BOOK[book]))
+                 instruments=len(universe))
         failures = []
         closed = []
         sources = set()
-        probes = await asyncio.gather(*(probe(spec) for spec in BY_BOOK[book]))
+        probes = await asyncio.gather(*(probe(spec) for spec in universe))
         for failure, source, closed_detail in probes:
             if failure:
                 failures.append(failure)
@@ -125,13 +134,13 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
             add(book.value, "BLOCK", preview)
         elif closed:
             add(book.value, "WARN",
-                f"all contracts/history ready; {len(closed)}/{len(BY_BOOK[book])} "
+                f"all contracts/history ready; {len(closed)}/{len(universe)} "
                 f"venues currently closed")
         else:
-            add(book.value, "OK", f"all {len(BY_BOOK[book])} instruments ready; "
+            add(book.value, "OK", f"all {len(universe)} enabled instruments ready; "
                 f"sources={','.join(sorted(sources))}")
         log.info("ibkr_multiasset.preflight_book_complete", book=book.value,
-                 passed=len(BY_BOOK[book]) - len(failures), failed=len(failures))
+                 passed=len(universe) - len(failures), failed=len(failures))
 
         edge = await db.fetchone(
             """SELECT SUM(CASE WHEN kind = 'trade' THEN 1 ELSE 0 END) AS n,

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -6,8 +6,12 @@ import asyncio
 from dataclasses import dataclass
 import time
 
+import structlog
+
 from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
 from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
+
+log = structlog.get_logger()
 
 
 @dataclass(frozen=True)
@@ -26,7 +30,8 @@ class MultiAssetPreflightReport:
         return not any(result.severity == "BLOCK" for result in self.results)
 
 
-async def preflight(settings, db, *, client=None, timeout_seconds: int = 30):
+async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
+                    books: tuple[IBKRBook, ...] | None = None):
     cfg = settings.ibkr
     results: list[MultiAssetPreflightResult] = []
 
@@ -34,7 +39,48 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30):
         results.append(MultiAssetPreflightResult(book, severity, detail))
 
     own_client = client is None
-    client = client or IBKRReadOnlyMarketData(settings)
+    client = client or IBKRReadOnlyMarketData(
+        settings, client_id=cfg.multiasset_preflight_client_id)
+    semaphore = asyncio.Semaphore(cfg.multiasset_preflight_concurrency)
+
+    def pacing_error(exc: Exception) -> bool:
+        detail = str(exc).lower()
+        return any(marker in detail for marker in ("pacing", "error 162", "error 420"))
+
+    async def probe(spec):
+        attempts = cfg.multiasset_preflight_pacing_retries + 1
+        for attempt in range(attempts):
+            try:
+                async with semaphore:
+                    market_open = (await client.is_market_open(spec)
+                                   if hasattr(client, "is_market_open") else True)
+                    quote = await asyncio.wait_for(client.get_quote(spec), timeout_seconds)
+                    bars = await asyncio.wait_for(client.get_daily_bars(spec), timeout_seconds)
+                if len(bars) < 21:
+                    return f"{spec.key}: only {len(bars)} daily bars", None, None
+                if not market_open:
+                    source = getattr(quote, "source", "none") if quote else "none"
+                    return None, source, f"{spec.key}: venue closed; contract/history ready"
+                if quote is None:
+                    return f"{spec.key}: no executable BBO", None, None
+                age = time.time() - float(quote.timestamp)
+                if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
+                    return f"{spec.key}: stale BBO ({age:.0f}s old)", None, None
+                source = getattr(quote, "source", "ibkr")
+                if source != "ibkr":
+                    return f"{spec.key}: non-executable {source} quote", source, None
+                return None, source, None
+            except Exception as exc:  # noqa: BLE001
+                if pacing_error(exc) and attempt + 1 < attempts:
+                    delay = cfg.multiasset_preflight_retry_seconds * (2 ** attempt)
+                    log.warning("ibkr_multiasset.preflight_pacing_retry", key=spec.key,
+                                attempt=attempt + 1, delay_seconds=delay,
+                                error=str(exc)[:160])
+                    await asyncio.sleep(delay)
+                    continue
+                prefix = "pacing exhausted" if pacing_error(exc) else "probe failed"
+                return f"{spec.key}: {prefix}: {str(exc)[:140]}", None, None
+        return f"{spec.key}: pacing retry exhausted", None, None  # pragma: no cover
     if not getattr(client, "readonly", False) or hasattr(client, "place_order"):
         add("isolation", "BLOCK", "market-data client is not structurally read-only")
     else:
@@ -54,52 +100,52 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30):
         mode = "enabled" if cfg.multiasset_paper_enabled else "staged (activation off)"
         add("feature gate", "OK", mode)
 
-    for book in IBKRBook:
+    for book in (books or tuple(IBKRBook)):
         book_cfg = cfg.multiasset_books[book.value]
         if not book_cfg.enabled:
             add(book.value, "WARN", "book disabled")
             continue
+        log.info("ibkr_multiasset.preflight_book_start", book=book.value,
+                 instruments=len(BY_BOOK[book]))
         failures = []
+        closed = []
         sources = set()
-        for spec in BY_BOOK[book]:
-            try:
-                quote = await asyncio.wait_for(client.get_quote(spec), timeout_seconds)
-                bars = await asyncio.wait_for(client.get_daily_bars(spec), timeout_seconds)
-                if len(bars) < 21:
-                    failures.append(f"{spec.key}: only {len(bars)} daily bars")
-                elif quote is None:
-                    failures.append(f"{spec.key}: no executable BBO")
-                else:
-                    age = time.time() - float(quote.timestamp)
-                    if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
-                        failures.append(f"{spec.key}: stale BBO ({age:.0f}s old)")
-                    source = getattr(quote, "source", "ibkr")
-                    if source != "ibkr":
-                        failures.append(f"{spec.key}: non-executable {source} quote")
-                    sources.add(source)
-            except Exception as exc:  # noqa: BLE001
-                failures.append(f"{spec.key}: {str(exc)[:160]}")
+        probes = await asyncio.gather(*(probe(spec) for spec in BY_BOOK[book]))
+        for failure, source, closed_detail in probes:
+            if failure:
+                failures.append(failure)
+            if source:
+                sources.add(source)
+            if closed_detail:
+                closed.append(closed_detail)
         if failures:
             preview = "; ".join(failures[:3])
             if len(failures) > 3:
                 preview += f"; +{len(failures) - 3} more"
             add(book.value, "BLOCK", preview)
+        elif closed:
+            add(book.value, "WARN",
+                f"all contracts/history ready; {len(closed)}/{len(BY_BOOK[book])} "
+                f"venues currently closed")
         else:
             add(book.value, "OK", f"all {len(BY_BOOK[book])} instruments ready; "
                 f"sources={','.join(sorted(sources))}")
+        log.info("ibkr_multiasset.preflight_book_complete", book=book.value,
+                 passed=len(BY_BOOK[book]) - len(failures), failed=len(failures))
 
         edge = await db.fetchone(
-            """SELECT COUNT(*) AS n, COALESCE(SUM(pnl_usd), 0) AS pnl,
+            """SELECT SUM(CASE WHEN kind = 'trade' THEN 1 ELSE 0 END) AS n,
+                      COALESCE(SUM(pnl_usd), 0) AS pnl,
                       COALESCE(SUM(CASE WHEN pnl_usd > 0 THEN pnl_usd ELSE 0 END), 0) AS gains,
                       ABS(COALESCE(SUM(CASE WHEN pnl_usd < 0 THEN pnl_usd ELSE 0 END), 0)) AS losses
-                 FROM ibkr_paper_ledger WHERE book = ? AND kind = 'trade'""",
+                 FROM ibkr_paper_ledger WHERE book = ?""",
             (book.value,))
         n, pnl = int(edge["n"] or 0), float(edge["pnl"] or 0)
         gains, losses = float(edge["gains"] or 0), float(edge["losses"] or 0)
         profit_factor = gains / losses if losses else (float("inf") if gains else 0.0)
         proven = n >= 30 and pnl > 0 and profit_factor > 1.1
         add(f"{book.value}:edge", "OK" if proven else "WARN",
-            f"forward paper evidence: {n} exits, ${pnl:.2f} trade P&L, "
+            f"forward paper evidence: {n} exits, ${pnl:.2f} net P&L, "
             f"profit factor {profit_factor:.2f}")
     if own_client:
         await client.close()

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time as wall_time, timezone
+import json
 import math
 import time
 from uuid import uuid4
@@ -10,7 +11,9 @@ from zoneinfo import ZoneInfo
 
 import structlog
 
-from auramaur.exchange.ibkr_instruments import BY_BOOK, ContractKind, IBKRBook
+from auramaur.exchange.ibkr_instruments import (
+    BY_BOOK, BY_KEY, ContractKind, IBKRBook, InstrumentSpec,
+)
 from auramaur.strategy.protocols import ExecutionMode
 
 log = structlog.get_logger()
@@ -86,8 +89,28 @@ class IBKRMultiAssetPaperBook:
 
     def _quote_fresh(self, quote) -> bool:
         age = time.time() - float(quote.timestamp)
-        return (getattr(quote, "source", "ibkr") == "ibkr"
+        return (getattr(quote, "source", "") == "ibkr_live"
                 and 0 <= age <= self._settings.ibkr.multiasset_max_quote_age_seconds)
+
+    @staticmethod
+    def _serialize_spec(spec: InstrumentSpec) -> str:
+        values = {name: getattr(spec, name) for name in spec.__dataclass_fields__}
+        values["book"] = spec.book.value
+        values["kind"] = spec.kind.value
+        return json.dumps(values, sort_keys=True)
+
+    @staticmethod
+    def _position_spec(row) -> InstrumentSpec | None:
+        known = BY_KEY.get(row["instrument_key"])
+        if known is not None:
+            return known
+        raw = row["instrument_spec_json"]
+        if not raw:
+            return None
+        values = json.loads(raw)
+        values["book"] = IBKRBook(values["book"])
+        values["kind"] = ContractKind(values["kind"])
+        return InstrumentSpec(**values)
 
     @staticmethod
     def _momentum(bars) -> float | None:
@@ -141,10 +164,12 @@ class IBKRMultiAssetPaperBook:
             await self._db.execute(
                 """INSERT INTO ibkr_paper_positions
                    (book, instrument_key, con_id, currency, quantity, multiplier,
-                    fx_to_usd, avg_cost, current_price, price_source)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    fx_to_usd, avg_cost, current_price, price_source,
+                    instrument_spec_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (self.book.value, spec.key, quote.con_id, spec.currency, quantity,
-                 quote.multiplier, fx, price, price, quote.source))
+                 quote.multiplier, fx, price, price, quote.source,
+                 self._serialize_spec(spec)))
         else:
             pnl = (price - float(entry_price)) * quantity * quote.multiplier * fx
             await self._db.execute(
@@ -169,13 +194,21 @@ class IBKRMultiAssetPaperBook:
         disabled = set(self._settings.ibkr.multiasset_disabled_instruments)
         universe = tuple(spec for spec in BY_BOOK[self.book]
                          if spec.key not in disabled)
-        if not universe:
+        held_specs = {}
+        for key, row in positions.items():
+            spec = self._position_spec(row)
+            if spec is None:
+                log.error("ibkr_multiasset.unmanageable_orphan", book=self.book.value,
+                          key=key)
+                continue
+            held_specs[key] = spec
+        if not universe and not held_specs:
             return 0
         count = min(len(universe), self._settings.ibkr.multiasset_refreshes_per_cycle)
         selected = [universe[(cursor + i) % len(universe)] for i in range(count)]
         # Open positions are always managed, even when outside the refresh slice.
         keys = {spec.key for spec in selected}
-        selected.extend(spec for spec in universe if spec.key in positions and spec.key not in keys)
+        selected.extend(spec for key, spec in held_specs.items() if key not in keys)
         # Mark/manage every held position before considering new risk.
         selected.sort(key=lambda spec: spec.key not in positions)
         unmarked_positions = set(positions)
@@ -196,30 +229,39 @@ class IBKRMultiAssetPaperBook:
                 if held and int(quote.con_id) != held_con_id:
                     raise RuntimeError(
                         f"held contract mismatch: expected {held_con_id}, got {quote.con_id}")
-                spread_bps = (quote.ask - quote.bid) / ((quote.ask + quote.bid) / 2) * 10_000
                 fx = await self._client.get_fx_to_usd(spec.currency)
-                if fx is None or spread_bps > cfg.max_spread_bps:
-                    continue
-                bars = (await self._client.get_daily_bars_by_con_id(spec, held_con_id)
-                        if held else await self._client.get_daily_bars(spec))
-                momentum = self._momentum(bars)
-                if momentum is None:
-                    continue
                 if held:
+                    # Protective exits depend only on an executable live quote.
+                    # Use the entry FX snapshot if the cross is temporarily absent.
+                    mark_fx = float(fx if fx is not None else held["fx_to_usd"])
                     entry = float(held["avg_cost"])
                     gain_pct = (quote.bid / entry - 1) * 100
-                    pnl = (quote.bid - entry) * float(held["quantity"]) * quote.multiplier * fx
+                    pnl = ((quote.bid - entry) * float(held["quantity"])
+                           * quote.multiplier * mark_fx)
                     await self._db.execute(
                         """UPDATE ibkr_paper_positions SET current_price=?,
                            unrealized_pnl_usd=?, price_source=?, updated_at=datetime('now')
                            WHERE book=? AND instrument_key=?""",
                         (quote.bid, pnl, quote.source, self.book.value, spec.key))
                     unmarked_positions.discard(spec.key)
-                    if (gain_pct <= -cfg.stop_loss_pct or gain_pct >= cfg.take_profit_pct
-                            or momentum <= self._settings.ibkr.multiasset_exit_momentum_pct):
+                    hard_exit = (gain_pct <= -cfg.stop_loss_pct
+                                 or gain_pct >= cfg.take_profit_pct)
+                    momentum_exit = False
+                    if not hard_exit:
+                        bars = await self._client.get_daily_bars_by_con_id(spec, held_con_id)
+                        momentum = self._momentum(bars)
+                        momentum_exit = (momentum is not None and momentum <=
+                                         self._settings.ibkr.multiasset_exit_momentum_pct)
+                    if hard_exit or momentum_exit:
                         await self._fill(spec, quote, "SELL", float(held["quantity"]),
-                                         fx, entry_price=entry)
+                                         mark_fx, entry_price=entry)
                         positions.pop(spec.key, None)
+                    continue
+                spread_bps = (quote.ask - quote.bid) / ((quote.ask + quote.bid) / 2) * 10_000
+                if fx is None or spread_bps > cfg.max_spread_bps:
+                    continue
+                momentum = self._momentum(await self._client.get_daily_bars(spec))
+                if momentum is None:
                     continue
                 loss_exposure = await self._loss_exposure()
                 if (unmarked_positions or loss_exposure <= -cfg.daily_loss_limit_usd
@@ -229,7 +271,7 @@ class IBKRMultiAssetPaperBook:
                     continue
                 deployed = sum(
                     float(row["quantity"]) * self._capital_per_unit(
-                        next(item for item in universe if item.key == key),
+                        held_specs.get(key) or BY_KEY[key],
                         float(row["avg_cost"]), float(row["fx_to_usd"]))
                     for key, row in positions.items())
                 deployment_cap = cfg.budget_usd * cfg.max_deployment_pct / 100
@@ -246,7 +288,7 @@ class IBKRMultiAssetPaperBook:
                 error = str(exc)[:300]
                 log.warning("ibkr_multiasset.instrument_error", book=self.book.value,
                             key=spec.key, error=error)
-        next_cursor = (cursor + count) % len(universe)
+        next_cursor = (cursor + count) % len(universe) if universe else 0
         await self._db.execute(
             """INSERT INTO ibkr_paper_state
                (book, refresh_cursor, last_cycle_at, last_success_at, last_error)

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -166,7 +166,11 @@ class IBKRMultiAssetPaperBook:
             "SELECT refresh_cursor FROM ibkr_paper_state WHERE book = ?",
             (self.book.value,))
         cursor = int(state["refresh_cursor"] or 0) if state else 0
-        universe = BY_BOOK[self.book]
+        disabled = set(self._settings.ibkr.multiasset_disabled_instruments)
+        universe = tuple(spec for spec in BY_BOOK[self.book]
+                         if spec.key not in disabled)
+        if not universe:
+            return 0
         count = min(len(universe), self._settings.ibkr.multiasset_refreshes_per_cycle)
         selected = [universe[(cursor + i) % len(universe)] for i in range(count)]
         # Open positions are always managed, even when outside the refresh slice.

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -159,7 +159,7 @@ class IBKRMultiAssetPaperBook:
         cfg = self.config
         if not self._settings.ibkr.multiasset_paper_enabled or not cfg.enabled:
             return 0
-        if not self.market_open():
+        if not hasattr(self._client, "is_market_open") and not self.market_open():
             return 0
         positions = await self._positions()
         state = await self._db.fetchone(
@@ -180,16 +180,24 @@ class IBKRMultiAssetPaperBook:
         for spec in selected:
             try:
                 held = positions.get(spec.key)
+                held_con_id = int(held["con_id"]) if held else 0
+                if hasattr(self._client, "is_market_open") and not await self._client.is_market_open(
+                        spec, con_id=held_con_id):
+                    continue
                 quote = (await self._client.get_quote_by_con_id(
-                    spec, int(held["con_id"])) if held
+                    spec, held_con_id) if held
                     else await self._client.get_quote(spec))
                 if quote is None or not self._quote_fresh(quote):
                     continue
+                if held and int(quote.con_id) != held_con_id:
+                    raise RuntimeError(
+                        f"held contract mismatch: expected {held_con_id}, got {quote.con_id}")
                 spread_bps = (quote.ask - quote.bid) / ((quote.ask + quote.bid) / 2) * 10_000
                 fx = await self._client.get_fx_to_usd(spec.currency)
                 if fx is None or spread_bps > cfg.max_spread_bps:
                     continue
-                bars = await self._client.get_daily_bars(spec)
+                bars = (await self._client.get_daily_bars_by_con_id(spec, held_con_id)
+                        if held else await self._client.get_daily_bars(spec))
                 momentum = self._momentum(bars)
                 if momentum is None:
                     continue

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -270,6 +270,9 @@ ibkr:
   multiasset_preflight_concurrency: 2
   multiasset_preflight_pacing_retries: 2
   multiasset_preflight_retry_seconds: 2.0
+  # TSEJ history/BBO is not entitled on the current IBKR username. Keep the
+  # contract in the catalog and re-enable it after preflight passes.
+  multiasset_disabled_instruments: ["7203.T"]
   multiasset_min_momentum_pct: 1.0
   multiasset_exit_momentum_pct: -0.5
   multiasset_books:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -257,6 +257,8 @@ ibkr:
   # Activated after read-only TWS contract/history preflight. Individual books
   # still fail closed without fresh native executable quotes.
   multiasset_client_id: 3
+  multiasset_preflight_client_id: 97
+  # Ship disabled; enable deliberately in defaults.local.yaml after preflight.
   multiasset_paper_enabled: false
   multiasset_cycle_seconds: 900
   multiasset_refreshes_per_cycle: 12
@@ -264,6 +266,10 @@ ibkr:
   multiasset_max_quote_age_seconds: 120
   # Re-discover futures/options/bonds during long-running sessions.
   multiasset_contract_cache_seconds: 21600
+  # Keep contract/history bursts below IBKR pacing thresholds.
+  multiasset_preflight_concurrency: 2
+  multiasset_preflight_pacing_retries: 2
+  multiasset_preflight_retry_seconds: 2.0
   multiasset_min_momentum_pct: 1.0
   multiasset_exit_momentum_pct: -0.5
   multiasset_books:

--- a/config/settings.py
+++ b/config/settings.py
@@ -1092,11 +1092,15 @@ class IBKRConfig(BaseModel):
     # structurally simulated ETF pillar to read TWS port 7496, still readonly.
     etf_quote_port: int = 7497
     multiasset_client_id: int = 3
+    multiasset_preflight_client_id: int = 97
     multiasset_paper_enabled: bool = False
     multiasset_cycle_seconds: int = 900
     multiasset_refreshes_per_cycle: int = 12
     multiasset_max_quote_age_seconds: int = 120
     multiasset_contract_cache_seconds: int = 21_600
+    multiasset_preflight_concurrency: int = 2
+    multiasset_preflight_pacing_retries: int = 2
+    multiasset_preflight_retry_seconds: float = 2.0
     multiasset_min_momentum_pct: float = 1.0
     multiasset_exit_momentum_pct: float = -0.5
     multiasset_books: dict[str, IBKRMultiAssetBookConfig] = Field(default_factory=lambda: {
@@ -1139,13 +1143,19 @@ class IBKRConfig(BaseModel):
                           "options", "bonds"}
         if set(self.multiasset_books) != expected_books:
             raise ValueError("IBKR multi-asset config must define exactly six books")
-        if self.multiasset_client_id in {self.client_id, self.equity_client_id}:
-            raise ValueError("IBKR multi-asset client id must be unique")
+        client_ids = {self.client_id, self.equity_client_id,
+                      self.multiasset_client_id, self.multiasset_preflight_client_id}
+        if len(client_ids) != 4:
+            raise ValueError("IBKR API client ids must be unique")
         if self.multiasset_cycle_seconds <= 0 or self.multiasset_refreshes_per_cycle <= 0:
             raise ValueError("IBKR multi-asset cycle and refresh limits must be positive")
         if (self.multiasset_max_quote_age_seconds <= 0
                 or self.multiasset_contract_cache_seconds <= 0):
             raise ValueError("IBKR multi-asset quote/cache limits must be positive")
+        if (self.multiasset_preflight_concurrency <= 0
+                or self.multiasset_preflight_pacing_retries < 0
+                or self.multiasset_preflight_retry_seconds < 0):
+            raise ValueError("IBKR multi-asset preflight pacing limits are invalid")
         symbols = [symbol.strip().upper() for symbol in self.etf_symbols]
         if not symbols:
             raise ValueError("IBKR ETF experiment requires at least one symbol")

--- a/config/settings.py
+++ b/config/settings.py
@@ -1101,6 +1101,7 @@ class IBKRConfig(BaseModel):
     multiasset_preflight_concurrency: int = 2
     multiasset_preflight_pacing_retries: int = 2
     multiasset_preflight_retry_seconds: float = 2.0
+    multiasset_disabled_instruments: list[str] = []
     multiasset_min_momentum_pct: float = 1.0
     multiasset_exit_momentum_pct: float = -0.5
     multiasset_books: dict[str, IBKRMultiAssetBookConfig] = Field(default_factory=lambda: {
@@ -1156,6 +1157,9 @@ class IBKRConfig(BaseModel):
                 or self.multiasset_preflight_pacing_retries < 0
                 or self.multiasset_preflight_retry_seconds < 0):
             raise ValueError("IBKR multi-asset preflight pacing limits are invalid")
+        if len(self.multiasset_disabled_instruments) != len(
+                set(self.multiasset_disabled_instruments)):
+            raise ValueError("IBKR disabled instrument keys must be unique")
         symbols = [symbol.strip().upper() for symbol in self.etf_symbols]
         if not symbols:
             raise ValueError("IBKR ETF experiment requires at least one symbol")

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -13,11 +13,15 @@ method. A live-account TWS login does not make these books live.
 | `futures` | micro equity index, rates, energy, metals and agriculture | nearest contract with >7 days to expiry; exact held `conId` retained | conservative per-contract capital plus multiplier P&L |
 | `international_equity` | Canada, UK, Europe, Japan, Hong Kong and Australia | native listing, exchange and currency | fractional shares, mark translated to USD |
 | `options` | 30–60 DTE ATM calls and puts on liquid ETFs | exact qualified chain contract; exact held `conId` retained | whole contracts, 100 multiplier |
-| `bonds` | US Treasury tenors and investment-grade corporates | maturity-bounded IBKR bond scanner, exact `conId` | $1,000 face-value units |
+| `bonds` | US Treasury tenors and a US corporate issue | maturity-bounded IBKR bond scanner, exact `conId` | $1,000 face-value units |
 
 The catalog is in `auramaur/exchange/ibkr_instruments.py`. Instrument keys are
 unique and every entry declares its security type, exchange, currency, calendar,
 multiplier and discovery policy.
+
+`multiasset_disabled_instruments` is the explicit entitlement quarantine. The
+current username lacks TSEJ data, so `7203.T` remains catalogued but does not
+enter runtime or paper evidence until its preflight succeeds.
 
 ## Isolation and risk
 

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -35,10 +35,26 @@ enter runtime or paper evidence until its preflight succeeds.
   limit, stop, take-profit and maximum spread.
 - Open positions are marked before new risk is allowed. Realized commissions
   and unrealized losses count toward the daily loss limit.
-- Quotes older than the configured age are rejected.
+- Only TWS quotes explicitly tagged `ibkr_live` (`marketDataType=1`) can create
+  marks or fills. Frozen, delayed, delayed-frozen, unknown, stale and synthetic
+  quotes fail closed.
+- A dropped TWS socket clears contract/session caches and reconnects under a
+  single connection lock; concurrent book cycles cannot create duplicate API
+  sessions.
 - Futures/options/bonds are periodically rediscovered, while held derivatives
   continue to be marked and exited using their original `conId`.
-- `price_source` is stored on every position and fill.
+- The complete instrument specification is persisted with an opened position.
+  Removing or disabling a catalog entry therefore cannot strand it: held
+  positions remain markable and exit-manageable.
+- Hard stops and take-profits run from a fresh executable BBO before entry-only
+  spread, FX-refresh, history and momentum gates. If a current FX cross is
+  temporarily missing, exits use the position's stored entry FX conversion.
+- `price_source` is stored on every position and fill. Monitoring counts only
+  closed `trade` rows in trade count and win rate, while commissions and
+  financing remain included in net P&L.
+- Schema migrations verify the required columns before advancing
+  `schema_version`; lock/busy errors are propagated and cannot leave a database
+  falsely stamped as migrated.
 
 ## Option-data limitation
 
@@ -58,6 +74,11 @@ API selected. Run:
 auramaur ibkr-multiasset-preflight
 ```
 
+The TWS username may be a live-account login when IBKR paper credentials are
+unavailable. This changes only the quote session: the socket is still opened
+with `readonly=True`, the adapter has no order method, and all simulated
+positions/fills remain in Auramaur's local database.
+
 The preflight checks structural isolation, schema, every configured contract,
 fresh BBOs, at least 21 daily bars, quote provenance, and per-book forward
 evidence. Run it during each venue's session when diagnosing BBO availability;
@@ -66,6 +87,18 @@ closed venues are expected to lack executable quotes.
 The startup books panel and periodic strategy table report each book separately.
 `ibkr_paper_state.last_cycle_at`, `last_success_at`, and `last_error` provide
 machine-readable health.
+
+Enable the experiment only in the machine-local override after the PR and
+preflight gates pass:
+
+```yaml
+ibkr:
+  multiasset_paper_enabled: true
+```
+
+The tracked default remains `false`, so a fresh checkout cannot start the six
+books accidentally. To stop new cycles, set the local override back to `false`;
+existing local paper positions remain in the isolated tables for inspection.
 
 ## Graduation
 

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -37,6 +37,11 @@ def test_gather_books_attribution_and_modes():
             "('p1', 'polymarket', 'BUY', 10, 0.50, 0.55, 0), "
             "('p2', 'polymarket', 'BUY', 10, 0.86, 0.86, 1), "
             "('XBTUSDC', 'kraken', 'BUY', 0.001, 70000, 70000, 0)")
+        await db.execute(
+            "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) VALUES "
+            "('fx', 'trade', 5, 'ibkr-win'), "
+            "('fx', 'trade', -2, 'ibkr-loss'), "
+            "('fx', 'commission', -1, 'ibkr-fee')")
         await db.commit()
 
         books = {b["book"]: b for b in await gather_books(db)}
@@ -44,6 +49,9 @@ def test_gather_books_attribution_and_modes():
         assert books["bias_harvest"]["open_paper_n"] == 1
         assert books["bias_harvest"]["paper_pnl"] == 2.0
         assert books["kraken_directional"]["open_n"] == 1  # via exchange, not signals
+        assert books["ibkr_fx"]["paper_n"] == 2
+        assert books["ibkr_fx"]["paper_pnl"] == 2
+        assert books["ibkr_fx"]["win_pct"] == 50
 
         # Renders without error.
         render_books_table(list(books.values()))

--- a/tests/test_ibkr_instruments.py
+++ b/tests/test_ibkr_instruments.py
@@ -14,6 +14,10 @@ def test_derivatives_and_bonds_declare_discovery_policy():
         assert spec.kind is ContractKind.FUTURE
         assert spec.expiry_policy == "front_liquid"
         assert spec.multiplier > 1
+    grains = {spec.key: spec for spec in BY_BOOK[IBKRBook.FUTURES]
+              if spec.key in {"ZC", "ZW"}}
+    assert all(spec.contract_multiplier == 5000 and spec.multiplier == 50
+               for spec in grains.values())
     for spec in BY_BOOK[IBKRBook.OPTIONS]:
         assert spec.kind is ContractKind.OPTION
         assert 0 < spec.option_dte_min <= spec.option_dte_max

--- a/tests/test_ibkr_market_data.py
+++ b/tests/test_ibkr_market_data.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import asyncio
+import sys
+import types
+
+import pytest
+
+from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
+from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
+from config.settings import Settings
+
+
+@pytest.mark.asyncio
+async def test_ibkr_liquid_hours_drive_holidays_and_sessions():
+    client = IBKRReadOnlyMarketData(Settings())
+    contract = SimpleNamespace(conId=756733)
+
+    async def resolve(spec):
+        return contract
+
+    client.resolve = resolve
+    client._ib = SimpleNamespace(reqContractDetailsAsync=lambda c: _details())
+    client._connected = True
+
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    assert await client.is_market_open(
+        spec, now=datetime(2026, 7, 17, 15, tzinfo=timezone.utc))
+    assert not await client.is_market_open(
+        spec, now=datetime(2026, 7, 17, 22, tzinfo=timezone.utc))
+    assert not await client.is_market_open(
+        spec, now=datetime(2026, 7, 18, 15, tzinfo=timezone.utc))
+
+
+async def _details():
+    return [SimpleNamespace(
+        liquidHours="20260717:0930-20260717:1600;20260718:CLOSED",
+        tradingHours="", timeZoneId="America/New_York")]
+
+
+@pytest.mark.asyncio
+async def test_preflight_client_id_does_not_collide_with_daemon(monkeypatch):
+    captured = {}
+
+    class FakeIB:
+        async def connectAsync(self, **kwargs):
+            captured.update(kwargs)
+
+        def reqMarketDataType(self, value):
+            pass
+
+    module = types.ModuleType("ib_async")
+    module.IB = FakeIB
+    monkeypatch.setitem(sys.modules, "ib_async", module)
+    settings = Settings()
+    client = IBKRReadOnlyMarketData(
+        settings, client_id=settings.ibkr.multiasset_preflight_client_id)
+    await client._ensure_connected()
+    assert captured["clientId"] == 97
+    assert captured["clientId"] != settings.ibkr.multiasset_client_id
+    assert captured["readonly"] is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_probes_establish_only_one_socket(monkeypatch):
+    calls = 0
+
+    class FakeIB:
+        async def connectAsync(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(0.01)
+
+        def reqMarketDataType(self, value):
+            pass
+
+    module = types.ModuleType("ib_async")
+    module.IB = FakeIB
+    monkeypatch.setitem(sys.modules, "ib_async", module)
+    client = IBKRReadOnlyMarketData(Settings(), client_id=97)
+    await asyncio.gather(*(client._ensure_connected() for _ in range(20)))
+    assert calls == 1

--- a/tests/test_ibkr_market_data.py
+++ b/tests/test_ibkr_market_data.py
@@ -80,3 +80,53 @@ async def test_concurrent_probes_establish_only_one_socket(monkeypatch):
     client = IBKRReadOnlyMarketData(Settings(), client_id=97)
     await asyncio.gather(*(client._ensure_connected() for _ in range(20)))
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_socket_reconnects(monkeypatch):
+    instances = []
+
+    class FakeIB:
+        def __init__(self):
+            self.alive = False
+            instances.append(self)
+
+        async def connectAsync(self, **kwargs):
+            self.alive = True
+
+        def isConnected(self):
+            return self.alive
+
+        def reqMarketDataType(self, value):
+            pass
+
+    module = types.ModuleType("ib_async")
+    module.IB = FakeIB
+    monkeypatch.setitem(sys.modules, "ib_async", module)
+    client = IBKRReadOnlyMarketData(Settings(), client_id=97)
+    await client._ensure_connected()
+    instances[0].alive = False
+    await client._ensure_connected()
+    assert len(instances) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market_data_type,source", [
+    (1, "ibkr_live"), (2, "ibkr_frozen"), (3, "ibkr_delayed"),
+    (4, "ibkr_delayed_frozen"),
+])
+async def test_quote_provenance_comes_from_ibkr_market_data_type(
+        market_data_type, source):
+    now = datetime.now(timezone.utc)
+    ticker = SimpleNamespace(bid=100, ask=101, time=now,
+                             marketDataType=market_data_type)
+
+    class FakeIB:
+        async def reqTickersAsync(self, contract):
+            return [ticker]
+
+    client = IBKRReadOnlyMarketData(Settings())
+    client._ib = FakeIB()
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    quote = await client._quote_contract(spec, SimpleNamespace(conId=123))
+    assert quote.source == source

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -1,0 +1,61 @@
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from auramaur.db.database import Database
+
+
+@pytest.mark.asyncio
+async def test_v23_migration_adds_verified_columns(tmp_path):
+    path = tmp_path / "v23.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(
+        """CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (23);
+        CREATE TABLE ibkr_paper_positions (
+          book TEXT, instrument_key TEXT, con_id INTEGER, currency TEXT,
+          quantity REAL, multiplier REAL, fx_to_usd REAL, avg_cost REAL,
+          current_price REAL, unrealized_pnl_usd REAL, opened_at TEXT,
+          updated_at TEXT, PRIMARY KEY (book, instrument_key));
+        CREATE TABLE ibkr_paper_fills (
+          id INTEGER PRIMARY KEY, book TEXT, instrument_key TEXT, con_id INTEGER,
+          side TEXT, quantity REAL, multiplier REAL, price REAL, currency TEXT,
+          fx_to_usd REAL, commission_usd REAL, fill_ref TEXT UNIQUE,
+          filled_at TEXT);
+        """)
+    raw.close()
+
+    db = Database(str(path))
+    await db.connect()
+    version = await db.fetchone("SELECT version FROM schema_version")
+    position_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
+    fill_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_fills)")
+    assert version["version"] == 25
+    assert {row["name"] for row in position_columns} >= {
+        "price_source", "instrument_spec_json"}
+    assert "price_source" in {row["name"] for row in fill_columns}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v23_migration_does_not_stamp_version_after_busy_error():
+    db = Database(":memory:")
+    await db.connect()
+    await db.execute("UPDATE schema_version SET version = 23")
+    await db.commit()
+    connection = db._db
+
+    class BusyConnection:
+        async def execute(self, sql, params=()):
+            if sql.startswith("ALTER TABLE"):
+                raise aiosqlite.OperationalError("database is locked")
+            return await connection.execute(sql, params)
+
+    db._db = BusyConnection()
+    with pytest.raises(aiosqlite.OperationalError, match="locked"):
+        await db._migrate_v23_to_v24()
+    version = await db.fetchone("SELECT version FROM schema_version")
+    assert version["version"] == 23
+    db._db = connection
+    await db.close()

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from auramaur.db.database import Database
-from auramaur.exchange.ibkr_instruments import ContractKind, IBKRBook
+from auramaur.exchange.ibkr_instruments import BY_BOOK, ContractKind, IBKRBook
 from auramaur.exchange.ibkr_market_data import MarketDataQuote
 from auramaur.strategy.ibkr_multiasset_paper import IBKRMultiAssetPaperBook
 from config.settings import Settings
@@ -58,7 +58,7 @@ async def test_all_six_books_write_only_isolated_paper_tables():
     assert {row["book"] for row in rows} == {book.value for book in IBKRBook}
     assert (await db.fetchone("SELECT COUNT(*) AS n FROM ibkr_paper_fills"))["n"] == 6
     assert (await db.fetchone(
-        "SELECT COUNT(*) AS n FROM ibkr_paper_fills WHERE price_source='ibkr'"))["n"] == 6
+        "SELECT COUNT(*) AS n FROM ibkr_paper_fills WHERE price_source='ibkr_live'"))["n"] == 6
     # The shared prediction-market wallet is not touched.
     assert (await db.fetchone("SELECT COUNT(*) AS n FROM cost_basis"))["n"] == 0
     assert (await db.fetchone("SELECT COUNT(*) AS n FROM pnl_ledger"))["n"] == 0
@@ -121,6 +121,80 @@ async def test_stale_quote_cannot_create_fill():
     pillar.market_open = lambda now=None: True
     assert await pillar.run_once() == 0
     assert (await db.fetchone("SELECT COUNT(*) AS n FROM ibkr_paper_fills"))["n"] == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_delayed_quote_cannot_create_fill():
+    class DelayedMarketData(FakeMarketData):
+        async def get_quote(self, spec):
+            quote = await super().get_quote(spec)
+            return MarketDataQuote(quote.key, quote.bid, quote.ask, quote.timestamp,
+                                   quote.con_id, quote.currency, quote.multiplier,
+                                   "ibkr_delayed")
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    pillar = IBKRMultiAssetPaperBook(
+        settings, DelayedMarketData(), db, IBKRBook.GLOBAL_ETF)
+    assert await pillar.run_once() == 0
+    assert (await db.fetchone("SELECT COUNT(*) AS n FROM ibkr_paper_fills"))["n"] == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stop_executes_during_spread_and_history_dislocation():
+    class DislocatedMarketData(FakeMarketData):
+        async def get_quote_by_con_id(self, spec, con_id):
+            return MarketDataQuote(spec.key, 80, 120, time.time(), con_id,
+                                   spec.currency, spec.multiplier)
+
+        async def get_fx_to_usd(self, currency):
+            return None
+
+        async def get_daily_bars_by_con_id(self, spec, con_id, duration="3 M"):
+            raise AssertionError("hard stops must not wait for history")
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    seed = IBKRMultiAssetPaperBook(settings, FakeMarketData(), db, IBKRBook.GLOBAL_ETF)
+    quote = await FakeMarketData().get_quote(spec)
+    await seed._fill(spec, quote, "BUY", 1, 1.0)
+    pillar = IBKRMultiAssetPaperBook(
+        settings, DislocatedMarketData(), db, IBKRBook.GLOBAL_ETF)
+    await pillar.run_once()
+    assert await db.fetchone(
+        "SELECT 1 FROM ibkr_paper_positions WHERE instrument_key = ?", (spec.key,)) is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_disabled_held_instrument_is_still_managed_and_exited():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    seed = IBKRMultiAssetPaperBook(settings, FakeMarketData(), db, IBKRBook.GLOBAL_ETF)
+    quote = await FakeMarketData().get_quote(spec)
+    await seed._fill(spec, quote, "BUY", 1, 1.0)
+    settings.ibkr.multiasset_disabled_instruments = [spec.key]
+
+    class StopMarketData(FakeMarketData):
+        async def get_quote_by_con_id(self, held_spec, con_id):
+            return MarketDataQuote(held_spec.key, 80, 81, time.time(), con_id,
+                                   held_spec.currency, held_spec.multiplier)
+
+    pillar = IBKRMultiAssetPaperBook(
+        settings, StopMarketData(), db, IBKRBook.GLOBAL_ETF)
+    await pillar.run_once()
+    assert await db.fetchone(
+        "SELECT 1 FROM ibkr_paper_positions WHERE instrument_key = ?", (spec.key,)) is None
     await db.close()
 
 

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,12 +26,17 @@ class FakeMarketData:
     async def get_fx_to_usd(self, currency):
         return 1.0
 
+    async def is_market_open(self, spec, *, con_id=0, now=None):
+        return True
+
+    async def get_daily_bars_by_con_id(self, spec, con_id, duration="3 M"):
+        return await self.get_daily_bars(spec, duration)
+
     async def get_quote_by_con_id(self, spec, con_id):
         self.con_ids_requested.append(con_id)
         quote = await self.get_quote(spec)
         return MarketDataQuote(quote.key, quote.bid, quote.ask, quote.timestamp,
-                               con_id, quote.currency, quote.multiplier,
-                               source="held_contract")
+                               con_id, quote.currency, quote.multiplier)
 
 
 @pytest.mark.asyncio
@@ -137,6 +143,9 @@ async def test_open_position_is_marked_by_original_contract_id():
     assert row is not None
     await pillar.run_once()
     assert int(row["con_id"]) in client.con_ids_requested
+    marked = await db.fetchone(
+        "SELECT updated_at, con_id FROM ibkr_paper_positions WHERE book='futures'")
+    assert int(marked["con_id"]) == int(row["con_id"])
     await db.close()
 
 
@@ -162,3 +171,36 @@ def test_futures_calendar_closes_friday_and_reopens_sunday_evening():
     assert not pillar.market_open(datetime(2026, 7, 17, 22, tzinfo=timezone.utc))
     assert not pillar.market_open(datetime(2026, 7, 19, 21, tzinfo=timezone.utc))
     assert pillar.market_open(datetime(2026, 7, 19, 23, tzinfo=timezone.utc))
+
+
+@pytest.mark.asyncio
+async def test_broker_calendar_honours_holiday_and_split_sessions():
+    from auramaur.exchange.ibkr_instruments import BY_BOOK
+    from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
+
+    class FakeIB:
+        async def reqContractDetailsAsync(self, contract):
+            return [SimpleNamespace(
+                liquidHours=("20260720:CLOSED;"
+                             "20260721:0930-20260721:1130,"
+                             "20260721:1230-20260721:1600"),
+                tradingHours="", timeZoneId="America/New_York")]
+
+    client = IBKRReadOnlyMarketData(Settings())
+    client._ib = FakeIB()
+    client._connected = True
+    contract = SimpleNamespace(conId=123)
+
+    async def resolve(spec):
+        return contract
+
+    client.resolve = resolve
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    assert not await client.is_market_open(
+        spec, now=datetime(2026, 7, 20, 15, tzinfo=timezone.utc))
+    assert await client.is_market_open(
+        spec, now=datetime(2026, 7, 21, 14, tzinfo=timezone.utc))
+    assert not await client.is_market_open(
+        spec, now=datetime(2026, 7, 21, 16, tzinfo=timezone.utc))
+    assert await client.is_market_open(
+        spec, now=datetime(2026, 7, 21, 18, tzinfo=timezone.utc))

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -1,4 +1,5 @@
 import time
+import asyncio
 
 import pytest
 
@@ -87,4 +88,99 @@ async def test_preflight_blocks_synthetic_quotes_as_non_executable():
     settings.ibkr.enabled = True
     report = await preflight(settings, db, client=SyntheticClient())
     assert not report.ready
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_accepts_closed_venue_with_contract_history():
+    class ClosedClient(ReadyClient):
+        async def is_market_open(self, spec):
+            return False
+
+        async def get_quote(self, spec):
+            return None
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    report = await preflight(settings, db, client=ClosedClient())
+    assert report.ready
+    book_results = [r for r in report.results if r.book in {
+        "global_etf", "fx", "futures", "international_equity", "options", "bonds"}]
+    assert all(result.severity == "WARN" for result in book_results)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_retries_transient_pacing_errors():
+    class PacingClient(ReadyClient):
+        def __init__(self):
+            self.attempts = set()
+
+        async def get_quote(self, spec):
+            if spec.key not in self.attempts:
+                self.attempts.add(spec.key)
+                raise RuntimeError("Error 162: pacing violation")
+            return await super().get_quote(spec)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    settings.ibkr.multiasset_preflight_retry_seconds = 0
+    report = await preflight(settings, db, client=PacingClient())
+    assert report.ready
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_bounds_concurrency_and_retries_pacing_errors():
+    class PacingClient(ReadyClient):
+        def __init__(self):
+            self.active = 0
+            self.max_active = 0
+            self.attempts = {}
+
+        async def get_quote(self, spec):
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            await asyncio.sleep(0)
+            self.active -= 1
+            count = self.attempts.get(spec.key, 0)
+            self.attempts[spec.key] = count + 1
+            if count == 0:
+                raise RuntimeError("IBKR error 162: historical data pacing violation")
+            return await super().get_quote(spec)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    settings.ibkr.multiasset_preflight_concurrency = 2
+    settings.ibkr.multiasset_preflight_retry_seconds = 0
+    client = PacingClient()
+    report = await preflight(settings, db, client=client)
+    assert report.ready
+    assert client.max_active <= 2
+    assert all(attempts == 2 for attempts in client.attempts.values())
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_edge_evidence_is_net_of_commissions_and_financing():
+    db = Database(":memory:")
+    await db.connect()
+    await db.execute(
+        "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) VALUES "
+        "('global_etf', 'trade', 10, 'trade-1'), "
+        "('global_etf', 'commission', -1.5, 'fee-1'), "
+        "('global_etf', 'financing', -0.5, 'finance-1')")
+    await db.commit()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    report = await preflight(settings, db, client=ReadyClient())
+    edge = next(result for result in report.results if result.book == "global_etf:edge")
+    assert "1 exits" in edge.detail
+    assert "$8.00 net P&L" in edge.detail
     await db.close()

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -4,6 +4,7 @@ import asyncio
 import pytest
 
 from auramaur.db.database import Database
+from auramaur.exchange.ibkr_instruments import IBKRBook
 from auramaur.exchange.ibkr_market_data import MarketDataQuote
 from auramaur.monitoring.ibkr_multiasset_preflight import preflight
 from config.settings import Settings
@@ -131,6 +132,28 @@ async def test_preflight_retries_transient_pacing_errors():
     settings.ibkr.multiasset_preflight_retry_seconds = 0
     report = await preflight(settings, db, client=PacingClient())
     assert report.ready
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_entitlement_quarantine_skips_instrument_but_reports_coverage():
+    class EntitledClient(ReadyClient):
+        async def get_quote(self, spec):
+            assert spec.key != "7203.T"
+            return await super().get_quote(spec)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    settings.ibkr.multiasset_disabled_instruments = ["7203.T"]
+    report = await preflight(
+        settings, db, client=EntitledClient(),
+        books=(IBKRBook.INTERNATIONAL_EQUITY,))
+    assert report.ready
+    coverage = next(r for r in report.results
+                    if r.book == "international_equity:coverage")
+    assert coverage.severity == "WARN" and "7203.T" in coverage.detail
     await db.close()
 
 


### PR DESCRIPTION
## Summary
- pin held futures/options/bonds to their original IBKR contract IDs for quotes and history
- use IBKR liquid-hours metadata for holiday, split-session, and overnight calendar checks
- make full-universe preflight bounded, pacing-aware, retryable, book-scoped, and safe alongside the daemon
- normalize IBKR qualification multipliers separately from paper P&L units (including CBOT grains)
- quarantine unsubscribed instruments explicitly while preserving them in the catalog
- qualify forward-paper edge using net P&L after commissions and financing

## Real TWS validation
- global ETFs: 20/20 contracts/history ready
- FX: 10/10 ready
- futures: 9/9 ready
- international equities: 8/8 entitled listings ready; 7203.T explicitly TSE-entitlement gated
- options: 10/10 contracts/history diagnostics ready; synthetic estimates remain non-executable until native OPRA BBOs are available
- direct bonds: 5/5 Treasury/corporate contracts ready
- all connections read-only; daemon client 3 and preflight client 97 are isolated

## Validation
- 1161 passed, 1 skipped
- ruff check .
- git diff --check