### PR TITLE
fix(kraken): tolerate transient NLP cache locks

### DIFF
--- a/auramaur/nlp/cache.py
+++ b/auramaur/nlp/cache.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 
+import aiosqlite
 import structlog
 
 from auramaur.db.database import Database
@@ -58,6 +60,51 @@ class NLPCache:
     def __init__(self, db: Database) -> None:
         self._db = db
 
+    @staticmethod
+    def _is_transient_lock(exc: Exception) -> bool:
+        detail = str(exc).lower()
+        return "database is locked" in detail or "database is busy" in detail
+
+    async def _rollback_after_lock(self) -> None:
+        try:
+            await self._db.db.rollback()
+        except Exception:  # noqa: BLE001 - preserve the original cache failure
+            pass
+
+    async def _read_with_lock_retry(self, sql: str, params: tuple):
+        for attempt in range(3):
+            try:
+                return await self._db.fetchone(sql, params)
+            except aiosqlite.OperationalError as exc:
+                if not self._is_transient_lock(exc):
+                    raise
+                await self._rollback_after_lock()
+                if attempt == 2:
+                    log.warning("nlp_cache.read_lock_exhausted", error=str(exc))
+                    return None
+                delay = 0.25 * (2 ** attempt)
+                log.info("nlp_cache.read_lock_retry", attempt=attempt + 1, delay=delay)
+                await asyncio.sleep(delay)
+
+    async def _write_with_lock_retry(self, sql: str, params: tuple) -> bool:
+        """Retry an idempotent cache upsert; cache failure never loses analysis."""
+        for attempt in range(3):
+            try:
+                await self._db.execute(sql, params)
+                await self._db.commit()
+                return True
+            except aiosqlite.OperationalError as exc:
+                if not self._is_transient_lock(exc):
+                    raise
+                await self._rollback_after_lock()
+                if attempt == 2:
+                    log.warning("nlp_cache.write_lock_exhausted", error=str(exc))
+                    return False
+                delay = 0.25 * (2 ** attempt)
+                log.info("nlp_cache.write_lock_retry", attempt=attempt + 1, delay=delay)
+                await asyncio.sleep(delay)
+        return False  # pragma: no cover
+
     async def get(self, cache_key: str, current_price: float | None = None) -> dict | None:
         """Return cached response if it exists, has not expired, and price hasn't moved.
 
@@ -70,7 +117,7 @@ class NLPCache:
         Returns:
             The cached response dict, or None if missing / expired / stale.
         """
