### PR TITLE
Portability hardening: private-state bundle, env schema, single migration path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ POLYGON_PRIVATE_KEY=0x...
 POLYMARKET_API_KEY=
 POLYMARKET_API_SECRET=
 POLYMARKET_PASSPHRASE=
+# Proxy-wallet address (0x...) — needed by the redeem/maintenance CLIs.
+POLYMARKET_PROXY_ADDRESS=
 
 # Kalshi (config: kalshi.enabled + kalshi.environment=demo|prod)
 # API key ID from the Kalshi dashboard, plus the path to the RSA private key
@@ -38,6 +40,10 @@ KRAKEN_API_SECRET=
 # Google Gemini — LLM fallback for off-hours / when Claude's daily budget is low
 # (config: gemini.enabled + gemini.model). Get a key at aistudio.google.com.
 GEMINI_API_KEY=
+
+# Claude CLI token auth — alternative to the interactive /login for headless
+# or container hosts (docker compose exec auramaur claude). Optional.
+# CLAUDE_CODE_OAUTH_TOKEN=
 
 # Hugging Face Hub — free read token for the evidence-relevance embedder
 # (sentence-transformers model downloads). Anonymous access works but is

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ logs/
 runtime/
 secrets/
 deploy/ibgateway/ibgateway-*-standalone-linux-x64.sh
+
+# Encrypted backup/bundle blobs — off-host artifacts, never versioned
+*.age

