### PR TITLE
fix(ibgateway): auto-place the 2FA dialog clear of the Authenticating window

### DIFF
--- a/deploy/ibgateway/Dockerfile
+++ b/deploy/ibgateway/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates fluxbox gosu netcat-openbsd novnc openjdk-17-jre-headless \
-       procps websockify x11vnc xauth xvfb \
+       procps websockify x11vnc xauth xdotool xvfb \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --uid 10002 --create-home ibgateway \

--- a/deploy/ibgateway/entrypoint.sh
+++ b/deploy/ibgateway/entrypoint.sh
@@ -49,6 +49,26 @@ x11vnc -display "$DISPLAY" -rfbauth "$vnc_runtime/vnc.pass" \
     -localhost -forever -shared >/tmp/x11vnc.log 2>&1 &
 websockify --web=/usr/share/novnc/ 6080 localhost:5900 >/tmp/novnc.log 2>&1 &
 
+# The 2FA dialog opens underneath the larger "Authenticating..." window and
+# loses any restacking fight with it, so park each new dialog top-left where
+# nothing overlaps it.
+(
+    last=""
+    while :; do
+        w=$(xdotool search --onlyvisible --name 'Second Factor' 2>/dev/null | head -1)
+        if [ -n "$w" ]; then
+            if [ "$w" != "$last" ]; then
+                xdotool windowmove "$w" 10 20 windowraise "$w" \
+                    windowactivate "$w" 2>/dev/null || true
+                last=$w
+            fi
+        else
+            last=""
+        fi
+        sleep 3
+    done
+) >/tmp/2fa-watch.log 2>&1 &
+
 gateway=$(find "${IB_GATEWAY_HOME:-/opt/ibgateway}" -type f -name ibgateway -perm -u+x | head -1)
 if [ -z "$gateway" ]; then
     echo "IB Gateway executable not found" >&2


### PR DESCRIPTION
## Summary
- The IB Gateway "Second Factor Authentication" dialog opens entirely underneath the larger "Authenticating..." window and loses any restacking fight with it, so the noVNC session looks stuck at every weekly reauth until someone intervenes by hand.
- Bake `xdotool` into the gateway image and run a small watcher loop in the entrypoint that parks each newly appearing 2FA dialog at the top-left of the screen, where nothing overlaps it. Each dialog is moved once (tracked by window id), so a user dragging it afterwards is not fought.

## Testing
- Same change is already built and verified on the deployment host: image contains `xdotool`, entrypoint keeps its executable bit, and the watcher block is present in the baked image.
- Manual `xdotool windowmove` of a live "Second Factor Authentication" window (the same operation the watcher performs) made the dialog visible and usable during today's real reauth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)