### PR TITLE
fix(kalshi): harden execution and settlement accounting

### DIFF
--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -321,7 +321,8 @@ class ExitExecutionMixin:
 
         # Never sell more than we hold
         order.size = min(order.size, pos.size)
-        if order.size < 1:
+        minimum = 0.01 if market.fractional_trading_enabled else 1.0
+        if order.size < minimum:
             return False
 
         order.source = "exit"

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -280,6 +280,9 @@ class ExecutionGateway:
         try:
             if router:
                 order = await router.route(signal, market, size_dollars, is_live)
+            elif callable(getattr(type(exchange), "prepare_executable_order", None)):
+                order = await exchange.prepare_executable_order(
+                    signal, market, size_dollars, is_live)
             else:
                 order = exchange.prepare_order(signal, market, size_dollars, is_live)
         except UnmarketableSignal as skip:

--- a/auramaur/broker/kalshi_settlements.py
+++ b/auramaur/broker/kalshi_settlements.py
@@ -34,6 +34,15 @@ log = structlog.get_logger()
 _MAX_PAGES = 25  # 200/page → up to 5000 settlements; far beyond current history
 
 
+def _field(obj, *names, default=None):
+    """Read the current fixed-point field first, with legacy compatibility."""
+    for name in names:
+        value = obj.get(name) if isinstance(obj, dict) else getattr(obj, name, None)
+        if value not in (None, ""):
+            return value
+    return default
+
+
 async def sweep_kalshi_settlements(
     db: Database, kalshi_client, *, dry_run: bool = False,
     max_pages: int = _MAX_PAGES,
@@ -49,12 +58,13 @@ async def sweep_kalshi_settlements(
 
     results: list[dict] = []
     for st in settlements:
-        ticker = getattr(st, "ticker", "") or ""
-        settled_time = getattr(st, "settled_time", None)
-        result = (getattr(st, "result", "") or "").lower()
-        revenue_cents = getattr(st, "revenue", 0) or 0
-        yes_count = float(getattr(st, "yes_count", 0) or 0)
-        no_count = float(getattr(st, "no_count", 0) or 0)
+        ticker = str(_field(st, "ticker", default="") or "")
+        settled_time = _field(st, "settled_time")
+        result = str(_field(st, "market_result", "result", default="") or "").lower()
+        revenue_cents = float(_field(st, "revenue", default=0) or 0)
+        yes_count = float(_field(st, "yes_count_fp", "yes_count", default=0) or 0)
+        no_count = float(_field(st, "no_count_fp", "no_count", default=0) or 0)
+        fee = float(_field(st, "fee_cost", default=0) or 0)
         if not ticker or settled_time is None:
             continue
 
@@ -67,8 +77,24 @@ async def sweep_kalshi_settlements(
         token = "YES" if yes_count >= no_count else "NO"
         qty = max(yes_count, no_count)
         revenue = revenue_cents / 100.0
+        if qty <= 0 or result not in ("yes", "no"):
+            log.error("kalshi_settlements.schema_mismatch", ticker=ticker,
+                      result=result, yes_count=yes_count, no_count=no_count)
+            results.append({
+                "ticker": ticker, "result": result, "qty": qty,
+                "revenue": revenue, "pnl": None, "settled": settled_iso,
+                "booked": False, "reason": "invalid settlement schema",
+            })
+            continue
 
+        venue_cost = float(_field(
+            st,
+            "yes_total_cost_dollars" if token == "YES" else "no_total_cost_dollars",
+            default=0,
+        ) or 0)
         cost = await _cost_basis(db, ticker)
+        if cost is None and venue_cost > 0:
+            cost = venue_cost
         if cost is None:
             log.warning("kalshi_settlements.no_cost_basis", ticker=ticker,
                         revenue=revenue, settled=settled_iso)
@@ -79,10 +105,10 @@ async def sweep_kalshi_settlements(
             })
             continue
 
-        pnl = round(revenue - cost, 4)
+        pnl = round(revenue - cost - fee, 4)
         results.append({
             "ticker": ticker, "result": result, "qty": qty,
-            "revenue": revenue, "pnl": pnl, "settled": settled_iso,
+            "revenue": revenue, "fees": fee, "pnl": pnl, "settled": settled_iso,
             "booked": not dry_run, "reason": "",
         })
         if dry_run:
@@ -90,7 +116,7 @@ async def sweep_kalshi_settlements(
 
         await record_ledger_event(
             db, market_id=ticker, kind="settlement", token=token, qty=qty,
-            pnl=pnl, fees=0.0, is_paper=False, source_ref=source_ref,
+            pnl=pnl, fees=fee, is_paper=False, source_ref=source_ref,
             realized_at=settled_iso,
         )
         # Close out our records the way _settle_position does, minus

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -636,6 +636,28 @@ CREATE TABLE IF NOT EXISTS slippage_log (
     timestamp TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Decision-time Kalshi book snapshots. These separate forecasting edge from
+-- execution edge and make paper graduation auditable against live liquidity.
+CREATE TABLE IF NOT EXISTS kalshi_execution_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    market_id TEXT NOT NULL,
+    strategy_source TEXT DEFAULT '',
+    token TEXT NOT NULL,
+    side TEXT NOT NULL,
+    requested_size REAL NOT NULL,
+    fillable_size REAL NOT NULL,
+    best_bid REAL,
+    best_ask REAL,
+    vwap REAL,
+    marginal_price REAL,
+    fair_probability REAL,
+    market_probability REAL,
+    is_live INTEGER NOT NULL DEFAULT 0,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_kalshi_execution_samples_market_time
+    ON kalshi_execution_samples(market_id, observed_at);
+
 CREATE TABLE IF NOT EXISTS redemptions (
     condition_id TEXT PRIMARY KEY,
     asset_id TEXT DEFAULT '',

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
+from collections import deque
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
 from datetime import datetime
 from auramaur.killswitch import kill_switch_present
 
@@ -64,6 +67,8 @@ class KalshiClient:
         self._markets_api = None
         self._portfolio_api = None
         self._semaphore = asyncio.Semaphore(_RATE_LIMIT)
+        self._rate_lock = asyncio.Lock()
+        self._read_times: deque[float] = deque()
         # order_id -> Order for live order tracking. The order monitor polls
         # this dict to reconcile fills and TTL-cancel resting orders; its
         # presence is also the duck-typed signal that tells the monitor this
@@ -84,7 +89,7 @@ class KalshiClient:
         host = (
             "https://demo-api.kalshi.co/trade-api/v2"
             if cfg.environment == "demo"
-            else "https://api.elections.kalshi.com/trade-api/v2"
+            else "https://external-api.kalshi.com/trade-api/v2"
         )
 
         configuration = Configuration(host=host)
@@ -111,6 +116,7 @@ class KalshiClient:
         the worker thread (body included), so a stall blocks only that thread,
         not the event loop.
         """
+        await self._throttle_read()
         async with self._semaphore:
             return await asyncio.to_thread(fn, *args, **kwargs)
 
@@ -132,8 +138,27 @@ class KalshiClient:
         def _run():
             return fn(*args, **kwargs).data
 
+        await self._throttle_read()
         async with self._semaphore:
             return await asyncio.to_thread(_run)
+
+    async def _throttle_read(self) -> None:
+        """Enforce a real per-second read budget."""
+        # A few protocol tests and lightweight adapters construct the client
+        # with __new__; initialize these defensively without weakening runtime.
+        if not hasattr(self, "_rate_lock"):
+            self._rate_lock = asyncio.Lock()
+            self._read_times = deque()
+        while True:
+            async with self._rate_lock:
+                now = time.monotonic()
+                while self._read_times and now - self._read_times[0] >= 1.0:
+                    self._read_times.popleft()
+                if len(self._read_times) < _RATE_LIMIT:
+                    self._read_times.append(now)
+                    return
+                delay = max(0.001, 1.0 - (now - self._read_times[0]))
+            await asyncio.sleep(delay)
 
     # ------------------------------------------------------------------
     # MarketDiscovery protocol
@@ -342,10 +367,12 @@ class KalshiClient:
                 token = TokenType.NO
                 exec_price = market.outcome_no_price + market.spread / 2 + aggression
 
-        exec_price = max(0.01, min(0.99, round(exec_price, 2)))
+        exec_price = self._quantize_price(exec_price, market, side)
 
         # Kalshi contracts are $1 notional; position_size in dollars = number of contracts
-        contract_count = round(position_size / exec_price, 2) if exec_price > 0 else 0
+        raw_count = position_size / exec_price if exec_price > 0 else 0
+        contract_count = (round(raw_count, 2) if market.fractional_trading_enabled
+                          else float(int(raw_count)))
         if contract_count < 1:
             # Bump a risk-approved sub-minimum order up to 1 contract rather
             # than dropping it. One contract is at most $0.99 of notional.
@@ -366,6 +393,73 @@ class KalshiClient:
             price=exec_price,
             dry_run=not is_live,
         )
+
+    async def prepare_executable_order(
+        self, signal: Signal, market: Market, position_size: float, is_live: bool,
+    ) -> Order | None:
+        """Build against a fresh book and cap size to executable depth.
+
+        This runs for paper too: a paper cell must not graduate on quantity or
+        price that the live book could not have filled at decision time.
+        """
+        order = self.prepare_order(signal, market, position_size, is_live)
+        if order is None:
+            return None
+        book = await self.get_order_book(order.market_id)
+        if order.token == TokenType.NO:
+            book = OrderBook(
+                bids=[OrderBookLevel(price=round(1 - x.price, 4), size=x.size)
+                      for x in book.asks],
+                asks=[OrderBookLevel(price=round(1 - x.price, 4), size=x.size)
+                      for x in book.bids],
+            )
+        fillable, vwap, marginal = book.fill_to_size(
+            order.size, is_buy=order.side == OrderSide.BUY)
+        try:
+            db = getattr(self._paper, "db", None)
+            if db is not None:
+                await db.execute(
+                    """INSERT INTO kalshi_execution_samples
+                       (market_id, strategy_source, token, side, requested_size,
+                        fillable_size, best_bid, best_ask, vwap, marginal_price,
+                        fair_probability, market_probability, is_live)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (market.id, signal.strategy_source, order.token.value,
+                     order.side.value, order.size, fillable, book.best_bid,
+                     book.best_ask, vwap, marginal, signal.claude_prob,
+                     signal.market_prob, 1 if is_live else 0),
+                )
+                await db.commit()
+        except Exception as e:
+            log.debug("kalshi.execution_sample_error", error=str(e))
+        if fillable <= 0 or marginal <= 0:
+            log.info("kalshi.order_unmarketable", market_id=market.id,
+                     reason="no executable book depth")
+            return None
+        order.size = round(min(order.size, fillable), 2)
+        if not market.fractional_trading_enabled:
+            order.size = float(int(order.size))
+        if order.size < (0.01 if market.fractional_trading_enabled else 1.0):
+            log.info("kalshi.order_unmarketable", market_id=market.id,
+                     reason="executable depth below contract minimum")
+            return None
+        order.price = self._quantize_price(marginal, market, order.side)
+        return order
+
+    @staticmethod
+    def _quantize_price(price: float, market: Market, side: OrderSide) -> float:
+        value = Decimal(str(max(0.001, min(0.999, price))))
+        step = Decimal("0.01")
+        for raw in market.price_ranges or []:
+            try:
+                if Decimal(str(raw.get("start", "0"))) <= value <= Decimal(str(raw.get("end", "1"))):
+                    step = Decimal(str(raw.get("step", "0.01")))
+                    break
+            except Exception:
+                continue
+        rounding = ROUND_UP if side == OrderSide.BUY else ROUND_DOWN
+        value = (value / step).to_integral_value(rounding=rounding) * step
+        return float(max(Decimal("0.001"), min(Decimal("0.999"), value)))
 
     @staticmethod
     def _v2_book_side(token: TokenType, side: OrderSide) -> str:
@@ -468,13 +562,13 @@ class KalshiClient:
             # (a NO order carries the NO price, so 1 - price is the YES price.)
             v2_side = self._v2_book_side(order.token, order.side)
             yes_price = order.price if order.token == TokenType.YES else 1.0 - order.price
-            yes_price = max(0.01, min(0.99, yes_price))
-            count = int(order.size)
-            if count < 1:
+            yes_price = max(0.001, min(0.999, yes_price))
+            count = round(order.size, 2)
+            if count < 0.01:
                 return OrderResult(
                     order_id="SKIP_ZERO", market_id=order.market_id,
                     status="rejected", is_paper=False,
-                    error_message="order size < 1 contract")
+                    error_message="order size < 0.01 contract")
 
             body = {
                 "ticker": order.token_id,
@@ -506,6 +600,7 @@ class KalshiClient:
                 )
                 return resp.read()
 
+            await self._throttle_read()
             async with self._semaphore:
                 raw = await asyncio.to_thread(_post)
             data = json.loads(raw) if raw else {}
@@ -652,7 +747,7 @@ class KalshiClient:
 
             # Price in terms of the outcome leg we hold (v2 prices are dollars;
             # legacy yes_price is cents → /100).
-            outcome = str(od.get("side") or od.get("outcome_side") or "yes").lower()
+            outcome = str(od.get("outcome_side") or od.get("side") or "yes").lower()
             if outcome == "no":
                 price = _num("no_price_dollars")
             else:
@@ -691,6 +786,7 @@ class KalshiClient:
             )
 
         try:
+            await self._throttle_read()
             async with self._semaphore:
                 await asyncio.to_thread(_delete)
             log.info("order.cancelled", exchange="kalshi", order_id=order_id, via="v2")
@@ -740,20 +836,21 @@ class KalshiClient:
             if not oid or oid in self._live_pending:
                 continue
             try:
-                side = (
-                    OrderSide.BUY
-                    if str(o.get("action", "")).lower() == "buy"
-                    else OrderSide.SELL
-                )
-                token = (
-                    TokenType.NO
-                    if str(o.get("side", "")).lower() == "no"
-                    else TokenType.YES
-                )
+                outcome = str(o.get("outcome_side") or o.get("side") or "yes").lower()
+                token = TokenType.NO if outcome == "no" else TokenType.YES
+                book_side = str(o.get("book_side") or "").lower()
+                if book_side:
+                    side = (OrderSide.BUY if (book_side == "bid") == (token == TokenType.YES)
+                            else OrderSide.SELL)
+                else:
+                    side = (OrderSide.BUY if str(o.get("action", "")).lower() == "buy"
+                            else OrderSide.SELL)
                 ticker = str(o.get("ticker") or "")
                 # Kalshi quotes everything as a yes_price in cents; a NO order's
                 # own price is the complement.
-                yes_price = float(o.get("yes_price", 0) or 0) / 100
+                yes_price = float(o.get("yes_price_dollars", 0) or 0)
+                if yes_price <= 0:
+                    yes_price = float(o.get("yes_price", 0) or 0) / 100
                 price = (1 - yes_price) if token == TokenType.NO else yes_price
                 created_raw = o.get("created_time") or o.get("created_ts")
                 try:
@@ -764,9 +861,8 @@ class KalshiClient:
                     )
                 except (TypeError, ValueError):
                     created = datetime.now(timezone.utc)
-                remaining = float(
-                    o.get("remaining_count", o.get("count", 0)) or 0
-                )
+                remaining = float(o.get("remaining_count_fp") or
+                                  o.get("remaining_count") or o.get("count") or 0)
                 self._live_pending[oid] = Order(
                     market_id=ticker,
                     exchange="kalshi",
@@ -810,11 +906,21 @@ class KalshiClient:
 
         self._init_api()
         try:
-            raw = await self._call_raw(
-                self._portfolio_api.get_positions_without_preload_content,
-            )
-            data = _json.loads(raw)
-            positions = data.get("market_positions", [])
+            positions = []
+            cursor = None
+            while True:
+                kwargs = {"limit": 1000}
+                if cursor:
+                    kwargs["cursor"] = cursor
+                raw = await self._call_raw(
+                    self._portfolio_api.get_positions_without_preload_content,
+                    **kwargs,
+                )
+                data = _json.loads(raw)
+                positions.extend(data.get("market_positions", []))
+                cursor = data.get("cursor")
+                if not cursor:
+                    break
 
             synced = 0
             synced_ids: list[str] = []
@@ -1097,6 +1203,9 @@ class KalshiClient:
                 strike_type=str(_get("strike_type", "") or "").lower(),
                 floor_strike=_opt_float(_get("floor_strike")),
                 cap_strike=_opt_float(_get("cap_strike")),
+                price_level_structure=str(_get("price_level_structure", "linear_cent") or "linear_cent"),
+                price_ranges=list(_get("price_ranges", []) or []),
+                fractional_trading_enabled=bool(_get("fractional_trading_enabled", False)),
             )
         except Exception as e:
             log.warning("kalshi.parse_error", error=str(e))

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -79,6 +79,10 @@ class Market(BaseModel):
     strike_type: str = ""
     floor_strike: float | None = None
     cap_strike: float | None = None
+    # Kalshi fixed-point execution metadata.
+    price_level_structure: str = "linear_cent"
+    price_ranges: list[dict[str, str]] = Field(default_factory=list)
+    fractional_trading_enabled: bool = False
     # Polymarket UMA optimistic-oracle resolution state, surfaced by Gamma.
     # `uma_status` is the current stage ("" → no proposal yet, "proposed" →
     # outcome proposed and in the liveness window, "disputed" → actively

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -202,7 +202,8 @@ class EconIndicatorPillar:
             log.warning("econ_indicator.order_rejected", market_id=market.id,
                         status=res.status, error=res.reason)
             return False
-        await self._record_position(signal, market, res.order, res.result)
+        if res.status != "pending" and res.result.filled_size > 0:
+            await self._record_position(signal, market, res.order, res.result)
         log.info("econ_indicator.entered", market_id=market.id, side=side.value,
                  model_p=round(model_p, 3), market_p=round(market_p, 3),
                  paper=res.result.is_paper)

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -183,7 +183,8 @@ class InformedFlowPillar:
                         status=res.status, error=res.reason)
             return False
 