--- a/deploy/check-env.py
+++ b/deploy/check-env.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Env-schema drift checker: manifest vs .env.example vs local .env.
+
+Compares NAMES ONLY. Values are never read into memory as values — each line
+is split at the first '=' and everything right of it is discarded immediately.
+Nothing right of an '=' is ever printed.
+
+Checks:
+  1. every manifest entry (unless in_example: false) appears in .env.example
+  2. every .env.example name appears in the manifest
+  3. if .env exists: every name in it is known to the manifest
+     (unknown names are usually typos or no-ops, e.g. KALSHI_ENABLED)
+  4. with --profile live: every `required: live` name is present in .env
+
+Exit 0 clean, 1 on drift.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+# Nested pydantic-settings overrides (env_nested_delimiter="__") are an open
+# namespace mapping onto config; any FOO__BAR name is legitimate.
+NESTED = "__"
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def env_names(path: Path, include_commented: bool) -> set[str]:
+    names: set[str] = set()
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if include_commented and line.startswith("#"):
+            line = line.lstrip("# ")
+        if "=" not in line or line.startswith("#"):
+            continue
+        name = line.split("=", 1)[0].strip()
+        if NAME_RE.match(name):
+            names.add(name)
+    return names
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", choices=["paper", "live"], default="paper",
+                    help="live additionally requires the `required: live` set in .env")
+    args = ap.parse_args()
+
+    manifest_path = ROOT / "deploy" / "env.manifest.yaml"
+    manifest: dict[str, dict] = yaml.safe_load(manifest_path.read_text())
+    bad_names = [n for n in manifest if not NAME_RE.match(n)]
+    if bad_names:
+        print(f"DRIFT: malformed manifest names: {sorted(bad_names)}")
+        return 1
+
+    example = env_names(ROOT / ".env.example", include_commented=True)
+    problems: list[str] = []
+
+    for name, spec in manifest.items():
+        if spec.get("in_example", True) and name not in example:
+            problems.append(f"manifest name missing from .env.example: {name}")
+    for name in sorted(example - manifest.keys()):
+        if NESTED in name:
+            continue
+        problems.append(f".env.example name missing from manifest: {name}")
+
+    dotenv = ROOT / ".env"
+    if dotenv.exists():
+        local = env_names(dotenv, include_commented=False)
+        for name in sorted(local):
+            if name in manifest or NESTED in name:
+                continue
+            problems.append(f"unknown name in .env (typo or no-op?): {name}")
+        if args.profile == "live":
+            required = {n for n, s in manifest.items() if s.get("required") == "live"}
+            for name in sorted(required - local):
+                problems.append(f"required-for-live name missing from .env: {name}")
+    elif args.profile == "live":
+        problems.append("no .env present but --profile live requested")
+
+    if problems:
+        print(f"DRIFT ({len(problems)}):")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print("env schema clean: manifest, .env.example"
+          + (", .env" if dotenv.exists() else "") + " agree")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/env.manifest.yaml
+++ b/deploy/env.manifest.yaml
@@ -1,0 +1,112 @@
+# Environment-variable schema. NAMES AND CLASSIFICATION ONLY — never values.
+# deploy/check-env.py enforces this against .env.example and the local .env
+# (names only; values are never read). Every variable any deployment reads
+# must have an entry; an unknown name in .env is treated as drift (it is
+# usually a typo or a no-op, e.g. KALSHI_ENABLED vs the kalshi.enabled config).
+#
+# type:
+#   secret       sensitive value (keys, tokens, private keys)
+#   secret_file  value is a path pointing at a secret file on disk
+#   config       non-sensitive setting
+# required:
+#   live         must be present in .env on a live host (check-env --profile live)
+#   optional     may be absent; consumers fall back to defaults
+#   invocation   supplied per-invocation to deploy tooling, not kept in .env
+# targets: where the variable is consumed (host = native process, compose,
+#   deploy = backup/migration/monitor tooling)
+# in_example: false marks names deliberately absent from .env.example
+#   (deploy tooling and Compose build-time knobs)
+
+# LLM providers
+ANTHROPIC_API_KEY_PRIMARY:   {type: secret, required: live, targets: [host, compose]}
+ANTHROPIC_API_KEY_SECONDARY: {type: secret, required: optional, targets: [host, compose]}
+OPENAI_API_KEY:              {type: secret, required: optional, targets: [host, compose]}
+GEMINI_API_KEY:              {type: secret, required: optional, targets: [host, compose]}
+HF_TOKEN:                    {type: secret, required: optional, targets: [host, compose]}
+CLAUDE_CODE_OAUTH_TOKEN:     {type: secret, required: optional, targets: [host, compose]}
+
+# Polymarket
+POLYGON_PRIVATE_KEY:       {type: secret, required: live, targets: [host, compose]}
+POLYMARKET_API_KEY:        {type: secret, required: optional, targets: [host, compose]}
+POLYMARKET_API_SECRET:     {type: secret, required: optional, targets: [host, compose]}
+POLYMARKET_PASSPHRASE:     {type: secret, required: optional, targets: [host, compose]}
+POLYMARKET_PROXY_ADDRESS:  {type: config, required: optional, targets: [host, compose]}
+
+# Kalshi
+KALSHI_API_KEY:            {type: secret, required: optional, targets: [host, compose]}
+KALSHI_PRIVATE_KEY_PATH:   {type: secret_file, required: optional, targets: [host, compose]}
+KALSHI_PRIVATE_KEY_SOURCE: {type: secret_file, required: optional, targets: [compose]}
+
+# Other venues
+CRYPTODOTCOM_API_KEY:      {type: secret, required: optional, targets: [host, compose]}
+CRYPTODOTCOM_API_SECRET:   {type: secret, required: optional, targets: [host, compose]}
+KRAKEN_API_KEY:            {type: secret, required: optional, targets: [host, compose]}
+KRAKEN_API_SECRET:         {type: secret, required: optional, targets: [host, compose]}
+
+# Data sources
+NEWSAPI_KEY:          {type: secret, required: optional, targets: [host, compose]}
+REDDIT_CLIENT_ID:     {type: secret, required: optional, targets: [host, compose]}
+REDDIT_CLIENT_SECRET: {type: secret, required: optional, targets: [host, compose]}
+REDDIT_USER_AGENT:    {type: config, required: optional, targets: [host, compose]}
+TWITTER_BEARER_TOKEN: {type: secret, required: optional, targets: [host, compose]}
+FRED_API_KEY:         {type: secret, required: optional, targets: [host, compose]}
+BLS_API_KEY:          {type: secret, required: optional, targets: [host, compose]}
+BEA_API_KEY:          {type: secret, required: optional, targets: [host, compose]}
+CONGRESS_API_KEY:     {type: secret, required: optional, targets: [host, compose]}
+EIA_API_KEY:          {type: secret, required: optional, targets: [host, compose]}
+
+# Alerts
+TELEGRAM_BOT_TOKEN:  {type: secret, required: optional, targets: [host, compose]}
+TELEGRAM_CHAT_ID:    {type: config, required: optional, targets: [host, compose]}
+DISCORD_WEBHOOK_URL: {type: secret, required: optional, targets: [host, compose]}
+
+# Risk / safety gates
+RISK_TOLERANCE:                      {type: config, required: optional, targets: [host, compose]}
+AURAMAUR_LIVE:                       {type: config, required: live, targets: [host, compose]}
+AURAMAUR_CONTAINER_LIVE:             {type: config, required: live, targets: [compose]}
+AURAMAUR_CONTAINER_ENABLE_TRANSFERS: {type: config, required: live, targets: [compose]}
+AURAMAUR_ENABLE_TRANSFERS:           {type: config, required: optional, targets: [host, compose]}
+
+# IBKR
+IBKR_ENABLED:                  {type: config, required: optional, targets: [host, compose]}
+IBKR_QUOTE_ENVIRONMENT:        {type: config, required: optional, targets: [compose]}
+IBKR_QUOTE_PORT:               {type: config, required: optional, targets: [compose]}
+IBKR_MULTIASSET_PAPER_ENABLED: {type: config, required: optional, targets: [compose]}
+AURAMAUR_HEALTH_REQUIRE_IBKR:  {type: config, required: optional, targets: [host, compose], in_example: false}
+AURAMAUR_IBKR_ENVIRONMENT:     {type: config, required: optional, targets: [host], in_example: false}
+AURAMAUR_IBKR_HOST:            {type: config, required: optional, targets: [host], in_example: false}
+AURAMAUR_IBKR_PORT:            {type: config, required: optional, targets: [host], in_example: false}
+
+# Compose networking / images (build- and up-time)
+AURAMAUR_BROKER_SUBNET: {type: config, required: optional, targets: [compose]}
+AURAMAUR_BOT_IP:        {type: config, required: optional, targets: [compose]}
+IB_GATEWAY_IP:          {type: config, required: optional, targets: [compose]}
+AURAMAUR_UID:           {type: config, required: invocation, targets: [compose], in_example: false}
+AURAMAUR_GID:           {type: config, required: invocation, targets: [compose], in_example: false}
+AURAMAUR_IMAGE:         {type: config, required: invocation, targets: [compose], in_example: false}
+AURAMAUR_VERSION:       {type: config, required: invocation, targets: [compose], in_example: false}
+AURAMAUR_PLATFORM:      {type: config, required: invocation, targets: [compose], in_example: false}
+CLAUDE_CODE_VERSION:    {type: config, required: invocation, targets: [compose], in_example: false}
+CLAUDE_CONFIG_DIR:      {type: config, required: invocation, targets: [compose], in_example: false}
+IB_GATEWAY_HEALTH_PORT: {type: config, required: invocation, targets: [compose], in_example: false}
+IB_GATEWAY_IMAGE:       {type: config, required: invocation, targets: [compose], in_example: false}
+IB_GATEWAY_INSTALLER:   {type: config, required: invocation, targets: [compose], in_example: false}
+IB_GATEWAY_NOVNC_PORT:  {type: config, required: invocation, targets: [compose], in_example: false}
+IB_GATEWAY_VERSION:     {type: config, required: invocation, targets: [compose], in_example: false}
+
+# Portable runtime paths
+AURAMAUR_STATE_DIR:        {type: config, required: optional, targets: [host, compose]}
+AURAMAUR_DB_PATH:          {type: config, required: optional, targets: [host, compose, deploy]}
+AURAMAUR_LOG_DIR:          {type: config, required: optional, targets: [host, compose]}
+AURAMAUR_KILL_SWITCH_PATH: {type: config, required: optional, targets: [host, compose]}
+AURAMAUR_LOCAL_CONFIG:     {type: config, required: optional, targets: [host, compose]}
+AGENT_DB_PATH:             {type: config, required: optional, targets: [host], in_example: false}
+
+# Backup / monitor tooling (never kept in .env; exported where the timers run)
+AURAMAUR_BACKUP_AGE_RECIPIENT: {type: config, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_BACKUP_AGE_IDENTITY:  {type: secret_file, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_BACKUP_REMOTE:        {type: config, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_BACKUP_DIR:           {type: config, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_BACKUP_KEEP:          {type: config, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_BUNDLE_NO_UPLOAD:     {type: config, required: invocation, targets: [deploy], in_example: false}
+AURAMAUR_MONITOR_WEBHOOK_URL:  {type: secret, required: invocation, targets: [deploy], in_example: false}

--- a/deploy/offsite-backup.sh
+++ b/deploy/offsite-backup.sh
@@ -3,7 +3,7 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-: "${AURAMAUR_BACKUP_AGE_RECIPIENT:?Set an age recipient (age1...)}"
+: "${AURAMAUR_BACKUP_AGE_RECIPIENT:?Set one or more age recipients (age1..., space-separated)}"
 : "${AURAMAUR_BACKUP_REMOTE:?Set an rclone destination, e.g. remote:auramaur}"
 command -v age >/dev/null || { echo "age is required" >&2; exit 1; }
 command -v rclone >/dev/null || { echo "rclone is required" >&2; exit 1; }
@@ -12,6 +12,8 @@ backup=$(deploy/backup.sh | tail -1)
 encrypted="$backup.age"
 trap 'rm -f "$encrypted"' EXIT
 
-age -r "$AURAMAUR_BACKUP_AGE_RECIPIENT" -o "$encrypted" "$backup"
+set --
+for r in $AURAMAUR_BACKUP_AGE_RECIPIENT; do set -- "$@" -r "$r"; done
+age "$@" -o "$encrypted" "$backup"
 rclone copyto "$encrypted" "$AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"
 echo "Encrypted backup uploaded: $AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"

--- a/deploy/offsite-bundle.sh
+++ b/deploy/offsite-bundle.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Full private-state bundle: everything a bare host needs beyond git + the DB.
+# The DB has its own daily path (deploy/offsite-backup.sh); run THIS after any
+# credential/config change and at least monthly. See docs/SECRETS.md.
+set -eu
+umask 077
+
+cd "$(dirname "$0")/.."
+
+: "${AURAMAUR_BACKUP_AGE_RECIPIENT:?Set one or more age recipients (age1..., space-separated)}"
+command -v age >/dev/null || { echo "age is required" >&2; exit 1; }
+if [ "${AURAMAUR_BUNDLE_NO_UPLOAD:-0}" != "1" ]; then
+    : "${AURAMAUR_BACKUP_REMOTE:?Set an rclone destination, or AURAMAUR_BUNDLE_NO_UPLOAD=1}"
+    command -v rclone >/dev/null || { echo "rclone is required" >&2; exit 1; }
+fi
+
+# Private state beyond the checkout and the SQLite backups. Deliberately
+# explicit, mirrors docs/PORTABLE_DEPLOYMENT.md "Cutover" item 3.
+members=""
+for m in .env secrets config/defaults.local.yaml runtime/config \
+         runtime/ibgateway runtime/claude; do
+    if [ -e "$m" ]; then
+        members="$members $m"
+    else
+        echo "WARN: $m missing — not bundled (ok if it never existed)" >&2
+    fi
+done
+case " $members " in
+    *" .env "*|*" secrets "*) ;;
+    *) echo "Nothing secret to bundle (no .env, no secrets/) — aborting" >&2; exit 1 ;;
+esac
+
+out_dir=${AURAMAUR_BACKUP_DIR:-runtime/state/backups}
+mkdir -p "$out_dir"
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+plain="$out_dir/auramaur-bundle-$timestamp.tar.gz"
+encrypted="$plain.age"
+trap 'rm -f "$plain"' EXIT
+
+# Gateway logs are bulky and operational — never leave the host.
+# shellcheck disable=SC2086 # members is a space-separated repo-relative list
+tar --exclude '*.log' --exclude '*.log.*' -czf "$plain" $members
+
+set --
+for r in $AURAMAUR_BACKUP_AGE_RECIPIENT; do set -- "$@" -r "$r"; done
+age "$@" -o "$encrypted" "$plain"
+chmod 0600 "$encrypted"
+
+echo "Bundle members:$members"
+if [ "${AURAMAUR_BUNDLE_NO_UPLOAD:-0}" = "1" ]; then
+    echo "Encrypted bundle (NOT uploaded): $encrypted"
+else
+    rclone copyto "$encrypted" "$AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"
+    echo "Encrypted bundle uploaded: $AURAMAUR_BACKUP_REMOTE/$(basename "$encrypted")"
+fi

--- a/deploy/restore-bundle.sh
+++ b/deploy/restore-bundle.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Decrypt and stage a private-state bundle made by deploy/offsite-bundle.sh.
+# Extracts into a fresh staging directory — never directly over a live tree —
+# so the operator diffs/moves files deliberately. See docs/SECRETS.md.
+set -eu
+umask 077
+
+cd "$(dirname "$0")/.."
+
+bundle=${1:-}
+dest=${2:-runtime/restore-$(date -u +%Y%m%dT%H%M%SZ)}
+identity=${AURAMAUR_BACKUP_AGE_IDENTITY:-}
+
+if [ -z "$bundle" ] || [ ! -f "$bundle" ]; then
+    echo "usage: deploy/restore-bundle.sh bundle.tar.gz.age [dest-dir]" >&2
+    echo "       AURAMAUR_BACKUP_AGE_IDENTITY=path/to/age-identity.txt" >&2
+    exit 1
+fi
+[ -n "$identity" ] && [ -f "$identity" ] \
+    || { echo "AURAMAUR_BACKUP_AGE_IDENTITY must point at an age identity file" >&2; exit 1; }
+command -v age >/dev/null || { echo "age is required" >&2; exit 1; }
+if [ -e "$dest" ]; then
+    echo "Refusing to extract into existing path: $dest" >&2
+    exit 1
+fi
+
+plain=$(mktemp "${TMPDIR:-/tmp}/auramaur-bundle.XXXXXX.tar.gz")
+trap 'rm -f "$plain"' EXIT
+age -d -i "$identity" -o "$plain" "$bundle"
+
+# No absolute paths, no traversal — a tampered bundle must not write outside dest.
+if tar -tzf "$plain" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+    echo "Bundle contains absolute or traversal paths — refusing to extract" >&2
+    exit 1
+fi
+for expected in .env secrets/kalshi-private.pem; do
+    tar -tzf "$plain" | grep -qx "$expected" \
+        || echo "WARN: expected member missing from bundle: $expected" >&2
+done
+
+mkdir -p "$dest"
+tar -xzf "$plain" -C "$dest"
+chmod -R go-rwx "$dest"
+
+echo "Staged into: $dest"
+echo "Review, then move members into place (paths are repo-relative)."
+echo "The database is separate: deploy/restore.sh <auramaur-*.db.gz>"

--- a/docs/MIGRATION_HOST.md
+++ b/docs/MIGRATION_HOST.md
@@ -1,4 +1,11 @@
-# Host migration checklist
+# Host migration checklist (DEPRECATED — native launchd path)
+
+> **DEPRECATED 2026-07.** The deployment is the portable Compose stack;
+> migrate with `scripts/migrate_portable.sh` per `docs/PORTABLE_DEPLOYMENT.md`
+> (private state travels as a `deploy/offsite-bundle.sh` bundle — see
+> `docs/SECRETS.md`). Of `scripts/migrate_host.sh`, only `decommission`
+> survives, for wiping a native host before hand-back; Phase 3 below remains
+> its checklist. Phases 1–2 are historical.
 
 Moving the bot to a new machine (e.g. laptop replacement). The companion
 script `scripts/migrate_host.sh` mechanizes each phase; this file is the
@@ -70,9 +77,10 @@ the NEW bot traded; if it did, rsync the DB BACK before restarting OLD.
 
 On OLD: `scripts/migrate_host.sh decommission`
 — after an interactive confirmation it: bootouts + deletes the
-LaunchAgent, securely removes `.env` (Polygon private key + venue API
-keys — the real hazard on a returned machine), removes the DBs/WAL,
-logs, local config, `~/.claude` credentials, and the repo checkout.
+LaunchAgent, securely removes `.env` and `private-key.pem` (Polygon
+private key + venue API keys — the real hazard on a returned machine),
+removes `secrets/`, the DBs/WAL, logs, `runtime/` (Gateway + Claude
+state), local config, and the cached Gateway installer.
 Also remember, outside this repo's scope:
 
 - [ ] Straummaur: stop its recorder, rsync `~/Straummaur/data` to NEW,

--- a/docs/PORTABLE_DEPLOYMENT.md
+++ b/docs/PORTABLE_DEPLOYMENT.md
@@ -82,10 +82,18 @@ Desktop and must not be loaded alongside the legacy native LaunchAgent.
 
 `deploy/backup.sh` uses SQLite's online backup API, integrity-checks the result,
 compresses it, and retains 14 local copies by default. Copy these encrypted to
-off-host object storage. `deploy/offsite-backup.sh` encrypts with an age public
-recipient and uploads through rclone; configure only the public recipient and
+off-host object storage. `deploy/offsite-backup.sh` encrypts with age public
+recipients (space-separated; use at least a primary plus an offline recovery
+recipient) and uploads through rclone; configure only the public recipients and
 remote destination on the VM. `deploy/restore.sh BACKUP` refuses to run while
 Auramaur is active or overwrite an existing DB.
+
+The database is only half the private state. `deploy/offsite-bundle.sh`
+bundles `.env`, `secrets/`, local YAML overrides, Gateway settings, and Claude
+authentication into one age-encrypted tarball and uploads it; run it after any
+credential or config change. `deploy/restore-bundle.sh` stages a bundle into a
+fresh directory for deliberate placement. Identity handling, rotation, and the
+quarterly restore drill are documented in `docs/SECRETS.md`.
 
 The supplied systemd monitor timer checks both containers, the SQLite schema,
 and the authenticated IB Gateway API socket every five minutes. It can post to
@@ -105,8 +113,10 @@ published by this repository.
 
 1. Stage and paper-test NEW with `scripts/migrate_portable.sh stage`.
 2. OLD: `scripts/migrate_portable.sh freeze`, then `export`.
-3. Transfer the verified DB backup, `.env`, `secrets/`, local config, Gateway
-   settings, and Claude authentication through an encrypted channel.
+3. Transfer the verified DB backup plus a `deploy/offsite-bundle.sh` bundle
+   (covers `.env`, `secrets/`, local config, Gateway settings, and Claude
+   authentication) through an encrypted channel; stage on NEW with
+   `deploy/restore-bundle.sh`.
 4. Restore on NEW while stopped. Leave OLD kill-switched.
 5. Start NEW, authenticate Gateway if necessary, and run `deploy/verify.sh`.
 6. Compare account IDs, cash, positions, open orders, and live/paper mode with

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,77 @@
+# Secrets, encrypted bundles, and the age identity
+
+This repository is **public**. Nothing secret is ever committed — not even
+encrypted. Private state lives on the host and, encrypted, in off-host object
+storage. Git history on a protected branch cannot be scrubbed, so the rule has
+no exceptions.
+
+## What is private state
+
+Two pieces, with different cadences:
+
+1. **The database** — `deploy/backup.sh` (local, verified) and
+   `deploy/offsite-backup.sh` (age-encrypted, uploaded via rclone). Runs daily
+   via the supplied systemd timer.
+2. **Everything else a bare host needs** — `deploy/offsite-bundle.sh` bundles
+   `.env`, `secrets/`, `config/defaults.local.yaml`, `runtime/config/`,
+   `runtime/ibgateway/` (minus logs), and `runtime/claude/` into one
+   age-encrypted tarball and uploads it. Run it **after any credential or
+   config change**, and at least monthly.
+
+Restore is the mirror image: `deploy/restore-bundle.sh BUNDLE.tar.gz.age`
+stages into a fresh directory (never over a live tree), then
+`deploy/restore.sh BACKUP.db.gz` for the database.
+
+Deliberately **not** in the bundle: the age identity itself (see below), the
+rclone configuration (recreate it from the storage provider's console), the IB
+Gateway installer (re-download from IBKR), and anything outside this repo
+(Straummaur data, `~/.hermes`).
+
+## The age identity
+
+Encryption uses public recipients only — hosts that take backups never hold a
+decryption key. `AURAMAUR_BACKUP_AGE_RECIPIENT` accepts **multiple
+space-separated recipients**; every bundle should be encrypted to at least two:
+
+- **Primary identity** — lives in a password manager or hardware-backed key
+  store. Used for routine restores.
+- **Recovery identity** — generated once, stored **offline** (printed or on a
+  USB stick in a separate physical location). Never typed into a cloud
+  service.
+- Optional per-machine identity added during provisioning, removed when the
+  machine is decommissioned.
+
+Rules:
+
+- The identity never touches GitHub — not the repository, not Actions
+  secrets. A passphrase held only in Actions secrets is a single point of
+  failure owned by someone else; do not use it as a recovery path.
+- Losing every identity means the backups are noise. The recovery identity
+  exists so that losing the password manager is survivable.
+- Rotating: generate a new pair, add the new recipient, re-run
+  `offsite-bundle.sh` and `offsite-backup.sh`, then retire the old identity
+  once fresh backups exist under the new one.
+
+## Restore drill
+
+A backup that has never been restored is a hope, not a backup. Quarterly, on
+any machine with `age` installed:
+
+```sh
+AURAMAUR_BACKUP_AGE_IDENTITY=path/to/identity.txt \
+  deploy/restore-bundle.sh path/to/auramaur-bundle-*.tar.gz.age /tmp/drill
+```
+
+Check the staged tree contains `.env`, `secrets/kalshi-private.pem`, and the
+Gateway/Claude state, then delete the staging directory. Do the same for the
+newest database backup with `deploy/restore.sh` on a scratch path
+(`AURAMAUR_DB_PATH=/tmp/drill.db`). Exercise the **recovery** identity at
+least once a year so it is known-good, not assumed-good.
+
+## Environment schema
+
+`deploy/env.manifest.yaml` classifies every environment variable (secret vs
+config, where it is required). `deploy/check-env.py` compares the manifest,
+`.env.example`, and the local `.env` **by name only — values are never read
+or printed** — and fails on drift. Run it before cutover and whenever `.env`
+changes shape.

--- a/scripts/migrate_host.sh
+++ b/scripts/migrate_host.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
-# Host-migration helper — see docs/MIGRATION_HOST.md for the phase gates.
+# DEPRECATED — the native launchd migration path is retired.
 #
-#   stage                      (NEW) preflight checks for the paper shakedown
-#   freeze                     (OLD) kill-switch + bootout: nothing trades
-#   pull  user@oldhost:/path   (NEW) rsync private state from the frozen OLD
-#   install-agent              (NEW) template + bootstrap the LaunchAgent
-#   verify                     (NEW) post-cutover health gate
-#   decommission               (OLD) wipe secrets/state before hand-back
+# Migration and cutover now go through the portable Compose stack:
+#   scripts/migrate_portable.sh stage|freeze|export|verify
+#   docs/PORTABLE_DEPLOYMENT.md  (procedure)  ·  docs/SECRETS.md  (bundles)
 #
-# The one invariant: NEVER two live bots. `pull` refuses to run unless the
-# source is frozen (KILL_SWITCH present on OLD).
+# The one surviving command is `decommission`: wiping private state off a
+# native host before hand-back. Everything else errors out below so the two
+# migration systems can never drift apart again (the old PRIVATE_STATE list
+# here had already fallen behind — it omitted secrets/ and runtime/).
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -18,127 +17,39 @@ LABEL="is.auramaur.bot"
 PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
 UID_N="$(id -u)"
 
-# Private state that git does NOT carry — everything the new host needs
-# beyond the checkout. Deliberately explicit, not a glob of the repo root.
-PRIVATE_STATE=(
-    "auramaur.db"
-    "auramaur.db-wal"
-    "auramaur.db-shm"
-    ".env"
-    "config/defaults.local.yaml"
-    "logs/"
-    "agent_db_backup_20260705.db"
-)
-
 say()  { printf '\n== %s\n' "$*"; }
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 
-cmd_stage() {
-    say "stage: preflight for the paper shakedown (run on NEW)"
-    command -v git >/dev/null || fail "git missing"
-    .venv/bin/python -c 'import sys; assert sys.version_info >= (3,11)' \
-        2>/dev/null || fail "no .venv with Python 3.11+ (python -m venv .venv; pip install -e .)"
-    command -v claude >/dev/null || fail "claude CLI not on PATH (install + /login first)"
-    claude -p "reply with exactly OK" --output-format text 2>/dev/null | grep -q OK \
-        || fail "claude CLI call failed — not logged in?"
-    [ -f .env ] && fail ".env present — stage phase must run WITHOUT live credentials"
-    pmset -g 2>/dev/null | grep -qE ' sleep\s+0' \
-        || echo "WARN: system sleep is enabled — set 'pmset -c sleep 0' or run under caffeinate"
-    echo "stage preflight OK. Start the bot (paper: no .env) and watch it for a few hours."
-    echo "Gate checklist: docs/MIGRATION_HOST.md Phase 1."
-}
-
-cmd_freeze() {
-    say "freeze: halting the bot on THIS host (run on OLD)"
-    touch KILL_SWITCH
-    echo "KILL_SWITCH created — waiting for the bot to halt itself..."
-    for _ in $(seq 1 60); do
-        pgrep -f 'auramaur run' >/dev/null || break
-        sleep 2
-    done
-    pgrep -f 'auramaur run' >/dev/null && fail "bot still running after 120s — investigate before proceeding"
-    if launchctl print "gui/${UID_N}/${LABEL}" >/dev/null 2>&1; then
-        launchctl bootout "gui/${UID_N}/${LABEL}"
-        echo "LaunchAgent booted out."
-    fi
-    echo "FROZEN. Nothing trades until the new host completes 'verify'."
-    echo "Leave KILL_SWITCH in place — it is the rollback anchor."
-}
-
-cmd_pull() {
-    local src="${1:-}"
-    [ -n "$src" ] || fail "usage: migrate_host.sh pull user@oldhost:/path/to/Auramaur"
-    say "pull: syncing private state from ${src} (run on NEW)"
-    # Refuse unless the source is frozen — the never-two-live-bots gate.
-    local host="${src%%:*}" path="${src#*:}"
-    ssh "$host" "test -f '${path}/KILL_SWITCH'" \
-        || fail "source is NOT frozen (no KILL_SWITCH at ${src}) — run 'freeze' on OLD first"
-    ssh "$host" "! pgrep -f 'auramaur run' >/dev/null" \
-        || fail "a bot process is still running on the source host"
-    for item in "${PRIVATE_STATE[@]}"; do
-        rsync -a --info=progress2 "${src}/${item}" "./$(dirname "$item")/" \
-            || echo "WARN: ${item} missing on source (ok if it never existed)"
-    done
-    # The kill switch must NOT travel: the new host starts armed.
-    rm -f KILL_SWITCH
-    sqlite3 auramaur.db "PRAGMA integrity_check;" | grep -qx ok \
-        || fail "pulled auramaur.db fails integrity_check"
-    echo "pull complete; DB integrity OK."
-}
-
-cmd_install_agent() {
-    say "install-agent: templating + bootstrapping the LaunchAgent (run on NEW)"
-    sed "s|/Users/YOURUSER|$HOME|g" scripts/launchd/is.auramaur.bot.plist.example > "$PLIST"
-    plutil -lint "$PLIST" >/dev/null || fail "templated plist fails lint"
-    launchctl bootout "gui/${UID_N}/${LABEL}" 2>/dev/null || true
-    launchctl bootstrap "gui/${UID_N}" "$PLIST"
-    echo "LaunchAgent bootstrapped. The bot should be starting now."
-}
-
-cmd_verify() {
-    say "verify: post-cutover health gate (run on NEW)"
-    [ -f KILL_SWITCH ] && fail "KILL_SWITCH present on the NEW host — remove it deliberately"
-    launchctl print "gui/${UID_N}/${LABEL}" 2>/dev/null | grep -q 'state = running' \
-        || fail "LaunchAgent not running"
-    [ "$(pgrep -f 'auramaur run' | wc -l | tr -d ' ')" = "1" ] \
-        || fail "expected exactly 1 bot process"
-    local log="logs/run_live_launchd.out"
-    for _ in $(seq 1 60); do
-        grep -q 'strategy books' "$log" 2>/dev/null && break
-        sleep 2
-    done
-    grep -q 'strategy books' "$log" || fail "startup banner never appeared in ${log}"
-    grep -q 'Instance: auramaur_' "$log" && fail "FALLBACK DB — primary auramaur.db was locked"
-    grep -qE 'Mode: LIVE' "$log" || echo "WARN: not in LIVE mode — is .env in place?"
-    grep -E 'Build:|Mode:' "$log" | head -2
-    echo "verify OK. Watch the first full cycle + compare cash/positions to the venue UI."
-}
-
 cmd_decommission() {
     say "decommission: wiping secrets/state on THIS host (run on OLD, LAST)"
-    echo "This deletes .env (private keys!), DBs, logs, local config,"
-    echo "~/.claude credentials, the LaunchAgent, and this checkout."
+    echo "This deletes .env (private keys!), secrets/, DBs, logs, runtime/,"
+    echo "local config, the LaunchAgent, and legacy key files."
     read -r -p "Type the hostname of THIS machine to confirm: " ans
     [ "$ans" = "$(hostname)" ] || fail "confirmation mismatch — aborted"
     pgrep -f 'auramaur run' >/dev/null && fail "bot still running — freeze first"
+    if command -v docker >/dev/null 2>&1 \
+        && docker compose ps --status running --services 2>/dev/null | grep -qx auramaur; then
+        fail "the Compose stack is still running — deploy/kill-switch.sh first"
+    fi
     launchctl bootout "gui/${UID_N}/${LABEL}" 2>/dev/null || true
     rm -f "$PLIST"
     rm -P .env 2>/dev/null || rm -f .env
+    rm -P private-key.pem 2>/dev/null || rm -f private-key.pem
+    rm -rf secrets
     rm -f auramaur*.db auramaur*.db-wal auramaur*.db-shm agent*.db
-    rm -rf logs data
+    rm -rf logs data runtime
     rm -f config/defaults.local.yaml
+    rm -f deploy/ibgateway/ibgateway-*-standalone-linux-x64.sh
     echo "Repo-local state wiped. Now, manually:"
     echo "  - rm -rf ~/.claude (CLI credentials) when done using Claude here"
     echo "  - handle Straummaur + ~/.hermes (see MIGRATION_HOST.md Phase 3)"
+    echo "  - rclone/keychain/shell-profile secrets outside the repo"
     echo "  - finally: rm -rf ${REPO_DIR}"
 }
 
 case "${1:-}" in
-    stage)          cmd_stage ;;
-    freeze)         cmd_freeze ;;
-    pull)           shift; cmd_pull "$@" ;;
-    install-agent)  cmd_install_agent ;;
-    verify)         cmd_verify ;;
     decommission)   cmd_decommission ;;
