### PR TITLE
Add portable Compose deployment with IB Gateway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.venv
+.env
+secrets
+runtime
+logs
+data
+*.db
+*.db-*
+*.db.lock
+KILL_SWITCH
+__pycache__
+.pytest_cache
+.ruff_cache
+dist
+build
+deploy/ibgateway/ibgateway-*-standalone-linux-x64.sh

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@ POLYMARKET_PASSPHRASE=
 # API key ID from the Kalshi dashboard, plus the path to the RSA private key
 # file Kalshi gives you (PEM). Required when kalshi.enabled=true.
 KALSHI_API_KEY=
-KALSHI_PRIVATE_KEY_PATH=
+KALSHI_PRIVATE_KEY_PATH=/run/auramaur-kalshi-private.pem
+KALSHI_PRIVATE_KEY_SOURCE=./secrets/kalshi-private.pem
 
 # Crypto.com Exchange (config: cryptodotcom.enabled + cryptodotcom.environment=sandbox|prod)
 # Required only for live/private order placement; market discovery is public.
@@ -66,6 +67,33 @@ RISK_TOLERANCE=50
 
 # Safety
 AURAMAUR_LIVE=false
+# Compose-only deployment gates. Keep both false throughout paper shakedown;
+# arm them explicitly on the final host only after verification.
+AURAMAUR_CONTAINER_LIVE=false
+AURAMAUR_CONTAINER_ENABLE_TRANSFERS=false
+# The dedicated IBKR live login is a read-only quote source. Port 4002 is an
+# intentional deployment-local choice; local paper execution remains separate.
+IBKR_QUOTE_ENVIRONMENT=live
+IBKR_QUOTE_PORT=4002
+IBKR_ENABLED=true
+IBKR_MULTIASSET_PAPER_ENABLED=true
+# Stable private addresses make the Gateway Trusted IP entry survive restarts.
+# Override the subnet if it conflicts with another Docker network on the host.
+AURAMAUR_BROKER_SUBNET=172.18.0.0/16
+AURAMAUR_BOT_IP=172.18.0.3
+IB_GATEWAY_IP=172.18.0.2
+# Portable runtime paths (Compose supplies these automatically). Native hosts
+# may override them to keep mutable state outside the checkout.
+# AURAMAUR_STATE_DIR=/var/lib/auramaur
+# AURAMAUR_DB_PATH=/var/lib/auramaur/auramaur.db
+# AURAMAUR_LOG_DIR=/var/log/auramaur
+# AURAMAUR_KILL_SWITCH_PATH=/var/lib/auramaur/KILL_SWITCH
+# AURAMAUR_LOCAL_CONFIG=/etc/auramaur/defaults.local.yaml
+
+# Docker/VM IB Gateway connection. Pydantic nested settings use __ separators.
+# IBKR__HOST=ibgateway
+# IBKR__PAPER_PORT=4002
+# IBKR__LIVE_PORT=4001
 # Separate gate for cross-venue fund transfers (Kraken -> Polymarket). Must be
 # true AND transfers.enabled in config AND a whitelisted address AND per-move
 # approval before any funds move. Leave false unless you are actively moving funds.

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,38 @@
+name: container
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  auramaur:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/auramaur
+          tags: |
+            type=ref,event=tag
+            type=sha,format=long
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ data/risk_tolerance
 # Runtime trading logs (operational figures — never version; PUBLIC repo)
 logs/
 *.out