-        await self._record_position(signal, market, res.order, res.result)
+        if res.status != "pending" and res.result.filled_size > 0:
+            await self._record_position(signal, market, res.order, res.result)
         log.info("informed_flow.entered", market_id=market.id,
                  side=signal.recommended_side.value, informed=flow.informed_side,
                  abnormal=flow.abnormal_count, paper=res.result.is_paper)

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -298,7 +298,8 @@ class LongHorizonPillar:
                         status=res.status, error=res.reason)
             return False
 
-        await self._record_position(signal, market, res.order, res.result)
+        if res.status != "pending" and res.result.filled_size > 0:
+            await self._record_position(signal, market, res.order, res.result)
         log.info("long_horizon.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,
                  size=res.order.size, edge=round(edge_fav, 3),
@@ -351,6 +352,9 @@ class LongHorizonPillar:
                 continue
             token_id = r["token_id"] or (
                 r["clob_token_yes"] if token == "YES" else r["clob_token_no"]) or ""
+            exit_price = (max(0.001, min(0.999, round(mark, 4)))
+                          if self._venue == "kalshi"
+                          else max(0.01, min(0.99, round(mark, 2))))
             order = Order(
                 market_id=r["market_id"],
                 exchange=self._venue,
@@ -358,7 +362,7 @@ class LongHorizonPillar:
                 side=OrderSide.SELL,
                 token=TokenType(token),
                 size=float(r["size"]),
-                price=max(0.01, min(0.99, round(mark, 2))),
+                price=exit_price,
                 order_type=OrderType.LIMIT,
                 dry_run=bool(r["is_paper"]) or not self._settings.is_live,
                 source="exit",

--- a/docs/KALSHI_HARDENING.md
+++ b/docs/KALSHI_HARDENING.md
@@ -1,0 +1,49 @@
+# Kalshi hardening and experiment workflow
+
+Kalshi remains paper-first. Live orders still require the environment gate,
+configuration gate, and per-order `dry_run=False`; the kill switch and risk
+gateway remain authoritative.
+
+## Execution contract
+
+- Current fixed-point (`*_fp`, `*_dollars`) fields are canonical. Legacy fields
+  are compatibility fallbacks only.
+- Prices are quantized using each market's `price_ranges[].step`; quantities
+  retain Kalshi's 0.01-contract precision.
+- Direction uses `outcome_side` and `book_side` before deprecated side/action
+  fields.
+- Every directional entry is checked against a fresh order book. Requested
+  quantity is capped to executable depth and the limit becomes the marginal
+  price needed to fill that quantity.
+- The same check applies to paper entries, preventing graduation on impossible
+  fills. Decision-time book measurements are stored in
+  `kalshi_execution_samples`.
+- A live `pending` order is not a position. Only confirmed fill quantities may
+  update portfolio or cost basis.
+
+## Accounting contract
+
+- Position snapshots must consume every API cursor before local reconciliation.
+  A failed page aborts before the deletion phase.
+- Settlement booking reads fixed-point quantities, venue costs, result, revenue,
+  and fees. Internal cost basis is preferred; venue cost is the recovery source
+  when local cost is unavailable.
+- Settlement P&L is `revenue - cost - fee`, and source references make booking
+  idempotent.
+
+## Experiment cells
+
+Keep each strategy and parameter variant on a distinct `strategy_source`. Review
+resolved net P&L, drawdown, Brier score, executable fill ratio, VWAP versus the
+decision midpoint, and fee drag separately. Do not graduate using signal count
+or synthetic fill count.
+
+For informed flow, export `kalshi_execution_samples` alongside signal evidence
+and resolution outcomes. Stratify by abnormal-size multiple, dominance, time to
+close, category, and price band before changing uplift. Long-horizon entries
+should be evaluated for maker execution separately from time-sensitive economic
+release and settlement-arbitrage entries.
+
+Before increasing live capital, require current-schema fixture tests, a complete
+position/settlement reconciliation, no unknown-cost settlements, and positive
+resolved net P&L after venue fees.

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -417,6 +417,19 @@ class TestKalshiV2CreateOrder:
             "/portfolio/events/orders")
 
     @pytest.mark.asyncio
+    async def test_subpenny_and_fractional_values_survive_submission(self):
+        """The v2 fixed-point migration must survive the final HTTP boundary."""
+        client = self._client({"order_id": "ord-fp"})
+        order = Order(market_id="KXFP", exchange="kalshi", side=OrderSide.BUY,
+                      token=TokenType.YES, token_id="KXFP", size=0.25,
+                      price=0.004, dry_run=False)
+        result = await client.place_order(order)
+        assert result.status == "pending"
+        body = self._body_sent(client)
+        assert body["price"] == "0.0040"
+        assert body["count"] == "0.25"
+
+    @pytest.mark.asyncio
     async def test_response_without_order_id_rejects(self):
         """A body lacking order_id (soft rejection) → rejected, no ghost order."""
         client = self._client({"error": "too_few_contracts"})

--- a/tests/test_kalshi_settlements.py
+++ b/tests/test_kalshi_settlements.py
@@ -111,6 +111,21 @@ async def test_sweep_falls_back_to_filled_trades_for_cost():
     assert out[0]["booked"] is False  # dry run
 
 
+@pytest.mark.asyncio
+async def test_sweep_parses_current_fixed_point_schema_and_fees():
+    """Current Kalshi fields must not silently become zero-sized, fee-free rows."""
+    settlement = SimpleNamespace(
+        ticker="KXFP-1", market_result="yes", yes_count_fp="10.25",
+        no_count_fp="0.00", yes_total_cost_dollars="6.1500",
+        revenue=1025, fee_cost="0.35", settled_time=SETTLED_AT,
+    )
+    db = _db(cost_row=None, trades_net=None)
+    out = await sweep_kalshi_settlements(db, _client([settlement]), dry_run=True)
+    assert out[0]["qty"] == pytest.approx(10.25)
+    assert out[0]["fees"] == pytest.approx(0.35)
+    assert out[0]["pnl"] == pytest.approx(10.25 - 6.15 - 0.35)
+
+
 # --- Resolution-tracker detection now actually works for Kalshi ---
 
 def test_kalshi_market_carries_status_and_result():

--- a/tests/test_prepare_order.py
+++ b/tests/test_prepare_order.py
@@ -1,8 +1,10 @@
 """Tests for exchange-specific prepare_order logic."""
 
+import pytest
+
 from auramaur.exchange.client import PolymarketClient
 from auramaur.exchange.models import (
-    Confidence, Market, OrderSide, Signal, TokenType,
+    Confidence, Market, OrderBook, OrderBookLevel, OrderSide, Signal, TokenType,
 )
 
 
@@ -94,6 +96,49 @@ class TestPolymarketPrepareOrder:
 
 
 class TestKalshiPrepareOrder:
+    def test_subpenny_market_uses_declared_tick(self):
+        from auramaur.exchange.kalshi import KalshiClient
+        client = KalshiClient.__new__(KalshiClient)
+        market = _make_market(yes_price=0.041)
+        market.spread = 0.002
+        market.exchange = "kalshi"
+        market.ticker = market.id
+        market.price_ranges = [{"start": "0", "end": "0.1", "step": "0.001"}]
+        order = client.prepare_order(_make_signal(OrderSide.BUY), market, 10, False)
+        assert order.price == pytest.approx(0.062)
+
+    @pytest.mark.asyncio
+    async def test_fresh_book_caps_paper_size_to_executable_depth(self):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+        from auramaur.exchange.kalshi import KalshiClient
+
+        client = KalshiClient.__new__(KalshiClient)
+        client._paper = SimpleNamespace(db=None)
+        client.get_order_book = AsyncMock(return_value=OrderBook(
+            bids=[OrderBookLevel(price=0.40, size=20)],
+            asks=[OrderBookLevel(price=0.42, size=3),
+                  OrderBookLevel(price=0.43, size=2)],
+        ))
+        market = _make_market(yes_price=0.41)
+        market.exchange = "kalshi"
+        market.ticker = market.id
+        order = await client.prepare_executable_order(
+            _make_signal(OrderSide.BUY), market, 25, False)
+        assert order is not None
+        assert order.size == 5
+        assert order.price == pytest.approx(0.43)
+
+    def test_non_fractional_market_builds_integral_count(self):
+        from auramaur.exchange.kalshi import KalshiClient
+        client = KalshiClient.__new__(KalshiClient)
+        market = _make_market(yes_price=0.41)
+        market.exchange = "kalshi"
+        market.ticker = market.id
+        market.fractional_trading_enabled = False
+        order = client.prepare_order(_make_signal(), market, 10, False)
+        assert order.size == int(order.size)
+
     def _make_client(self):
         from auramaur.exchange.kalshi import KalshiClient
         client = KalshiClient.__new__(KalshiClient)


### PR DESCRIPTION
## Summary
- migrate Kalshi execution, order reconciliation, and settlements to current fixed-point API contracts
- make confirmed fills authoritative, preventing live pending orders from creating phantom positions
- reconcile complete paginated position snapshots and book settlement fees with fail-loud schema validation
- validate paper and live entries against fresh executable depth and record decision-time execution telemetry
- preserve subpenny/fractional behavior through entry, HTTP submission, and Kalshi exit paths
- document the hardened accounting and experiment-graduation workflow

## Safety
- paper trading remains the default
- the three live gates, kill switch, risk gateway, and absolute exposure cap are unchanged
- no live API calls or orders were made during implementation

## Verification
- full suite: 1225 passed, 2 skipped
- post-rebase core Kalshi suite: 58 passed
- git diff --check passed