### PR TITLE
Harden execution accounting and exposure guards

### DIFF
--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -147,10 +147,14 @@ class ExecutionGateway:
                 "AND is_paper = ? AND size > 0",
                 (order.market_id, order.token.value, is_paper_flag),
             )
-        except Exception:
-            # A read failure must not block trading — fail open (the per-order
-            # risk-manager cap still applies).
-            return None
+        except Exception as e:
+            # This is the only guard that sees aggregate exposure. The per-order
+            # risk check cannot protect against stacked entries, so an unknown
+            # aggregate must never become permission to place another live BUY.
+            log.error("gateway.market_cap_read_failed",
+                      market_id=order.market_id, token=order.token.value,
+                      is_live=is_live, error=str(e))
+            return "market_cap: aggregate exposure unavailable"
         held = float(row["held"]) if row else 0.0
         proposed = order.size * order.price
         if held + proposed > cap + 1e-9:
@@ -225,6 +229,16 @@ class ExecutionGateway:
         if order_a is None or order_b is None:
             skip = ExecutionResult(status="skipped", reason="leg build failed")
             return skip, ExecutionResult(status="skipped", reason="leg build failed")
+
+        cap_a = await self._exceeds_market_cap(order_a, is_live=is_live_a)
+        cap_b = await self._exceeds_market_cap(order_b, is_live=is_live_b)
+        if cap_a is not None or cap_b is not None:
+            return (
+                ExecutionResult(status="skipped", order=order_a,
+                                reason=cap_a or "paired leg blocked by market cap"),
+                ExecutionResult(status="skipped", order=order_b,
+                                reason=cap_b or "paired leg blocked by market cap"),
+            )
 
         res_a = await self._place_and_record(
             order_a, strategy_source=a.signal.strategy_source,
@@ -370,6 +384,29 @@ class ExecutionGateway:
         keeps its own half-fill / rollback / inventory logic. ``legs`` items are
         ``(order, exchange_client, exchange_name)``.
         """
+        # External multi-leg paths bypass ``submit`` but are still entries.
+        # Check every BUY before any leg leaves the building. When two legs add
+        # the same market/token in one batch, reserve earlier legs locally so
+        # the batch cannot collectively exceed the cap.
+        reservations: dict[tuple[str, str, int], float] = {}
+        for order, _client, _exchange_name in legs:
+            if order.side != OrderSide.BUY:
+                continue
+            is_live = not order.dry_run
+            blocked = await self._exceeds_market_cap(order, is_live=is_live)
+            key = (order.market_id, order.token.value, 0 if is_live else 1)
+            proposed = order.size * order.price
+            cap = getattr(self.settings.risk, "max_stake_abs_ceiling", 25.0)
+            if blocked is None and reservations.get(key, 0.0) + proposed > cap + 1e-9:
+                blocked = "market_cap: multi-leg batch exceeds aggregate ceiling"
+            if blocked is not None:
+                skipped = ExecutionResult(status="skipped", order=order, reason=blocked)
+                rejected = OrderResult(order_id="MARKET_CAP", market_id=order.market_id,
+                                       status="rejected", is_paper=order.dry_run,
+                                       error_message=blocked)
+                return [(rejected, skipped) for order, _client, _name in legs]
+            reservations[key] = reservations.get(key, 0.0) + proposed
+
         if concurrent:
             results = await asyncio.gather(
                 *(client.place_order(order) for order, client, _ in legs))
@@ -465,8 +502,18 @@ class ExecutionGateway:
                 is_paper=result.is_paper,
             )
             if self.pnl_tracker:
-                await self.pnl_tracker.record_fill(fill)
-                recorded_fill = fill
+                try:
+                    await self.pnl_tracker.record_fill(fill)
+                    recorded_fill = fill
+                except Exception as e:
+                    # The order already executed. Never turn a persistence fault
+                    # into an apparent placement failure that callers may retry.
+                    log.critical(
+                        "gateway.fill_record_failed",
+                        order_id=result.order_id,
+                        market_id=order.market_id,
+                        error=str(e),
+                    )
 
         if result.status in _OK_STATUSES:
             # Mirror into legacy `trades` table so the CLI stats view,

--- a/auramaur/broker/pnl.py
+++ b/auramaur/broker/pnl.py
@@ -43,6 +43,36 @@ class PnLTracker:
         SELL: decreases position size, realizes P&L at
               ``(sell_price - avg_cost) * size``.
         """
+        # Exchange/order ids are the idempotency key. The monitor can observe
+        # the same terminal fill more than once after a restart or persistence
+        # timeout; replaying it would double the position and realized P&L.
+        existing = await self._db.fetchone(
+            "SELECT market_id, side, token, size, price, is_paper FROM fills "
+            "WHERE order_id = ? AND side = ? LIMIT 1",
+            (fill.order_id, fill.side.value),
+        )
+        if existing is not None:
+            same = (
+                existing["market_id"] == fill.market_id
+                and existing["side"] == fill.side.value
+                and existing["token"].upper() == fill.token.value.upper()
+                and abs(float(existing["size"]) - fill.size) < 1e-9
+                and abs(float(existing["price"]) - fill.price) < 1e-9
+                and int(existing["is_paper"]) == (1 if fill.is_paper else 0)
+            )
+            if same:
+                log.info("pnl.fill_duplicate_ignored", order_id=fill.order_id)
+                return
+            raise ValueError(f"conflicting fill replay for order {fill.order_id}")
+
+        try:
+            await self._record_fill_once(fill)
+        except Exception:
+            await self._db.rollback()
+            raise
+
+    async def _record_fill_once(self, fill: Fill) -> None:
+        """Write one new fill and its cost basis as a single transaction."""
         # 1. Persist the fill
         cursor = await self._db.execute(
             """INSERT INTO fills
@@ -82,6 +112,7 @@ class PnLTracker:
 
         fill_cost = fill.price * fill.size
 
+        ledger_event: dict | None = None
         if fill.side == OrderSide.BUY:
             # 3. BUY — increase position, recalculate weighted average
             new_size = old_size + fill.size
@@ -136,19 +167,13 @@ class PnLTracker:
             except Exception as e:
                 log.debug("pnl.daily_stats_error", error=str(e))
 
-            # Unified realized-P&L ledger: one row per realization event,
-            # idempotent on fill rowid (the backfill uses the same ref).
-            from auramaur.broker.ledger import record_ledger_event
-            await record_ledger_event(
-                self._db,
-                market_id=fill.market_id,
-                kind="sell",
-                token=fill.token.value,
-                qty=sell_size,
-                pnl=pnl,
-                fees=fill.fee,
-                is_paper=fill.is_paper,
-                source_ref=f"fill:{fill_rowid}",
+            # Defer the ancillary ledger until the authoritative fill + cost
+            # basis transaction commits. The ledger is independently
+            # idempotent and must never commit this transaction halfway through.
+            ledger_event = dict(
+                market_id=fill.market_id, kind="sell", token=fill.token.value,
+                qty=sell_size, pnl=pnl, fees=fill.fee,
+                is_paper=fill.is_paper, source_ref=f"fill:{fill_rowid}",
                 realized_at=fill.timestamp.isoformat(),
             )
 
@@ -187,6 +212,10 @@ class PnLTracker:
             ),
         )
         await self._db.commit()
+
+        if ledger_event is not None:
+            from auramaur.broker.ledger import record_ledger_event
+            await record_ledger_event(self._db, **ledger_event)
 
         log.info(
             "pnl.fill_recorded",

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -692,3 +692,6 @@ class Database:
 
     async def commit(self) -> None:
         await self.db.commit()
+
+    async def rollback(self) -> None:
+        await self.db.rollback()

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -626,10 +626,10 @@ class PolymarketClient:
     async def get_order_status(self, order_id: str) -> OrderResult:
         """Query the CLOB API for the current status of an order.
 
-        When the CLOB returns None for an order, it means the order no longer
-        exists in the active-order index — either filled-and-settled long ago,
-        or cancelled. We return a terminal "cancelled" result so callers can
-        drop it from their pending-order tracking instead of re-polling forever.
+        A missing active-order record is ambiguous: the order may have filled
+        and aged out, or it may have been cancelled. Keep it non-terminal until
+        trade-history reconciliation can prove which happened; labelling it
+        cancelled here silently loses real fills.
         """
         await self.clob_call(self._init_clob_client)
         try:
@@ -643,10 +643,11 @@ class PolymarketClient:
             return OrderResult(
                 order_id=order_id,
                 market_id="",
-                status="cancelled",
+                status="pending",
                 filled_size=0,
                 filled_price=0,
                 is_paper=False,
+                error_message="order absent from active index; terminal status unknown",
             )
 
         try:

--- a/auramaur/treasury/coinbase_paper.py
+++ b/auramaur/treasury/coinbase_paper.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import structlog
 
 from auramaur.broker.pnl import PnLTracker
@@ -42,7 +44,7 @@ class CoinbasePaperBook:
         notional = qty * price
         fee_pct = self._settings.coinbase.paper_fee_pct / 100.0
         fill = Fill(
-            order_id=f"coinbase-paper-{pair}",
+            order_id=f"coinbase-paper-{pair}-{uuid4().hex}",
             market_id=f"coinbase:{product}",
             token_id=product,
             side=side,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,29 @@ still close their databases.
 from __future__ import annotations
 
 import gc
+import os
+import sys
+
+import pytest
+
+# Tests exercise order paths while an operator may intentionally have the real
+# repository kill switch armed. Keep configuration and safety-file state local
+# to each test process; dedicated kill-switch tests override the path directly.
+os.environ["AURAMAUR_LOCAL_CONFIG"] = "/tmp/auramaur-test-no-local-config.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kill_switch(monkeypatch, tmp_path):
+    import auramaur.killswitch as killswitch
+
+    monkeypatch.setattr(killswitch, "KILL_SWITCH_PATH", tmp_path / "KILL_SWITCH")
+    # Exchange modules import the function directly, so patch those bound names
+    # without changing the function exercised by tests/test_killswitch.py.
+    for module in tuple(sys.modules.values()):
+        if (module is not None and module is not killswitch
+                and getattr(module, "__dict__", {}).get("kill_switch_present")
+                is killswitch.kill_switch_present):
+            monkeypatch.setattr(module, "kill_switch_present", lambda: False)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -81,6 +81,24 @@ def test_submit_records_fill_cost_basis_and_trade():
     asyncio.run(run())
 
 
+def test_record_fill_is_idempotent_by_order_id():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        tracker = PnLTracker(db, Settings())
+        from auramaur.exchange.models import Fill
+        fill = Fill(order_id="same-order", market_id="m1", token_id="tok",
+                    side=OrderSide.BUY, token=TokenType.YES,
+                    size=10, price=0.5, is_paper=True)
+        await tracker.record_fill(fill)
+        await tracker.record_fill(fill)
+        assert len(await db.fetchall("SELECT 1 FROM fills")) == 1
+        row = await db.fetchone(
+            "SELECT size FROM cost_basis WHERE market_id='m1' AND token='YES'")
+        assert float(row["size"]) == 10
+    asyncio.run(run())
+
+
 def test_submit_blocks_buy_that_exceeds_aggregate_market_cap():
     """A BUY that would push TOTAL (held + new) exposure on a (market, token)
     past the $25 ceiling is skipped — even though the single order is sub-cap.
@@ -149,6 +167,24 @@ def test_submit_market_cap_does_not_block_opposite_token_leg():
             "SELECT size FROM cost_basis WHERE market_id='m1' AND token='NO'")
         assert len(no_cb) == 1
 
+    asyncio.run(run())
+
+
+def test_submit_market_cap_read_failure_fails_closed():
+    async def run():
+        db = MagicMock()
+        db.fetchone = AsyncMock(side_effect=RuntimeError("database locked"))
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=10, price=0.5)
+        result = OrderResult(order_id="p1", market_id="m1", status="paper",
+                             filled_size=10, filled_price=0.5, is_paper=True)
+        ex = _paper_exchange(order, result)
+        gw = ExecutionGateway(router=None, exchange=ex, exchange_name="polymarket",
+                              settings=Settings(), db=db, pnl_tracker=None)
+        res = await gw.submit(_intent("m1"))
+        assert res.status == "skipped"
+        assert "unavailable" in res.reason
+        ex.place_order.assert_not_awaited()
     asyncio.run(run())
 
 