+runtime/
+secrets/
+deploy/ibgateway/ibgateway-*-standalone-linux-x64.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:22-bookworm-slim AS node_runtime
+
+FROM python:3.12-slim AS runtime
+
+ARG CLAUDE_CODE_VERSION=2.1.214
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH=/app/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+COPY --from=node_runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gosu passwd sqlite3 tini \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && pip install --no-cache-dir uv \
+    && rm -rf /var/lib/apt/lists/* /root/.cache
+
+WORKDIR /app
+COPY pyproject.toml uv.lock README.md ./
+COPY auramaur ./auramaur
+COPY config ./config
+RUN uv sync --frozen --no-dev --extra kalshi --extra ibkr \
+    && uv pip install --python .venv/bin/python \
+       --index-url https://download.pytorch.org/whl/cpu "torch==2.12.0" \
+    && uv pip install --python .venv/bin/python "sentence-transformers==5.5.1"
+
+RUN groupadd --gid 10001 auramaur \
+    && useradd --uid 10001 --gid 10001 --create-home auramaur \
+    && mkdir -p /app/state /app/logs /home/auramaur/.claude \
+    && chown -R auramaur:auramaur /app /home/auramaur
+
+COPY --chown=auramaur:auramaur deploy/docker/auramaur-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/auramaur-entrypoint.sh"]
+CMD ["auramaur", "run", "--hybrid"]
+
+HEALTHCHECK --interval=60s --timeout=15s --start-period=90s --retries=3 \
+    CMD ["python", "-m", "auramaur.health"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ strategies trade on paper and earn live capital only by clearing the graduation
 ladder. Calibration learns from every market resolution. Ongoing research, not a
 finished product.
 
+For a common Docker Compose deployment across macOS, WSL, and a single Ubuntu
+VM—including a first-class, GUI-authenticated IB Gateway service—see
+[`docs/PORTABLE_DEPLOYMENT.md`](docs/PORTABLE_DEPLOYMENT.md).
+
 ## License
 
 MIT.

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
@@ -1256,7 +1257,8 @@ class AuramaurBot(
         self._running = True
 
         db_path = self._components.db.db_path
-        if db_path != "auramaur.db":
+        from auramaur.runtime import db_path as runtime_db_path
+        if Path(db_path).resolve() != runtime_db_path().resolve():
             console.print(f"  [yellow]Instance: {db_path}[/]")
         # Persistent Claude-budget counter lives in the same sqlite file —
         # point it at this instance's path (multi-instance runs use

--- a/auramaur/cli/run.py
+++ b/auramaur/cli/run.py
@@ -8,6 +8,7 @@ import click
 from rich.live import Live
 
 from auramaur.db.database import Database
+from auramaur.runtime import db_path as runtime_db_path
 from config.settings import Settings
 
 from auramaur.cli._base import console, main
@@ -55,7 +56,12 @@ def run(agent: bool, hybrid: bool, exchange: str | None):
     else:
         console.print("[bold blue]Starting Auramaur bot...[/]")
     from auramaur.cli import AuramaurBot  # call-time lookup keeps test patch working
-    bot = AuramaurBot(settings=settings, exchange_filter=exchange, hybrid=hybrid)
+    bot = AuramaurBot(
+        settings=settings,
+        db_path=str(runtime_db_path()),
+        exchange_filter=exchange,
+        hybrid=hybrid,
+    )
     asyncio.run(bot.run())
 
 @main.command()

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -6,13 +6,14 @@ import aiosqlite
 import structlog
 
 from auramaur.db.models import SCHEMA_VERSION, TABLES
+from auramaur.runtime import db_path as runtime_db_path
 
 log = structlog.get_logger()
 
 
 class Database:
-    def __init__(self, db_path: str = "auramaur.db"):
-        self.db_path = db_path
+    def __init__(self, db_path: str | None = None):
+        self.db_path = str(runtime_db_path()) if db_path is None else db_path
         self._db: aiosqlite.Connection | None = None
 
     async def connect(self) -> None:

--- a/auramaur/health.py
+++ b/auramaur/health.py
@@ -1,0 +1,54 @@
+"""Container/native liveness probe without placing orders or claiming an IB client ID."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+import sys
+from pathlib import Path
+
+from auramaur.killswitch import kill_switch_present
+from auramaur.runtime import db_path
+
+
+def _database_health(path: Path) -> tuple[bool, str]:
+    if not path.is_file():
+        return False, "database missing"
+    try:
+        uri = f"file:{path.resolve()}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=5) as conn:
+            result = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+        return result is not None, f"schema version {result[0]}" if result else "no schema version"
+    except sqlite3.Error as exc:
+        return False, str(exc)
+
+
+def _ibkr_socket_health() -> tuple[bool, str]:
+    host = os.environ.get("AURAMAUR_IBKR_HOST", "ibgateway")
+    environment = os.environ.get("AURAMAUR_IBKR_ENVIRONMENT", "paper")
+    default_port = "4002" if environment == "paper" else "4001"
+    port = int(os.environ.get("AURAMAUR_IBKR_PORT", default_port))
+    try:
+        with socket.create_connection((host, port), timeout=3):
+            return True, f"{host}:{port} reachable"
+    except OSError as exc:
+        return False, str(exc)
+
+
+def main() -> int:
+    db_ok, db_detail = _database_health(db_path())
+    ib_ok, ib_detail = _ibkr_socket_health()
+    require_ibkr = os.environ.get("AURAMAUR_HEALTH_REQUIRE_IBKR", "false").lower() == "true"
+    payload = {
+        "database": {"ok": db_ok, "detail": db_detail},
+        "ibkr_socket": {"ok": ib_ok, "detail": ib_detail},
+        "kill_switch": kill_switch_present(),
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0 if db_ok and (ib_ok or not require_ibkr) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/auramaur/killswitch.py
+++ b/auramaur/killswitch.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-# Repo root = one level up from this file's package dir (auramaur/ -> repo root).
-_REPO_ROOT = Path(__file__).resolve().parent.parent
+from auramaur.runtime import kill_switch_path
 
 # The canonical kill-switch path. Arm/disarm tooling should create/remove THIS
 # file so the check below reliably finds it regardless of launch directory.
-KILL_SWITCH_PATH = _REPO_ROOT / "KILL_SWITCH"
+KILL_SWITCH_PATH = kill_switch_path()
 
 
 def kill_switch_present() -> bool:

--- a/auramaur/runtime.py
+++ b/auramaur/runtime.py
@@ -1,0 +1,30 @@
+"""Portable runtime paths shared by native and container deployments."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _path_from_env(name: str, default: Path) -> Path:
+    value = os.environ.get(name)
+    return Path(value).expanduser() if value else default
+
+
+def state_dir() -> Path:
+    return _path_from_env("AURAMAUR_STATE_DIR", REPO_ROOT)
+
+
+def db_path() -> Path:
+    return _path_from_env("AURAMAUR_DB_PATH", state_dir() / "auramaur.db")
+
+
+def log_dir() -> Path:
+    return _path_from_env("AURAMAUR_LOG_DIR", REPO_ROOT / "logs")
+
+
+def kill_switch_path() -> Path:
+    return _path_from_env("AURAMAUR_KILL_SWITCH_PATH", state_dir() / "KILL_SWITCH")

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,91 @@
+name: auramaur
+
+services:
+  auramaur:
+    platform: ${AURAMAUR_PLATFORM:-linux/amd64}
+    image: ${AURAMAUR_IMAGE:-auramaur}:${AURAMAUR_VERSION:-local}
+    build:
+      context: .
+      args:
+        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-2.1.214}
+    # A clean exit is deliberate (notably KILL_SWITCH); crashes restart.
+    restart: on-failure
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      # Container deployment gates are deliberately separate from a legacy
+      # workstation .env so a parallel shakedown cannot inherit live authority.
+      AURAMAUR_LIVE: ${AURAMAUR_CONTAINER_LIVE:-false}
+      AURAMAUR_ENABLE_TRANSFERS: ${AURAMAUR_CONTAINER_ENABLE_TRANSFERS:-false}
+      AURAMAUR_STATE_DIR: /app/state
+      AURAMAUR_DB_PATH: /app/state/auramaur.db
+      AURAMAUR_LOG_DIR: /app/logs
+      LOGGING__FILE: /app/logs/auramaur.log
+      AURAMAUR_KILL_SWITCH_PATH: /app/state/KILL_SWITCH
+      AURAMAUR_LOCAL_CONFIG: /app/runtime-config/defaults.local.yaml
+      AURAMAUR_IBKR_HOST: ibgateway
+      # The dedicated live account supplies quotes only. Auramaur execution
+      # remains in its local paper ledger until the independent gates above
+      # are deliberately armed at graduation.
+      AURAMAUR_IBKR_ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
+      AURAMAUR_IBKR_PORT: ${IBKR_QUOTE_PORT:-4002}
+      IBKR__HOST: ibgateway
+      IBKR__ENABLED: ${IBKR_ENABLED:-true}
+      IBKR__OPTIONS_ENABLED: "false"
+      IBKR__ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
+      IBKR__PAPER_PORT: ${IBKR_QUOTE_PORT:-4002}
+      IBKR__LIVE_PORT: ${IBKR_QUOTE_PORT:-4002}
+      IBKR__ETF_QUOTE_PORT: ${IBKR_QUOTE_PORT:-4002}
+      IBKR__READONLY: "true"
+      IBKR__PAPER_TRADE: "true"
+      IBKR__MULTIASSET_PAPER_ENABLED: ${IBKR_MULTIASSET_PAPER_ENABLED:-true}
+      IBKR__ETF_PAPER_ENABLED: "false"
+      KALSHI_PRIVATE_KEY_PATH: /run/auramaur-kalshi-private.pem
+      HOME: /home/auramaur
+      AURAMAUR_RUNTIME_UID: ${AURAMAUR_UID:-1000}
+      AURAMAUR_RUNTIME_GID: ${AURAMAUR_GID:-1000}
+    volumes:
+      - ./runtime/state:/app/state
+      - ./runtime/logs:/app/logs
+      - ./runtime/config:/app/runtime-config:ro
+      - ${CLAUDE_CONFIG_DIR:-./runtime/claude}:/home/auramaur/.claude
+      - ./secrets:/run/secrets:ro
+      - ${KALSHI_PRIVATE_KEY_SOURCE:-./private-key.pem}:/run/auramaur-kalshi-private.pem:ro
+    networks:
+      broker:
+        ipv4_address: ${AURAMAUR_BOT_IP:-172.18.0.3}
+    depends_on:
+      - ibgateway
+    stop_grace_period: 2m
+
+  ibgateway:
+    platform: ${AURAMAUR_PLATFORM:-linux/amd64}
+    image: ${IB_GATEWAY_IMAGE:-auramaur-ibgateway}:${IB_GATEWAY_VERSION:-local}
+    build:
+      context: deploy/ibgateway
+      args:
+        IB_GATEWAY_INSTALLER: ${IB_GATEWAY_INSTALLER:-ibgateway-latest-standalone-linux-x64.sh}
+    restart: unless-stopped
+    init: true
+    environment:
+      IB_GATEWAY_HEALTH_PORT: ${IB_GATEWAY_HEALTH_PORT:-4002}
+      IB_GATEWAY_VNC_PASSWORD_FILE: /run/secrets/ibgateway_vnc_password
+      AURAMAUR_RUNTIME_UID: ${AURAMAUR_UID:-1000}
+      AURAMAUR_RUNTIME_GID: ${AURAMAUR_GID:-1000}
+    volumes:
+      - ./runtime/ibgateway:/home/ibgateway/Jts
+      - ./secrets/ibgateway-vnc-password.txt:/run/secrets/ibgateway_vnc_password:ro
+    ports:
+      - "127.0.0.1:${IB_GATEWAY_NOVNC_PORT:-6080}:6080"
+    networks:
+      broker:
+        ipv4_address: ${IB_GATEWAY_IP:-172.18.0.2}
+    stop_grace_period: 2m
+
+networks:
+  broker:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${AURAMAUR_BROKER_SUBNET:-172.18.0.0/16}

--- a/config/settings.py
+++ b/config/settings.py
@@ -36,7 +36,10 @@ def _load_defaults() -> dict:
     if defaults_path.exists():
         with open(defaults_path) as f:
             base = yaml.safe_load(f) or {}
-    local_path = Path(__file__).parent / "defaults.local.yaml"
+    local_path = Path(os.environ.get(
+        "AURAMAUR_LOCAL_CONFIG",
+        Path(__file__).parent / "defaults.local.yaml",
+    ))
     if local_path.exists():
         with open(local_path) as f:
             base = _deep_merge(base, yaml.safe_load(f) or {})
@@ -1553,6 +1556,9 @@ class Settings(BaseSettings):
     model_config = {
         "env_file": str(Path(__file__).resolve().parent.parent / ".env"),
         "env_file_encoding": "utf-8",
+        # Portable deployments can override nested settings without editing a
+        # tracked YAML file, e.g. IBKR__HOST=ibgateway.
+        "env_nested_delimiter": "__",
         # Ignore env vars we don't declare. The process shares its environment
         # with libraries that read their own tokens directly (e.g. HF_TOKEN /
         # hf_token for huggingface_hub via sentence-transformers), and an

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+db=${AURAMAUR_DB_PATH:-runtime/state/auramaur.db}
+backup_dir=${AURAMAUR_BACKUP_DIR:-runtime/state/backups}
+keep=${AURAMAUR_BACKUP_KEEP:-14}
+
+if [ ! -f "$db" ]; then
+    echo "Database not found: $db" >&2
+    exit 1
+fi
+
+mkdir -p "$backup_dir"
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+target="$backup_dir/auramaur-$timestamp.db"
+
+sqlite3 "$db" ".timeout 30000" ".backup '$target'"
+result=$(sqlite3 "$target" "PRAGMA integrity_check;")
+if [ "$result" != "ok" ]; then
+    echo "Backup integrity check failed: $result" >&2
+    exit 1
+fi
+gzip "$target"
+chmod 0600 "$target.gz"
+
+# Retention is explicit and scoped to timestamped backups in this directory.
+find "$backup_dir" -type f -name 'auramaur-*.db.gz' -print \
+    | sort -r \
+    | awk "NR > $keep" \
+    | while IFS= read -r old; do rm -f -- "$old"; done
+
+echo "$target.gz"

--- a/deploy/docker/auramaur-entrypoint.sh
+++ b/deploy/docker/auramaur-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+mkdir -p "${AURAMAUR_STATE_DIR:-/app/state}" "${AURAMAUR_LOG_DIR:-/app/logs}"
+
+if [ -f "${AURAMAUR_KILL_SWITCH_PATH:-/app/state/KILL_SWITCH}" ]; then
+    echo "KILL_SWITCH present; refusing to start Auramaur" >&2
+    exit 0
+fi
+
+runtime_uid=${AURAMAUR_RUNTIME_UID:-1000}
+runtime_gid=${AURAMAUR_RUNTIME_GID:-1000}
+groupmod -o -g "$runtime_gid" auramaur
+usermod -o -u "$runtime_uid" -g "$runtime_gid" auramaur
+for dir in "${AURAMAUR_STATE_DIR:-/app/state}" "${AURAMAUR_LOG_DIR:-/app/logs}" "$HOME/.claude"; do
+    if ! gosu auramaur test -w "$dir"; then
+        echo "Runtime path is not writable by host UID $runtime_uid: $dir" >&2
+        echo "Set AURAMAUR_UID/AURAMAUR_GID to the host owner and re-run." >&2
+        exit 1
+    fi
+done
+
+exec gosu auramaur "$@"

--- a/deploy/ibgateway/Dockerfile
+++ b/deploy/ibgateway/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:24.04
+
+ARG IB_GATEWAY_INSTALLER=ibgateway-latest-standalone-linux-x64.sh
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DISPLAY=:1 \
+    IB_GATEWAY_HOME=/opt/ibgateway \
+    HOME=/home/ibgateway
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates fluxbox gosu netcat-openbsd novnc openjdk-17-jre-headless \
+       procps websockify x11vnc xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --uid 10002 --create-home ibgateway \
+    && mkdir -p /home/ibgateway/Jts /run/ibgateway "${IB_GATEWAY_HOME}" \
+    && chown -R ibgateway:ibgateway /home/ibgateway /run/ibgateway "${IB_GATEWAY_HOME}"
+
+# IBKR does not support unattended credential entry or a GUI-less Gateway.
+# Download the current offline Linux Gateway installer from IBKR, place it in
+# this directory under the ARG filename, then build. It is intentionally not
+# redistributed by this repository.
+COPY ${IB_GATEWAY_INSTALLER} /tmp/ibgateway-installer.sh
+RUN chown ibgateway:ibgateway /tmp/ibgateway-installer.sh \
+    && chmod 0700 /tmp/ibgateway-installer.sh \
+    && gosu ibgateway env HOME=/home/ibgateway \
+       /tmp/ibgateway-installer.sh -q -dir "${IB_GATEWAY_HOME}" \
+    && rm -f /tmp/ibgateway-installer.sh
+
+COPY --chown=ibgateway:ibgateway entrypoint.sh healthcheck.sh /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=4 \
+    CMD ["/usr/local/bin/healthcheck.sh"]

--- a/deploy/ibgateway/README.md
+++ b/deploy/ibgateway/README.md
@@ -1,0 +1,15 @@
+# IB Gateway image
+
+IBKR requires a GUI for authentication and does not support unattended
+credential entry. Download the current **offline Linux x86-64 IB Gateway**
+installer from IBKR into this directory as
+`ibgateway-latest-standalone-linux-x64.sh`, then build with Compose.
+
+The image runs Gateway on a virtual display and exposes noVNC on port 6080.
+Compose binds it to host loopback only. Reach a cloud host through Tailscale or
+an SSH tunnel; never publish 6080 or the API ports to the internet.
+
+After login, configure API ports 4002 (paper) and/or 4001 (live), automatic
+weekly restarts, trusted localhost/API access, and the intended read-only mode.
+Use a dedicated IBKR username so another Client Portal/TWS login does not break
+Gateway reconnection. Weekly interactive reauthentication remains required.

--- a/deploy/ibgateway/entrypoint.sh
+++ b/deploy/ibgateway/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+if [ "${IB_GATEWAY_DROPPED_PRIVILEGES:-false}" != "true" ]; then
+    runtime_uid=${AURAMAUR_RUNTIME_UID:-1000}
+    runtime_gid=${AURAMAUR_RUNTIME_GID:-1000}
+    groupmod -o -g "$runtime_gid" ibgateway
+    usermod -o -u "$runtime_uid" -g "$runtime_gid" ibgateway
+    install -d -m 1777 /tmp/.X11-unix
+    if ! gosu ibgateway test -w "$HOME/Jts"; then
+        echo "IB Gateway settings are not writable by host UID $runtime_uid: $HOME/Jts" >&2
+        exit 1
+    fi
+    export IB_GATEWAY_DROPPED_PRIVILEGES=true
+    exec gosu ibgateway env HOME=/home/ibgateway "$0" "$@"
+fi
+
+password_file=${IB_GATEWAY_VNC_PASSWORD_FILE:-/run/secrets/ibgateway_vnc_password}
+if [ ! -s "$password_file" ]; then
+    echo "Missing non-empty VNC password secret: $password_file" >&2
+    exit 1
+fi
+
+vnc_runtime=/tmp/auramaur-ibgateway
+mkdir -p "$HOME/Jts" "$vnc_runtime"
+x11vnc -storepasswd "$(cat "$password_file")" "$vnc_runtime/vnc.pass" >/dev/null
+chmod 0600 "$vnc_runtime/vnc.pass"
+
+Xvfb "$DISPLAY" -screen 0 1280x800x24 -nolisten tcp &
+xvfb_pid=$!
+x_socket="/tmp/.X11-unix/X${DISPLAY#:}"
+x_wait=0
+while [ ! -S "$x_socket" ]; do
+    if ! kill -0 "$xvfb_pid" 2>/dev/null; then
+        echo "Xvfb exited before display $DISPLAY became ready" >&2
+        exit 1
+    fi
+    x_wait=$((x_wait + 1))
+    if [ "$x_wait" -ge 100 ]; then
+        echo "Timed out waiting for Xvfb display $DISPLAY" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+fluxbox >/tmp/fluxbox.log 2>&1 &
+x11vnc -display "$DISPLAY" -rfbauth "$vnc_runtime/vnc.pass" \
+    -localhost -forever -shared >/tmp/x11vnc.log 2>&1 &
+websockify --web=/usr/share/novnc/ 6080 localhost:5900 >/tmp/novnc.log 2>&1 &
+
+gateway=$(find "${IB_GATEWAY_HOME:-/opt/ibgateway}" -type f -name ibgateway -perm -u+x | head -1)
+if [ -z "$gateway" ]; then
+    echo "IB Gateway executable not found" >&2
+    exit 1
+fi
+
+echo "IB Gateway GUI ready on container port 6080; authenticate manually."
+exec "$gateway"

--- a/deploy/ibgateway/healthcheck.sh
+++ b/deploy/ibgateway/healthcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+pgrep -f 'ibgateway|java' >/dev/null
+nc -z 127.0.0.1 "${IB_GATEWAY_HEALTH_PORT:-4002}"

--- a/deploy/init-runtime.sh
+++ b/deploy/init-runtime.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+mkdir -p runtime/state/backups runtime/logs runtime/config runtime/claude \
+    runtime/ibgateway secrets
+
+for dir in runtime/state runtime/logs runtime/config runtime/claude runtime/ibgateway secrets; do
+    chmod 0700 "$dir"
+done
+
+if [ ! -f secrets/ibgateway-vnc-password.txt ]; then
+    umask 077
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -base64 24 > secrets/ibgateway-vnc-password.txt
+    else
+        echo "Create a strong password in secrets/ibgateway-vnc-password.txt" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f runtime/config/defaults.local.yaml ]; then
+    printf '%s\n' '# Host-local overrides. Keep execution.live false through shakedown.' \
+        'execution:' '  live: false' > runtime/config/defaults.local.yaml
+    chmod 0600 runtime/config/defaults.local.yaml
+fi
+
+echo "Runtime directories initialized."
+echo "Compose defaults to UID:GID 1000:1000. If this host differs, export"
+echo "AURAMAUR_UID=$(id -u) and AURAMAUR_GID=$(id -g) before Compose commands."
+echo "Install venue secrets under ./secrets and review .env paths before starting."

--- a/deploy/kill-switch.sh
+++ b/deploy/kill-switch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+mkdir -p runtime/state
+touch runtime/state/KILL_SWITCH
+docker compose stop -t 120 auramaur
+echo "KILL_SWITCH armed and Auramaur stopped. IB Gateway remains available for inspection."

--- a/deploy/launchd/is.auramaur.compose.plist.example
+++ b/deploy/launchd/is.auramaur.compose.plist.example
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>is.auramaur.compose</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOURUSER/Auramaur/deploy/start.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/YOURUSER/Auramaur</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/Auramaur/runtime/logs/compose-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/Auramaur/runtime/logs/compose-launchd.log</string>
+</dict>
+</plist>

--- a/deploy/monitor.sh
+++ b/deploy/monitor.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+check() {
+    docker compose ps --status running --services | grep -qx auramaur
+    docker compose ps --status running --services | grep -qx ibgateway
+    docker compose exec -T -e AURAMAUR_HEALTH_REQUIRE_IBKR=true \
+        auramaur python -m auramaur.health
+    docker compose exec -T ibgateway /usr/local/bin/healthcheck.sh
+}
+
+if output=$(check 2>&1); then
+    echo "$output"
+    exit 0
+fi
+
+message="Auramaur deployment unhealthy on $(hostname): $output"
+echo "$message" >&2
+if [ -n "${AURAMAUR_MONITOR_WEBHOOK_URL:-}" ]; then
+    payload=$(printf '%s' "$message" | python3 -c \
+        'import json,sys; print(json.dumps({"content": sys.stdin.read()}))')
+    curl --fail --silent --show-error -X POST \
+        -H 'Content-Type: application/json' \
+        --data "$payload" \
+        "$AURAMAUR_MONITOR_WEBHOOK_URL" >/dev/null
+fi
+exit 1

--- a/deploy/offsite-backup.sh
+++ b/deploy/offsite-backup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+: "${AURAMAUR_BACKUP_AGE_RECIPIENT:?Set an age recipient (age1...)}"
+: "${AURAMAUR_BACKUP_REMOTE:?Set an rclone destination, e.g. remote:auramaur}"
+command -v age >/dev/null || { echo "age is required" >&2; exit 1; }
+command -v rclone >/dev/null || { echo "rclone is required" >&2; exit 1; }
+
+backup=$(deploy/backup.sh | tail -1)
+encrypted="$backup.age"
+trap 'rm -f "$encrypted"' EXIT
+
+age -r "$AURAMAUR_BACKUP_AGE_RECIPIENT" -o "$encrypted" "$backup"
+rclone copyto "$encrypted" "$AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"
+echo "Encrypted backup uploaded: $AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+source_backup=${1:-}
+target=${AURAMAUR_DB_PATH:-runtime/state/auramaur.db}
+
+if [ -z "$source_backup" ] || [ ! -f "$source_backup" ]; then
+    echo "usage: deploy/restore.sh path/to/auramaur-TIMESTAMP.db[.gz]" >&2
+    exit 1
+fi
+if docker compose ps --status running --services 2>/dev/null | grep -qx auramaur; then
+    echo "Auramaur is running; stop it before restoring state." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$target")"
+tmp=$(mktemp "${TMPDIR:-/tmp}/auramaur-restore.XXXXXX.db")
+trap 'rm -f "$tmp"' EXIT
+case "$source_backup" in
+    *.gz) gzip -cd "$source_backup" > "$tmp" ;;
+    *) cp "$source_backup" "$tmp" ;;
+esac
+
+result=$(sqlite3 "$tmp" "PRAGMA integrity_check;")
+if [ "$result" != "ok" ]; then
+    echo "Restore source fails integrity check: $result" >&2
+    exit 1
+fi
+if [ -e "$target" ]; then
+    echo "Refusing to overwrite existing database: $target" >&2
+    echo "Move it aside deliberately, then retry." >&2
+    exit 1
+fi
+mv "$tmp" "$target"
+chmod 0600 "$target"
+echo "Restored $target"

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+export AURAMAUR_UID=${AURAMAUR_UID:-$(id -u)}
+export AURAMAUR_GID=${AURAMAUR_GID:-$(id -g)}
+if [ -f runtime/state/KILL_SWITCH ]; then
+    echo "KILL_SWITCH present; refusing to start." >&2
+    exit 1
+fi
+docker compose up -d --remove-orphans
+docker compose ps

--- a/deploy/systemd/auramaur-backup.service
+++ b/deploy/systemd/auramaur-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Create and upload an encrypted Auramaur SQLite backup
+After=auramaur-compose.service
+
+[Service]
+Type=oneshot
+User=auramaur
+Group=auramaur
+WorkingDirectory=/opt/auramaur
+EnvironmentFile=/etc/auramaur/backup.env
+ExecStart=/opt/auramaur/deploy/offsite-backup.sh

--- a/deploy/systemd/auramaur-backup.timer
+++ b/deploy/systemd/auramaur-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily encrypted off-host Auramaur backup
+
+[Timer]
+OnCalendar=*-*-* 07:15:00 UTC
+RandomizedDelaySec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/auramaur-compose.service
+++ b/deploy/systemd/auramaur-compose.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Auramaur and IB Gateway Compose stack
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathExists=!/opt/auramaur/runtime/state/KILL_SWITCH
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=auramaur
+Group=auramaur
+WorkingDirectory=/opt/auramaur
+ExecStart=/opt/auramaur/deploy/start.sh
+ExecReload=/opt/auramaur/deploy/start.sh
+ExecStop=/usr/bin/docker compose stop -t 120
+TimeoutStartSec=0
+TimeoutStopSec=180
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/auramaur-monitor.service
+++ b/deploy/systemd/auramaur-monitor.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check Auramaur and authenticated IB Gateway health
+After=auramaur-compose.service
+
+[Service]
+Type=oneshot
+User=auramaur
+Group=auramaur
+WorkingDirectory=/opt/auramaur
+EnvironmentFile=-/etc/auramaur/monitor.env
+ExecStart=/opt/auramaur/deploy/monitor.sh

--- a/deploy/systemd/auramaur-monitor.timer
+++ b/deploy/systemd/auramaur-monitor.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Auramaur health checks every five minutes
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=5m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/verify.sh
+++ b/deploy/verify.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+if [ -f runtime/state/KILL_SWITCH ]; then
+    echo "FAIL: runtime/state/KILL_SWITCH is present" >&2
+    exit 1
+fi
+
+running=$(docker compose ps --status running --services | sort)
+echo "$running" | grep -qx auramaur || { echo "FAIL: Auramaur is not running" >&2; exit 1; }
+echo "$running" | grep -qx ibgateway || { echo "FAIL: IB Gateway is not running" >&2; exit 1; }
+
+count=$(docker compose ps --status running --services | grep -cx auramaur)
+[ "$count" -eq 1 ] || { echo "FAIL: expected one Auramaur service" >&2; exit 1; }
+
+docker compose exec -T auramaur python -m auramaur.health
+integrity=$(docker compose exec -T auramaur sqlite3 /app/state/auramaur.db 'PRAGMA quick_check;')
+[ "$integrity" = "ok" ] || { echo "FAIL: database quick_check: $integrity" >&2; exit 1; }
+docker compose exec -T ibgateway /usr/local/bin/healthcheck.sh
+
+echo "Verify OK: one Auramaur service, primary DB healthy, IB Gateway API reachable."
+echo "Compare account IDs, cash, positions, and paper/live mode against each venue UI."

--- a/docs/PORTABLE_DEPLOYMENT.md
+++ b/docs/PORTABLE_DEPLOYMENT.md
@@ -1,0 +1,116 @@
+# Portable workstation and single-VM deployment
+
+Auramaur and IB Gateway are one deployment with separate service lifecycles.
+The same x86-64 Compose stack runs on macOS (including Apple Silicon through
+Docker emulation), WSL 2, and an Ubuntu VM. Never run
+two live Auramaur instances against the same venue accounts.
+
+## Layout
+
+- `auramaur`: trading process, Claude CLI, SQLite, all venue clients
+- `ibgateway`: GUI-capable IB Gateway, persistent Jts settings, private API
+- `runtime/state`: SQLite, kill switch, verified backups
+- `runtime/ibgateway`: durable Gateway configuration
+- `runtime/claude`: container Claude login (or bind `CLAUDE_CONFIG_DIR`)
+- `runtime/config`: host-local YAML overrides
+- `secrets`: PEM/VNC secrets; never committed
+
+IB Gateway's API ports are not published to the host or internet. noVNC binds
+only to `127.0.0.1:6080`; on a VM, reach it with Tailscale or:
+
+```bash
+ssh -L 6080:127.0.0.1:6080 user@vm
+```
+
+Then open `http://127.0.0.1:6080/vnc.html`. IBKR requires interactive GUI
+authentication and weekly reauthentication; the deployment never automates or
+stores the IBKR login/2FA credentials. Use a dedicated IBKR username.
+
+Compose assigns Auramaur the stable private address `172.18.0.3`, which is the
+only non-loopback address that should be added to Gateway's Trusted IP list.
+If `172.18.0.0/16` conflicts with another Docker network, change
+`AURAMAUR_BROKER_SUBNET`, `AURAMAUR_BOT_IP`, and `IB_GATEWAY_IP` together before
+the first start.
+
+## First installation
+
+1. Install Docker Engine/Desktop with Compose.
+2. Download IBKR's current offline Linux x86-64 IB Gateway installer into
+   `deploy/ibgateway/ibgateway-latest-standalone-linux-x64.sh`.
+3. Run `deploy/init-runtime.sh`.
+   If the host user is not UID/GID 1000, export `AURAMAUR_UID=$(id -u)` and
+   `AURAMAUR_GID=$(id -g)` for every Compose invocation (a Compose env file is
+   convenient). This keeps bind-mounted state writable without running the bot
+   as root.
+4. Copy `.env.example` to `.env`; keep `AURAMAUR_LIVE=false`,
+   `AURAMAUR_CONTAINER_LIVE=false`, and
+   `AURAMAUR_CONTAINER_ENABLE_TRANSFERS=false`. The Compose-specific gates
+   prevent a parallel deployment from inheriting authority from a legacy
+   workstation `.env`.
+5. Put the Kalshi PEM and other file secrets in `secrets/`; use container paths
+   such as `KALSHI_PRIVATE_KEY_PATH=/run/auramaur-kalshi-private.pem`, and set
+   `KALSHI_PRIVATE_KEY_SOURCE` to its host path. Existing workstations default
+   to `./private-key.pem`; new deployments should use
+   `./secrets/kalshi-private.pem`.
+6. Copy any deliberate overrides into `runtime/config/defaults.local.yaml`.
+7. `docker compose build` and `deploy/start.sh`.
+8. Authenticate the dedicated live IBKR quote account through the secured
+   noVNC tunnel and configure API port 4002, auto-restart, API access, and
+   read-only mode. This live login supplies market data only: keep
+   `IBKR__PAPER_TRADE=true`, both Compose arming gates false, and Auramaur's
+   local configuration `execution.live=false` throughout the shakedown. The
+   Compose default enables the read-only six-book local simulator while
+   leaving the order-capable options path and separate ETF/OpenAI experiment
+   disabled.
+9. Run a multi-hour paper shakedown and `deploy/verify.sh`.
+
+Claude Code credentials persist in `runtime/claude`. Authenticate from the
+container with `docker compose exec auramaur claude`; for an existing host login,
+set `CLAUDE_CONFIG_DIR` to that host directory before starting Compose.
+
+## Supervisors
+
+On an Ubuntu VM create an `auramaur` system user with Docker access, make it the
+owner of `/opt/auramaur`, then install `deploy/systemd/auramaur-compose.service`
+under `/etc/systemd/system`. Enable it only after paper verification. On WSL,
+systemd does not by itself guarantee the
+WSL VM remains active; add a Windows Task Scheduler action at boot that invokes
+the distro and starts this unit. The macOS LaunchAgent example is for Docker
+Desktop and must not be loaded alongside the legacy native LaunchAgent.
+
+## Backup and restore
+
+`deploy/backup.sh` uses SQLite's online backup API, integrity-checks the result,
+compresses it, and retains 14 local copies by default. Copy these encrypted to
+off-host object storage. `deploy/offsite-backup.sh` encrypts with an age public
+recipient and uploads through rclone; configure only the public recipient and
+remote destination on the VM. `deploy/restore.sh BACKUP` refuses to run while
+Auramaur is active or overwrite an existing DB.
+
+The supplied systemd monitor timer checks both containers, the SQLite schema,
+and the authenticated IB Gateway API socket every five minutes. It can post to
+`AURAMAUR_MONITOR_WEBHOOK_URL`. The backup timer runs encrypted off-host backup
+daily. Install and enable these units only after their environment files under
+`/etc/auramaur` have been reviewed.
+
+## Immutable releases
+
+Tags and manual runs of `.github/workflows/container.yml` publish an amd64
+Auramaur image to GHCR with both release and full-commit tags. Set
+`AURAMAUR_IMAGE` and an immutable `AURAMAUR_VERSION` on the VM. IB Gateway is
+built privately from the operator-downloaded IBKR installer and is never
+published by this repository.
+
+## Cutover
+
+1. Stage and paper-test NEW with `scripts/migrate_portable.sh stage`.
+2. OLD: `scripts/migrate_portable.sh freeze`, then `export`.
+3. Transfer the verified DB backup, `.env`, `secrets/`, local config, Gateway
+   settings, and Claude authentication through an encrypted channel.
+4. Restore on NEW while stopped. Leave OLD kill-switched.
+5. Start NEW, authenticate Gateway if necessary, and run `deploy/verify.sh`.
+6. Compare account IDs, cash, positions, open orders, and live/paper mode with
+   every venue UI before accepting the cutover.
+
+Rollback requires stopping and kill-switching NEW first. If NEW traded, its DB
+is authoritative and must be backed up and restored to OLD before restart.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-kalshi = ["kalshi-python>=2.1.0"]
+# kalshi-python 2.1.x imports cryptography but omits it from its wheel metadata.
+kalshi = ["kalshi-python>=2.1.0", "cryptography>=42.0"]
 ibkr = ["ib_async>=1.0.0"]
 # Semantic evidence ranking. Optional: without it, relevance scoring falls back
 # to scikit-learn TF-IDF and then a no-dependency heuristic.

--- a/scripts/migrate_portable.sh
+++ b/scripts/migrate_portable.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Portable cutover helper for native macOS, WSL/Linux, and Compose hosts.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+case "${1:-}" in
+  stage)
+    command -v docker >/dev/null || fail "docker missing"
+    docker compose version >/dev/null || fail "Docker Compose plugin missing"
+    [ ! -f .env ] || fail "stage must run without live .env credentials"
+    [ -f deploy/ibgateway/ibgateway-latest-standalone-linux-x64.sh ] \
+      || fail "IB Gateway offline installer missing; see deploy/ibgateway/README.md"
+    deploy/init-runtime.sh
+    docker compose config >/dev/null
+    echo "Stage OK. Build and run the stack in paper mode; authenticate IB Gateway paper."
+    ;;
+  freeze)
+    mkdir -p runtime/state
+    touch runtime/state/KILL_SWITCH KILL_SWITCH
+    if command -v docker >/dev/null && docker compose ps --services 2>/dev/null | grep -qx auramaur; then
+      docker compose stop -t 120 auramaur
+    elif pgrep -f 'auramaur run' >/dev/null; then
+      pkill -TERM -f 'auramaur run'
+      i=0
+      while pgrep -f 'auramaur run' >/dev/null && [ "$i" -lt 60 ]; do sleep 2; i=$((i + 1)); done
+    fi
+    pgrep -f 'auramaur run' >/dev/null && fail "Auramaur process still running"
+    echo "FROZEN. Leave both kill switches in place on this host."
+    ;;
+  export)
+    [ -f KILL_SWITCH ] || [ -f runtime/state/KILL_SWITCH ] \
+      || fail "freeze this host before exporting"
+    pgrep -f 'auramaur run' >/dev/null && fail "Auramaur process still running"
+    mkdir -p runtime/state/backups
+    if [ -f runtime/state/auramaur.db ]; then
+      AURAMAUR_DB_PATH=runtime/state/auramaur.db deploy/backup.sh
+    elif [ -f auramaur.db ]; then
+      AURAMAUR_DB_PATH=auramaur.db AURAMAUR_BACKUP_DIR=runtime/state/backups deploy/backup.sh
+    else
+      fail "no Auramaur database found"
+    fi
+    echo "Export ready. Transfer the newest verified backup plus .env, secrets/,"
+    echo "runtime/config/, runtime/ibgateway/, and Claude credentials separately."
+    ;;
+  verify)
+    deploy/verify.sh
+    ;;
+  *)
+    echo "usage: scripts/migrate_portable.sh stage|freeze|export|verify" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sqlite3
+
+from auramaur.health import _database_health
+
+
+def test_database_health_requires_database(tmp_path):
+    ok, detail = _database_health(tmp_path / "missing.db")
+    assert ok is False
+    assert detail == "database missing"
+
+
+def test_database_health_reads_schema_version(tmp_path):
+    path = tmp_path / "healthy.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (24)")
+    ok, detail = _database_health(path)
+    assert ok is True
+    assert detail == "schema version 24"
+
+
+def test_database_health_rejects_uninitialized_sqlite(tmp_path):
+    path = tmp_path / "empty.db"
+    with sqlite3.connect(path):
+        pass
+    ok, detail = _database_health(path)
+    assert ok is False
+    assert "schema_version" in detail

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from auramaur import runtime
+from auramaur.db.database import Database
+
+
+def test_runtime_paths_default_to_repo(monkeypatch):
+    for name in (
+        "AURAMAUR_STATE_DIR", "AURAMAUR_DB_PATH", "AURAMAUR_LOG_DIR",
+        "AURAMAUR_KILL_SWITCH_PATH",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert runtime.db_path() == runtime.REPO_ROOT / "auramaur.db"
+    assert runtime.kill_switch_path() == runtime.REPO_ROOT / "KILL_SWITCH"
+
+
+def test_runtime_paths_are_environment_overridable(tmp_path, monkeypatch):
+    monkeypatch.setenv("AURAMAUR_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("AURAMAUR_LOG_DIR", str(tmp_path / "logs"))
+    assert runtime.db_path() == tmp_path / "state" / "auramaur.db"
+    assert runtime.log_dir() == tmp_path / "logs"
+
+    explicit = tmp_path / "other.db"
+    monkeypatch.setenv("AURAMAUR_DB_PATH", str(explicit))
+    assert runtime.db_path() == explicit
+    assert Database().db_path == str(explicit)
+
+
+def test_explicit_database_path_wins(tmp_path, monkeypatch):
+    monkeypatch.setenv("AURAMAUR_DB_PATH", str(tmp_path / "runtime.db"))
+    assert Database(":memory:").db_path == ":memory:"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -190,6 +190,14 @@ def test_hf_token_empty_leaves_environ_untouched(monkeypatch):
     assert "HF_TOKEN" not in os.environ
 
 
+def test_nested_environment_override_for_portable_broker(monkeypatch):
+    monkeypatch.setenv("IBKR__HOST", "ibgateway")
+    monkeypatch.setenv("IBKR__PAPER_PORT", "4002")
+    settings = Settings()
+    assert settings.ibkr.host == "ibgateway"
+    assert settings.ibkr.paper_port == 4002
+
+
 @pytest.mark.parametrize("override", [
     {"etf_symbols": ["SPY", "SPY"]},
     {"etf_paper_budget_usd": 100, "etf_max_entry_usd": 101},

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,7 @@ ibkr = [
     { name = "ib-async" },
 ]
 kalshi = [
+    { name = "cryptography" },
     { name = "kalshi-python" },
 ]
 
@@ -320,6 +321,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
     { name = "asyncpraw", specifier = ">=7.7" },
     { name = "click", specifier = ">=8.1" },
+    { name = "cryptography", marker = "extra == 'kalshi'", specifier = ">=42.0" },
     { name = "ddgs", specifier = ">=7.0" },
     { name = "fastmcp", marker = "extra == 'agent'", specifier = ">=2" },
     { name = "feedparser", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary
- package Auramaur and IB Gateway as a portable amd64 Compose stack for macOS, WSL 2, and a single Ubuntu VM
- persist application state, Gateway settings, Claude credentials, logs, and host-local configuration outside containers
- use a dedicated live IBKR session as a read-only quote source while all six IBKR books execute in the local paper ledger
- add backups, restore verification, monitoring, kill-switch, migration helpers, systemd and launchd supervisors, and an immutable GHCR workflow
- assign stable private service addresses for the Gateway Trusted IP restriction and wait for Xvfb before launching Gateway
- keep live execution and transfers behind separate Compose-specific gates that default off

## Safety
- IBKR API ports are private to the Compose network
- noVNC binds only to host loopback
- IBKR order-capable options and ETF OpenAI paths remain disabled
- installer, credentials, private keys, runtime state, and local configuration are ignored

## Validation
- 1167 passed, 1 skipped
- Ruff passes
- Compose configuration validates
- shell entrypoints and deployment scripts pass syntax checks
- both production-shaped containers report healthy
- isolated Gateway smoke test reaches the GUI without an X11 startup race
- read-only API probe confirms the dedicated IBKR account connection