### PR TITLE
fix(ibkr): pick option strikes from contracts listed for the chosen expiry

### DIFF
--- a/auramaur/exchange/ibkr_market_data.py
+++ b/auramaur/exchange/ibkr_market_data.py
@@ -234,17 +234,27 @@ class IBKRReadOnlyMarketData:
         if not expiries:
             raise LookupError(f"no option expiry in DTE window for {spec.key}")
         expiry = min(expiries, key=lambda item: item[0])[1]
-        strikes = [float(s) for s in chain.strikes if float(s) > 0]
-        if not strikes:
-            raise LookupError(f"no strikes for {spec.key}")
         direction = 1 if spec.option_right == "C" else -1
         target_strike = spot * (1 + direction * spec.option_moneyness_pct / 100)
-        strike = min(strikes, key=lambda value: abs(value - target_strike))
-        contract = Option(spec.symbol, expiry, strike, spec.option_right,
-                          "SMART", multiplier=str(int(spec.multiplier)),
-                          currency=spec.currency,
-                          tradingClass=getattr(chain, "tradingClass", ""))
-        return await self._qualify_one(contract)
+        # reqSecDefOptParams reports the union of strikes across every expiry
+        # (and mixes weekly/monthly trading classes), so an (expiry, strike)
+        # pair assembled from it may not be listed. Enumerate the contracts
+        # that actually exist for the chosen expiry and pick from those.
+        probe = Option(spec.symbol, expiry, 0.0, spec.option_right, "SMART",
+                       multiplier=str(int(spec.multiplier)),
+                       currency=spec.currency)
+        listed: dict[float, object] = {}
+        for detail in await self._ib.reqContractDetailsAsync(probe) or []:
+            candidate = detail.contract
+            strike_value = float(getattr(candidate, "strike", 0) or 0)
+            if strike_value > 0:
+                listed.setdefault(strike_value, candidate)
+        if not listed:
+            raise LookupError(
+                f"no listed {spec.option_right} option for {spec.key} expiry {expiry}")
+        # Contract-details contracts are fully specified (conId set) — no
+        # further qualification round-trip needed.
+        return listed[min(listed, key=lambda value: abs(value - target_strike))]
 
     async def _bond(self, spec: InstrumentSpec):
         """Discover an exact bond contract from IBKR's US bond scanner."""

--- a/tests/test_ibkr_market_data.py
+++ b/tests/test_ibkr_market_data.py
@@ -111,6 +111,59 @@ async def test_stale_socket_reconnects(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_atm_option_picks_a_strike_listed_for_the_chosen_expiry(monkeypatch):
+    from datetime import date, timedelta
+
+    # CI installs without --extra ibkr, so provide the two lazily imported
+    # contract constructors instead of importing the real ib_async.
+    module = types.ModuleType("ib_async")
+    module.Stock = lambda symbol, exchange, currency, primaryExchange="": (
+        SimpleNamespace(symbol=symbol, secType="STK", exchange=exchange,
+                        currency=currency, conId=0))
+    module.Option = (
+        lambda symbol, expiry, strike, right, exchange, multiplier="",
+        currency="", tradingClass="": SimpleNamespace(
+            symbol=symbol, lastTradeDateOrContractMonth=expiry, strike=strike,
+            right=right, exchange=exchange, multiplier=multiplier,
+            currency=currency, tradingClass=tradingClass))
+    monkeypatch.setitem(sys.modules, "ib_async", module)
+
+    expiry = (date.today() + timedelta(days=45)).strftime("%Y%m%d")
+    probes = []
+
+    class FakeIB:
+        async def qualifyContractsAsync(self, contract):
+            contract.conId = 1
+            return [contract]
+
+        async def reqTickersAsync(self, *contracts):
+            return [SimpleNamespace(marketPrice=lambda: 672.4)]
+
+        async def reqSecDefOptParamsAsync(self, symbol, fut_fop, sec_type, con_id):
+            # The union chain advertises 672, but that strike is only listed
+            # on other expiries — the chosen expiry trades 670/675 increments.
+            return [SimpleNamespace(
+                exchange="SMART", tradingClass="SPY", multiplier="100",
+                expirations=[expiry], strikes=[670.0, 672.0, 675.0])]
+
+        async def reqContractDetailsAsync(self, contract):
+            probes.append(contract)
+            return [
+                SimpleNamespace(contract=SimpleNamespace(conId=2, strike=670.0)),
+                SimpleNamespace(contract=SimpleNamespace(conId=3, strike=675.0)),
+            ]
+
+    client = IBKRReadOnlyMarketData(Settings())
+    client._ib = FakeIB()
+    client._connected = True
+    spec = next(s for s in BY_BOOK[IBKRBook.OPTIONS] if s.key == "SPY_ATM_C")
+    contract = await client._atm_option(spec)
+    assert float(contract.strike) == 670.0
+    assert int(contract.conId) == 2
+    assert float(probes[-1].strike) == 0.0
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("market_data_type,source", [
     (1, "ibkr_live"), (2, "ibkr_frozen"), (3, "ibkr_delayed"),
     (4, "ibkr_delayed_frozen"),


### PR DESCRIPTION
## Summary
- IBKR preflight and option discovery raised Error 200 ("No security definition") storms for SPY options: `reqSecDefOptParams` returns the **union** of strikes across every expiry (near-term expiries list $1 strikes, further-out weeklies only $5 increments), so pairing the chosen expiry with a union-nearest strike regularly produced contracts IBKR does not list.
- The missing US-equity API market-data subscription on the quote account (error 10089) compounded it: the spot estimate wobbled between the empty live-quote path and the bar-close fallback, changing which bogus strike got guessed between attempts.
- `_atm_option` now enumerates the contracts actually listed for the chosen expiry via `reqContractDetails` (strike left open) and picks the nearest listed strike to the moneyness target. The returned contract comes back fully specified (`conId` set), which also drops the extra qualification round-trip. Strike choice is now robust to both the union problem and the spot wobble.

## Testing
- New regression test `test_atm_option_picks_a_strike_listed_for_the_chosen_expiry`: chain union advertises a strike the chosen expiry does not trade; asserts the picked contract is one IBKR actually lists (nearest listed strike, conId preserved) and that the enumeration probe leaves the strike open.
- Full IBKR suite (33 tests) and `ruff check .` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)