@@ -265,6 +301,29 @@ def test_submit_paired_records_both_legs():
         fills = await db.fetchall("SELECT market_id FROM fills")
         assert {dict(f)["market_id"] for f in fills} == {"a", "b"}
 
+    asyncio.run(run())
+
+
+def test_submit_paired_checks_caps_before_placing_either_leg():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        flag = 0 if Settings().is_live else 1
+        await db.execute(
+            "INSERT INTO cost_basis (market_id, token, size, avg_cost, total_cost, is_paper)"
+            " VALUES ('a', 'YES', 60, 0.4, 24, ?)", (flag,))
+        await db.commit()
+        ex_a = _leg("a", place=OrderResult(order_id="pa", market_id="a", status="paper",
+                                            filled_size=20, filled_price=0.4, is_paper=True))
+        ex_b = _leg("b", place=OrderResult(order_id="pb", market_id="b", status="paper",
+                                            filled_size=20, filled_price=0.4, is_paper=True))
+        res_a, res_b = await _paired_gateway(db).submit_paired(
+            _intent("a"), _intent("b"), exchange_a=ex_a,
+            exchange_name_a="polymarket", exchange_b=ex_b,
+            exchange_name_b="polymarket")
+        assert res_a.status == "skipped" and res_b.status == "skipped"
+        ex_a.place_order.assert_not_awaited()
+        ex_b.place_order.assert_not_awaited()
     asyncio.run(run())
 
 
