### PR TITLE
feat(ibkr): add qualified contract registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,8 @@ IBKR_QUOTE_ENVIRONMENT=live
 IBKR_QUOTE_PORT=4002
 IBKR_ENABLED=true
 IBKR_MULTIASSET_PAPER_ENABLED=true
+# 1=live. Multi-asset paper fills fail closed for 2/3/4.
+IBKR_MARKET_DATA_TYPE=1
 # Stable private addresses make the Gateway Trusted IP entry survive restarts.
 # Override the subnet if it conflicts with another Docker network on the host.
 AURAMAUR_BROKER_SUBNET=172.18.0.0/16

--- a/auramaur/cli/diagnostics.py
+++ b/auramaur/cli/diagnostics.py
@@ -186,6 +186,33 @@ def ibkr_multiasset_preflight(book_names):
 
     sys.exit(asyncio.run(_run()))
 
+
+@main.command("ibkr-contract-approve")
+@click.argument("instrument_key")
+@click.option("--reason", required=True,
+              help="Operator rationale recorded with this contract identity.")
+def ibkr_contract_approve(instrument_key, reason):
+    """Approve a pending discovered identity (currently corporate bonds)."""
+    import asyncio
+    import sys
+    from auramaur.db.database import Database
+    from auramaur.exchange.ibkr_registry import approve
+
+    async def _run() -> int:
+        db = Database()
+        await db.connect()
+        try:
+            changed = await approve(db, instrument_key, reason)
+        finally:
+            await db.close()
+        if not changed:
+            console.print("[bold red]NOT APPROVED[/] — no pending current identity")
+            return 1
+        console.print(f"[bold green]APPROVED[/] {instrument_key}")
+        return 0
+
+    sys.exit(asyncio.run(_run()))
+
 @main.command()
 @click.option("--exchange", default=None, help="Exchange to evaluate (e.g. kalshi)")
 @click.option("--days", default=7, help="Window in days (default 7)")

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -112,6 +112,8 @@ class Database:
             await self._migrate_v23_to_v24()
         if from_version < 25:
             await self._migrate_v24_to_v25()
+        if from_version < 26:
+            await self._migrate_v25_to_v26()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -603,6 +605,15 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 25")
         await self._db.commit()
         log.info("database.migrated", from_version=24, to_version=25)
