### PR TITLE
fix(ibkr): multiasset books default OFF pending review remediation

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -257,7 +257,7 @@ ibkr:
   # Activated after read-only TWS contract/history preflight. Individual books
   # still fail closed without fresh native executable quotes.
   multiasset_client_id: 3
-  multiasset_paper_enabled: true
+  multiasset_paper_enabled: false
   multiasset_cycle_seconds: 900
   multiasset_refreshes_per_cycle: 12
   # Delayed/frozen quotes may be observed, but cannot create credible fills.


### PR DESCRIPTION
The multiasset system was pushed to main default-on without review. The high-effort review returned 10 blocking defects (delayed quotes pass the freshness gate; migration can strand the DB; dead TWS connection never detected; orphaned positions brick books; stops gated behind entry checks; et al. — full findings in the tracking issue). Per repo convention, experiments ship disabled and are enabled deliberately after approval. 🤖 Generated with [Claude Code](https://claude.com/claude-code)