### PR TITLE
fix(ibkr): enforce global gates in equity client

### DIFF
--- a/auramaur/exchange/ibkr_equity.py
+++ b/auramaur/exchange/ibkr_equity.py
@@ -176,8 +176,11 @@ class IBKREquityClient:
                                is_paper=True,
                                error_message=f"${usd_amount:.2f} exceeds cap ${cap:.2f}")
 
-        if dry_run is None:
-            dry_run = not self._settings.is_live
+        # A caller-supplied ``dry_run=False`` is only the per-order gate; it
+        # must never bypass either global live gate (or the kill switch folded
+        # into settings.is_live).  Downgrade safely to paper when any gate is
+        # closed, matching the main IBKR options client.
+        dry_run = bool(dry_run) or not self._settings.is_live
         # Price is only for paper sizing + the recorded fill estimate; the live
         # order sizes itself from cashQty, so a missing quote never blocks it.
         price = await self.get_price(symbol)
@@ -214,8 +217,7 @@ class IBKREquityClient:
         if abs(held) < 1e-6:
             return None  # nothing to close
 
-        if dry_run is None:
-            dry_run = not self._settings.is_live
+        dry_run = bool(dry_run) or not self._settings.is_live
         price = await self.get_price(symbol)
         value = round(held * price, 2) if price else 0.0
         if dry_run:
@@ -286,8 +288,7 @@ class IBKREquityClient:
                                is_paper=True,
                                error_message=f"${notional:.2f} exceeds cap ${cap:.2f}")
 
-        if dry_run is None:
-            dry_run = not self._settings.is_live
+        dry_run = bool(dry_run) or not self._settings.is_live
         if dry_run:
             log.info("ibkr_equity.share_order.paper", symbol=symbol, side=side_str,
                      qty=qty, limit=limit_price)
@@ -367,8 +368,7 @@ class IBKREquityClient:
         Converting BUYs the USD.<ccy> forex pair (e.g. USDCAD): buying USD, paying
         the source currency. On a cash account the proceeds settle T+1, so this is
         a buffer-maintainer, not same-cycle funding."""
-        if dry_run is None:
-            dry_run = not self._settings.is_live
+        dry_run = bool(dry_run) or not self._settings.is_live
 
         if kill_switch_present():
             log.critical("kill_switch.active", action="ibkr_fx_convert_blocked")

--- a/tests/test_ibkr_equity.py
+++ b/tests/test_ibkr_equity.py
@@ -150,6 +150,22 @@ async def test_no_price_paper_still_returns_paper():
     assert res.filled_size == 0.0
 
 
+async def test_explicit_live_order_cannot_bypass_closed_global_gates(monkeypatch):
+    """``dry_run=False`` is only one gate; closed global gates force paper."""
+    monkeypatch.setattr(
+        "auramaur.exchange.ibkr_equity.kill_switch_present", lambda: False)
+    client = IBKREquityClient(_settings(is_live=False, readonly=False))
+    client.get_price = AsyncMock(return_value=100.0)
+    client._place_cash_order = AsyncMock()
+
+    res = await client.place_order(
+        "SPY", OrderSide.BUY, 50.0, dry_run=False)
+
+    assert res.order_id == "PAPER"
+    assert res.is_paper is True
+    client._place_cash_order.assert_not_awaited()
+
+
 def _fake_ib_async(monkeypatch, created):
     """Install a fake ib_async whose MarketOrder records the order object so a
     test can assert on cashQty / totalQuantity."""


### PR DESCRIPTION
## Summary
- force equity entries and exits to paper unless the global live state is open
- apply the same invariant to exact-share orders and FX conversions
- add a regression test proving explicit `dry_run=False` cannot bypass closed global gates

## Validation
- 73 targeted IBKR and safety tests passed
- Ruff passed
- `git diff --check` passed

No runtime configuration is included in this PR.