+
+    async def _migrate_v25_to_v26(self) -> None:
+        """Register the persistent IBKR qualified-contract registry."""
+        required = await self.fetchall("PRAGMA table_info(ibkr_contract_registry)")
+        if not required:
+            raise RuntimeError("migration did not create ibkr_contract_registry")
+        await self._db.execute("UPDATE schema_version SET version = 26")
+        await self._db.commit()
+        log.info("database.migrated", from_version=25, to_version=26)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -563,6 +563,34 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_state (
     last_error TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Broker-qualified identities for the deterministic IBKR manifest. Discovery
+-- may refresh these rows but cannot introduce an undeclared instrument.
+CREATE TABLE IF NOT EXISTS ibkr_contract_registry (
+    instrument_key TEXT PRIMARY KEY,
+    book TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    manifest_hash TEXT NOT NULL,
+    con_id INTEGER NOT NULL,
+    local_symbol TEXT NOT NULL DEFAULT '',
+    trading_class TEXT NOT NULL DEFAULT '',
+    exchange TEXT NOT NULL DEFAULT '',
+    currency TEXT NOT NULL DEFAULT '',
+    multiplier REAL NOT NULL DEFAULT 1,
+    status TEXT NOT NULL CHECK(status IN
+        ('eligible', 'qualified_no_live_data', 'pending_approval',
+         'quarantined', 'drifted')),
+    approved INTEGER NOT NULL DEFAULT 0,
+    approval_reason TEXT NOT NULL DEFAULT '',
+    quote_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
+    has_history INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    qualified_at TEXT NOT NULL DEFAULT (datetime('now')),
+    validated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    approved_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ibkr_contract_registry_status
+    ON ibkr_contract_registry(book, status, approved);
 
 CREATE TABLE IF NOT EXISTS position_peaks (
     market_id TEXT PRIMARY KEY,

--- a/auramaur/exchange/ibkr_instruments.py
+++ b/auramaur/exchange/ibkr_instruments.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from enum import Enum
+import hashlib
+import json
 
 
 class IBKRBook(str, Enum):
@@ -48,7 +50,21 @@ class InstrumentSpec:
     option_right: str = ""
     option_dte_min: int = 0
     option_dte_max: int = 0
+    option_moneyness_pct: float = 0.0
     bond_query: str = ""
+    # Futures roll before expiry by this many calendar days. Discovery may use
+    # volume to choose between valid contracts, but never expands the product.
+    roll_days_before_expiry: int = 7
+    # Corporate bond discoveries require an explicit operator approval.
+    approval_required: bool = False
+
+    def manifest_hash(self) -> str:
+        """Stable identity for drift detection in the qualified registry."""
+        values = {name: getattr(self, name) for name in self.__dataclass_fields__}
+        values["book"] = self.book.value
+        values["kind"] = self.kind.value
+        payload = json.dumps(values, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def _stk(key: str, book: IBKRBook, symbol: str, exchange: str, currency: str,
@@ -65,14 +81,32 @@ GLOBAL_ETFS = (
     _stk("SPY", IBKRBook.GLOBAL_ETF, "SPY", "SMART", "USD", "us_equity", "S&P 500", primary="ARCA"),
     _stk("QQQ", IBKRBook.GLOBAL_ETF, "QQQ", "SMART", "USD", "us_equity", "Nasdaq-100", primary="NASDAQ"),
     _stk("IWM", IBKRBook.GLOBAL_ETF, "IWM", "SMART", "USD", "us_equity", "Russell 2000", primary="ARCA"),
+    _stk("DIA", IBKRBook.GLOBAL_ETF, "DIA", "SMART", "USD", "us_equity", "Dow Jones Industrial Average", primary="ARCA"),
+    _stk("VTI", IBKRBook.GLOBAL_ETF, "VTI", "SMART", "USD", "us_equity", "Total US stock market", primary="ARCA"),
+    *tuple(_stk(symbol, IBKRBook.GLOBAL_ETF, symbol, "SMART", "USD", asset,
+                description, primary="ARCA") for symbol, asset, description in (
+        ("XLK", "sector_technology", "US technology sector"),
+        ("XLF", "sector_financials", "US financial sector"),
+        ("XLV", "sector_healthcare", "US healthcare sector"),
+        ("XLE", "sector_energy", "US energy sector"),
+        ("XLI", "sector_industrials", "US industrial sector"),
+        ("XLY", "sector_discretionary", "US consumer discretionary sector"),
+        ("XLP", "sector_staples", "US consumer staples sector"),
+        ("XLU", "sector_utilities", "US utilities sector"),
+        ("XLB", "sector_materials", "US materials sector"),
+        ("XLRE", "sector_real_estate", "US real-estate sector"),
+        ("XLC", "sector_communications", "US communications sector"),
+    )),
     _stk("VEA", IBKRBook.GLOBAL_ETF, "VEA", "SMART", "USD", "international", "Developed markets ex-US", primary="ARCA"),
     _stk("VWO", IBKRBook.GLOBAL_ETF, "VWO", "SMART", "USD", "international", "Emerging markets", primary="ARCA"),
     _stk("INDA", IBKRBook.GLOBAL_ETF, "INDA", "SMART", "USD", "international", "India equities", primary="CBOE"),
     _stk("MCHI", IBKRBook.GLOBAL_ETF, "MCHI", "SMART", "USD", "international", "China equities", primary="NASDAQ"),
     _stk("EWJ", IBKRBook.GLOBAL_ETF, "EWJ", "SMART", "USD", "international", "Japan equities", primary="ARCA"),
+    _stk("EWC", IBKRBook.GLOBAL_ETF, "EWC", "SMART", "USD", "international", "Canada equities", primary="ARCA"),
     _stk("EWZ", IBKRBook.GLOBAL_ETF, "EWZ", "SMART", "USD", "international", "Brazil equities", primary="ARCA"),
     _stk("TLT", IBKRBook.GLOBAL_ETF, "TLT", "SMART", "USD", "rates", "Long US Treasuries", primary="NASDAQ"),
     _stk("IEF", IBKRBook.GLOBAL_ETF, "IEF", "SMART", "USD", "rates", "Intermediate US Treasuries", primary="NASDAQ"),
+    _stk("SHY", IBKRBook.GLOBAL_ETF, "SHY", "SMART", "USD", "rates", "Short US Treasuries", primary="NASDAQ"),
     _stk("TIP", IBKRBook.GLOBAL_ETF, "TIP", "SMART", "USD", "rates", "US inflation-linked Treasuries", primary="ARCA"),
     _stk("LQD", IBKRBook.GLOBAL_ETF, "LQD", "SMART", "USD", "credit", "Investment-grade credit", primary="ARCA"),
     _stk("HYG", IBKRBook.GLOBAL_ETF, "HYG", "SMART", "USD", "credit", "High-yield credit", primary="ARCA"),
@@ -96,17 +130,17 @@ FUTURES = tuple(
     InstrumentSpec(key, IBKRBook.FUTURES, ContractKind.FUTURE, symbol, exchange,
                    currency, asset, description, multiplier=multiplier,
                    paper_capital_per_unit_usd=capital, calendar="FUTURES",
-                   expiry_policy="front_liquid")
-    for key, symbol, exchange, currency, asset, description, multiplier, capital in (
-        ("MES", "MES", "CME", "USD", "equity_index", "Micro E-mini S&P 500", 5, 2500),
-        ("MNQ", "MNQ", "CME", "USD", "equity_index", "Micro E-mini Nasdaq-100", 2, 3500),
-        ("M2K", "M2K", "CME", "USD", "equity_index", "Micro E-mini Russell 2000", 5, 1500),
-        ("ZN", "ZN", "CBOT", "USD", "rates", "10-year US Treasury note", 1000, 3000),
-        ("MCL", "MCL", "NYMEX", "USD", "energy", "Micro WTI crude oil", 100, 1500),
-        ("MGC", "MGC", "COMEX", "USD", "metals", "Micro Gold", 10, 2000),
-        ("SIC", "SIC", "COMEX", "USD", "metals", "100-ounce Silver", 100, 1000),
-        ("ZC", "ZC", "CBOT", "USD", "agriculture", "Corn", 50, 2500),
-        ("ZW", "ZW", "CBOT", "USD", "agriculture", "Wheat", 50, 3000),
+                   expiry_policy="front_liquid", roll_days_before_expiry=roll_days)
+    for key, symbol, exchange, currency, asset, description, multiplier, capital, roll_days in (
+        ("MES", "MES", "CME", "USD", "equity_index", "Micro E-mini S&P 500", 5, 2500, 7),
+        ("MNQ", "MNQ", "CME", "USD", "equity_index", "Micro E-mini Nasdaq-100", 2, 3500, 7),
+        ("M2K", "M2K", "CME", "USD", "equity_index", "Micro E-mini Russell 2000", 5, 1500, 7),
+        ("ZN", "ZN", "CBOT", "USD", "rates", "10-year US Treasury note", 1000, 3000, 10),
+        ("MCL", "MCL", "NYMEX", "USD", "energy", "Micro WTI crude oil", 100, 1500, 10),
+        ("MGC", "MGC", "COMEX", "USD", "metals", "Micro Gold", 10, 2000, 10),
+        ("SIC", "SIC", "COMEX", "USD", "metals", "100-ounce Silver", 100, 1000, 10),
+        ("ZC", "ZC", "CBOT", "USD", "agriculture", "Corn", 50, 2500, 20),
+        ("ZW", "ZW", "CBOT", "USD", "agriculture", "Wheat", 50, 3000, 20),
     )
 )
 
@@ -131,12 +165,15 @@ INTERNATIONAL_EQUITIES = (
 )
 
 OPTIONS = tuple(
-    InstrumentSpec(f"{symbol}_ATM_{right}", IBKRBook.OPTIONS,
+    InstrumentSpec(f"{symbol}_{bucket}_{right}", IBKRBook.OPTIONS,
                    ContractKind.OPTION, symbol, "SMART", "USD", "options",
-                   f"{symbol} 30-60 DTE ATM {right}", multiplier=100,
+                   f"{symbol} 30-60 DTE {bucket} {right}", multiplier=100,
                    paper_capital_per_unit_usd=0,
-                   option_right=right, option_dte_min=30, option_dte_max=60)
-    for symbol in ("SPY", "QQQ", "IWM", "TLT", "GLD")
+                   option_right=right, option_dte_min=30, option_dte_max=60,
+                   option_moneyness_pct=moneyness)
+    for symbol in ("SPY", "QQQ", "IWM", "DIA", "VTI", "XLF", "XLE",
+                   "XLV", "TLT", "GLD")
+    for bucket, moneyness in (("ATM", 0.0), ("OTM5", 5.0))
     for right in ("C", "P")
 )
 
@@ -146,7 +183,7 @@ BONDS = tuple(
     InstrumentSpec(key, IBKRBook.BONDS, ContractKind.BOND, "", "SMART", "USD",
                    asset, description, multiplier=10,
                    paper_capital_per_unit_usd=1000, calendar="US_BOND",
-                   bond_query=query)
+                   bond_query=query, approval_required=key.startswith("CORP_"))
     for key, asset, description, query in (
         ("UST_2Y", "government", "US Treasury near 2-year maturity", "UST:2Y"),
         ("UST_5Y", "government", "US Treasury near 5-year maturity", "UST:5Y"),

--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -148,7 +148,7 @@ class IBKRReadOnlyMarketData:
         from ib_async import Future
         seed = Future(spec.symbol, exchange=spec.exchange, currency=spec.currency)
         details = await self._ib.reqContractDetailsAsync(seed)
-        cutoff = date.today() + timedelta(days=7)
+        cutoff = date.today() + timedelta(days=spec.roll_days_before_expiry)
         candidates = []
         for detail in details or []:
             contract = detail.contract
@@ -172,7 +172,24 @@ class IBKRReadOnlyMarketData:
                 candidates.append((expiry, contract))
         if not candidates:
             raise LookupError(f"no non-expiring front future found for {spec.key}")
-        return await self._qualify_one(min(candidates, key=lambda item: item[0])[1])
+        candidates.sort(key=lambda item: item[0])
+        # Compare only the nearest valid expiries. Volume confirms the active
+        # contract without allowing discovery to leave the declared product.
+        shortlist = candidates[:3]
+        request = getattr(self._ib, "reqTickersAsync", None)
+        if callable(request) and len(shortlist) > 1:
+            try:
+                tickers = await request(*(contract for _, contract in shortlist))
+                volumes = {int(getattr(t.contract, "conId", 0) or 0):
+                           float(getattr(t, "volume", 0) or 0) for t in tickers}
+                chosen = max(shortlist, key=lambda item: (
+                    volumes.get(int(getattr(item[1], "conId", 0) or 0), 0),
+                    -item[0].toordinal()))[1]
+                return await self._qualify_one(chosen)
+            except Exception as exc:  # noqa: BLE001 - deterministic fallback
+                log.warning("ibkr_multiasset.future_volume_fallback",
+                            key=spec.key, error=str(exc)[:120])
+        return await self._qualify_one(shortlist[0][1])
 
     async def _underlying(self, symbol: str):
         from ib_async import Stock
@@ -220,7 +237,9 @@ class IBKRReadOnlyMarketData:
         strikes = [float(s) for s in chain.strikes if float(s) > 0]
         if not strikes:
             raise LookupError(f"no strikes for {spec.key}")
-        strike = min(strikes, key=lambda value: abs(value - spot))
+        direction = 1 if spec.option_right == "C" else -1
+        target_strike = spot * (1 + direction * spec.option_moneyness_pct / 100)
+        strike = min(strikes, key=lambda value: abs(value - target_strike))
         contract = Option(spec.symbol, expiry, strike, spec.option_right,
                           "SMART", multiplier=str(int(spec.multiplier)),
                           currency=spec.currency,
@@ -252,9 +271,17 @@ class IBKRReadOnlyMarketData:
                       if getattr(row.contractDetails.contract, "secType", "") == "BOND"]
         if not candidates:
             raise LookupError(f"bond scanner found no match for {spec.key}")
-        # Scanner ordering provides the requested yield ranking; conId makes the
-        # selected issue unambiguous even when descriptive fields are sparse.
-        return await self._qualify_one(candidates[0])
+        def rank(contract):
+            raw = str(getattr(contract, "lastTradeDateOrContractMonth", "")
+                      or getattr(contract, "maturity", ""))[:8]
+            try:
+                maturity_distance = abs((datetime.strptime(raw, "%Y%m%d").date()
+                                         - target).days)
+            except ValueError:
+                maturity_distance = 999_999
+            # Stable tie-break avoids depending on scanner ordering.
+            return maturity_distance, int(getattr(contract, "conId", 0) or 0)
+        return await self._qualify_one(min(candidates, key=rank))
 
     async def get_quote(self, spec: InstrumentSpec) -> MarketDataQuote | None:
         contract = await self.resolve(spec)

--- a/auramaur/exchange/ibkr_registry.py
+++ b/auramaur/exchange/ibkr_registry.py
@@ -1,0 +1,90 @@
+"""Persistence boundary between the reviewed manifest and IBKR discovery."""
+
+from __future__ import annotations
+
+from auramaur.exchange.ibkr_instruments import InstrumentSpec
+
+
+async def record_validation(db, spec: InstrumentSpec, contract, *, quote_source: str,
+                            has_history: bool, error: str = "") -> str:
+    """Upsert one declared instrument without overwriting operator approval."""
+    existing = await db.fetchone(
+        "SELECT manifest_hash, con_id, approved FROM ibkr_contract_registry "
+        "WHERE instrument_key=?",
+        (spec.key,))
+    same_manifest = bool(existing and existing["manifest_hash"] == spec.manifest_hash())
+    discovered_con_id = int(getattr(contract, "conId", 0) or 0)
+    identity_changed = bool(
+        existing and discovered_con_id and int(existing["con_id"])
+        and discovered_con_id != int(existing["con_id"]))
+    approved = int(existing["approved"]) if same_manifest else int(not spec.approval_required)
+    if error:
+        status = "quarantined"
+    elif existing and (not same_manifest or identity_changed):
+        status = "drifted"
+        approved = 0
+    elif spec.approval_required and not approved:
+        status = "pending_approval"
+    elif quote_source != "ibkr_live" or not has_history:
+        status = "qualified_no_live_data"
+    else:
+        status = "eligible"
+    con_id = discovered_con_id
+    await db.execute(
+        """INSERT INTO ibkr_contract_registry
+           (instrument_key, book, kind, manifest_hash, con_id, local_symbol,
+            trading_class, exchange, currency, multiplier, status, approved,
+            quote_source, has_history, last_error)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(instrument_key) DO UPDATE SET
+             book=excluded.book, kind=excluded.kind,
+             manifest_hash=excluded.manifest_hash,
+             con_id=CASE WHEN excluded.con_id != 0 THEN excluded.con_id ELSE con_id END,
+             local_symbol=CASE WHEN excluded.local_symbol != ''
+                               THEN excluded.local_symbol ELSE local_symbol END,
+             trading_class=CASE WHEN excluded.trading_class != ''
+                                THEN excluded.trading_class ELSE trading_class END,
+             exchange=CASE WHEN excluded.exchange != ''
+                           THEN excluded.exchange ELSE exchange END,
+             currency=CASE WHEN excluded.currency != ''
+                           THEN excluded.currency ELSE currency END,
+             multiplier=CASE WHEN excluded.con_id != 0
+                             THEN excluded.multiplier ELSE multiplier END,
+             status=excluded.status, approved=excluded.approved,
+             quote_source=excluded.quote_source, has_history=excluded.has_history,
+             last_error=excluded.last_error, validated_at=datetime('now'),
+             qualified_at=CASE WHEN excluded.con_id != 0
+                                    AND ibkr_contract_registry.con_id != excluded.con_id
+                               THEN datetime('now') ELSE qualified_at END""",
+        (spec.key, spec.book.value, spec.kind.value, spec.manifest_hash(), con_id,
+         str(getattr(contract, "localSymbol", "") or ""),
+         str(getattr(contract, "tradingClass", "") or ""),
+         str(getattr(contract, "exchange", spec.exchange) or spec.exchange),
+         str(getattr(contract, "currency", spec.currency) or spec.currency),
+         float(getattr(contract, "multiplier", spec.multiplier) or spec.multiplier),
+         status, approved, quote_source, int(has_history), error[:300]))
+    await db.commit()
+    return status
+
+
+async def approve(db, instrument_key: str, reason: str) -> bool:
+    """Approve the current manifest identity; drift invalidates this approval."""
+    cursor = await db.execute(
+        """UPDATE ibkr_contract_registry SET approved=1,
+           status=CASE WHEN quote_source='ibkr_live' AND has_history=1
+                       THEN 'eligible' ELSE 'qualified_no_live_data' END,
+           approval_reason=?, approved_at=datetime('now'), validated_at=datetime('now')
+           WHERE instrument_key=? AND status IN ('pending_approval', 'drifted')""",
+        (reason.strip(), instrument_key))
+    await db.commit()
+    return cursor.rowcount == 1
+
+
+async def eligible_keys(db) -> set[str]:
+    rows = await db.fetchall(
+        "SELECT instrument_key, manifest_hash FROM ibkr_contract_registry "
+        "WHERE status='eligible' AND approved=1 AND has_history=1")
+    from auramaur.exchange.ibkr_instruments import BY_KEY
+    return {row["instrument_key"] for row in rows
+            if row["instrument_key"] in BY_KEY
+            and row["manifest_hash"] == BY_KEY[row["instrument_key"]].manifest_hash()}

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 import time
+from types import SimpleNamespace
 
 import structlog
 
 from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
 from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
+from auramaur.exchange.ibkr_registry import record_validation
 
 log = structlog.get_logger()
 
@@ -52,23 +54,44 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         for attempt in range(attempts):
             try:
                 async with semaphore:
+                    contract = (await client.resolve(spec)
+                                if hasattr(client, "resolve") else None)
                     market_open = (await client.is_market_open(spec)
                                    if hasattr(client, "is_market_open") else True)
                     quote = await asyncio.wait_for(client.get_quote(spec), timeout_seconds)
                     bars = await asyncio.wait_for(client.get_daily_bars(spec), timeout_seconds)
+                if contract is None:
+                    contract = SimpleNamespace(
+                        conId=int(getattr(quote, "con_id", 0) or 0),
+                        exchange=spec.exchange, currency=spec.currency,
+                        multiplier=spec.multiplier)
                 if len(bars) < 21:
+                    await record_validation(db, spec, contract,
+                                            quote_source=getattr(quote, "source", "none"),
+                                            has_history=False, error="insufficient history")
                     return f"{spec.key}: only {len(bars)} daily bars", None, None
                 if not market_open:
                     source = getattr(quote, "source", "none") if quote else "none"
+                    await record_validation(db, spec, contract, quote_source=source,
+                                            has_history=True)
                     return None, source, f"{spec.key}: venue closed; contract/history ready"
                 if quote is None:
+                    await record_validation(db, spec, contract, quote_source="none",
+                                            has_history=True, error="no executable BBO")
                     return f"{spec.key}: no executable BBO", None, None
                 age = time.time() - float(quote.timestamp)
                 if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
+                    await record_validation(db, spec, contract,
+                                            quote_source=getattr(quote, "source", "none"),
+                                            has_history=True, error="stale BBO")
                     return f"{spec.key}: stale BBO ({age:.0f}s old)", None, None
                 source = getattr(quote, "source", "ibkr_unknown")
                 if source != "ibkr_live":
+                    await record_validation(db, spec, contract, quote_source=source,
+                                            has_history=True)
                     return f"{spec.key}: non-executable {source} quote", source, None
+                await record_validation(db, spec, contract, quote_source=source,
+                                        has_history=True)
                 return None, source, None
             except Exception as exc:  # noqa: BLE001
                 if pacing_error(exc) and attempt + 1 < attempts:
@@ -79,6 +102,11 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                     await asyncio.sleep(delay)
                     continue
                 prefix = "pacing exhausted" if pacing_error(exc) else "probe failed"
+                await record_validation(
+                    db, spec, SimpleNamespace(conId=0, exchange=spec.exchange,
+                                              currency=spec.currency,
+                                              multiplier=spec.multiplier),
+                    quote_source="none", has_history=False, error=str(exc))
                 return f"{spec.key}: {prefix}: {str(exc)[:140]}", None, None
         return f"{spec.key}: pacing retry exhausted", None, None  # pragma: no cover
     if not getattr(client, "readonly", False) or hasattr(client, "place_order"):
@@ -87,7 +115,7 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         add("isolation", "OK", "read-only client exposes no broker order method")
 
     required = {"ibkr_paper_positions", "ibkr_paper_fills",
-                "ibkr_paper_ledger", "ibkr_paper_state"}
+                "ibkr_paper_ledger", "ibkr_paper_state", "ibkr_contract_registry"}
     rows = await db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
     missing = required - {row["name"] for row in rows}
     add("database", "BLOCK" if missing else "OK",
@@ -141,6 +169,13 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                 f"sources={','.join(sorted(sources))}")
         log.info("ibkr_multiasset.preflight_book_complete", book=book.value,
                  passed=len(universe) - len(failures), failed=len(failures))
+        registry = await db.fetchall(
+            "SELECT status, COUNT(*) AS n FROM ibkr_contract_registry "
+            "WHERE book=? GROUP BY status ORDER BY status", (book.value,))
+        counts = {row["status"]: int(row["n"]) for row in registry}
+        add(f"{book.value}:registry",
+            "OK" if set(counts) <= {"eligible"} else "WARN",
+            ", ".join(f"{status}={count}" for status, count in counts.items()))
 
         edge = await db.fetchone(
             """SELECT SUM(CASE WHEN kind = 'trade' THEN 1 ELSE 0 END) AS n,

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -192,8 +192,13 @@ class IBKRMultiAssetPaperBook:
             (self.book.value,))
         cursor = int(state["refresh_cursor"] or 0) if state else 0
         disabled = set(self._settings.ibkr.multiasset_disabled_instruments)
+        eligible = None
+        if self._settings.ibkr.multiasset_registry_required:
+            from auramaur.exchange.ibkr_registry import eligible_keys
+            eligible = await eligible_keys(self._db)
         universe = tuple(spec for spec in BY_BOOK[self.book]
-                         if spec.key not in disabled)
+                         if spec.key not in disabled
+                         and (eligible is None or spec.key in eligible))
         held_specs = {}
         for key, row in positions.items():
             spec = self._position_spec(row)

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,8 @@ services:
       IBKR__HOST: ibgateway
       IBKR__ENABLED: ${IBKR_ENABLED:-true}
       IBKR__OPTIONS_ENABLED: "false"
+      # Paper books reject delayed/frozen prices; request native live data.
+      IBKR__MARKET_DATA_TYPE: ${IBKR_MARKET_DATA_TYPE:-1}
       IBKR__ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
       IBKR__PAPER_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__LIVE_PORT: ${IBKR_QUOTE_PORT:-4002}

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -270,6 +270,9 @@ ibkr:
   multiasset_preflight_concurrency: 2
   multiasset_preflight_pacing_retries: 2
   multiasset_preflight_retry_seconds: 2.0
+  # Runtime universe = deterministic manifest intersected with this machine's
+  # qualified, approved broker registry. Run preflight before enabling books.
+  multiasset_registry_required: true
   # TSEJ history/BBO is not entitled on the current IBKR username. Keep the
   # contract in the catalog and re-enable it after preflight passes.
   multiasset_disabled_instruments: ["7203.T"]
@@ -282,13 +285,13 @@ ibkr:
     international_equity: {enabled: true, budget_usd: 5000, max_positions: 5, max_position_pct: 12, max_deployment_pct: 50, daily_loss_limit_usd: 100, stop_loss_pct: 6, take_profit_pct: 12, max_spread_bps: 50}
     options: {enabled: true, budget_usd: 3000, max_positions: 3, max_position_pct: 10, max_deployment_pct: 30, daily_loss_limit_usd: 100, stop_loss_pct: 35, take_profit_pct: 50, max_spread_bps: 300}
     bonds: {enabled: true, budget_usd: 10000, max_positions: 4, max_position_pct: 20, max_deployment_pct: 60, daily_loss_limit_usd: 75, stop_loss_pct: 3, take_profit_pct: 6, max_spread_bps: 100}
-  # Multi-asset ETF universe: broad US, sectors, international, rates, real
-  # assets, and defensives. Long-only instruments avoid leverage/inverse decay.
+  # Operator-visible mirror of the typed GLOBAL_ETFS manifest. A test enforces
+  # exact equality so the legacy intelligence experiment cannot drift.
   etf_symbols: ["SPY", "QQQ", "IWM", "DIA", "VTI",
     "XLK", "XLF", "XLV", "XLE", "XLI", "XLY", "XLP", "XLU", "XLB", "XLRE", "XLC",
-    "VEA", "VWO", "EWC", "EWJ",
-    "TLT", "IEF", "SHY", "TIP",
-    "GLD", "SLV", "DBC", "VNQ"]
+    "VEA", "VWO", "INDA", "MCHI", "EWJ", "EWC", "EWZ",
+    "TLT", "IEF", "SHY", "TIP", "LQD", "HYG", "EMB",
+    "GLD", "SLV", "DBC", "VNQ", "UUP"]
   etf_paper_budget_usd: 5000.0
   etf_max_entry_usd: 250.0
   etf_max_deployment_pct: 50.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -1059,6 +1059,12 @@ class IBKRMultiAssetBookConfig(BaseModel):
         return self
 
 
+def _canonical_ibkr_etf_symbols() -> list[str]:
+    """Keep the legacy ETF experiment on the typed multi-asset manifest."""
+    from auramaur.exchange.ibkr_instruments import GLOBAL_ETFS
+    return [spec.symbol for spec in GLOBAL_ETFS]
+
+
 class IBKRConfig(BaseModel):
     enabled: bool = False
     # `enabled` is the master switch (connect to IBKR at all). The two books
@@ -1104,6 +1110,10 @@ class IBKRConfig(BaseModel):
     multiasset_preflight_concurrency: int = 2
     multiasset_preflight_pacing_retries: int = 2
     multiasset_preflight_retry_seconds: float = 2.0
+    # Require a current broker-qualified identity before opening new risk.
+    # Kept false in model defaults so isolated test/library users can opt in;
+    # tracked deployment defaults enable it.
+    multiasset_registry_required: bool = False
     multiasset_disabled_instruments: list[str] = []
     multiasset_min_momentum_pct: float = 1.0
     multiasset_exit_momentum_pct: float = -0.5
@@ -1111,7 +1121,7 @@ class IBKRConfig(BaseModel):
         name: IBKRMultiAssetBookConfig() for name in (
             "global_etf", "fx", "futures", "international_equity", "options", "bonds")
     })
-    etf_symbols: list[str] = ["SPY", "QQQ", "IWM"]
+    etf_symbols: list[str] = Field(default_factory=_canonical_ibkr_etf_symbols)
     etf_paper_budget_usd: float = 5_000.0
     etf_max_entry_usd: float = 250.0
     etf_max_deployment_pct: float = 50.0

--- a/deploy/env.manifest.yaml
+++ b/deploy/env.manifest.yaml
@@ -72,6 +72,7 @@ IBKR_ENABLED:                  {type: config, required: optional, targets: [host
 IBKR_QUOTE_ENVIRONMENT:        {type: config, required: optional, targets: [compose]}
 IBKR_QUOTE_PORT:               {type: config, required: optional, targets: [compose]}
 IBKR_MULTIASSET_PAPER_ENABLED: {type: config, required: optional, targets: [compose]}
+IBKR_MARKET_DATA_TYPE:         {type: config, required: optional, targets: [compose]}
 AURAMAUR_HEALTH_REQUIRE_IBKR:  {type: config, required: optional, targets: [host, compose], in_example: false}
 AURAMAUR_IBKR_ENVIRONMENT:     {type: config, required: optional, targets: [host], in_example: false}
 AURAMAUR_IBKR_HOST:            {type: config, required: optional, targets: [host], in_example: false}

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -10,7 +10,7 @@ method. A live-account TWS login does not make these books live.
 |---|---|---|---|
 | `global_etf` | US-listed global equity, rates, credit, commodity, currency and real-estate ETFs | Qualified `STK` with primary exchange | fractional shares at ask/bid |
 | `fx` | ten liquid G10 crosses | `CASH` on `IDEALPRO` | 1,000-base-unit lots, USD translation |
-| `futures` | micro equity index, rates, energy, metals and agriculture | nearest contract with >7 days to expiry; exact held `conId` retained | conservative per-contract capital plus multiplier P&L |
+| `futures` | micro equity index, rates, energy, metals and agriculture | product-specific roll buffer, then highest reported volume among nearest valid expiries; exact held `conId` retained | conservative per-contract capital plus multiplier P&L |
 | `international_equity` | Canada, UK, Europe, Japan, Hong Kong and Australia | native listing, exchange and currency | fractional shares, mark translated to USD |
 | `options` | 30–60 DTE ATM calls and puts on liquid ETFs | exact qualified chain contract; exact held `conId` retained | whole contracts, 100 multiplier |
 | `bonds` | US Treasury tenors and a US corporate issue | maturity-bounded IBKR bond scanner, exact `conId` | $1,000 face-value units |
@@ -18,6 +18,32 @@ method. A live-account TWS login does not make these books live.
 The catalog is in `auramaur/exchange/ibkr_instruments.py`. Instrument keys are
 unique and every entry declares its security type, exchange, currency, calendar,
 multiplier and discovery policy.
+
+## Manifest and qualified registry
+
+The trading space is deliberately hybrid. The version-controlled catalog is the
+only authority allowed to introduce economic exposure. IBKR probing qualifies
+those declarations into exact broker identities; it never adds a ticker or
+scanner result to the universe by itself.
+
+Successful preflight writes `ibkr_contract_registry`, including the manifest
+hash, `conId`, local symbol, trading class, exchange, currency, multiplier,
+quote provenance, history availability, and validation time. With
+`multiasset_registry_required: true`, new entries require a current `eligible`
+row whose manifest hash still matches. A catalog edit therefore fails closed
+until the instrument is probed again. Existing positions remain manageable by
+their persisted specification and original `conId`.
+
+Static listings, FX, futures, options, and government bond policies become
+eligible after successful qualification. Corporate bond scanner results need an
+operator to approve the exact issue:
+
+```console
+auramaur ibkr-contract-approve CORP_5Y --reason "reviewed issuer, maturity and liquidity"
+```
+
+Changing the manifest invalidates prior approval. Failed probes are quarantined;
+disabled instruments remain outside probing and runtime eligibility.
 
 `multiasset_disabled_instruments` is the explicit entitlement quarantine. The
 current username lacks TSEJ data, so `7203.T` remains catalogued but does not
@@ -83,6 +109,10 @@ The preflight checks structural isolation, schema, every configured contract,
 fresh BBOs, at least 21 daily bars, quote provenance, and per-book forward
 evidence. Run it during each venue's session when diagnosing BBO availability;
 closed venues are expected to lack executable quotes.
+
+Set `IBKR_MARKET_DATA_TYPE=1` in the compose environment. Values 2–4 may still
+qualify contracts and expose delayed/frozen data for diagnostics, but registry
+status becomes `qualified_no_live_data` and the runtime will not open risk.
 
 The startup books panel and periodic strategy table report each book separately.
 `ibkr_paper_state.last_cycle_at`, `last_success_at`, and `last_error` provide

--- a/tests/test_ibkr_instruments.py
+++ b/tests/test_ibkr_instruments.py
@@ -7,6 +7,9 @@ def test_catalog_has_unique_typed_keys_and_all_six_books():
     assert len(BY_KEY) == len(CATALOG)
     assert set(BY_BOOK) == set(IBKRBook)
     assert all(BY_BOOK[book] for book in IBKRBook)
+    broad = {spec.key for spec in BY_BOOK[IBKRBook.GLOBAL_ETF]}
+    assert {"DIA", "VTI", "XLK", "XLF", "XLV", "XLE", "SHY", "EWC"} <= broad
+    assert len({spec.manifest_hash() for spec in CATALOG}) == len(CATALOG)
 
 
 def test_derivatives_and_bonds_declare_discovery_policy():
@@ -14,6 +17,7 @@ def test_derivatives_and_bonds_declare_discovery_policy():
         assert spec.kind is ContractKind.FUTURE
         assert spec.expiry_policy == "front_liquid"
         assert spec.multiplier > 1
+        assert spec.roll_days_before_expiry >= 7
     grains = {spec.key: spec for spec in BY_BOOK[IBKRBook.FUTURES]
               if spec.key in {"ZC", "ZW"}}
     assert all(spec.contract_multiplier == 5000 and spec.multiplier == 50
@@ -23,9 +27,11 @@ def test_derivatives_and_bonds_declare_discovery_policy():
         assert 0 < spec.option_dte_min <= spec.option_dte_max
         assert spec.option_right in {"C", "P"}
         assert spec.multiplier == 100
+        assert spec.option_moneyness_pct in {0, 5}
     for spec in BY_BOOK[IBKRBook.BONDS]:
         assert spec.kind is ContractKind.BOND
         assert spec.bond_query
+    assert BY_KEY["CORP_5Y"].approval_required
 
 
 def test_fx_uses_idealpro_and_native_equities_are_not_usd_only():

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -31,10 +31,13 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
     version = await db.fetchone("SELECT version FROM schema_version")
     position_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
     fill_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_fills)")
-    assert version["version"] == 25
+    assert version["version"] == 26
     assert {row["name"] for row in position_columns} >= {
         "price_source", "instrument_spec_json"}
     assert "price_source" in {row["name"] for row in fill_columns}
+    registry = await db.fetchall("PRAGMA table_info(ibkr_contract_registry)")
+    assert {"instrument_key", "manifest_hash", "con_id", "status", "approved"} <= {
+        row["name"] for row in registry}
     await db.close()
 
 

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -45,6 +45,7 @@ async def test_all_six_books_write_only_isolated_paper_tables():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 1
     for cfg in settings.ibkr.multiasset_books.values():
         cfg.max_position_pct = 40
@@ -71,6 +72,7 @@ async def test_daily_loss_gate_blocks_entries():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     await db.execute(
         "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) "
         "VALUES ('global_etf', 'trade', -101, 'loss')")
@@ -90,6 +92,7 @@ async def test_intracycle_commission_tightens_loss_gate():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 2
     cfg = settings.ibkr.multiasset_books["global_etf"]
     cfg.daily_loss_limit_usd = 0.5
@@ -204,6 +207,7 @@ async def test_open_position_is_marked_by_original_contract_id():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 1
     client = FakeMarketData()
     client.con_ids_requested = []

--- a/tests/test_ibkr_registry.py
+++ b/tests/test_ibkr_registry.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.ibkr_instruments import BY_KEY
+from auramaur.exchange.ibkr_registry import approve, eligible_keys, record_validation
+
+
+@pytest.mark.asyncio
+async def test_registry_auto_approves_declared_static_instrument():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    status = await record_validation(
+        db, spec, SimpleNamespace(conId=756733, localSymbol="SPY",
+                                  tradingClass="SPY", exchange="SMART",
+                                  currency="USD", multiplier="1"),
+        quote_source="ibkr_live", has_history=True)
+    assert status == "eligible"
+    assert await eligible_keys(db) == {"SPY"}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_corporate_bond_requires_operator_approval():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["CORP_5Y"]
+    contract = SimpleNamespace(conId=1234, exchange="SMART", currency="USD",
+                               multiplier="10")
+    assert await record_validation(db, spec, contract, quote_source="ibkr_live",
+                                   has_history=True) == "pending_approval"
+    assert "CORP_5Y" not in await eligible_keys(db)
+    assert await approve(db, "CORP_5Y", "reviewed issue and maturity")
+    assert "CORP_5Y" in await eligible_keys(db)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_manifest_drift_revokes_existing_approval(monkeypatch):
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    contract = SimpleNamespace(conId=1, exchange="SMART", currency="USD",
+                               multiplier="1")
+    await record_validation(db, spec, contract, quote_source="ibkr_live",
+                            has_history=True)
+    monkeypatch.setattr(type(spec), "manifest_hash", lambda _self: "changed")
+    assert await record_validation(db, spec, contract, quote_source="ibkr_live",
+                                   has_history=True) == "drifted"
+    assert "SPY" not in await eligible_keys(db)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_contract_identity_drift_requires_reapproval_but_failure_preserves_identity():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    original = SimpleNamespace(conId=11, localSymbol="SPY", exchange="SMART",
+                               currency="USD", multiplier="1")
+    await record_validation(db, spec, original, quote_source="ibkr_live",
+                            has_history=True)
+    failed = SimpleNamespace(conId=0, exchange="SMART", currency="USD", multiplier="1")
+    assert await record_validation(db, spec, failed, quote_source="none",
+                                   has_history=False, error="socket lost") == "quarantined"
+    row = await db.fetchone(
+        "SELECT con_id, local_symbol FROM ibkr_contract_registry WHERE instrument_key='SPY'")
+    assert (row["con_id"], row["local_symbol"]) == (11, "SPY")
+    changed = SimpleNamespace(conId=12, localSymbol="SPY", exchange="SMART",
+                              currency="USD", multiplier="1")
+    assert await record_validation(db, spec, changed, quote_source="ibkr_live",
+                                   has_history=True) == "drifted"
+    assert "SPY" not in await eligible_keys(db)
+    assert await approve(db, "SPY", "verified broker identity replacement")
+    assert "SPY" in await eligible_keys(db)
+    await db.close()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -162,6 +162,8 @@ def test_yaml_defaults_safe():
     assert ibkr["auto_fx_enabled"] is False
     assert {"SPY", "QQQ", "IWM", "TLT", "GLD", "VEA"}.issubset(
         ibkr["etf_symbols"])
+    from auramaur.exchange.ibkr_instruments import GLOBAL_ETFS
+    assert ibkr["etf_symbols"] == [spec.symbol for spec in GLOBAL_ETFS]
     assert 0 < ibkr["etf_max_entry_usd"] <= ibkr["etf_paper_budget_usd"]
     assert [m["alias"] for m in ibkr["etf_models"]] == ["luna", "terra", "sol"]
 


### PR DESCRIPTION
## Summary
- expand IBKR's deterministic multi-asset manifest and keep the ETF experiment synchronized
- persist broker-qualified contract identities with manifest and conId drift detection, quarantine states, and explicit corporate-bond approval
- require eligible registry entries for new runtime risk while preserving exact-conId management of held positions
- improve futures roll selection, option coverage, deterministic bond selection, diagnostics, configuration, and operator documentation

## Validation
- 62 focused IBKR, registry, migration, paper-book, and settings tests passed
- Ruff passed on all touched Python files
- git diff --check passed

## Full-suite note
The full suite cannot collect on native Windows because the existing trading engine imports Unix-only fcntl. Linux CI remains the authoritative full-suite run; the failure is unrelated to this change.