### PR TITLE
Harden trading security boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ private-key.pem
 *.zip
 *.db.backup_*
 data/transfer_ledger.json
+data/transfer_ledger.sqlite3
 data/risk_tolerance
 
 # DB backup blobs (never version runtime data)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:22-bookworm-slim AS node_runtime
+FROM node:22-bookworm-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS node_runtime
 
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 
 ARG CLAUDE_CODE_VERSION=2.1.214
 
@@ -18,7 +18,7 @@ RUN apt-get update \
     && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
     && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-    && pip install --no-cache-dir uv \
+    && pip install --no-cache-dir "uv==0.8.15" \
     && rm -rf /var/lib/apt/lists/* /root/.cache
 
 WORKDIR /app

--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -249,9 +249,9 @@ class KrakenSpotClient:
                                    is_paper=True,
                                    error_message=f"order ${notional:.2f} exceeds cap ${cap:.2f}")
 
-        # 4. Three-gate live decision → validate-only unless explicitly live.
-        if dry_run is None:
-            dry_run = not self._settings.is_live
+        # 4. Three-gate live decision.  ``dry_run=False`` opens only the
+        # per-order gate; it must never override either global live gate.
+        dry_run = bool(dry_run) or not self._settings.is_live
         validate = bool(dry_run)
 
         params = {"pair": pair, "type": side_str, "ordertype": ordertype, "volume": str(volume)}

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -158,6 +158,7 @@ class ClaudeAnalyzer:
 
         for attempt in range(1, max_attempts + 1):
             try:
+                from auramaur.subprocess_security import analysis_subprocess_env
                 proc = await asyncio.create_subprocess_exec(
                     "claude", "-p", prompt,
                     "--output-format", "text",
@@ -165,6 +166,7 @@ class ClaudeAnalyzer:
                     "--effort", use_effort,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=analysis_subprocess_env(),
                 )
                 stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=180)
 

--- a/auramaur/nlp/ensemble_analyzer.py
+++ b/auramaur/nlp/ensemble_analyzer.py
@@ -353,6 +353,7 @@ class EnsembleAnalyzer:
 
         for attempt in range(1, max_attempts + 1):
             try:
+                from auramaur.subprocess_security import analysis_subprocess_env
                 proc = await asyncio.create_subprocess_exec(
                     "claude", "-p", prompt,
                     "--output-format", "text",
@@ -361,6 +362,7 @@ class EnsembleAnalyzer:
                     "--max-turns", "1",
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=analysis_subprocess_env(),
                 )
                 stdout, stderr = await asyncio.wait_for(
                     proc.communicate(),

--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -961,6 +961,7 @@ class StrategicAnalyzer:
                 ``nlp.effort_primary``.
         """
         import asyncio
+        from auramaur.subprocess_security import analysis_subprocess_env
 
         use_model = model or self._model
         use_effort = effort or self._settings.nlp.effort_primary
@@ -990,6 +991,7 @@ class StrategicAnalyzer:
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=analysis_subprocess_env(),
                 )
                 # Longer timeout for deep reasoning (up to 8 min)
                 stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=480)

--- a/auramaur/nlp/tool_use_analyzer.py
+++ b/auramaur/nlp/tool_use_analyzer.py
@@ -137,10 +137,12 @@ class ToolUseAnalyzer:
         # operators who later switch to an API key.
 
         try:
+            from auramaur.subprocess_security import analysis_subprocess_env
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                env=analysis_subprocess_env(),
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
         except asyncio.TimeoutError:

--- a/auramaur/strategy/agent_analyzer.py
+++ b/auramaur/strategy/agent_analyzer.py
@@ -354,6 +354,8 @@ class AgentAnalyzer:
         memory). The agent's sanctioned state is world_model.json, passed
         explicitly in the prompt; it needs nothing from the ambient context.
         """
+        from auramaur.subprocess_security import analysis_subprocess_env
+
         cmd = [
             "claude", "-p", prompt,
             "--output-format", "text",
@@ -380,6 +382,7 @@ class AgentAnalyzer:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=tempfile.gettempdir(),
+                    env=analysis_subprocess_env(),
                 )
                 stdout, stderr = await asyncio.wait_for(
                     proc.communicate(), timeout=self._timeout_seconds,

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -426,6 +426,7 @@ class AgentTraderPillar:
     async def _call_model(self, prompt: str, model: str, effort: str, cfg) -> str:
         from auramaur.nlp import call_budget
         from auramaur.nlp.errors import BudgetExhausted
+        from auramaur.subprocess_security import analysis_subprocess_env
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
@@ -446,6 +447,7 @@ class AgentTraderPillar:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=tempfile.gettempdir(),
+            env=analysis_subprocess_env(),
         )
         try:
             stdout, stderr = await asyncio.wait_for(

--- a/auramaur/strategy/correlation.py
+++ b/auramaur/strategy/correlation.py
@@ -77,12 +77,14 @@ For each related pair, respond with a JSON array of objects:
 If no relationships found, return []. Only return the JSON array, no other text."""
 
         try:
+            from auramaur.subprocess_security import analysis_subprocess_env
             proc = await asyncio.create_subprocess_exec(
                 "claude", "-p", prompt,
                 "--output-format", "text",
                 "--model", self._model,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                env=analysis_subprocess_env(),
             )
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=120)
             raw = stdout.decode().strip()

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -373,6 +373,7 @@ class TermStructurePillar:
     async def _call_model(self, prompt: str, cfg) -> str:
         from auramaur.nlp import call_budget
         from auramaur.nlp.errors import BudgetExhausted
+        from auramaur.subprocess_security import analysis_subprocess_env
 
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
@@ -391,6 +392,7 @@ class TermStructurePillar:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=tempfile.gettempdir(),
+            env=analysis_subprocess_env(),
         )
         try:
             stdout, stderr = await asyncio.wait_for(

--- a/auramaur/subprocess_security.py
+++ b/auramaur/subprocess_security.py
@@ -1,0 +1,35 @@
+"""Least-privilege environments for untrusted analysis subprocesses."""
+
+from __future__ import annotations
+
+import os
+
+
+# Claude needs its own authentication and a small amount of normal process
+# plumbing. Venue keys, wallet keys, webhooks, and database paths are omitted.
+_ANALYSIS_ENV_ALLOWLIST = {
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "HOME",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "LANG",
+    "LC_ALL",
+    "NO_PROXY",
+    "PATH",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "TERM",
+    "TMPDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+}
+
+
+def analysis_subprocess_env() -> dict[str, str]:
+    """Return a new environment containing no trading or signing secrets."""
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name in _ANALYSIS_ENV_ALLOWLIST
+    }

--- a/auramaur/treasury/transfers.py
+++ b/auramaur/treasury/transfers.py
@@ -25,6 +25,8 @@ don't duplicate the HMAC.
 from __future__ import annotations
 
 import json
+import sqlite3
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from auramaur.killswitch import kill_switch_present
@@ -35,7 +37,7 @@ from pydantic import BaseModel
 
 log = structlog.get_logger()
 
-_LEDGER = Path("data/transfer_ledger.json")
+_LEDGER = Path("data/transfer_ledger.sqlite3")
 
 # An approver receives a summary dict and returns True to authorize. The default
 # denies — approval must be an explicit, deliberate act.
@@ -68,21 +70,128 @@ class TransferManager:
     def _today(self) -> str:
         return datetime.now(timezone.utc).date().isoformat()
 
-    def _spent_today(self) -> float:
-        try:
-            data = json.loads(self._ledger_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return 0.0
-        return float(data.get(self._today(), 0.0))
-
-    def _record(self, amount_usd: float) -> None:
-        try:
-            data = json.loads(self._ledger_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            data = {}
-        data[self._today()] = float(data.get(self._today(), 0.0)) + amount_usd
+    def _connect_ledger(self) -> sqlite3.Connection:
+        """Open the enforcement ledger; errors intentionally propagate closed."""
         self._ledger_path.parent.mkdir(parents=True, exist_ok=True)
-        self._ledger_path.write_text(json.dumps(data, indent=2))
+        db = sqlite3.connect(self._ledger_path, timeout=30, isolation_level=None)
+        db.execute("PRAGMA busy_timeout=30000")
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS transfer_reservations (
+                   id TEXT PRIMARY KEY,
+                   day TEXT NOT NULL,
+                   asset TEXT NOT NULL,
+                   dest_key TEXT NOT NULL,
+                   amount_usd REAL NOT NULL CHECK(amount_usd > 0),
+                   status TEXT NOT NULL CHECK(status IN ('reserved', 'executed')),
+                   refid TEXT NOT NULL DEFAULT '',
+                   created_at TEXT NOT NULL DEFAULT (datetime('now'))
+               )"""
+        )
+        db.execute(
+            "CREATE TABLE IF NOT EXISTS transfer_ledger_meta "
+            "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        self._migrate_legacy_ledger(db)
+        return db
+
+    def _migrate_legacy_ledger(self, db: sqlite3.Connection) -> None:
+        """Import the old JSON totals once; malformed state fails closed."""
+        marker = db.execute(
+            "SELECT 1 FROM transfer_ledger_meta WHERE key = 'legacy_json_migrated'"
+        ).fetchone()
+        if marker:
+            return
+        legacy_path = self._ledger_path.with_suffix(".json")
+        if legacy_path.exists():
+            try:
+                legacy = json.loads(legacy_path.read_text())
+                if not isinstance(legacy, dict):
+                    raise ValueError("root must be an object")
+                rows = []
+                for day, amount in legacy.items():
+                    amount_f = float(amount)
+                    if amount_f < 0:
+                        raise ValueError(f"negative amount for {day}")
+                    if amount_f:
+                        rows.append((f"legacy-{day}", str(day), amount_f))
+            except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:
+                raise RuntimeError(f"legacy transfer ledger is invalid: {e}") from e
+            db.executemany(
+                "INSERT OR IGNORE INTO transfer_reservations "
+                "(id, day, asset, dest_key, amount_usd, status) "
+                "VALUES (?, ?, 'USDC', 'legacy-json', ?, 'executed')",
+                rows,
+            )
+        db.execute(
+            "INSERT INTO transfer_ledger_meta (key, value) "
+            "VALUES ('legacy_json_migrated', datetime('now'))"
+        )
+
+    def _spent_today(self) -> float:
+        db = self._connect_ledger()
+        try:
+            row = db.execute(
+                "SELECT COALESCE(SUM(amount_usd), 0) FROM transfer_reservations "
+                "WHERE day = ? AND status IN ('reserved', 'executed')",
+                (self._today(),),
+            ).fetchone()
+            return float(row[0])
+        finally:
+            db.close()
+
+    def _reserve(self, reservation_id: str, asset: str, dest_key: str,
+                 amount_usd: float, daily_cap_usd: float) -> float:
+        """Atomically enforce the cap and reserve allowance before withdrawal."""
+        db = self._connect_ledger()
+        try:
+            db.execute("BEGIN IMMEDIATE")
+            row = db.execute(
+                "SELECT COALESCE(SUM(amount_usd), 0) FROM transfer_reservations "
+                "WHERE day = ? AND status IN ('reserved', 'executed')",
+                (self._today(),),
+            ).fetchone()
+            spent = float(row[0])
+            if spent + amount_usd > daily_cap_usd:
+                db.rollback()
+                raise ValueError(
+                    f"daily cap ${daily_cap_usd:.2f} would be exceeded "
+                    f"(${spent:.2f} already moved or reserved today)"
+                )
+            db.execute(
+                "INSERT INTO transfer_reservations "
+                "(id, day, asset, dest_key, amount_usd, status) "
+                "VALUES (?, ?, ?, ?, ?, 'reserved')",
+                (reservation_id, self._today(), asset, dest_key, amount_usd),
+            )
+            db.commit()
+            return spent
+        finally:
+            db.close()
+
+    def _release(self, reservation_id: str) -> None:
+        db = self._connect_ledger()
+        try:
+            db.execute(
+                "DELETE FROM transfer_reservations WHERE id = ? AND status = 'reserved'",
+                (reservation_id,),
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    def _mark_executed(self, reservation_id: str, refid: str) -> None:
+        db = self._connect_ledger()
+        try:
+            cursor = db.execute(
+                "UPDATE transfer_reservations SET status = 'executed', refid = ? "
+                "WHERE id = ? AND status = 'reserved'",
+                (refid, reservation_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("transfer reservation missing during finalization")
+            db.commit()
+        finally:
+            db.close()
 
     # ------------------------------------------------------------------
     # Transfer
@@ -122,39 +231,71 @@ class TransferManager:
         if amount_usd > cfg.per_transfer_cap_usd:
             return blocked(f"${amount_usd:.2f} over per-transfer cap ${cfg.per_transfer_cap_usd:.2f}")
 
-        # 4. Daily cap.
-        spent = self._spent_today()
-        if spent + amount_usd > cfg.daily_cap_usd:
-            return blocked(f"daily cap ${cfg.daily_cap_usd:.2f} would be exceeded "
-                           f"(${spent:.2f} already moved today)")
-
-        summary = {"asset": asset, "amount_usd": amount_usd, "dest_key": dest_key,
-                   "spent_today": spent, "daily_cap": cfg.daily_cap_usd}
-
-        # 5. Armed? If not, this is a preview — nothing moves.
+        # 4. Armed? If not, this is a preview — nothing moves.
         if not self._settings.transfers_armed:
+            spent = self._spent_today()
+            summary = {"asset": asset, "amount_usd": amount_usd, "dest_key": dest_key,
+                       "spent_today": spent, "daily_cap": cfg.daily_cap_usd}
             log.info("transfer.dry_run", reason="transfers not armed", **summary)
             return TransferResult(status="dry_run", asset=asset, amount=amount_usd,
                                   dest_key=dest_key,
                                   reason="transfers not armed (set AURAMAUR_ENABLE_TRANSFERS "
                                          "+ transfers.enabled) — preview only, nothing moved")
 
-        # 6. Human approval.
-        if cfg.require_approval and not approver(summary):
+        # 5. Human approval. Approval precedes reservation so a rejected
+        # preview cannot consume daily allowance.
+        try:
+            spent_preview = self._spent_today()
+        except (OSError, sqlite3.Error, RuntimeError) as e:
+            return blocked(f"transfer ledger unavailable; refusing withdrawal: {e}")
+        preview = {"asset": asset, "amount_usd": amount_usd, "dest_key": dest_key,
+                   "spent_today": spent_preview, "daily_cap": cfg.daily_cap_usd}
+        if cfg.require_approval and not approver(preview):
             return TransferResult(status="rejected", asset=asset, amount=amount_usd,
                                   dest_key=dest_key, reason="approval not granted")
 
+        # 6. Reserve daily allowance in one cross-process transaction. A process
+        # crash after this point leaves a reservation that counts against the
+        # cap (fail closed) until an operator reconciles it.
+        reservation_id = uuid.uuid4().hex
+        try:
+            spent = self._reserve(
+                reservation_id, asset, dest_key, amount_usd, cfg.daily_cap_usd,
+            )
+        except (OSError, sqlite3.Error, RuntimeError) as e:
+            return blocked(f"transfer ledger unavailable; refusing withdrawal: {e}")
+        except ValueError as e:
+            return blocked(str(e))
+
+        summary = {"asset": asset, "amount_usd": amount_usd, "dest_key": dest_key,
+                   "spent_today": spent, "daily_cap": cfg.daily_cap_usd,
+                   "reservation_id": reservation_id}
+
         # === EXECUTE — real, irreversible withdrawal ===
         log.warning("transfer.executing", **summary)
-        resp = await self._kraken._private(
-            "Withdraw", {"asset": asset, "key": dest_key, "amount": str(amount_usd)},
-        )
+        try:
+            resp = await self._kraken._private(
+                "Withdraw", {"asset": asset, "key": dest_key, "amount": str(amount_usd)},
+            )
+        except Exception:
+            # An exception can be an uncertain network outcome: retain the
+            # reservation so a retry cannot exceed the cap or double-withdraw.
+            log.exception("transfer.outcome_uncertain", **summary)
+            return TransferResult(status="rejected", asset=asset, amount=amount_usd,
+                                  dest_key=dest_key,
+                                  reason="withdrawal outcome uncertain; reservation retained")
         if resp.get("error"):
+            self._release(reservation_id)
             return TransferResult(status="rejected", asset=asset, amount=amount_usd,
                                   dest_key=dest_key, reason=str(resp["error"])[:200])
 
         refid = str(resp.get("result", {}).get("refid", ""))
-        self._record(amount_usd)
+        if not refid:
+            log.error("transfer.missing_refid", **summary)
+            return TransferResult(status="rejected", asset=asset, amount=amount_usd,
+                                  dest_key=dest_key,
+                                  reason="withdrawal response missing refid; reservation retained")
+        self._mark_executed(reservation_id, refid)
         log.warning("transfer.executed", refid=refid, **summary)
         return TransferResult(status="executed", asset=asset, amount=amount_usd,
                               dest_key=dest_key, refid=refid)

--- a/config/settings.py
+++ b/config/settings.py
@@ -1005,8 +1005,8 @@ class BrokerConfig(BaseModel):
 
 class KalshiConfig(BaseModel):
     enabled: bool = False
-    api_key: str = ""
-    private_key_path: str = ""
+    api_key: str = Field(default="", repr=False, exclude=True)
+    private_key_path: str = Field(default="", repr=False, exclude=True)
     environment: str = "demo"  # "demo" | "prod"
 
 
@@ -1227,8 +1227,8 @@ class IBKRConfig(BaseModel):
 
 class CryptoComConfig(BaseModel):
     enabled: bool = False
-    api_key: str = ""
-    api_secret: str = ""
+    api_key: str = Field(default="", repr=False, exclude=True)
+    api_secret: str = Field(default="", repr=False, exclude=True)
     environment: str = "sandbox"  # "sandbox" | "prod"
 
 
@@ -1449,44 +1449,44 @@ class LoggingConfig(BaseModel):
 
 class Settings(BaseSettings):
     # API Keys
-    anthropic_api_key_primary: str = ""
-    anthropic_api_key_secondary: str = ""
-    openai_api_key: str = ""
-    polygon_private_key: str = ""
-    polymarket_api_key: str = ""
-    polymarket_api_secret: str = ""
-    polymarket_passphrase: str = ""
+    anthropic_api_key_primary: str = Field(default="", repr=False, exclude=True)
+    anthropic_api_key_secondary: str = Field(default="", repr=False, exclude=True)
+    openai_api_key: str = Field(default="", repr=False, exclude=True)
+    polygon_private_key: str = Field(default="", repr=False, exclude=True)
+    polymarket_api_key: str = Field(default="", repr=False, exclude=True)
+    polymarket_api_secret: str = Field(default="", repr=False, exclude=True)
+    polymarket_passphrase: str = Field(default="", repr=False, exclude=True)
     polymarket_proxy_address: str = ""
-    newsapi_key: str = ""
-    reddit_client_id: str = ""
-    reddit_client_secret: str = ""
+    newsapi_key: str = Field(default="", repr=False, exclude=True)
+    reddit_client_id: str = Field(default="", repr=False, exclude=True)
+    reddit_client_secret: str = Field(default="", repr=False, exclude=True)
     reddit_user_agent: str = "auramaur/0.1"
-    twitter_bearer_token: str = ""
-    fred_api_key: str = ""
-    bls_api_key: str = ""
-    bea_api_key: str = ""
-    congress_api_key: str = ""
-    eia_api_key: str = ""
-    telegram_bot_token: str = ""
+    twitter_bearer_token: str = Field(default="", repr=False, exclude=True)
+    fred_api_key: str = Field(default="", repr=False, exclude=True)
+    bls_api_key: str = Field(default="", repr=False, exclude=True)
+    bea_api_key: str = Field(default="", repr=False, exclude=True)
+    congress_api_key: str = Field(default="", repr=False, exclude=True)
+    eia_api_key: str = Field(default="", repr=False, exclude=True)
+    telegram_bot_token: str = Field(default="", repr=False, exclude=True)
     telegram_chat_id: str = ""
-    discord_webhook_url: str = ""
+    discord_webhook_url: str = Field(default="", repr=False, exclude=True)
 
     # Kalshi
-    kalshi_api_key: str = ""
-    kalshi_private_key_path: str = ""
+    kalshi_api_key: str = Field(default="", repr=False, exclude=True)
+    kalshi_private_key_path: str = Field(default="", repr=False, exclude=True)
 
     # Crypto.com
-    cryptodotcom_api_key: str = ""
-    cryptodotcom_api_secret: str = ""
+    cryptodotcom_api_key: str = Field(default="", repr=False, exclude=True)
+    cryptodotcom_api_secret: str = Field(default="", repr=False, exclude=True)
 
     # Kraken (spot). Used for read-only wallet/balance checks today; no trading
     # adapter is wired yet. Key needs only the "Query Funds" permission —
     # leave "Withdraw Funds" OFF.
-    kraken_api_key: str = ""
-    kraken_api_secret: str = ""
+    kraken_api_key: str = Field(default="", repr=False, exclude=True)
+    kraken_api_secret: str = Field(default="", repr=False, exclude=True)
 
     # Google Gemini — LLM fallback for off-hours / when Claude budget is low.
-    gemini_api_key: str = ""
+    gemini_api_key: str = Field(default="", repr=False, exclude=True)
 
     # Hugging Face Hub token — used by the sentence-transformers evidence
     # embedder (nlp/relevance.py). Anonymous downloads work but are
@@ -1494,7 +1494,7 @@ class Settings(BaseSettings):
     # reads HF_TOKEN from the process environment, not from our Settings, so
     # model_post_init exports it (pydantic-settings parses .env into fields
     # without touching os.environ).
-    hf_token: str = ""
+    hf_token: str = Field(default="", repr=False, exclude=True)
 
     # Global risk-tolerance lever: 0=most conservative, 50=neutral, 100=YOLO.
     # Scales the whole prob/stat/risk surface at the RiskManager gateway.

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -56,6 +56,51 @@ async def test_usd_notional_converts_quote():
     assert abs(await c.usd_notional("XEUR", 1.0, price=100.0) - 116.0) < 1e-9
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit_dry_run", [False, None])
+async def test_spot_order_stays_validate_only_when_global_live_gates_closed(
+    explicit_dry_run,
+):
+    """The per-order flag cannot override AURAMAUR_LIVE/execution.live."""
+    settings = MagicMock()
+    settings.is_live = False
+    settings.kraken.directional_enabled = True
+    settings.kraken.max_order_usd = 100.0
+    client = KrakenSpotClient(settings)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
+    client._private = AsyncMock(return_value={"error": [], "result": {}})
+
+    with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+        result = await client.place_spot_order(
+            "XBTUSDC", OrderSide.BUY, 0.001, price=50_000.0,
+            dry_run=explicit_dry_run,
+        )
+
+    assert result.is_paper is True
+    assert client._private.await_args.args[1]["validate"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_spot_order_can_execute_only_when_all_live_gates_open():
+    settings = MagicMock()
+    settings.is_live = True
+    settings.kraken.directional_enabled = True
+    settings.kraken.max_order_usd = 100.0
+    client = KrakenSpotClient(settings)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
+    client._private = AsyncMock(
+        return_value={"error": [], "result": {"txid": ["live-order"]}}
+    )
+
+    with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+        result = await client.place_spot_order(
+            "XBTUSDC", OrderSide.BUY, 0.001, price=50_000.0, dry_run=False,
+        )
+
+    assert result.is_paper is False
+    assert "validate" not in client._private.await_args.args[1]
+
+
 def _pillar(*, holding: bool):
     s = MagicMock()
     s.risk_tolerance = 50.0

--- a/tests/test_settings_secrets.py
+++ b/tests/test_settings_secrets.py
@@ -1,0 +1,20 @@
+from config.settings import Settings
+
+
+def test_secrets_are_excluded_from_repr_and_serialization():
+    settings = Settings(
+        _env_file=None,
+        kraken_api_secret="kraken-secret",
+        polygon_private_key="wallet-secret",
+        discord_webhook_url="webhook-secret",
+    )
+
+    rendered = repr(settings)
+    dumped = settings.model_dump()
+
+    assert "kraken-secret" not in rendered
+    assert "wallet-secret" not in rendered
+    assert "webhook-secret" not in rendered
+    assert "kraken_api_secret" not in dumped
+    assert "polygon_private_key" not in dumped
+    assert "discord_webhook_url" not in dumped

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -1,0 +1,19 @@
+from auramaur.subprocess_security import analysis_subprocess_env
+
+
+def test_analysis_environment_excludes_trading_secrets(monkeypatch):
+    monkeypatch.setenv("PATH", "/bin")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "claude-auth")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "kraken-secret")
+    monkeypatch.setenv("POLYGON_PRIVATE_KEY", "wallet-key")
+    monkeypatch.setenv("POLYMARKET_API_KEY", "venue-key")
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "webhook")
+
+    child_env = analysis_subprocess_env()
+
+    assert child_env["CLAUDE_CODE_OAUTH_TOKEN"] == "claude-auth"
+    assert child_env["PATH"] == "/bin"
+    assert "KRAKEN_API_SECRET" not in child_env
+    assert "POLYGON_PRIVATE_KEY" not in child_env
+    assert "POLYMARKET_API_KEY" not in child_env
+    assert "DISCORD_WEBHOOK_URL" not in child_env

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,0 +1,92 @@
+"""Security invariants for irreversible cross-venue withdrawals."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from auramaur.treasury.transfers import TransferManager
+
+
+def _settings(*, cap: float = 100.0, armed: bool = True):
+    return SimpleNamespace(
+        transfers_armed=armed,
+        transfers=SimpleNamespace(
+            allowed_withdraw_keys=["polymarket-usdc"],
+            min_transfer_usd=1.0,
+            per_transfer_cap_usd=cap,
+            daily_cap_usd=cap,
+            require_approval=True,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transfers_cannot_race_daily_cap(tmp_path):
+    kraken = SimpleNamespace(
+        _private=AsyncMock(return_value={"error": [], "result": {"refid": "ok"}})
+    )
+    ledger = tmp_path / "transfers.sqlite3"
+    managers = [TransferManager(_settings(), kraken, ledger) for _ in range(2)]
+
+    with patch("auramaur.treasury.transfers.kill_switch_present", return_value=False):
+        first, second = await asyncio.gather(*[
+            manager.transfer("polymarket-usdc", 60.0, approver=lambda _: True)
+            for manager in managers
+        ])
+
+    assert sorted([first.status, second.status]) == ["blocked", "executed"]
+    assert kraken._private.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_api_rejection_releases_reservation(tmp_path):
+    kraken = SimpleNamespace(
+        _private=AsyncMock(side_effect=[
+            {"error": ["rejected"], "result": {}},
+            {"error": [], "result": {"refid": "second"}},
+        ])
+    )
+    manager = TransferManager(_settings(), kraken, tmp_path / "transfers.sqlite3")
+
+    with patch("auramaur.treasury.transfers.kill_switch_present", return_value=False):
+        rejected = await manager.transfer(
+            "polymarket-usdc", 100.0, approver=lambda _: True,
+        )
+        retried = await manager.transfer(
+            "polymarket-usdc", 100.0, approver=lambda _: True,
+        )
+
+    assert rejected.status == "rejected"
+    assert retried.status == "executed"
+
+
+@pytest.mark.asyncio
+async def test_uncertain_outcome_retains_reservation(tmp_path):
+    kraken = SimpleNamespace(_private=AsyncMock(side_effect=TimeoutError("timeout")))
+    manager = TransferManager(_settings(), kraken, tmp_path / "transfers.sqlite3")
+
+    with patch("auramaur.treasury.transfers.kill_switch_present", return_value=False):
+        uncertain = await manager.transfer(
+            "polymarket-usdc", 60.0, approver=lambda _: True,
+        )
+        blocked = await manager.transfer(
+            "polymarket-usdc", 60.0, approver=lambda _: True,
+        )
+
+    assert "uncertain" in uncertain.reason
+    assert blocked.status == "blocked"
+
+
+def test_legacy_json_total_is_migrated_and_enforced(tmp_path):
+    import json
+    from datetime import datetime, timezone
+
+    ledger = tmp_path / "transfer_ledger.sqlite3"
+    ledger.with_suffix(".json").write_text(json.dumps({
+        datetime.now(timezone.utc).date().isoformat(): 80.0,
+    }))
+    manager = TransferManager(_settings(), SimpleNamespace(), ledger)
+
+    assert manager._spent_today() == 80.0


### PR DESCRIPTION
## Summary
- enforce Kraken global live gates even when callers pass an explicit per-order live flag
- replace the transfer JSON counter with transactional SQLite reservations and legacy migration
- retain reservations for uncertain withdrawal outcomes to prevent retry-based cap bypasses
- isolate Claude analysis subprocesses from venue, wallet, webhook, and database credentials
- exclude secret settings from repr and serialization
- pin Docker base image digests and the uv installer version

## Security impact
Closes the live-order gate bypass in the Kraken adapter and prevents concurrent withdrawals from racing the daily transfer cap. Analysis subprocesses now receive an explicit least-privilege environment.

## Verification
- Ruff: passed
- git diff --check: passed
- focused security tests: 20 passed
- full suite after rebasing: 1194 passed, 1 skipped, 2 deselected

The two deselected assertions inspect committed default IBKR values but are overridden by the operator's local runtime profile; they are unrelated to this change. The repository kill switch remained armed throughout verification.