@@ -443,6 +502,47 @@ def test_place_legs_concurrent_places_all_and_records_each():
         rows = await db.fetchall("SELECT strategy_source FROM trades")
         assert len(rows) == 3 and all(dict(r)["strategy_source"] == "negrisk_arb" for r in rows)
         assert len(await db.fetchall("SELECT 1 FROM fills")) == 3
+    asyncio.run(run())
+
+
+def test_place_legs_batch_reservation_blocks_collective_over_cap():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        clients = []
+        legs = []
+        for _ in range(2):
+            order = Order(market_id="same", exchange="polymarket", token_id="tok",
+                          side=OrderSide.BUY, token=TokenType.YES,
+                          size=30, price=0.5, dry_run=True)
+            client = MagicMock(); client.place_order = AsyncMock()
+            clients.append(client)
+            legs.append((order, client, "polymarket"))
+        out = await _gateway(db, MagicMock()).place_legs(
+            legs, strategy_source="arb", concurrent=True)
+        assert all(result.status == "rejected" for result, _ in out)
+        assert all(exec_result.status == "skipped" for _, exec_result in out)
+        for client in clients:
+            client.place_order.assert_not_awaited()
+    asyncio.run(run())
+
+
+def test_fill_record_failure_does_not_turn_execution_into_submission_failure():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        order = Order(market_id="m1", exchange="polymarket", token_id="tok",
+                      side=OrderSide.BUY, token=TokenType.YES, size=10, price=0.5)
+        result = OrderResult(order_id="p1", market_id="m1", status="paper",
+                             filled_size=10, filled_price=0.5, is_paper=True)
+        pnl = MagicMock(); pnl.record_fill = AsyncMock(side_effect=RuntimeError("disk full"))
+        gw = ExecutionGateway(router=None, exchange=_paper_exchange(order, result),
+                              exchange_name="polymarket", settings=Settings(), db=db,
+                              pnl_tracker=pnl)
+        res = await gw.submit(_intent("m1"))
+        assert res.status == "paper"
+        assert res.result is result
+        assert res.fill is None
     asyncio.run(run())
 
 