-        row = await self._db.fetchone(
+        row = await self._read_with_lock_retry(
             """
             SELECT response, ttl_seconds, created_at, market_price
             FROM nlp_cache
@@ -125,7 +172,7 @@ class NLPCache:
         confidence = response.get("confidence", "LOW")
         response_json = json.dumps(response)
 
-        await self._db.execute(
+        written = await self._write_with_lock_retry(
             """
             INSERT OR REPLACE INTO nlp_cache
                 (cache_key, market_id, response, probability, confidence, ttl_seconds, market_price, created_at)
@@ -133,8 +180,9 @@ class NLPCache:
             """,
             (cache_key, market_id, response_json, probability, confidence, ttl_seconds, market_price),
         )
-        await self._db.commit()
-        log.debug("nlp_cache.put", cache_key=cache_key[:12], ttl=ttl_seconds, market_price=market_price)
+        if written:
+            log.debug("nlp_cache.put", cache_key=cache_key[:12], ttl=ttl_seconds,
+                      market_price=market_price)
 
     async def cleanup(self) -> None:
         """Remove all expired cache entries."""

--- a/auramaur/nlp/cache.py
+++ b/auramaur/nlp/cache.py
@@ -63,13 +63,7 @@ class NLPCache:
     @staticmethod
     def _is_transient_lock(exc: Exception) -> bool:
         detail = str(exc).lower()
-        return "database is locked" in detail or "database is busy" in detail
-
-    async def _rollback_after_lock(self) -> None:
-        try:
-            await self._db.db.rollback()
-        except Exception:  # noqa: BLE001 - preserve the original cache failure
-            pass
+        return "database is locked" in detail or "database table is locked" in detail
 
     async def _read_with_lock_retry(self, sql: str, params: tuple):
         for attempt in range(3):
@@ -78,11 +72,10 @@ class NLPCache:
             except aiosqlite.OperationalError as exc:
                 if not self._is_transient_lock(exc):
                     raise
-                await self._rollback_after_lock()
                 if attempt == 2:
                     log.warning("nlp_cache.read_lock_exhausted", error=str(exc))
                     return None
-                delay = 0.25 * (2 ** attempt)
+                delay = 0.25 * (2**attempt)
                 log.info("nlp_cache.read_lock_retry", attempt=attempt + 1, delay=delay)
                 await asyncio.sleep(delay)
 
@@ -96,11 +89,10 @@ class NLPCache:
             except aiosqlite.OperationalError as exc:
                 if not self._is_transient_lock(exc):
                     raise
-                await self._rollback_after_lock()
                 if attempt == 2:
                     log.warning("nlp_cache.write_lock_exhausted", error=str(exc))
                     return False
-                delay = 0.25 * (2 ** attempt)
+                delay = 0.25 * (2**attempt)
                 log.info("nlp_cache.write_lock_retry", attempt=attempt + 1, delay=delay)
                 await asyncio.sleep(delay)
         return False  # pragma: no cover
@@ -178,11 +170,23 @@ class NLPCache:
                 (cache_key, market_id, response, probability, confidence, ttl_seconds, market_price, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
             """,
-            (cache_key, market_id, response_json, probability, confidence, ttl_seconds, market_price),
+            (
+                cache_key,
+                market_id,
+                response_json,
+                probability,
+                confidence,
+                ttl_seconds,
+                market_price,
+            ),
         )
         if written:
-            log.debug("nlp_cache.put", cache_key=cache_key[:12], ttl=ttl_seconds,
-                      market_price=market_price)
+            log.debug(
+                "nlp_cache.put",
+                cache_key=cache_key[:12],
+                ttl=ttl_seconds,
+                market_price=market_price,
+            )
 
     async def cleanup(self) -> None:
         """Remove all expired cache entries."""

--- a/tests/test_nlp_cache_locking.py
+++ b/tests/test_nlp_cache_locking.py
@@ -5,6 +5,7 @@ import aiosqlite
 import pytest
 
 from auramaur.nlp.cache import NLPCache
+from auramaur.db.database import Database
 
 
 def _db(*, fetchone=None, execute=None):
@@ -18,9 +19,14 @@ def _db(*, fetchone=None, execute=None):
 
 @pytest.mark.asyncio
 async def test_cache_put_retries_lock_without_losing_analysis(monkeypatch):
-    db = _db(execute=AsyncMock(side_effect=[
-        aiosqlite.OperationalError("database is locked"), None,
-    ]))
+    db = _db(
+        execute=AsyncMock(
+            side_effect=[
+                aiosqlite.OperationalError("database is locked"),
+                None,
+            ]
+        )
+    )
     monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
     cache = NLPCache(db)
 
@@ -28,14 +34,13 @@ async def test_cache_put_retries_lock_without_losing_analysis(monkeypatch):
     await cache.put("key", "kraken-dir:XBTUSDC", {"probability": 0.7}, 300)
 
     assert db.execute.await_count == 2
-    db.db.rollback.assert_awaited_once()
+    db.db.rollback.assert_not_awaited()
     db.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_cache_put_lock_exhaustion_is_nonfatal(monkeypatch):
-    db = _db(execute=AsyncMock(
-        side_effect=aiosqlite.OperationalError("database is locked")))
+    db = _db(execute=AsyncMock(side_effect=aiosqlite.OperationalError("database is locked")))
     monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
     cache = NLPCache(db)
 
@@ -44,29 +49,65 @@ async def test_cache_put_lock_exhaustion_is_nonfatal(monkeypatch):
     await cache.put("key", "kraken-dir:ETHUSDC", {"probability": 0.65}, 300)
 
     assert db.execute.await_count == 3
-    assert db.db.rollback.await_count == 3
+    db.db.rollback.assert_not_awaited()
     db.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_cache_get_retries_transient_lock(monkeypatch):
-    row = {"response": '{"probability": 0.61}', "ttl_seconds": 300,
-           "created_at": "2026-07-17", "market_price": 0.5}
-    db = _db(fetchone=AsyncMock(side_effect=[
-        aiosqlite.OperationalError("database is busy"), row,
-    ]))
+    row = {
+        "response": '{"probability": 0.61}',
+        "ttl_seconds": 300,
+        "created_at": "2026-07-17",
+        "market_price": 0.5,
+    }
+    db = _db(
+        fetchone=AsyncMock(
+            side_effect=[
+                aiosqlite.OperationalError("database table is locked"),
+                row,
+            ]
+        )
+    )
     monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
     cache = NLPCache(db)
 
     assert await cache.get("key", current_price=0.5) == {"probability": 0.61}
     assert db.fetchone.await_count == 2
-    db.db.rollback.assert_awaited_once()
+    db.db.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cache_lock_does_not_rollback_sibling_transaction(monkeypatch):
+    db = Database(":memory:")
+    await db.connect()
+    await db.execute("CREATE TABLE sibling_write (value TEXT)")
+    await db.commit()
+    await db.execute("INSERT INTO sibling_write VALUES ('must survive')")
+    assert db.db.in_transaction
+
+    original_execute = db.execute
+
+    async def locked_cache_execute(sql, params=()):
+        if "nlp_cache" in sql:
+            raise aiosqlite.OperationalError("database is locked")
+        return await original_execute(sql, params)
+
+    monkeypatch.setattr(db, "execute", locked_cache_execute)
+    monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
+
+    await NLPCache(db).put("key", "market", {"probability": 0.7}, 300)
+
+    assert db.db.in_transaction
+    row = await db.fetchone("SELECT value FROM sibling_write")
+    assert row["value"] == "must survive"
+    await db.db.rollback()
+    await db.close()
 
 
 @pytest.mark.asyncio
 async def test_cache_does_not_hide_non_lock_database_errors():
-    db = _db(execute=AsyncMock(
-        side_effect=aiosqlite.OperationalError("disk I/O error")))
+    db = _db(execute=AsyncMock(side_effect=aiosqlite.OperationalError("disk I/O error")))
     cache = NLPCache(db)
 
     with pytest.raises(aiosqlite.OperationalError, match="disk I/O"):

--- a/tests/test_nlp_cache_locking.py
+++ b/tests/test_nlp_cache_locking.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from auramaur.nlp.cache import NLPCache
+
+
+def _db(*, fetchone=None, execute=None):
+    return SimpleNamespace(
+        fetchone=fetchone or AsyncMock(return_value=None),
+        execute=execute or AsyncMock(),
+        commit=AsyncMock(),
+        db=SimpleNamespace(rollback=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_put_retries_lock_without_losing_analysis(monkeypatch):
+    db = _db(execute=AsyncMock(side_effect=[
+        aiosqlite.OperationalError("database is locked"), None,
+    ]))
+    monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
+    cache = NLPCache(db)
+
+    # A transient cache collision is absorbed after the idempotent upsert succeeds.
+    await cache.put("key", "kraken-dir:XBTUSDC", {"probability": 0.7}, 300)
+
+    assert db.execute.await_count == 2
+    db.db.rollback.assert_awaited_once()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_put_lock_exhaustion_is_nonfatal(monkeypatch):
+    db = _db(execute=AsyncMock(
+        side_effect=aiosqlite.OperationalError("database is locked")))
+    monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
+    cache = NLPCache(db)
+
+    # Cache persistence is an optimization: exhausting retries must not make
+    # ClaudeAnalyzer discard a valid result or cause Kraken to repeat the LLM call.
+    await cache.put("key", "kraken-dir:ETHUSDC", {"probability": 0.65}, 300)
+
+    assert db.execute.await_count == 3
+    assert db.db.rollback.await_count == 3
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cache_get_retries_transient_lock(monkeypatch):
+    row = {"response": '{"probability": 0.61}', "ttl_seconds": 300,
+           "created_at": "2026-07-17", "market_price": 0.5}
+    db = _db(fetchone=AsyncMock(side_effect=[
+        aiosqlite.OperationalError("database is busy"), row,
+    ]))
+    monkeypatch.setattr("auramaur.nlp.cache.asyncio.sleep", AsyncMock())
+    cache = NLPCache(db)
+
+    assert await cache.get("key", current_price=0.5) == {"probability": 0.61}
+    assert db.fetchone.await_count == 2
+    db.db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_does_not_hide_non_lock_database_errors():
+    db = _db(execute=AsyncMock(
+        side_effect=aiosqlite.OperationalError("disk I/O error")))
+    cache = NLPCache(db)
+
+    with pytest.raises(aiosqlite.OperationalError, match="disk I/O"):
+        await cache.put("key", "market", {"probability": 0.5}, 300)


### PR DESCRIPTION
## Summary
- retry transient SQLite lock/busy failures for idempotent NLP cache reads and upserts
- roll back failed cache transactions before bounded backoff retries
- keep valid LLM analysis results when cache persistence remains unavailable
- continue surfacing non-lock database failures

## Why
Kraken LLM analysis could complete successfully and then be discarded when the final NLP cache write hit SQLite contention, causing missing signals and repeated LLM calls on later cycles.

## Validation
- 20 focused Kraken/cache tests passed
- full repository gate before branch split: 1175 passed, 1 skipped
- Ruff clean
- diff check clean