### PR TITLE
Improve IBKR paper trading risk model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,8 @@ IBKR_QUOTE_ENVIRONMENT=live
 IBKR_QUOTE_PORT=4002
 IBKR_ENABLED=true
 IBKR_MULTIASSET_PAPER_ENABLED=true
+# 1=live. Multi-asset paper fills fail closed for 2/3/4.
+IBKR_MARKET_DATA_TYPE=1
 # Stable private addresses make the Gateway Trusted IP entry survive restarts.
 # Override the subnet if it conflicts with another Docker network on the host.
 AURAMAUR_BROKER_SUBNET=172.18.0.0/16

--- a/auramaur/cli/diagnostics.py
+++ b/auramaur/cli/diagnostics.py
@@ -186,6 +186,33 @@ def ibkr_multiasset_preflight(book_names):
 
     sys.exit(asyncio.run(_run()))
 
+
+@main.command("ibkr-contract-approve")
+@click.argument("instrument_key")
+@click.option("--reason", required=True,
+              help="Operator rationale recorded with this contract identity.")
+def ibkr_contract_approve(instrument_key, reason):
+    """Approve a pending discovered identity (currently corporate bonds)."""
+    import asyncio
+    import sys
+    from auramaur.db.database import Database
+    from auramaur.exchange.ibkr_registry import approve
+
+    async def _run() -> int:
+        db = Database()
+        await db.connect()
+        try:
+            changed = await approve(db, instrument_key, reason)
+        finally:
+            await db.close()
+        if not changed:
+            console.print("[bold red]NOT APPROVED[/] — no pending current identity")
+            return 1
+        console.print(f"[bold green]APPROVED[/] {instrument_key}")
+        return 0
+
+    sys.exit(asyncio.run(_run()))
+
 @main.command()
 @click.option("--exchange", default=None, help="Exchange to evaluate (e.g. kalshi)")
 @click.option("--days", default=7, help="Window in days (default 7)")

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -114,6 +114,8 @@ class Database:
             await self._migrate_v24_to_v25()
         if from_version < 26:
             await self._migrate_v25_to_v26()
+        if from_version < 27:
+            await self._migrate_v26_to_v27()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -614,6 +616,20 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 26")
         await self._db.commit()
         log.info("database.migrated", from_version=25, to_version=26)
+
+    async def _migrate_v26_to_v27(self) -> None:
+        """Persist immutable entry risk for IBKR paper positions."""
+        for table in ("ibkr_paper_positions", "ibkr_etf_positions"):
+            for name in ("stop_price", "initial_risk_usd"):
+                try:
+                    await self._db.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {name} REAL NOT NULL DEFAULT 0")
+                except aiosqlite.OperationalError as exc:
+                    if "duplicate column name" not in str(exc).lower():
+                        raise
+        await self._db.execute("UPDATE schema_version SET version = 27")
+        await self._db.commit()
+        log.info("database.migrated", from_version=26, to_version=27)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -112,6 +112,8 @@ class Database:
             await self._migrate_v23_to_v24()
         if from_version < 25:
             await self._migrate_v24_to_v25()
+        if from_version < 26:
+            await self._migrate_v25_to_v26()
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -603,6 +605,15 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 25")
         await self._db.commit()
         log.info("database.migrated", from_version=24, to_version=25)