--- a/tests/test_live_gate.py
+++ b/tests/test_live_gate.py
@@ -46,6 +46,7 @@ async def test_clean_state_allows_live(tmp_path, monkeypatch):
 async def test_kill_switch_blocks(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "KILL_SWITCH").write_text("")  # in tmp cwd — never the real file
+    monkeypatch.setattr("auramaur.monitoring.live_gate.kill_switch_present", lambda: True)
     db = await _db()
     try:
         rep = await preflight(Settings(), db)

--- a/tests/test_onchain_redeemer.py
+++ b/tests/test_onchain_redeemer.py
@@ -107,6 +107,7 @@ def test_kill_switch_blocks_live_submission(tmp_path, monkeypatch):
     """Presence of KILL_SWITCH file blocks even with all gates open."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "KILL_SWITCH").write_text("halt")
+    monkeypatch.setattr("auramaur.broker.onchain.kill_switch_present", lambda: True)
     db = Database(":memory:")
     r = OnChainRedeemer(
         _make_settings(live=True, execution_live=True, enable_redemption=True), db

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -211,6 +211,17 @@ async def test_get_order_status_filled(client):
 
 
 @pytest.mark.asyncio
+async def test_get_order_status_missing_stays_ambiguous_pending(client):
+    mock_clob = MagicMock()
+    mock_clob.get_order.return_value = None
+    client._clob_client = mock_clob
+    result = await client.get_order_status("aged-out")
+    assert result.status == "pending"
+    assert result.filled_size == 0
+    assert "unknown" in result.error_message
+
+
+@pytest.mark.asyncio
 async def test_cancel_order_success(client):
     """Mock cancel succeeds."""
     mock_clob = MagicMock()

--- a/tests/test_risk_checks.py
+++ b/tests/test_risk_checks.py
@@ -54,7 +54,7 @@ async def test_kill_switch_inactive():
 
 @pytest.mark.asyncio
 async def test_kill_switch_active():
-    with patch.object(Path, "exists", return_value=True):
+    with patch("auramaur.risk.checks.kill_switch_present", return_value=True):
         result = await check_kill_switch()
         assert result.passed is False
 

--- a/tests/test_triple_gate.py
+++ b/tests/test_triple_gate.py
@@ -173,7 +173,7 @@ async def test_kill_switch_blocks_order(paper_trader):
     client = PolymarketClient(settings, paper_trader)
 
     order = _make_order(dry_run=False)
-    with patch.object(Path, "exists", return_value=True):
+    with patch("auramaur.exchange.client.kill_switch_present", return_value=True):
         result = await client.place_order(order)
 
     # Neither paper nor live should execute
@@ -189,7 +189,7 @@ async def test_kill_switch_blocks_even_paper(paper_trader):
     client = PolymarketClient(settings, paper_trader)
 
     order = _make_order(dry_run=True)
-    with patch.object(Path, "exists", return_value=True):
+    with patch("auramaur.exchange.client.kill_switch_present", return_value=True):
         result = await client.place_order(order)
 
     paper_trader.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
- preserve ambiguous aged-out CLOB orders instead of silently marking possible fills cancelled
- make fill/cost-basis recording idempotent and transactional while preserving the authoritative execution result on bookkeeping faults
- fail closed when aggregate exposure is unavailable and enforce the cap across paired/concurrent entry paths
- generate unique Coinbase paper fill IDs and isolate tests from operational kill-switch/local-config state

## Validation
- uv run ruff check auramaur tests
- uv run pytest -q — 1204 passed, 1 skipped
- git diff --check

The repository KILL_SWITCH remains armed and was not modified.