### PR TITLE
fix(nlp): anchor the strategic world model to the runtime state dir

### DIFF
--- a/auramaur/nlp/strategic.py
+++ b/auramaur/nlp/strategic.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime, timezone
-from pathlib import Path
 
 import structlog
 from pydantic import BaseModel, Field
@@ -28,11 +27,14 @@ from auramaur.db.database import Database
 from auramaur.exchange.models import Market
 from auramaur.nlp.cache import NLPCache, coarse_evidence_digest, make_cache_key
 from auramaur.nlp.prompts import format_evidence
+from auramaur.runtime import state_dir
 
 log = structlog.get_logger()
 
-# Persistent world model lives on disk
-_WORLD_MODEL_PATH = Path("world_model.json")
+# Persistent world model lives on disk, anchored to the state dir — a bare
+# relative path resolves against the container's read-only CWD (agent_analyzer
+# learned this the same way).
+_WORLD_MODEL_PATH = state_dir() / "world_model.json"
 
 # Maximum calibration history to include in context
 _MAX_CALIBRATION_ENTRIES = 50


### PR DESCRIPTION
## Summary
- Companion to 4e1940b (agent analyzer): `auramaur/nlp/strategic.py` still wrote `world_model.json` as a bare relative path, which the container resolves against the read-only `/app` image layer — every Polymarket strategic-analysis cycle that persisted the world model failed with `[Errno 13] Permission denied` (seen live 2026-07-19), and the file was silently excluded from state backups.
- Resolve it through `runtime.state_dir()` exactly like the DB, kill switch, and the agent analyzer world model. Native (non-container) runs keep the repo-root default.

## Testing
- `ruff` clean; the strategic/NLP test files (39 tests) pass.
- Smoke-checked path resolution: with `AURAMAUR_STATE_DIR` set, the module resolves `<state_dir>/world_model.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)