-    *) grep '^#' "$0" | sed -n '2,12p'; exit 1 ;;
+    stage|freeze|pull|install-agent|verify)
+        fail "'$1' is retired — use scripts/migrate_portable.sh (docs/PORTABLE_DEPLOYMENT.md)" ;;
+    *) grep '^#' "$0" | sed -n '2,11p'; exit 1 ;;
 esac

--- a/scripts/migrate_portable.sh
+++ b/scripts/migrate_portable.sh
@@ -42,8 +42,8 @@ case "${1:-}" in
     else
       fail "no Auramaur database found"
     fi
-    echo "Export ready. Transfer the newest verified backup plus .env, secrets/,"
-    echo "runtime/config/, runtime/ibgateway/, and Claude credentials separately."
+    echo "Export ready. Transfer the newest verified backup plus a private-state"
+    echo "bundle: deploy/offsite-bundle.sh (see docs/SECRETS.md)."
     ;;
   verify)
     deploy/verify.sh


### PR DESCRIPTION
Follow-up to #302, closing the portability gaps found in the deployment audit.

## What
1. **Full private-state bundle** — `deploy/offsite-bundle.sh` encrypts everything a bare host needs beyond git and the DB backup (`.env`, `secrets/`, local YAML overrides, Gateway settings, Claude auth) to one or more age recipients and uploads via rclone. `deploy/restore-bundle.sh` decrypts into a fresh staging directory, validates expected members, and refuses absolute/traversal paths. A local round-trip drill (bundle → restore with the *recovery* recipient → checksum comparison of all files) and a tampered-bundle test both pass.
2. **age identity hygiene** — multi-recipient support in `deploy/offsite-backup.sh` too; `docs/SECRETS.md` documents identity storage (password manager primary, offline recovery), rotation, why the identity never touches GitHub, and a quarterly restore drill.
3. **Env schema** — `deploy/env.manifest.yaml` classifies every variable (secret vs config, targets, when required); `deploy/check-env.py` compares manifest / `.env.example` / local `.env` **by name only — values are never read or printed** — and fails on drift. Real vars missing from `.env.example` added (`POLYMARKET_PROXY_ADDRESS`, `CLAUDE_CODE_OAUTH_TOKEN`).
4. **One migration path** — `scripts/migrate_host.sh` is deprecated down to `decommission` only (its PRIVATE_STATE list had drifted from the portable docs); `decommission` now also wipes `secrets/`, `runtime/`, legacy key files, and the cached Gateway installer, and refuses to run while the Compose stack is up. `docs/MIGRATION_HOST.md` carries a deprecation banner.

## Why
The offsite path only protected the database; credentials, Gateway state, and local config had no verified, repeatable backup or restore. Two migration systems had already drifted apart. Secrets stay off GitHub entirely (public repo) — encrypted bundles live in off-host object storage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)