+
+    async def _migrate_v25_to_v26(self) -> None:
+        """Register the persistent IBKR qualified-contract registry."""
+        required = await self.fetchall("PRAGMA table_info(ibkr_contract_registry)")
+        if not required:
+            raise RuntimeError("migration did not create ibkr_contract_registry")
+        await self._db.execute("UPDATE schema_version SET version = 26")
+        await self._db.commit()
+        log.info("database.migrated", from_version=25, to_version=26)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -563,6 +563,34 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_state (
     last_error TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Broker-qualified identities for the deterministic IBKR manifest. Discovery
+-- may refresh these rows but cannot introduce an undeclared instrument.
+CREATE TABLE IF NOT EXISTS ibkr_contract_registry (
+    instrument_key TEXT PRIMARY KEY,
+    book TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    manifest_hash TEXT NOT NULL,
+    con_id INTEGER NOT NULL,
+    local_symbol TEXT NOT NULL DEFAULT '',
+    trading_class TEXT NOT NULL DEFAULT '',
+    exchange TEXT NOT NULL DEFAULT '',
+    currency TEXT NOT NULL DEFAULT '',
+    multiplier REAL NOT NULL DEFAULT 1,
+    status TEXT NOT NULL CHECK(status IN
+        ('eligible', 'qualified_no_live_data', 'pending_approval',
+         'quarantined', 'drifted')),
+    approved INTEGER NOT NULL DEFAULT 0,
+    approval_reason TEXT NOT NULL DEFAULT '',
+    quote_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
+    has_history INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    qualified_at TEXT NOT NULL DEFAULT (datetime('now')),
+    validated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    approved_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ibkr_contract_registry_status
+    ON ibkr_contract_registry(book, status, approved);
 
 CREATE TABLE IF NOT EXISTS position_peaks (
     market_id TEXT PRIMARY KEY,

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -477,6 +477,8 @@ CREATE TABLE IF NOT EXISTS ibkr_etf_positions (
     current_price REAL,
     unrealized_pnl REAL NOT NULL DEFAULT 0,
     peak_pnl_pct REAL NOT NULL DEFAULT 0,
+    stop_price REAL NOT NULL DEFAULT 0,
+    initial_risk_usd REAL NOT NULL DEFAULT 0,
     opened_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (model_alias, symbol)
@@ -518,6 +520,8 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_positions (
     avg_cost REAL NOT NULL,
     current_price REAL,
     unrealized_pnl_usd REAL NOT NULL DEFAULT 0,
+    stop_price REAL NOT NULL DEFAULT 0,
+    initial_risk_usd REAL NOT NULL DEFAULT 0,
     price_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
     instrument_spec_json TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/auramaur/exchange/ibkr_instruments.py
+++ b/auramaur/exchange/ibkr_instruments.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from enum import Enum
+import hashlib
+import json
 
 
 class IBKRBook(str, Enum):
@@ -48,7 +50,21 @@ class InstrumentSpec:
     option_right: str = ""
     option_dte_min: int = 0
     option_dte_max: int = 0
+    option_moneyness_pct: float = 0.0
     bond_query: str = ""
+    # Futures roll before expiry by this many calendar days. Discovery may use
+    # volume to choose between valid contracts, but never expands the product.
+    roll_days_before_expiry: int = 7
+    # Corporate bond discoveries require an explicit operator approval.
+    approval_required: bool = False
+
+    def manifest_hash(self) -> str:
+        """Stable identity for drift detection in the qualified registry."""
+        values = {name: getattr(self, name) for name in self.__dataclass_fields__}
+        values["book"] = self.book.value
+        values["kind"] = self.kind.value
+        payload = json.dumps(values, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def _stk(key: str, book: IBKRBook, symbol: str, exchange: str, currency: str,
@@ -65,14 +81,32 @@ GLOBAL_ETFS = (
     _stk("SPY", IBKRBook.GLOBAL_ETF, "SPY", "SMART", "USD", "us_equity", "S&P 500", primary="ARCA"),
     _stk("QQQ", IBKRBook.GLOBAL_ETF, "QQQ", "SMART", "USD", "us_equity", "Nasdaq-100", primary="NASDAQ"),
     _stk("IWM", IBKRBook.GLOBAL_ETF, "IWM", "SMART", "USD", "us_equity", "Russell 2000", primary="ARCA"),
+    _stk("DIA", IBKRBook.GLOBAL_ETF, "DIA", "SMART", "USD", "us_equity", "Dow Jones Industrial Average", primary="ARCA"),
+    _stk("VTI", IBKRBook.GLOBAL_ETF, "VTI", "SMART", "USD", "us_equity", "Total US stock market", primary="ARCA"),
+    *tuple(_stk(symbol, IBKRBook.GLOBAL_ETF, symbol, "SMART", "USD", asset,
+                description, primary="ARCA") for symbol, asset, description in (
+        ("XLK", "sector_technology", "US technology sector"),
+        ("XLF", "sector_financials", "US financial sector"),
+        ("XLV", "sector_healthcare", "US healthcare sector"),
+        ("XLE", "sector_energy", "US energy sector"),
+        ("XLI", "sector_industrials", "US industrial sector"),
+        ("XLY", "sector_discretionary", "US consumer discretionary sector"),
+        ("XLP", "sector_staples", "US consumer staples sector"),
+        ("XLU", "sector_utilities", "US utilities sector"),
+        ("XLB", "sector_materials", "US materials sector"),
+        ("XLRE", "sector_real_estate", "US real-estate sector"),
+        ("XLC", "sector_communications", "US communications sector"),
+    )),
     _stk("VEA", IBKRBook.GLOBAL_ETF, "VEA", "SMART", "USD", "international", "Developed markets ex-US", primary="ARCA"),
     _stk("VWO", IBKRBook.GLOBAL_ETF, "VWO", "SMART", "USD", "international", "Emerging markets", primary="ARCA"),
     _stk("INDA", IBKRBook.GLOBAL_ETF, "INDA", "SMART", "USD", "international", "India equities", primary="CBOE"),
     _stk("MCHI", IBKRBook.GLOBAL_ETF, "MCHI", "SMART", "USD", "international", "China equities", primary="NASDAQ"),
     _stk("EWJ", IBKRBook.GLOBAL_ETF, "EWJ", "SMART", "USD", "international", "Japan equities", primary="ARCA"),
+    _stk("EWC", IBKRBook.GLOBAL_ETF, "EWC", "SMART", "USD", "international", "Canada equities", primary="ARCA"),
     _stk("EWZ", IBKRBook.GLOBAL_ETF, "EWZ", "SMART", "USD", "international", "Brazil equities", primary="ARCA"),
     _stk("TLT", IBKRBook.GLOBAL_ETF, "TLT", "SMART", "USD", "rates", "Long US Treasuries", primary="NASDAQ"),
     _stk("IEF", IBKRBook.GLOBAL_ETF, "IEF", "SMART", "USD", "rates", "Intermediate US Treasuries", primary="NASDAQ"),
+    _stk("SHY", IBKRBook.GLOBAL_ETF, "SHY", "SMART", "USD", "rates", "Short US Treasuries", primary="NASDAQ"),
     _stk("TIP", IBKRBook.GLOBAL_ETF, "TIP", "SMART", "USD", "rates", "US inflation-linked Treasuries", primary="ARCA"),
     _stk("LQD", IBKRBook.GLOBAL_ETF, "LQD", "SMART", "USD", "credit", "Investment-grade credit", primary="ARCA"),
     _stk("HYG", IBKRBook.GLOBAL_ETF, "HYG", "SMART", "USD", "credit", "High-yield credit", primary="ARCA"),
@@ -96,17 +130,17 @@ FUTURES = tuple(
     InstrumentSpec(key, IBKRBook.FUTURES, ContractKind.FUTURE, symbol, exchange,
                    currency, asset, description, multiplier=multiplier,
                    paper_capital_per_unit_usd=capital, calendar="FUTURES",
-                   expiry_policy="front_liquid")
-    for key, symbol, exchange, currency, asset, description, multiplier, capital in (
-        ("MES", "MES", "CME", "USD", "equity_index", "Micro E-mini S&P 500", 5, 2500),
-        ("MNQ", "MNQ", "CME", "USD", "equity_index", "Micro E-mini Nasdaq-100", 2, 3500),
-        ("M2K", "M2K", "CME", "USD", "equity_index", "Micro E-mini Russell 2000", 5, 1500),
-        ("ZN", "ZN", "CBOT", "USD", "rates", "10-year US Treasury note", 1000, 3000),
-        ("MCL", "MCL", "NYMEX", "USD", "energy", "Micro WTI crude oil", 100, 1500),
-        ("MGC", "MGC", "COMEX", "USD", "metals", "Micro Gold", 10, 2000),
-        ("SIC", "SIC", "COMEX", "USD", "metals", "100-ounce Silver", 100, 1000),
-        ("ZC", "ZC", "CBOT", "USD", "agriculture", "Corn", 50, 2500),
-        ("ZW", "ZW", "CBOT", "USD", "agriculture", "Wheat", 50, 3000),
+                   expiry_policy="front_liquid", roll_days_before_expiry=roll_days)
+    for key, symbol, exchange, currency, asset, description, multiplier, capital, roll_days in (
+        ("MES", "MES", "CME", "USD", "equity_index", "Micro E-mini S&P 500", 5, 2500, 7),
+        ("MNQ", "MNQ", "CME", "USD", "equity_index", "Micro E-mini Nasdaq-100", 2, 3500, 7),
+        ("M2K", "M2K", "CME", "USD", "equity_index", "Micro E-mini Russell 2000", 5, 1500, 7),
+        ("ZN", "ZN", "CBOT", "USD", "rates", "10-year US Treasury note", 1000, 3000, 10),
+        ("MCL", "MCL", "NYMEX", "USD", "energy", "Micro WTI crude oil", 100, 1500, 10),
+        ("MGC", "MGC", "COMEX", "USD", "metals", "Micro Gold", 10, 2000, 10),
+        ("SIC", "SIC", "COMEX", "USD", "metals", "100-ounce Silver", 100, 1000, 10),
+        ("ZC", "ZC", "CBOT", "USD", "agriculture", "Corn", 50, 2500, 20),
+        ("ZW", "ZW", "CBOT", "USD", "agriculture", "Wheat", 50, 3000, 20),
     )
 )
 
@@ -131,12 +165,15 @@ INTERNATIONAL_EQUITIES = (
 )
 
 OPTIONS = tuple(
-    InstrumentSpec(f"{symbol}_ATM_{right}", IBKRBook.OPTIONS,
+    InstrumentSpec(f"{symbol}_{bucket}_{right}", IBKRBook.OPTIONS,
                    ContractKind.OPTION, symbol, "SMART", "USD", "options",
-                   f"{symbol} 30-60 DTE ATM {right}", multiplier=100,
+                   f"{symbol} 30-60 DTE {bucket} {right}", multiplier=100,
                    paper_capital_per_unit_usd=0,
-                   option_right=right, option_dte_min=30, option_dte_max=60)
-    for symbol in ("SPY", "QQQ", "IWM", "TLT", "GLD")
+                   option_right=right, option_dte_min=30, option_dte_max=60,
+                   option_moneyness_pct=moneyness)
+    for symbol in ("SPY", "QQQ", "IWM", "DIA", "VTI", "XLF", "XLE",
+                   "XLV", "TLT", "GLD")
+    for bucket, moneyness in (("ATM", 0.0), ("OTM5", 5.0))
     for right in ("C", "P")
 )
 
@@ -146,7 +183,7 @@ BONDS = tuple(
     InstrumentSpec(key, IBKRBook.BONDS, ContractKind.BOND, "", "SMART", "USD",
                    asset, description, multiplier=10,
                    paper_capital_per_unit_usd=1000, calendar="US_BOND",
-                   bond_query=query)
+                   bond_query=query, approval_required=key.startswith("CORP_"))
     for key, asset, description, query in (
         ("UST_2Y", "government", "US Treasury near 2-year maturity", "UST:2Y"),
         ("UST_5Y", "government", "US Treasury near 5-year maturity", "UST:5Y"),

--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -148,7 +148,7 @@ class IBKRReadOnlyMarketData:
         from ib_async import Future
         seed = Future(spec.symbol, exchange=spec.exchange, currency=spec.currency)
         details = await self._ib.reqContractDetailsAsync(seed)
-        cutoff = date.today() + timedelta(days=7)
+        cutoff = date.today() + timedelta(days=spec.roll_days_before_expiry)
         candidates = []
         for detail in details or []:
             contract = detail.contract
@@ -172,7 +172,24 @@ class IBKRReadOnlyMarketData:
                 candidates.append((expiry, contract))
         if not candidates:
             raise LookupError(f"no non-expiring front future found for {spec.key}")
-        return await self._qualify_one(min(candidates, key=lambda item: item[0])[1])
+        candidates.sort(key=lambda item: item[0])
+        # Compare only the nearest valid expiries. Volume confirms the active
+        # contract without allowing discovery to leave the declared product.
+        shortlist = candidates[:3]
+        request = getattr(self._ib, "reqTickersAsync", None)
+        if callable(request) and len(shortlist) > 1:
+            try:
+                tickers = await request(*(contract for _, contract in shortlist))
+                volumes = {int(getattr(t.contract, "conId", 0) or 0):
+                           float(getattr(t, "volume", 0) or 0) for t in tickers}
+                chosen = max(shortlist, key=lambda item: (
+                    volumes.get(int(getattr(item[1], "conId", 0) or 0), 0),
+                    -item[0].toordinal()))[1]
+                return await self._qualify_one(chosen)
+            except Exception as exc:  # noqa: BLE001 - deterministic fallback
+                log.warning("ibkr_multiasset.future_volume_fallback",
+                            key=spec.key, error=str(exc)[:120])
+        return await self._qualify_one(shortlist[0][1])
 
     async def _underlying(self, symbol: str):
         from ib_async import Stock
@@ -220,7 +237,9 @@ class IBKRReadOnlyMarketData:
         strikes = [float(s) for s in chain.strikes if float(s) > 0]
         if not strikes:
             raise LookupError(f"no strikes for {spec.key}")
-        strike = min(strikes, key=lambda value: abs(value - spot))
+        direction = 1 if spec.option_right == "C" else -1
+        target_strike = spot * (1 + direction * spec.option_moneyness_pct / 100)
+        strike = min(strikes, key=lambda value: abs(value - target_strike))
         contract = Option(spec.symbol, expiry, strike, spec.option_right,
                           "SMART", multiplier=str(int(spec.multiplier)),
                           currency=spec.currency,
@@ -252,9 +271,17 @@ class IBKRReadOnlyMarketData:
                       if getattr(row.contractDetails.contract, "secType", "") == "BOND"]
         if not candidates:
             raise LookupError(f"bond scanner found no match for {spec.key}")
-        # Scanner ordering provides the requested yield ranking; conId makes the
-        # selected issue unambiguous even when descriptive fields are sparse.
-        return await self._qualify_one(candidates[0])
+        def rank(contract):
+            raw = str(getattr(contract, "lastTradeDateOrContractMonth", "")
+                      or getattr(contract, "maturity", ""))[:8]
+            try:
+                maturity_distance = abs((datetime.strptime(raw, "%Y%m%d").date()
+                                         - target).days)
+            except ValueError:
+                maturity_distance = 999_999
+            # Stable tie-break avoids depending on scanner ordering.
+            return maturity_distance, int(getattr(contract, "conId", 0) or 0)
+        return await self._qualify_one(min(candidates, key=rank))
 
     async def get_quote(self, spec: InstrumentSpec) -> MarketDataQuote | None:
         contract = await self.resolve(spec)

--- a/auramaur/exchange/ibkr_registry.py
+++ b/auramaur/exchange/ibkr_registry.py
@@ -1,0 +1,90 @@
+"""Persistence boundary between the reviewed manifest and IBKR discovery."""
+
+from __future__ import annotations
+
+from auramaur.exchange.ibkr_instruments import InstrumentSpec
+
+
+async def record_validation(db, spec: InstrumentSpec, contract, *, quote_source: str,
+                            has_history: bool, error: str = "") -> str:
+    """Upsert one declared instrument without overwriting operator approval."""
+    existing = await db.fetchone(
+        "SELECT manifest_hash, con_id, approved FROM ibkr_contract_registry "
+        "WHERE instrument_key=?",
+        (spec.key,))
+    same_manifest = bool(existing and existing["manifest_hash"] == spec.manifest_hash())
+    discovered_con_id = int(getattr(contract, "conId", 0) or 0)
+    identity_changed = bool(
+        existing and discovered_con_id and int(existing["con_id"])
+        and discovered_con_id != int(existing["con_id"]))
+    approved = int(existing["approved"]) if same_manifest else int(not spec.approval_required)
+    if error:
+        status = "quarantined"
+    elif existing and (not same_manifest or identity_changed):
+        status = "drifted"
+        approved = 0
+    elif spec.approval_required and not approved:
+        status = "pending_approval"
+    elif quote_source != "ibkr_live" or not has_history:
+        status = "qualified_no_live_data"
+    else:
+        status = "eligible"
+    con_id = discovered_con_id
+    await db.execute(
+        """INSERT INTO ibkr_contract_registry
+           (instrument_key, book, kind, manifest_hash, con_id, local_symbol,
+            trading_class, exchange, currency, multiplier, status, approved,
+            quote_source, has_history, last_error)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(instrument_key) DO UPDATE SET
+             book=excluded.book, kind=excluded.kind,
+             manifest_hash=excluded.manifest_hash,
+             con_id=CASE WHEN excluded.con_id != 0 THEN excluded.con_id ELSE con_id END,
+             local_symbol=CASE WHEN excluded.local_symbol != ''
+                               THEN excluded.local_symbol ELSE local_symbol END,
+             trading_class=CASE WHEN excluded.trading_class != ''
+                                THEN excluded.trading_class ELSE trading_class END,
+             exchange=CASE WHEN excluded.exchange != ''
+                           THEN excluded.exchange ELSE exchange END,
+             currency=CASE WHEN excluded.currency != ''
+                           THEN excluded.currency ELSE currency END,
+             multiplier=CASE WHEN excluded.con_id != 0
+                             THEN excluded.multiplier ELSE multiplier END,
+             status=excluded.status, approved=excluded.approved,
+             quote_source=excluded.quote_source, has_history=excluded.has_history,
+             last_error=excluded.last_error, validated_at=datetime('now'),
+             qualified_at=CASE WHEN excluded.con_id != 0
+                                    AND ibkr_contract_registry.con_id != excluded.con_id
+                               THEN datetime('now') ELSE qualified_at END""",
+        (spec.key, spec.book.value, spec.kind.value, spec.manifest_hash(), con_id,
+         str(getattr(contract, "localSymbol", "") or ""),
+         str(getattr(contract, "tradingClass", "") or ""),
+         str(getattr(contract, "exchange", spec.exchange) or spec.exchange),
+         str(getattr(contract, "currency", spec.currency) or spec.currency),
+         float(getattr(contract, "multiplier", spec.multiplier) or spec.multiplier),
+         status, approved, quote_source, int(has_history), error[:300]))
+    await db.commit()
+    return status
+
+
+async def approve(db, instrument_key: str, reason: str) -> bool:
+    """Approve the current manifest identity; drift invalidates this approval."""
+    cursor = await db.execute(
+        """UPDATE ibkr_contract_registry SET approved=1,
+           status=CASE WHEN quote_source='ibkr_live' AND has_history=1
+                       THEN 'eligible' ELSE 'qualified_no_live_data' END,
+           approval_reason=?, approved_at=datetime('now'), validated_at=datetime('now')
+           WHERE instrument_key=? AND status IN ('pending_approval', 'drifted')""",
+        (reason.strip(), instrument_key))
+    await db.commit()
+    return cursor.rowcount == 1
+
+
+async def eligible_keys(db) -> set[str]:
+    rows = await db.fetchall(
+        "SELECT instrument_key, manifest_hash FROM ibkr_contract_registry "
+        "WHERE status='eligible' AND approved=1 AND has_history=1")
+    from auramaur.exchange.ibkr_instruments import BY_KEY
+    return {row["instrument_key"] for row in rows
+            if row["instrument_key"] in BY_KEY
+            and row["manifest_hash"] == BY_KEY[row["instrument_key"]].manifest_hash()}

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 import time
+from types import SimpleNamespace
 
 import structlog
 
 from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
 from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
+from auramaur.exchange.ibkr_registry import record_validation
 
 log = structlog.get_logger()
 
@@ -52,23 +54,44 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         for attempt in range(attempts):
             try:
                 async with semaphore:
+                    contract = (await client.resolve(spec)
+                                if hasattr(client, "resolve") else None)
                     market_open = (await client.is_market_open(spec)
                                    if hasattr(client, "is_market_open") else True)
                     quote = await asyncio.wait_for(client.get_quote(spec), timeout_seconds)
                     bars = await asyncio.wait_for(client.get_daily_bars(spec), timeout_seconds)
+                if contract is None:
+                    contract = SimpleNamespace(
+                        conId=int(getattr(quote, "con_id", 0) or 0),
+                        exchange=spec.exchange, currency=spec.currency,
+                        multiplier=spec.multiplier)
                 if len(bars) < 21:
+                    await record_validation(db, spec, contract,
+                                            quote_source=getattr(quote, "source", "none"),
+                                            has_history=False, error="insufficient history")
                     return f"{spec.key}: only {len(bars)} daily bars", None, None
                 if not market_open:
                     source = getattr(quote, "source", "none") if quote else "none"
+                    await record_validation(db, spec, contract, quote_source=source,
+                                            has_history=True)
                     return None, source, f"{spec.key}: venue closed; contract/history ready"
                 if quote is None:
+                    await record_validation(db, spec, contract, quote_source="none",
+                                            has_history=True, error="no executable BBO")
                     return f"{spec.key}: no executable BBO", None, None
                 age = time.time() - float(quote.timestamp)
                 if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
+                    await record_validation(db, spec, contract,
+                                            quote_source=getattr(quote, "source", "none"),
+                                            has_history=True, error="stale BBO")
                     return f"{spec.key}: stale BBO ({age:.0f}s old)", None, None
                 source = getattr(quote, "source", "ibkr_unknown")
                 if source != "ibkr_live":
+                    await record_validation(db, spec, contract, quote_source=source,
+                                            has_history=True)
                     return f"{spec.key}: non-executable {source} quote", source, None
+                await record_validation(db, spec, contract, quote_source=source,
+                                        has_history=True)
                 return None, source, None
             except Exception as exc:  # noqa: BLE001
                 if pacing_error(exc) and attempt + 1 < attempts:
@@ -79,6 +102,11 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                     await asyncio.sleep(delay)
                     continue
                 prefix = "pacing exhausted" if pacing_error(exc) else "probe failed"
+                await record_validation(
+                    db, spec, SimpleNamespace(conId=0, exchange=spec.exchange,
+                                              currency=spec.currency,
+                                              multiplier=spec.multiplier),
+                    quote_source="none", has_history=False, error=str(exc))
                 return f"{spec.key}: {prefix}: {str(exc)[:140]}", None, None
         return f"{spec.key}: pacing retry exhausted", None, None  # pragma: no cover
     if not getattr(client, "readonly", False) or hasattr(client, "place_order"):
@@ -87,7 +115,7 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         add("isolation", "OK", "read-only client exposes no broker order method")
 
     required = {"ibkr_paper_positions", "ibkr_paper_fills",
-                "ibkr_paper_ledger", "ibkr_paper_state"}
+                "ibkr_paper_ledger", "ibkr_paper_state", "ibkr_contract_registry"}
     rows = await db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
     missing = required - {row["name"] for row in rows}
     add("database", "BLOCK" if missing else "OK",
@@ -141,6 +169,13 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                 f"sources={','.join(sorted(sources))}")
         log.info("ibkr_multiasset.preflight_book_complete", book=book.value,
                  passed=len(universe) - len(failures), failed=len(failures))
+        registry = await db.fetchall(
+            "SELECT status, COUNT(*) AS n FROM ibkr_contract_registry "
+            "WHERE book=? GROUP BY status ORDER BY status", (book.value,))
+        counts = {row["status"]: int(row["n"]) for row in registry}
+        add(f"{book.value}:registry",
+            "OK" if set(counts) <= {"eligible"} else "WARN",
+            ", ".join(f"{status}={count}" for status, count in counts.items()))
 
         edge = await db.fetchone(
             """SELECT SUM(CASE WHEN kind = 'trade' THEN 1 ELSE 0 END) AS n,

--- a/auramaur/risk/ibkr_evidence.py
+++ b/auramaur/risk/ibkr_evidence.py
@@ -1,0 +1,70 @@
+"""Pre-registered evidence contract for graduating an IBKR paper strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from statistics import fmean, pstdev
+
+
+@dataclass(frozen=True, slots=True)
+class IBKREvidence:
+    observations: int
+    elapsed_days: int
+    net_pnl_usd: float
+    mean_pnl_usd: float
+    mean_lower_95_usd: float
+    max_drawdown_usd: float
+    brier_score: float | None
+    baseline_brier_score: float | None
+    ready: bool
+    reasons: tuple[str, ...]
+
+
+def _max_drawdown(pnls: list[float]) -> float:
+    equity = peak = drawdown = 0.0
+    for pnl in pnls:
+        equity += pnl
+        peak = max(peak, equity)
+        drawdown = max(drawdown, peak - equity)
+    return drawdown
+
+
+def evaluate_ibkr_evidence(
+    net_trade_pnls: list[float], *, elapsed_days: int,
+    budget_usd: float, probabilities: list[float] | None = None,
+    outcomes: list[int] | None = None, min_observations: int = 200,
+    min_elapsed_days: int = 180, max_drawdown_pct: float = 10.0,
+) -> IBKREvidence:
+    """Evaluate a deliberately demanding, immutable graduation contract.
+
+    P&Ls must already include spreads, slippage, commissions, financing, rolls,
+    and intelligence cost. The normal lower bound is intentionally conservative;
+    callers should additionally retain a walk-forward/out-of-sample split.
+    """
+    n = len(net_trade_pnls)
+    mean = fmean(net_trade_pnls) if n else 0.0
+    se = pstdev(net_trade_pnls) / math.sqrt(n) if n > 1 else math.inf
+    lower = mean - 1.96 * se
+    drawdown = _max_drawdown(net_trade_pnls)
+    brier = baseline = None
+    if probabilities is not None and outcomes is not None and probabilities:
+        pairs = list(zip(probabilities, outcomes))
+        brier = fmean((p - y) ** 2 for p, y in pairs)
+        base_p = fmean(y for _, y in pairs)
+        baseline = fmean((base_p - y) ** 2 for _, y in pairs)
+    reasons = []
+    if n < min_observations:
+        reasons.append(f"{n}/{min_observations} cost-adjusted observations")
+    if elapsed_days < min_elapsed_days:
+        reasons.append(f"{elapsed_days}/{min_elapsed_days} elapsed days")
+    if lower <= 0:
+        reasons.append("95% lower confidence bound on mean P&L is not positive")
+    if drawdown > budget_usd * max_drawdown_pct / 100:
+        reasons.append("maximum drawdown exceeds the pre-registered budget limit")
+    if brier is not None and baseline is not None and brier >= baseline:
+        reasons.append("forecast Brier score does not beat the base-rate forecast")
+    return IBKREvidence(
+        n, elapsed_days, sum(net_trade_pnls), mean, lower, drawdown,
+        brier, baseline, not reasons, tuple(reasons),
+    )

--- a/auramaur/risk/ibkr_math.py
+++ b/auramaur/risk/ibkr_math.py
@@ -1,0 +1,65 @@
+"""Small, auditable risk primitives for the IBKR paper experiments."""
+
+from __future__ import annotations
+
+import math
+from statistics import fmean, pstdev
+
+
+def closes_from_bars(bars) -> list[float]:
+    return [float(close) for _, close in bars if close is not None and float(close) > 0]
+
+
+def log_returns(closes: list[float]) -> list[float]:
+    return [math.log(b / a) for a, b in zip(closes, closes[1:]) if a > 0 and b > 0]
+
+
+def annualized_volatility(closes: list[float], periods: int = 252) -> float | None:
+    returns = log_returns(closes)
+    if len(returns) < 20:
+        return None
+    vol = pstdev(returns) * math.sqrt(periods)
+    return vol if math.isfinite(vol) and vol > 0 else None
+
+
+def normalized_momentum(closes: list[float], horizons=(20, 60, 120),
+                        periods: int = 252) -> float | None:
+    """Mean horizon return divided by its forecast standard deviation.
+
+    Missing long horizons are ignored, allowing a safe warm-up at 20 sessions.
+    The result is dimensionless and therefore comparable across asset classes.
+    """
+    vol = annualized_volatility(closes, periods)
+    if vol is None:
+        return None
+    scores = []
+    for horizon in horizons:
+        if len(closes) <= horizon:
+            continue
+        ret = math.log(closes[-1] / closes[-horizon - 1])
+        forecast_sigma = vol * math.sqrt(horizon / periods)
+        if forecast_sigma > 0:
+            scores.append(ret / forecast_sigma)
+    return fmean(scores) if scores else None
+
+
+def stop_distance(price: float, annual_vol: float, stop_vol_multiple: float,
+                  floor_pct: float) -> float:
+    daily_sigma = price * annual_vol / math.sqrt(252)
+    return max(price * floor_pct / 100, daily_sigma * stop_vol_multiple)
+
+
+def risk_quantity(risk_budget_usd: float, stop_distance_price: float,
+                  multiplier: float, fx_to_usd: float, *, fractional: bool) -> float:
+    unit_risk = stop_distance_price * multiplier * fx_to_usd
+    if unit_risk <= 0 or risk_budget_usd <= 0:
+        return 0.0
+    raw = risk_budget_usd / unit_risk
+    return math.floor(raw * 10_000) / 10_000 if fractional else float(math.floor(raw))
+
+
+def adverse_fill(bid: float, ask: float, side: str, slippage_bps: float) -> float:
+    """Cross the spread and add a conservative, deterministic impact floor."""
+    if side == "BUY":
+        return ask * (1 + slippage_bps / 10_000)
+    return bid * (1 - slippage_bps / 10_000)

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -12,6 +12,10 @@ import structlog
 
 from auramaur.exchange.models import Market, OrderSide
 from auramaur.strategy.protocols import ExecutionMode
+from auramaur.risk.ibkr_math import (
+    adverse_fill, annualized_volatility, normalized_momentum,
+    risk_quantity, stop_distance,
+)
 
 log = structlog.get_logger()
 _ET = ZoneInfo("America/New_York")
@@ -237,6 +241,14 @@ class IBKRETFPaperPillar:
             return 0.0
         return float(row["pnl"] or 0.0) if row else 0.0
 
+    async def _daily_equity_change(self) -> float:
+        """Realized and current open losses both consume the daily envelope."""
+        realized = await self._daily_realized()
+        row = await self._db.fetchone(
+            """SELECT COALESCE(SUM(unrealized_pnl), 0) AS pnl
+                 FROM ibkr_etf_positions WHERE model_alias = ?""", (self._alias,))
+        return realized + float(row["pnl"] or 0) if row else realized
+
     async def _positions(self) -> dict[str, tuple[float, float]]:
         rows = await self._db.fetchall(
             """SELECT symbol, quantity, avg_cost FROM ibkr_etf_positions
@@ -256,7 +268,8 @@ class IBKRETFPaperPillar:
                WHERE model_alias = ? AND symbol = ?""", (self._alias, symbol))
         return float(row["peak_pnl_pct"])
 
-    async def _fill(self, symbol: str, side: OrderSide, qty: float, price: float) -> None:
+    async def _fill(self, symbol: str, side: OrderSide, qty: float, price: float,
+                    *, stop_price: float = 0, initial_risk_usd: float = 0) -> None:
         fee = self._s.ibkr.etf_fee_per_order_usd
         fill_ref = f"ibkr-etf-paper-{self._alias}-{symbol}-{uuid4().hex}"
         await self._db.execute(
@@ -271,9 +284,10 @@ class IBKRETFPaperPillar:
         if side == OrderSide.BUY:
             await self._db.execute(
                 """INSERT INTO ibkr_etf_positions
-                   (model_alias, symbol, quantity, avg_cost, current_price)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (self._alias, symbol, qty, price, price))
+                    (model_alias, symbol, quantity, avg_cost, current_price,
+                     stop_price, initial_risk_usd)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (self._alias, symbol, qty, price, price, stop_price, initial_risk_usd))
         else:
             position = await self._db.fetchone(
                 """SELECT quantity, avg_cost FROM ibkr_etf_positions
@@ -310,7 +324,8 @@ class IBKRETFPaperPillar:
             asset_class = self._asset_class(symbol)
             class_allocated[asset_class] = class_allocated.get(asset_class, 0.0) + qty * entry
         position_count = len(positions)
-        daily_loss_hit = await self._daily_realized() <= -cfg.etf_daily_loss_limit_usd
+        daily_loss_hit = await self._daily_equity_change() <= -cfg.etf_daily_loss_limit_usd
+        unmarked_positions = set(positions)
 
         # Refresh only a bounded slice per cycle so a 28-instrument universe
         # cannot trigger 28 LLM calls at once. Held positions get first claim;
@@ -326,7 +341,8 @@ class IBKRETFPaperPillar:
         refresh_order = held_order + candidates
         refresh_set = set(refresh_order[:cfg.etf_max_signal_refreshes_per_cycle])
 
-        for symbol in symbols:
+        # Held positions must receive fresh marks before any new risk is opened.
+        for symbol in held_order + candidates:
             try:
                 quote = await self._client.get_quote(symbol)
             except Exception as exc:  # noqa: BLE001
@@ -353,7 +369,11 @@ class IBKRETFPaperPillar:
                 gain = (quote.bid - entry) / entry * 100
                 peak = await self._peak(symbol, gain)
                 reason = None
-                if gain <= -cfg.etf_stop_loss_pct:
+                risk_row = await self._db.fetchone(
+                    """SELECT stop_price FROM ibkr_etf_positions
+                         WHERE model_alias=? AND symbol=?""", (self._alias, symbol))
+                stored_stop = float(risk_row["stop_price"] or 0) if risk_row else 0
+                if (stored_stop > 0 and quote.bid <= stored_stop) or gain <= -cfg.etf_stop_loss_pct:
                     reason = "stop_loss"
                 elif gain >= cfg.etf_take_profit_pct:
                     reason = "take_profit"
@@ -362,7 +382,8 @@ class IBKRETFPaperPillar:
                 elif prob is not None and prob < cfg.etf_exit_prob:
                     reason = "llm_bearish"
                 if reason:
-                    await self._fill(symbol, OrderSide.SELL, qty, quote.bid)
+                    exit_price = adverse_fill(quote.bid, quote.ask, "SELL", cfg.etf_slippage_bps)
+                    await self._fill(symbol, OrderSide.SELL, qty, exit_price)
                     self._cooldown[symbol] = time.time() + (
                         cfg.etf_reentry_cooldown_hours * 3600)
                     await self._db.execute(
@@ -377,14 +398,18 @@ class IBKRETFPaperPillar:
                     class_allocated[asset_class] = max(
                         0.0, class_allocated.get(asset_class, 0.0) - cost)
                     position_count -= 1
+                    unmarked_positions.discard(symbol)
                     log.info("ibkr_etf.paper.exit", symbol=symbol, reason=reason,
                              model_alias=self._alias,
                              gain_pct=round(gain, 2),
                              probability=(round(prob, 3) if prob is not None else None))
                 else:
                     await self._mirror(symbol, qty, entry, quote.bid)
+                    unmarked_positions.discard(symbol)
+                daily_loss_hit = await self._daily_equity_change() <= -cfg.etf_daily_loss_limit_usd
             elif (view is not None and conf_ok and prob >= cfg.etf_min_prob
                   and not daily_loss_hit
+                  and not unmarked_positions
                   and position_count < cfg.etf_max_positions
                   and time.time() >= self._cooldown.get(symbol, 0)):
                 deployment_cap = cfg.etf_paper_budget_usd * cfg.etf_max_deployment_pct / 100.0
@@ -394,19 +419,43 @@ class IBKRETFPaperPillar:
                     deployment_cap - allocated,
                     class_cap - class_allocated.get(asset_class, 0.0),
                 )
+                closes_raw = await self._client.get_adjusted_daily_closes(symbol)
+                closes = [float(close) for _, close in closes_raw if close and close > 0]
+                annual_vol = annualized_volatility(closes)
+                momentum = normalized_momentum(closes)
+                if annual_vol is None or momentum is None or momentum <= 0:
+                    continue
                 notional = min(cfg.etf_max_entry_usd, remaining)
                 if notional <= cfg.etf_fee_per_order_usd:
                     continue
-                qty = (notional - cfg.etf_fee_per_order_usd) / quote.ask
-                await self._fill(symbol, OrderSide.BUY, qty, quote.ask)
-                entry = quote.ask
+                entry = adverse_fill(quote.bid, quote.ask, "BUY", cfg.etf_slippage_bps)
+                distance = stop_distance(entry, annual_vol, cfg.etf_stop_vol_multiple,
+                                         cfg.etf_min_stop_pct)
+                risk_budget = cfg.etf_paper_budget_usd * cfg.etf_risk_per_position_pct / 100
+                qty = min(
+                    (notional - cfg.etf_fee_per_order_usd) / entry,
+                    risk_quantity(risk_budget, distance, 1, 1, fractional=True),
+                )
+                if qty <= 0:
+                    continue
+                initial_risk = qty * distance
+                open_risk = await self._db.fetchone(
+                    """SELECT COALESCE(SUM(initial_risk_usd), 0) AS risk
+                         FROM ibkr_etf_positions WHERE model_alias=?""", (self._alias,))
+                max_risk = cfg.etf_paper_budget_usd * cfg.etf_max_portfolio_risk_pct / 100
+                if float(open_risk["risk"] or 0) + initial_risk > max_risk:
+                    continue
+                await self._fill(symbol, OrderSide.BUY, qty, entry,
+                                 stop_price=entry - distance,
+                                 initial_risk_usd=initial_risk)
                 await self._mirror(symbol, qty, entry, quote.bid)
-                allocated += notional
+                actual_cost = qty * entry + cfg.etf_fee_per_order_usd
+                allocated += actual_cost
                 class_allocated[asset_class] = (
-                    class_allocated.get(asset_class, 0.0) + notional)
+                    class_allocated.get(asset_class, 0.0) + actual_cost)
                 position_count += 1
                 entries += 1
-                log.info("ibkr_etf.paper.entry", symbol=symbol, usd=round(notional, 2),
+                log.info("ibkr_etf.paper.entry", symbol=symbol, usd=round(actual_cost, 2),
                          model_alias=self._alias,
                          probability=round(prob, 3), confidence=confidence,
                          spread_bps=round(spread_bps, 2))

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -192,8 +192,13 @@ class IBKRMultiAssetPaperBook:
             (self.book.value,))
         cursor = int(state["refresh_cursor"] or 0) if state else 0
         disabled = set(self._settings.ibkr.multiasset_disabled_instruments)
+        eligible = None
+        if self._settings.ibkr.multiasset_registry_required:
+            from auramaur.exchange.ibkr_registry import eligible_keys
+            eligible = await eligible_keys(self._db)
         universe = tuple(spec for spec in BY_BOOK[self.book]
-                         if spec.key not in disabled)
+                         if spec.key not in disabled
+                         and (eligible is None or spec.key in eligible))
         held_specs = {}
         for key, row in positions.items():
             spec = self._position_spec(row)

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -15,6 +15,10 @@ from auramaur.exchange.ibkr_instruments import (
     BY_BOOK, BY_KEY, ContractKind, IBKRBook, InstrumentSpec,
 )
 from auramaur.strategy.protocols import ExecutionMode
+from auramaur.risk.ibkr_math import (
+    adverse_fill, annualized_volatility, closes_from_bars,
+    normalized_momentum, risk_quantity, stop_distance,
+)
 
 log = structlog.get_logger()
 
@@ -114,10 +118,7 @@ class IBKRMultiAssetPaperBook:
 
     @staticmethod
     def _momentum(bars) -> float | None:
-        closes = [float(close) for _, close in bars if close and close > 0]
-        if len(closes) < 21:
-            return None
-        return (closes[-1] / closes[-21] - 1) * 100
+        return normalized_momentum(closes_from_bars(bars))
 
     @staticmethod
     def _commission(spec, quantity: float, notional_usd: float) -> float:
@@ -145,8 +146,9 @@ class IBKRMultiAssetPaperBook:
         return float(math.floor(raw))
 
     async def _fill(self, spec, quote, side: str, quantity: float,
-                    fx: float, entry_price: float | None = None) -> None:
-        price = quote.ask if side == "BUY" else quote.bid
+                    fx: float, entry_price: float | None = None,
+                    stop_price: float = 0, initial_risk_usd: float = 0) -> None:
+        price = adverse_fill(quote.bid, quote.ask, side, self.config.slippage_bps)
         capital = quantity * self._capital_per_unit(spec, price, fx)
         fee = self._commission(spec, quantity, capital)
         fill_ref = f"ibkr-{self.book.value}-paper-{uuid4().hex}"
@@ -165,11 +167,11 @@ class IBKRMultiAssetPaperBook:
                 """INSERT INTO ibkr_paper_positions
                    (book, instrument_key, con_id, currency, quantity, multiplier,
                     fx_to_usd, avg_cost, current_price, price_source,
-                    instrument_spec_json)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    instrument_spec_json, stop_price, initial_risk_usd)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (self.book.value, spec.key, quote.con_id, spec.currency, quantity,
                  quote.multiplier, fx, price, price, quote.source,
-                 self._serialize_spec(spec)))
+                 self._serialize_spec(spec), stop_price, initial_risk_usd))
         else:
             pnl = (price - float(entry_price)) * quantity * quote.multiplier * fx
             await self._db.execute(
@@ -249,14 +251,16 @@ class IBKRMultiAssetPaperBook:
                            WHERE book=? AND instrument_key=?""",
                         (quote.bid, pnl, quote.source, self.book.value, spec.key))
                     unmarked_positions.discard(spec.key)
-                    hard_exit = (gain_pct <= -cfg.stop_loss_pct
+                    stored_stop = float(held["stop_price"] or 0)
+                    hard_exit = ((stored_stop > 0 and quote.bid <= stored_stop)
+                                 or gain_pct <= -cfg.stop_loss_pct
                                  or gain_pct >= cfg.take_profit_pct)
                     momentum_exit = False
                     if not hard_exit:
                         bars = await self._client.get_daily_bars_by_con_id(spec, held_con_id)
                         momentum = self._momentum(bars)
                         momentum_exit = (momentum is not None and momentum <=
-                                         self._settings.ibkr.multiasset_exit_momentum_pct)
+                                         self._settings.ibkr.multiasset_exit_normalized_momentum)
                     if hard_exit or momentum_exit:
                         await self._fill(spec, quote, "SELL", float(held["quantity"]),
                                          mark_fx, entry_price=entry)
@@ -265,14 +269,17 @@ class IBKRMultiAssetPaperBook:
                 spread_bps = (quote.ask - quote.bid) / ((quote.ask + quote.bid) / 2) * 10_000
                 if fx is None or spread_bps > cfg.max_spread_bps:
                     continue
-                momentum = self._momentum(await self._client.get_daily_bars(spec))
-                if momentum is None:
+                bars = await self._client.get_daily_bars(spec)
+                closes = closes_from_bars(bars)
+                momentum = normalized_momentum(closes)
+                annual_vol = annualized_volatility(closes)
+                if momentum is None or annual_vol is None:
                     continue
                 loss_exposure = await self._loss_exposure()
                 if (unmarked_positions or loss_exposure <= -cfg.daily_loss_limit_usd
                         or len(positions) >= cfg.max_positions):
                     continue
-                if momentum < self._settings.ibkr.multiasset_min_momentum_pct:
+                if momentum < self._settings.ibkr.multiasset_min_normalized_momentum:
                     continue
                 deployed = sum(
                     float(row["quantity"]) * self._capital_per_unit(
@@ -283,10 +290,29 @@ class IBKRMultiAssetPaperBook:
                 target = min(cfg.budget_usd * cfg.max_position_pct / 100,
                              deployment_cap - deployed)
                 unit_capital = self._capital_per_unit(spec, quote.ask, fx)
-                quantity = self._quantity(spec, target, unit_capital)
+                entry_price = adverse_fill(
+                    quote.bid, quote.ask, "BUY", cfg.slippage_bps)
+                distance = stop_distance(entry_price, annual_vol,
+                                         cfg.stop_vol_multiple, cfg.min_stop_pct)
+                risk_budget = cfg.budget_usd * cfg.risk_per_position_pct / 100
+                class_risk = sum(
+                    float(row["initial_risk_usd"] or 0)
+                    for key, row in positions.items()
+                    if (held_specs.get(key) or BY_KEY[key]).asset_class == spec.asset_class
+                )
+                class_risk_cap = cfg.budget_usd * cfg.max_asset_class_risk_pct / 100
+                risk_budget = min(risk_budget, class_risk_cap - class_risk)
+                quantity = min(
+                    self._quantity(spec, target, unit_capital),
+                    risk_quantity(risk_budget, distance, quote.multiplier, fx,
+                                  fractional=spec.kind is ContractKind.STOCK),
+                )
                 if quantity <= 0:
                     continue
-                await self._fill(spec, quote, "BUY", quantity, fx)
+                initial_risk = quantity * distance * quote.multiplier * fx
+                await self._fill(spec, quote, "BUY", quantity, fx,
+                                 stop_price=entry_price - distance,
+                                 initial_risk_usd=initial_risk)
                 positions = await self._positions()
                 entries += 1
             except Exception as exc:  # noqa: BLE001

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,8 @@ services:
       IBKR__HOST: ibgateway
       IBKR__ENABLED: ${IBKR_ENABLED:-true}
       IBKR__OPTIONS_ENABLED: "false"
+      # Paper books reject delayed/frozen prices; request native live data.
+      IBKR__MARKET_DATA_TYPE: ${IBKR_MARKET_DATA_TYPE:-1}
       IBKR__ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
       IBKR__PAPER_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__LIVE_PORT: ${IBKR_QUOTE_PORT:-4002}

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -218,16 +218,17 @@ ibkr:
   # PRE-REGISTERED EXPERIMENT (2026-06-09, Phase 6 of the edge-first redesign).
   # IBKR is an experiment, not a commitment. Criteria fixed BEFORE activation
   # so the decision can't drift:
-  #   * Success bar: >= 20 closed trades with positive realized P&L within 90
-  #     days of activation (the same bar the graduation ladder uses).
-  #   * Kill criteria: realized <= -$50 at any point, OR 90 days post-
-  #     activation without meeting the success bar -> set enabled:false and
+  #   * Success bar: the IBKR-specific evidence contract requires >=200
+  #     cost-adjusted observations over >=180 days, positive 95% lower bound on
+  #     mean P&L, bounded drawdown, and (for forecasts) Brier improvement over
+  #     the base rate. See risk/ibkr_evidence.py.
+  #   * Kill criteria: realized <= -$50 at any point, OR failure of the
+  #     pre-registered evidence contract at review -> set enabled:false and
   #     redesign before re-funding. No threshold-moving after the fact.
-  #   * Review date: 90 days after enabled flips true (record the date here
+  #   * Review date: 180 days after enabled flips true (record the date here
   #     when it does).
-  # NOTE: before scaling beyond the starter budget, wire IBKR fills through
-  # the pnl_ledger venue/category context so `auramaur pnl` and the
-  # graduation ladder can actually score it.
+  # NOTE: before scaling beyond the starter budget, expose the isolated IBKR
+  # ledgers through a report that calls the evidence contract above.
   # Ports: TWS 7497 paper / 7496 live; IB Gateway 4002 / 4001.
   enabled: true
   # Master switch above just connects. The two books are gated independently
@@ -278,13 +279,20 @@ ibkr:
   multiasset_disabled_instruments: ["7203.T"]
   multiasset_min_momentum_pct: 1.0
   multiasset_exit_momentum_pct: -0.5
+  # Cross-asset signals are volatility-standardized; raw percentage momentum is
+  # retained above only for old local overrides and is no longer used.
+  multiasset_min_normalized_momentum: 0.25
+  multiasset_exit_normalized_momentum: -0.10
   multiasset_books:
     global_etf: {enabled: true, budget_usd: 5000, max_positions: 6, max_position_pct: 12, max_deployment_pct: 60, daily_loss_limit_usd: 100, stop_loss_pct: 5, take_profit_pct: 10, max_spread_bps: 25}
     fx: {enabled: true, budget_usd: 5000, max_positions: 4, max_position_pct: 10, max_deployment_pct: 40, daily_loss_limit_usd: 75, stop_loss_pct: 2, take_profit_pct: 4, max_spread_bps: 15}
     futures: {enabled: true, budget_usd: 10000, max_positions: 3, max_position_pct: 15, max_deployment_pct: 40, daily_loss_limit_usd: 150, stop_loss_pct: 3, take_profit_pct: 6, max_spread_bps: 30}
     international_equity: {enabled: true, budget_usd: 5000, max_positions: 5, max_position_pct: 12, max_deployment_pct: 50, daily_loss_limit_usd: 100, stop_loss_pct: 6, take_profit_pct: 12, max_spread_bps: 50}
-    options: {enabled: true, budget_usd: 3000, max_positions: 3, max_position_pct: 10, max_deployment_pct: 30, daily_loss_limit_usd: 100, stop_loss_pct: 35, take_profit_pct: 50, max_spread_bps: 300}
-    bonds: {enabled: true, budget_usd: 10000, max_positions: 4, max_position_pct: 20, max_deployment_pct: 60, daily_loss_limit_usd: 75, stop_loss_pct: 3, take_profit_pct: 6, max_spread_bps: 100}
+    # Fail closed until option Greeks/expiry/assignment and bond duration/accrual
+    # are part of both sizing and the paper ledger. Generic price volatility is
+    # not sufficient evidence for either asset class.
+    options: {enabled: false, budget_usd: 3000, max_positions: 3, max_position_pct: 10, max_deployment_pct: 30, daily_loss_limit_usd: 100, stop_loss_pct: 35, take_profit_pct: 50, max_spread_bps: 300}
+    bonds: {enabled: false, budget_usd: 10000, max_positions: 4, max_position_pct: 20, max_deployment_pct: 60, daily_loss_limit_usd: 75, stop_loss_pct: 3, take_profit_pct: 6, max_spread_bps: 100}
   # Operator-visible mirror of the typed GLOBAL_ETFS manifest. A test enforces
   # exact equality so the legacy intelligence experiment cannot drift.
   etf_symbols: ["SPY", "QQQ", "IWM", "DIA", "VTI",
@@ -311,6 +319,11 @@ ibkr:
   etf_take_profit_pct: 8.0
   etf_trailing_stop_pct: 3.0
   etf_reentry_cooldown_hours: 24.0
+  etf_risk_per_position_pct: 0.25
+  etf_stop_vol_multiple: 2.0
+  etf_min_stop_pct: 1.0
+  etf_slippage_bps: 2.0
+  etf_max_portfolio_risk_pct: 1.0
   # Intelligence-cap experiment: identical evidence/prompt/risk across three
   # independent, isolated paper cells. Only model tier/reasoning effort changes.
   etf_models:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -270,6 +270,9 @@ ibkr:
   multiasset_preflight_concurrency: 2
   multiasset_preflight_pacing_retries: 2
   multiasset_preflight_retry_seconds: 2.0
+  # Runtime universe = deterministic manifest intersected with this machine's
+  # qualified, approved broker registry. Run preflight before enabling books.
+  multiasset_registry_required: true
   # TSEJ history/BBO is not entitled on the current IBKR username. Keep the
   # contract in the catalog and re-enable it after preflight passes.
   multiasset_disabled_instruments: ["7203.T"]
@@ -282,13 +285,13 @@ ibkr:
     international_equity: {enabled: true, budget_usd: 5000, max_positions: 5, max_position_pct: 12, max_deployment_pct: 50, daily_loss_limit_usd: 100, stop_loss_pct: 6, take_profit_pct: 12, max_spread_bps: 50}
     options: {enabled: true, budget_usd: 3000, max_positions: 3, max_position_pct: 10, max_deployment_pct: 30, daily_loss_limit_usd: 100, stop_loss_pct: 35, take_profit_pct: 50, max_spread_bps: 300}
     bonds: {enabled: true, budget_usd: 10000, max_positions: 4, max_position_pct: 20, max_deployment_pct: 60, daily_loss_limit_usd: 75, stop_loss_pct: 3, take_profit_pct: 6, max_spread_bps: 100}
-  # Multi-asset ETF universe: broad US, sectors, international, rates, real
-  # assets, and defensives. Long-only instruments avoid leverage/inverse decay.
+  # Operator-visible mirror of the typed GLOBAL_ETFS manifest. A test enforces
+  # exact equality so the legacy intelligence experiment cannot drift.
   etf_symbols: ["SPY", "QQQ", "IWM", "DIA", "VTI",
     "XLK", "XLF", "XLV", "XLE", "XLI", "XLY", "XLP", "XLU", "XLB", "XLRE", "XLC",
-    "VEA", "VWO", "EWC", "EWJ",
-    "TLT", "IEF", "SHY", "TIP",
-    "GLD", "SLV", "DBC", "VNQ"]
+    "VEA", "VWO", "INDA", "MCHI", "EWJ", "EWC", "EWZ",
+    "TLT", "IEF", "SHY", "TIP", "LQD", "HYG", "EMB",
+    "GLD", "SLV", "DBC", "VNQ", "UUP"]
   etf_paper_budget_usd: 5000.0
   etf_max_entry_usd: 250.0
   etf_max_deployment_pct: 50.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -1045,6 +1045,11 @@ class IBKRMultiAssetBookConfig(BaseModel):
     stop_loss_pct: float = 5.0
     take_profit_pct: float = 10.0
     max_spread_bps: float = 40.0
+    risk_per_position_pct: float = 0.25
+    max_asset_class_risk_pct: float = 0.50
+    stop_vol_multiple: float = 2.0
+    min_stop_pct: float = 0.50
+    slippage_bps: float = 2.0
 
     @model_validator(mode="after")
     def validate_risk(self):
@@ -1056,6 +1061,10 @@ class IBKRMultiAssetBookConfig(BaseModel):
             raise ValueError("IBKR paper book loss limits must be positive")
         if self.take_profit_pct <= 0 or self.max_spread_bps <= 0:
             raise ValueError("IBKR paper book exit/spread limits must be positive")
+        if not 0 < self.risk_per_position_pct <= self.max_asset_class_risk_pct <= 5:
+            raise ValueError("IBKR paper risk percentages are inconsistent")
+        if self.stop_vol_multiple <= 0 or self.min_stop_pct <= 0 or self.slippage_bps < 0:
+            raise ValueError("IBKR paper volatility/execution inputs are invalid")
         return self
 
 
@@ -1117,6 +1126,8 @@ class IBKRConfig(BaseModel):
     multiasset_disabled_instruments: list[str] = []
     multiasset_min_momentum_pct: float = 1.0
     multiasset_exit_momentum_pct: float = -0.5
+    multiasset_min_normalized_momentum: float = 0.25
+    multiasset_exit_normalized_momentum: float = -0.10
     multiasset_books: dict[str, IBKRMultiAssetBookConfig] = Field(default_factory=lambda: {
         name: IBKRMultiAssetBookConfig() for name in (
             "global_etf", "fx", "futures", "international_equity", "options", "bonds")
@@ -1141,6 +1152,11 @@ class IBKRConfig(BaseModel):
     etf_take_profit_pct: float = 8.0
     etf_trailing_stop_pct: float = 3.0
     etf_reentry_cooldown_hours: float = 24.0
+    etf_risk_per_position_pct: float = 0.25
+    etf_stop_vol_multiple: float = 2.0
+    etf_min_stop_pct: float = 1.0
+    etf_slippage_bps: float = 2.0
+    etf_max_portfolio_risk_pct: float = 1.0
     etf_models: list[OpenAIETFModel] = [
         OpenAIETFModel(alias="luna", model="gpt-5.6-luna", effort="low"),
         OpenAIETFModel(alias="terra", model="gpt-5.6-terra", effort="medium"),
@@ -1197,6 +1213,10 @@ class IBKRConfig(BaseModel):
             raise ValueError("IBKR ETF position and refresh limits must be positive")
         if self.etf_daily_loss_limit_usd <= 0 or self.etf_fee_per_order_usd < 0:
             raise ValueError("IBKR ETF loss limit must be positive and fees non-negative")
+        if not 0 < self.etf_risk_per_position_pct <= self.etf_max_portfolio_risk_pct <= 5:
+            raise ValueError("IBKR ETF risk percentages are inconsistent")
+        if self.etf_stop_vol_multiple <= 0 or self.etf_min_stop_pct <= 0 or self.etf_slippage_bps < 0:
+            raise ValueError("IBKR ETF volatility/execution inputs are invalid")
         if not 0 <= self.etf_exit_prob < self.etf_min_prob <= 1:
             raise ValueError("IBKR ETF probability thresholds must satisfy exit < entry")
         if self.etf_openai_daily_call_limit < len(self.etf_models):

--- a/config/settings.py
+++ b/config/settings.py
@@ -1059,6 +1059,12 @@ class IBKRMultiAssetBookConfig(BaseModel):
         return self
 
 
+def _canonical_ibkr_etf_symbols() -> list[str]:
+    """Keep the legacy ETF experiment on the typed multi-asset manifest."""
+    from auramaur.exchange.ibkr_instruments import GLOBAL_ETFS
+    return [spec.symbol for spec in GLOBAL_ETFS]
+
+
 class IBKRConfig(BaseModel):
     enabled: bool = False
     # `enabled` is the master switch (connect to IBKR at all). The two books
@@ -1104,6 +1110,10 @@ class IBKRConfig(BaseModel):
     multiasset_preflight_concurrency: int = 2
     multiasset_preflight_pacing_retries: int = 2
     multiasset_preflight_retry_seconds: float = 2.0
+    # Require a current broker-qualified identity before opening new risk.
+    # Kept false in model defaults so isolated test/library users can opt in;
+    # tracked deployment defaults enable it.
+    multiasset_registry_required: bool = False
     multiasset_disabled_instruments: list[str] = []
     multiasset_min_momentum_pct: float = 1.0
     multiasset_exit_momentum_pct: float = -0.5
@@ -1111,7 +1121,7 @@ class IBKRConfig(BaseModel):
         name: IBKRMultiAssetBookConfig() for name in (
             "global_etf", "fx", "futures", "international_equity", "options", "bonds")
     })
-    etf_symbols: list[str] = ["SPY", "QQQ", "IWM"]
+    etf_symbols: list[str] = Field(default_factory=_canonical_ibkr_etf_symbols)
     etf_paper_budget_usd: float = 5_000.0
     etf_max_entry_usd: float = 250.0
     etf_max_deployment_pct: float = 50.0

--- a/deploy/env.manifest.yaml
+++ b/deploy/env.manifest.yaml
@@ -72,6 +72,7 @@ IBKR_ENABLED:                  {type: config, required: optional, targets: [host
 IBKR_QUOTE_ENVIRONMENT:        {type: config, required: optional, targets: [compose]}
 IBKR_QUOTE_PORT:               {type: config, required: optional, targets: [compose]}
 IBKR_MULTIASSET_PAPER_ENABLED: {type: config, required: optional, targets: [compose]}
+IBKR_MARKET_DATA_TYPE:         {type: config, required: optional, targets: [compose]}
 AURAMAUR_HEALTH_REQUIRE_IBKR:  {type: config, required: optional, targets: [host, compose], in_example: false}
 AURAMAUR_IBKR_ENVIRONMENT:     {type: config, required: optional, targets: [host], in_example: false}
 AURAMAUR_IBKR_HOST:            {type: config, required: optional, targets: [host], in_example: false}

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -10,7 +10,7 @@ method. A live-account TWS login does not make these books live.
 |---|---|---|---|
 | `global_etf` | US-listed global equity, rates, credit, commodity, currency and real-estate ETFs | Qualified `STK` with primary exchange | fractional shares at ask/bid |
 | `fx` | ten liquid G10 crosses | `CASH` on `IDEALPRO` | 1,000-base-unit lots, USD translation |
-| `futures` | micro equity index, rates, energy, metals and agriculture | nearest contract with >7 days to expiry; exact held `conId` retained | conservative per-contract capital plus multiplier P&L |
+| `futures` | micro equity index, rates, energy, metals and agriculture | product-specific roll buffer, then highest reported volume among nearest valid expiries; exact held `conId` retained | conservative per-contract capital plus multiplier P&L |
 | `international_equity` | Canada, UK, Europe, Japan, Hong Kong and Australia | native listing, exchange and currency | fractional shares, mark translated to USD |
 | `options` | 30–60 DTE ATM calls and puts on liquid ETFs | exact qualified chain contract; exact held `conId` retained | whole contracts, 100 multiplier |
 | `bonds` | US Treasury tenors and a US corporate issue | maturity-bounded IBKR bond scanner, exact `conId` | $1,000 face-value units |
@@ -18,6 +18,32 @@ method. A live-account TWS login does not make these books live.
 The catalog is in `auramaur/exchange/ibkr_instruments.py`. Instrument keys are
 unique and every entry declares its security type, exchange, currency, calendar,
 multiplier and discovery policy.
+
+## Manifest and qualified registry
+
+The trading space is deliberately hybrid. The version-controlled catalog is the
+only authority allowed to introduce economic exposure. IBKR probing qualifies
+those declarations into exact broker identities; it never adds a ticker or
+scanner result to the universe by itself.
+
+Successful preflight writes `ibkr_contract_registry`, including the manifest
+hash, `conId`, local symbol, trading class, exchange, currency, multiplier,
+quote provenance, history availability, and validation time. With
+`multiasset_registry_required: true`, new entries require a current `eligible`
+row whose manifest hash still matches. A catalog edit therefore fails closed
+until the instrument is probed again. Existing positions remain manageable by
+their persisted specification and original `conId`.
+
+Static listings, FX, futures, options, and government bond policies become
+eligible after successful qualification. Corporate bond scanner results need an
+operator to approve the exact issue:
+
+```console
+auramaur ibkr-contract-approve CORP_5Y --reason "reviewed issuer, maturity and liquidity"
+```
+
+Changing the manifest invalidates prior approval. Failed probes are quarantined;
+disabled instruments remain outside probing and runtime eligibility.
 
 `multiasset_disabled_instruments` is the explicit entitlement quarantine. The
 current username lacks TSEJ data, so `7203.T` remains catalogued but does not
@@ -83,6 +109,10 @@ The preflight checks structural isolation, schema, every configured contract,
 fresh BBOs, at least 21 daily bars, quote provenance, and per-book forward
 evidence. Run it during each venue's session when diagnosing BBO availability;
 closed venues are expected to lack executable quotes.
+
+Set `IBKR_MARKET_DATA_TYPE=1` in the compose environment. Values 2–4 may still
+qualify contracts and expose delayed/frozen data for diagnostics, but registry
+status becomes `qualified_no_live_data` and the runtime will not open risk.
 
 The startup books panel and periodic strategy table report each book separately.
 `ibkr_paper_state.last_cycle_at`, `last_success_at`, and `last_error` provide

--- a/tests/test_ibkr_etf_paper.py
+++ b/tests/test_ibkr_etf_paper.py
@@ -22,7 +22,7 @@ class QuotesOnlyClient:
         return EquityQuote(self.bid, self.ask, time.time())
 
     async def get_adjusted_daily_closes(self, symbol):
-        return []
+        return [(f"session-{day:03d}", 75 + day * 0.2) for day in range(121)]
 
 
 class Aggregator:
@@ -62,7 +62,7 @@ async def test_bullish_view_opens_paper_position_at_ask():
     assert fill["model_alias"] == "luna"
     assert fill["symbol"] == "SPY"
     assert fill["side"] == "BUY"
-    assert fill["price"] == 100.0
+    assert fill["price"] == pytest.approx(100.02)
     pos = await db.fetchone("SELECT * FROM ibkr_etf_positions")
     assert pos["model_alias"] == "luna"
     assert await db.fetchone("SELECT * FROM fills") is None
@@ -85,11 +85,11 @@ async def test_bearish_refresh_closes_at_bid_and_attributes_ledger():
 
     fills = await db.fetchall("SELECT side, price FROM ibkr_etf_fills ORDER BY id")
     assert [(r["side"], r["price"]) for r in fills] == [
-        ("BUY", 100.0), ("SELL", 99.9)]
+        ("BUY", pytest.approx(100.02)), ("SELL", pytest.approx(99.88002))]
     ledger = await db.fetchall(
         "SELECT kind, pnl FROM ibkr_etf_ledger ORDER BY id")
     assert [row["kind"] for row in ledger] == ["commission", "commission", "trade"]
-    assert sum(row["pnl"] for row in ledger) == pytest.approx(-2.249)
+    assert sum(row["pnl"] for row in ledger) < -2.0
     assert await db.fetchone("SELECT * FROM ibkr_etf_positions") is None
     await db.close()
 
@@ -166,7 +166,7 @@ async def test_asset_class_cap_reduces_entry_size():
     await pillar.run_once()
     row = await db.fetchone(
         "SELECT quantity, avg_cost FROM ibkr_etf_positions WHERE model_alias='luna'")
-    assert row["quantity"] * row["avg_cost"] + 1.0 == pytest.approx(100.0)
+    assert row["quantity"] * row["avg_cost"] + 1.0 <= 100.0
     await db.close()
 
 

--- a/tests/test_ibkr_evidence.py
+++ b/tests/test_ibkr_evidence.py
@@ -1,0 +1,25 @@
+from auramaur.risk.ibkr_evidence import evaluate_ibkr_evidence
+
+
+def test_twenty_profitable_trades_cannot_graduate():
+    evidence = evaluate_ibkr_evidence([1.0] * 20, elapsed_days=90, budget_usd=5_000)
+    assert not evidence.ready
+    assert any("20/200" in reason for reason in evidence.reasons)
+
+
+def test_cost_adjusted_long_record_can_graduate_with_calibration():
+    pnls = [1.2 if i % 3 else -0.5 for i in range(240)]
+    outcomes = [1 if i % 3 else 0 for i in range(240)]
+    probabilities = [0.75 if outcome else 0.25 for outcome in outcomes]
+    evidence = evaluate_ibkr_evidence(
+        pnls, elapsed_days=220, budget_usd=5_000,
+        probabilities=probabilities, outcomes=outcomes)
+    assert evidence.ready
+    assert evidence.brier_score < evidence.baseline_brier_score
+
+
+def test_drawdown_and_uncertainty_fail_closed():
+    evidence = evaluate_ibkr_evidence(
+        [5.0] * 210 + [-100.0] * 10, elapsed_days=220, budget_usd=1_000)
+    assert not evidence.ready
+    assert evidence.max_drawdown_usd == 1_000

--- a/tests/test_ibkr_instruments.py
+++ b/tests/test_ibkr_instruments.py
@@ -7,6 +7,9 @@ def test_catalog_has_unique_typed_keys_and_all_six_books():
     assert len(BY_KEY) == len(CATALOG)
     assert set(BY_BOOK) == set(IBKRBook)
     assert all(BY_BOOK[book] for book in IBKRBook)
+    broad = {spec.key for spec in BY_BOOK[IBKRBook.GLOBAL_ETF]}
+    assert {"DIA", "VTI", "XLK", "XLF", "XLV", "XLE", "SHY", "EWC"} <= broad
+    assert len({spec.manifest_hash() for spec in CATALOG}) == len(CATALOG)
 
 
 def test_derivatives_and_bonds_declare_discovery_policy():
@@ -14,6 +17,7 @@ def test_derivatives_and_bonds_declare_discovery_policy():
         assert spec.kind is ContractKind.FUTURE
         assert spec.expiry_policy == "front_liquid"
         assert spec.multiplier > 1
+        assert spec.roll_days_before_expiry >= 7
     grains = {spec.key: spec for spec in BY_BOOK[IBKRBook.FUTURES]
               if spec.key in {"ZC", "ZW"}}
     assert all(spec.contract_multiplier == 5000 and spec.multiplier == 50
@@ -23,9 +27,11 @@ def test_derivatives_and_bonds_declare_discovery_policy():
         assert 0 < spec.option_dte_min <= spec.option_dte_max
         assert spec.option_right in {"C", "P"}
         assert spec.multiplier == 100
+        assert spec.option_moneyness_pct in {0, 5}
     for spec in BY_BOOK[IBKRBook.BONDS]:
         assert spec.kind is ContractKind.BOND
         assert spec.bond_query
+    assert BY_KEY["CORP_5Y"].approval_required
 
 
 def test_fx_uses_idealpro_and_native_equities_are_not_usd_only():

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -31,10 +31,13 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
     version = await db.fetchone("SELECT version FROM schema_version")
     position_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
     fill_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_fills)")
-    assert version["version"] == 25
+    assert version["version"] == 26
     assert {row["name"] for row in position_columns} >= {
         "price_source", "instrument_spec_json"}
     assert "price_source" in {row["name"] for row in fill_columns}
+    registry = await db.fetchall("PRAGMA table_info(ibkr_contract_registry)")
+    assert {"instrument_key", "manifest_hash", "con_id", "status", "approved"} <= {
+        row["name"] for row in registry}
     await db.close()
 
 

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -1,4 +1,5 @@
 import sqlite3
+from pathlib import Path
 
 import aiosqlite
 import pytest
@@ -7,8 +8,9 @@ from auramaur.db.database import Database
 
 
 @pytest.mark.asyncio
-async def test_v23_migration_adds_verified_columns(tmp_path):
-    path = tmp_path / "v23.db"
+async def test_v23_migration_adds_verified_columns():
+    path = Path("runtime/test-v23-migration.db")
+    path.unlink(missing_ok=True)
     raw = sqlite3.connect(path)
     raw.executescript(
         """CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
@@ -31,14 +33,15 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
     version = await db.fetchone("SELECT version FROM schema_version")
     position_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
     fill_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_fills)")
-    assert version["version"] == 26
+    assert version["version"] == 27
     assert {row["name"] for row in position_columns} >= {
-        "price_source", "instrument_spec_json"}
+        "price_source", "instrument_spec_json", "stop_price", "initial_risk_usd"}
     assert "price_source" in {row["name"] for row in fill_columns}
     registry = await db.fetchall("PRAGMA table_info(ibkr_contract_registry)")
     assert {"instrument_key", "manifest_hash", "con_id", "status", "approved"} <= {
         row["name"] for row in registry}
     await db.close()
+    path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -45,6 +45,7 @@ async def test_all_six_books_write_only_isolated_paper_tables():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 1
     for cfg in settings.ibkr.multiasset_books.values():
         cfg.max_position_pct = 40
@@ -71,6 +72,7 @@ async def test_daily_loss_gate_blocks_entries():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     await db.execute(
         "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) "
         "VALUES ('global_etf', 'trade', -101, 'loss')")
@@ -90,6 +92,7 @@ async def test_intracycle_commission_tightens_loss_gate():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 2
     cfg = settings.ibkr.multiasset_books["global_etf"]
     cfg.daily_loss_limit_usd = 0.5
@@ -204,6 +207,7 @@ async def test_open_position_is_marked_by_original_contract_id():
     await db.connect()
     settings = Settings()
     settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 1
     client = FakeMarketData()
     client.con_ids_requested = []

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -15,13 +15,14 @@ class FakeMarketData:
     con_ids_requested = []
 
     async def get_quote(self, spec):
-        price = 2.0 if spec.kind is ContractKind.OPTION else 100.0
+        price = (2.0 if spec.kind is ContractKind.OPTION else
+                 1.0 if spec.kind is ContractKind.FOREX else 100.0)
         return MarketDataQuote(spec.key, price, price * 1.0001, time.time(),
                                abs(hash(spec.key)) % 100000 + 1,
                                spec.currency, spec.multiplier)
 
     async def get_daily_bars(self, spec, duration="3 M"):
-        return [(f"2026-06-{day:02d}", 80 + day) for day in range(1, 22)]
+        return [(f"session-{day:03d}", 80 + day * 0.2) for day in range(121)]
 
     async def get_fx_to_usd(self, currency):
         return 1.0
@@ -48,6 +49,7 @@ async def test_all_six_books_write_only_isolated_paper_tables():
     settings.ibkr.multiasset_registry_required = False
     settings.ibkr.multiasset_refreshes_per_cycle = 1
     for cfg in settings.ibkr.multiasset_books.values():
+        cfg.enabled = True  # exercise isolation plumbing, including gated books
         cfg.max_position_pct = 40
         cfg.max_deployment_pct = 60
     for book in IBKRBook:
@@ -103,6 +105,30 @@ async def test_intracycle_commission_tightens_loss_gate():
     assert await pillar.run_once() == 1
     assert (await db.fetchone(
         "SELECT COUNT(*) AS n FROM ibkr_paper_positions"))["n"] == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_asset_class_risk_cap_bounds_correlated_entries():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
+    settings.ibkr.multiasset_refreshes_per_cycle = 2
+    cfg = settings.ibkr.multiasset_books["global_etf"]
+    cfg.max_positions = 2
+    cfg.max_position_pct = 40
+    cfg.max_deployment_pct = 80
+    cfg.risk_per_position_pct = 0.25
+    cfg.max_asset_class_risk_pct = 0.25
+    pillar = IBKRMultiAssetPaperBook(
+        settings, FakeMarketData(), db, IBKRBook.GLOBAL_ETF)
+    await pillar.run_once()
+    row = await db.fetchone(
+        "SELECT SUM(initial_risk_usd) AS risk FROM ibkr_paper_positions "
+        "WHERE book='global_etf'")
+    assert float(row["risk"] or 0) <= 12.5
     await db.close()
 
 
@@ -229,6 +255,8 @@ async def test_open_position_is_marked_by_original_contract_id():
 
 def test_books_declare_paper_simulated_mode_and_asset_calendars():
     settings = Settings()
+    assert not settings.ibkr.multiasset_books["options"].enabled
+    assert not settings.ibkr.multiasset_books["bonds"].enabled
     for book in IBKRBook:
         pillar = IBKRMultiAssetPaperBook(settings, None, None, book)
         assert pillar.execution_mode.value == "paper_simulated"

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -53,8 +53,8 @@ async def test_preflight_blocks_client_with_order_surface_and_missing_data():
     blocked = {result.book for result in report.results
                if result.severity == "BLOCK"}
     assert "isolation" in blocked
-    assert set(("global_etf", "fx", "futures", "international_equity",
-                "options", "bonds")) <= blocked
+    assert {"global_etf", "fx", "futures", "international_equity"} <= blocked
+    assert {"options", "bonds"}.isdisjoint(blocked)  # disabled books are not probed
     await db.close()
 
 
@@ -71,8 +71,8 @@ async def test_preflight_blocks_stale_quotes():
     settings.ibkr.enabled = True
     report = await preflight(settings, db, client=StaleClient())
     blocked = {result.book for result in report.results if result.severity == "BLOCK"}
-    assert {"global_etf", "fx", "futures", "international_equity",
-            "options", "bonds"} <= blocked
+    assert {"global_etf", "fx", "futures", "international_equity"} <= blocked
+    assert {"options", "bonds"}.isdisjoint(blocked)
     await db.close()
 
 

--- a/tests/test_ibkr_registry.py
+++ b/tests/test_ibkr_registry.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.ibkr_instruments import BY_KEY
+from auramaur.exchange.ibkr_registry import approve, eligible_keys, record_validation
+
+
+@pytest.mark.asyncio
+async def test_registry_auto_approves_declared_static_instrument():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    status = await record_validation(
+        db, spec, SimpleNamespace(conId=756733, localSymbol="SPY",
+                                  tradingClass="SPY", exchange="SMART",
+                                  currency="USD", multiplier="1"),
+        quote_source="ibkr_live", has_history=True)
+    assert status == "eligible"
+    assert await eligible_keys(db) == {"SPY"}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_corporate_bond_requires_operator_approval():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["CORP_5Y"]
+    contract = SimpleNamespace(conId=1234, exchange="SMART", currency="USD",
+                               multiplier="10")
+    assert await record_validation(db, spec, contract, quote_source="ibkr_live",
+                                   has_history=True) == "pending_approval"
+    assert "CORP_5Y" not in await eligible_keys(db)
+    assert await approve(db, "CORP_5Y", "reviewed issue and maturity")
+    assert "CORP_5Y" in await eligible_keys(db)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_manifest_drift_revokes_existing_approval(monkeypatch):
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    contract = SimpleNamespace(conId=1, exchange="SMART", currency="USD",
+                               multiplier="1")
+    await record_validation(db, spec, contract, quote_source="ibkr_live",
+                            has_history=True)
+    monkeypatch.setattr(type(spec), "manifest_hash", lambda _self: "changed")
+    assert await record_validation(db, spec, contract, quote_source="ibkr_live",
+                                   has_history=True) == "drifted"
+    assert "SPY" not in await eligible_keys(db)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_contract_identity_drift_requires_reapproval_but_failure_preserves_identity():
+    db = Database(":memory:")
+    await db.connect()
+    spec = BY_KEY["SPY"]
+    original = SimpleNamespace(conId=11, localSymbol="SPY", exchange="SMART",
+                               currency="USD", multiplier="1")
+    await record_validation(db, spec, original, quote_source="ibkr_live",
+                            has_history=True)
+    failed = SimpleNamespace(conId=0, exchange="SMART", currency="USD", multiplier="1")
+    assert await record_validation(db, spec, failed, quote_source="none",
+                                   has_history=False, error="socket lost") == "quarantined"
+    row = await db.fetchone(
+        "SELECT con_id, local_symbol FROM ibkr_contract_registry WHERE instrument_key='SPY'")
+    assert (row["con_id"], row["local_symbol"]) == (11, "SPY")
+    changed = SimpleNamespace(conId=12, localSymbol="SPY", exchange="SMART",
+                              currency="USD", multiplier="1")
+    assert await record_validation(db, spec, changed, quote_source="ibkr_live",
+                                   has_history=True) == "drifted"
+    assert "SPY" not in await eligible_keys(db)
+    assert await approve(db, "SPY", "verified broker identity replacement")
+    assert "SPY" in await eligible_keys(db)
+    await db.close()

--- a/tests/test_ibkr_risk_math.py
+++ b/tests/test_ibkr_risk_math.py
@@ -1,0 +1,29 @@
+import math
+
+import pytest
+
+from auramaur.risk.ibkr_math import (
+    adverse_fill, annualized_volatility, normalized_momentum, risk_quantity,
+    stop_distance,
+)
+
+
+def test_normalized_momentum_is_scale_invariant():
+    closes = [100 * math.exp(0.001 * i + 0.002 * math.sin(i)) for i in range(121)]
+    assert normalized_momentum(closes) == pytest.approx(
+        normalized_momentum([x * 100 for x in closes]))
+    assert annualized_volatility(closes) > 0
+
+
+def test_loss_at_stop_sizing_respects_multiplier_and_fx():
+    qty = risk_quantity(25, 0.5, 5, 1, fractional=False)
+    assert qty == 10
+    assert qty * 0.5 * 5 == 25
+    assert risk_quantity(25, 0.5, 100, 1, fractional=False) == 0
+
+
+def test_stop_and_fill_are_conservative():
+    distance = stop_distance(100, 0.20, 2, 0.5)
+    assert distance > 0.5
+    assert adverse_fill(99.9, 100, "BUY", 2) > 100
+    assert adverse_fill(99.9, 100, "SELL", 2) < 99.9

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -162,6 +162,8 @@ def test_yaml_defaults_safe():
     assert ibkr["auto_fx_enabled"] is False
     assert {"SPY", "QQQ", "IWM", "TLT", "GLD", "VEA"}.issubset(
         ibkr["etf_symbols"])
+    from auramaur.exchange.ibkr_instruments import GLOBAL_ETFS
+    assert ibkr["etf_symbols"] == [spec.symbol for spec in GLOBAL_ETFS]
     assert 0 < ibkr["etf_max_entry_usd"] <= ibkr["etf_paper_budget_usd"]
     assert [m["alias"] for m in ibkr["etf_models"]] == ["luna", "terra", "sol"]
 


### PR DESCRIPTION
## Summary
- replace raw cross-asset momentum with volatility-normalized multi-horizon signals
- size positions by loss at an immutable volatility stop, with FX/multiplier-aware risk and adverse paper slippage
- gate correlated asset-class and ETF portfolio risk, and count unrealized ETF losses before opening new exposure
- add schema migration v27 for persisted stop and initial-risk data
- add a pre-registered 200-observation/180-day statistical evidence contract
- fail closed for options and bonds until Greeks/assignment and duration/accrual accounting are implemented

## Verification
- 1213 passed, 2 skipped
- Ruff clean
- git diff --check clean

## Notes
The full suite was run on Windows with a process-local fcntl compatibility stub; production POSIX locking code is unchanged.