### PR TITLE
Harden venue research and execution evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ KILL_SWITCH
 venv/
 .pytest_cache/
 .ruff_cache/
+.isolated/
+.worktrees/
+.pytest-*/
 *.log
 *.log.*
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ When making git commits, use `Assisted-by: Claude (Anthropic)` in the commit mes
 - Daily loss limit: $200
 - Max open positions: 500
 - Minimum edge: 5% after fees
-- Kelly fraction: 40%
+- Kelly fraction: 30%
 - Confidence floor: LOW
 - Category exposure cap: 60%
 - Second opinion divergence max: 0.25

--- a/auramaur/backtest/engine.py
+++ b/auramaur/backtest/engine.py
@@ -10,7 +10,7 @@ import structlog
 
 from auramaur.db.database import Database
 from auramaur.risk.kelly import KellySizer
-from auramaur.strategy.signals import POLYMARKET_FEE_PCT
+from auramaur.strategy.signals import taker_fee_rate
 from config.settings import Settings
 
 log = structlog.get_logger()
@@ -25,6 +25,8 @@ class BacktestResult:
     max_drawdown_pct: float = 0.0
     sharpe_ratio: float = 0.0
     brier_score: float = 0.0
+    market_brier_score: float = 0.0
+    brier_improvement: float = 0.0
     accuracy: float = 0.0  # % of directional calls correct
     avg_edge: float = 0.0
     best_trade: float = 0.0
@@ -79,7 +81,9 @@ class BacktestEngine:
         edge_threshold = min_edge_pct if min_edge_pct is not None else self.settings.risk.min_edge_pct
         kf = kelly_fraction if kelly_fraction is not None else self.settings.kelly.fraction
         bank = bankroll if bankroll is not None else self.settings.execution.paper_initial_balance
-        stake_cap = max_stake if max_stake is not None else self.settings.risk.max_stake_per_market
+        configured_cap = max_stake if max_stake is not None else self.settings.risk.max_stake_per_market
+        stake_cap = bank * configured_cap if configured_cap <= 1.0 else configured_cap
+        stake_cap = min(stake_cap, self.settings.risk.max_stake_abs_ceiling)
 
         sizer = KellySizer(fraction=kf)
 
@@ -100,7 +104,8 @@ class BacktestEngine:
                 c.predicted_prob,
                 c.resolved_at,
                 c.category,
-                m.question
+                m.question,
+                COALESCE(m.exchange, s.exchange, 'polymarket') AS exchange
             FROM signals s
             INNER JOIN calibration c ON s.market_id = c.market_id
             LEFT JOIN markets m ON s.market_id = m.id
@@ -121,19 +126,19 @@ class BacktestEngine:
         max_dd = 0.0
         pnl_returns: list[float] = []
         brier_sum = 0.0
+        market_brier_sum = 0.0
         brier_count = 0
         correct_calls = 0
         total_edge = 0.0
         category_stats: dict[str, dict] = {}
 
-        seen_signals: set[int] = set()
+        # One decision per independent market. Repeated re-analysis of the same
+        # resolved contract is not independent evidence and must not multiply P&L.
+        seen_forecasts: set[str] = set()
+        traded_markets: set[str] = set()
 
         for row in rows:
             signal_id = row["signal_id"]
-            if signal_id in seen_signals:
-                continue
-            seen_signals.add(signal_id)
-
             claude_prob = row["claude_prob"]
             market_prob = row["market_prob"]
             edge_pct = row["edge"]  # stored as percentage
@@ -141,19 +146,25 @@ class BacktestEngine:
             category = row["category"] or "unknown"
             question = row["question"] or row["market_id"]
 
-            # Brier score: (predicted - actual)^2
-            brier_sum += (claude_prob - actual_outcome) ** 2
-            brier_count += 1
-
-            # Directional accuracy: did Claude correctly predict the direction?
-            predicted_yes = claude_prob > 0.5
-            actual_yes = actual_outcome == 1
-            if predicted_yes == actual_yes:
-                correct_calls += 1
+            # Forecast metrics use the first timestamped estimate per market.
+            if row["market_id"] not in seen_forecasts:
+                seen_forecasts.add(row["market_id"])
+                brier_sum += (claude_prob - actual_outcome) ** 2
+                market_brier_sum += (market_prob - actual_outcome) ** 2
+                brier_count += 1
+                predicted_yes = claude_prob > 0.5
+                actual_yes = actual_outcome == 1
+                if predicted_yes == actual_yes:
+                    correct_calls += 1
 
             # Check edge threshold
             if abs(edge_pct) < edge_threshold:
                 continue
+            # Trade the first actionable decision only. An earlier forecast
+            # below the edge bar must not suppress a later eligible signal.
+            if row["market_id"] in traded_markets:
+                continue
+            traded_markets.add(row["market_id"])
 
             # Simulate the trade
             trade_pnl = self._simulate_trade(
@@ -163,6 +174,8 @@ class BacktestEngine:
                 sizer=sizer,
                 bankroll=bank,
                 max_stake=stake_cap,
+                exchange=row["exchange"],
+                category=category,
             )
 
             result.total_trades += 1
@@ -231,18 +244,21 @@ class BacktestEngine:
 
         if brier_count > 0:
             result.brier_score = brier_sum / brier_count
+            result.market_brier_score = market_brier_sum / brier_count
+            result.brier_improvement = result.market_brier_score - result.brier_score
             result.accuracy = correct_calls / brier_count * 100
 
         if result.total_trades > 0:
             result.avg_edge = total_edge / result.total_trades
 
-        # Sharpe ratio (annualized, assuming ~1 trade per day)
+        # Per-trade signal-to-noise. Do not pretend irregular, overlapping
+        # prediction-market trades are 252 independent daily returns.
         if len(pnl_returns) >= 2:
             mean_ret = sum(pnl_returns) / len(pnl_returns)
             variance = sum((r - mean_ret) ** 2 for r in pnl_returns) / (len(pnl_returns) - 1)
             std_ret = math.sqrt(variance) if variance > 0 else 0
             if std_ret > 0:
-                result.sharpe_ratio = (mean_ret / std_ret) * math.sqrt(252)
+                result.sharpe_ratio = mean_ret / std_ret
 
         # Category breakdown — compute averages
         for cat_name, cat in category_stats.items():
@@ -289,6 +305,8 @@ class BacktestEngine:
                 "sharpe_ratio": round(result_a.sharpe_ratio, 2),
                 "max_drawdown_pct": round(result_a.max_drawdown_pct, 1),
                 "brier_score": round(result_a.brier_score, 4),
+                "market_brier_score": round(result_a.market_brier_score, 4),
+                "brier_improvement": round(result_a.brier_improvement, 4),
                 "avg_edge": round(result_a.avg_edge, 1),
                 "best_trade": round(result_a.best_trade, 2),
                 "worst_trade": round(result_a.worst_trade, 2),
@@ -301,6 +319,8 @@ class BacktestEngine:
                 "sharpe_ratio": round(result_b.sharpe_ratio, 2),
                 "max_drawdown_pct": round(result_b.max_drawdown_pct, 1),
                 "brier_score": round(result_b.brier_score, 4),
+                "market_brier_score": round(result_b.market_brier_score, 4),
+                "brier_improvement": round(result_b.brier_improvement, 4),
                 "avg_edge": round(result_b.avg_edge, 1),
                 "best_trade": round(result_b.best_trade, 2),
                 "worst_trade": round(result_b.worst_trade, 2),
@@ -318,6 +338,8 @@ class BacktestEngine:
         sizer: KellySizer | None = None,
         bankroll: float = 1000.0,
         max_stake: float = 25.0,
+        exchange: str = "polymarket",
+        category: str = "",
     ) -> float:
         """Simulate a single trade and return PnL.
 
@@ -345,15 +367,13 @@ class BacktestEngine:
         if stake <= 0:
             return 0.0
 
-        # Apply fee
-        fee = stake * (POLYMARKET_FEE_PCT / 100)
+        # Replay uses taker execution unless a strategy-specific simulator has
+        # captured a real maker fill. Fees use the same quadratic production
+        # schedule; executable-book replays should override this method.
+        fee_coefficient = taker_fee_rate(exchange, category)
 
-        # Model slippage: larger orders move price more
-        # Assume ~0.5% slippage per $10 of order size (based on typical PM liquidity)
-        slippage_pct = min(0.03, stake * 0.0005)  # Cap at 3%
-
-        # Model partial fills: larger orders have lower fill probability
-        # Orders >$15 may only partially fill
+        # Conservative fallback when historical depth is unavailable.
+        slippage_pct = min(0.03, stake * 0.0005)
         fill_rate = min(1.0, 15.0 / max(stake, 1.0))
         effective_stake = stake * fill_rate
 
@@ -364,6 +384,7 @@ class BacktestEngine:
             # BUY YES — slippage worsens our entry price
             entry_price = min(0.99, market_prob * (1 + slippage_pct))
             shares = effective_stake / entry_price
+            fee = shares * fee_coefficient * entry_price * (1.0 - entry_price)
             if actual_outcome == 1:
                 pnl = shares * (1.0 - entry_price) - fee
             else:
@@ -375,6 +396,7 @@ class BacktestEngine:
                 return 0.0
             entry_price = min(0.99, no_price * (1 + slippage_pct))
             shares = effective_stake / entry_price
+            fee = shares * fee_coefficient * entry_price * (1.0 - entry_price)
             if actual_outcome == 0:
                 pnl = shares * (1.0 - entry_price) - fee
             else:

--- a/auramaur/backtest/walk_forward.py
+++ b/auramaur/backtest/walk_forward.py
@@ -1,0 +1,51 @@
+"""Leakage-resistant walk-forward helpers for strategy research."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class WalkForwardFold:
+    train: tuple
+    test: tuple
+
+
+def event_unique(rows: Sequence[T], event_key: Callable[[T], str]) -> list[T]:
+    """Keep the earliest observation per independent event."""
+    seen: set[str] = set()
+    out: list[T] = []
+    for row in rows:
+        key = event_key(row)
+        if key not in seen:
+            seen.add(key)
+            out.append(row)
+    return out
+
+
+def expanding_walk_forward(
+    rows: Sequence[T], *, timestamp: Callable[[T], datetime],
+    event_key: Callable[[T], str], min_train: int = 100,
+    test_size: int = 25,
+) -> list[WalkForwardFold]:
+    """Chronological expanding-window folds with event-disjoint test sets."""
+    if min_train < 1 or test_size < 1:
+        raise ValueError("min_train and test_size must be positive")
+    ordered = event_unique(sorted(rows, key=timestamp), event_key)
+    folds: list[WalkForwardFold] = []
+    cursor = min_train
+    while cursor < len(ordered):
+        test = ordered[cursor:cursor + test_size]
+        if not test:
+            break
+        train = ordered[:cursor]
+        train_events = {event_key(x) for x in train}
+        test = [x for x in test if event_key(x) not in train_events]
+        if test:
+            folds.append(WalkForwardFold(tuple(train), tuple(test)))
+        cursor += test_size
+    return folds

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1092,6 +1092,55 @@ class AuramaurBot(
         except Exception as e:
             log.error("price_monitor.error", error=str(e))
 
+    async def _task_decision_marks(self) -> None:
+        """Attach executable 1m/5m/1h/24h marks to immutable decisions."""
+        from auramaur.research.polymarket_strategies import DecisionTracker
+
+        db = self._components.db
+        tracker = DecisionTracker(db)
+        horizons = (60, 300, 3600, 86400)
+        while True:
+            try:
+                for horizon in horizons:
+                    rows = await db.fetchall(
+                        """SELECT d.id, d.market_id, o.best_bid, o.best_ask
+                           FROM decision_snapshots d
+                           JOIN orderbook_snapshots o ON o.market_id = d.market_id
+                           WHERE unixepoch('now') - unixepoch(d.observed_at) >= ?
+                             AND NOT EXISTS (
+                                 SELECT 1 FROM decision_marks x
+                                 WHERE x.decision_id = d.id
+                                   AND x.horizon_seconds = ?)
+                             AND o.recorded_at = (
+                                 SELECT MIN(o2.recorded_at)
+                                 FROM orderbook_snapshots o2
+                                 WHERE o2.market_id = d.market_id
+                                   AND unixepoch(o2.recorded_at) >=
+                                       unixepoch(d.observed_at) + ?)
+                           LIMIT 250""",
+                        (horizon, horizon, horizon),
+                    )
+                    for row in rows:
+                        await tracker.mark(
+                            row["id"], horizon, bid=row["best_bid"],
+                            ask=row["best_ask"])
+            except Exception as exc:
+                log.warning("decision_marks.error", error=str(exc))
+            await asyncio.sleep(60)
+
+    async def _task_user_websocket(self) -> None:
+        """Run the authenticated lifecycle stream as a monitor wake-up lane."""
+        stream = self._components.user_websocket
+        if stream is None:
+            return
+        discovery = self._components.discovery
+        try:
+            markets = await discovery.get_markets(limit=100)
+            stream.subscribe([m.condition_id for m in markets if m.condition_id])
+            await stream.run()
+        except Exception as exc:
+            log.error("websocket.user_error", error=str(exc))
+
     async def _task_source_weights_update(self) -> None:
         """Periodically update ensemble source weights."""
         ensemble = self._components.ensemble
@@ -1451,6 +1500,11 @@ class AuramaurBot(
             tasks.append(asyncio.create_task(self._task_correlation_scan(), name="correlation"))
         if self._components.websocket:
             tasks.append(asyncio.create_task(self._task_price_monitor(), name="price_monitor"))
+        if self._components.user_websocket:
+            tasks.append(asyncio.create_task(
+                self._task_user_websocket(), name="user_websocket"))
+        tasks.append(asyncio.create_task(
+            self._task_decision_marks(), name="decision_marks"))
         if self._components.ensemble:
             tasks.append(asyncio.create_task(self._task_source_weights_update(), name="source_weights"))
         if self._components.feedback:

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -291,7 +291,17 @@ class OrderMonitorMixin:
             if self._watchdog is not None:
                 self._watchdog.beat()
 
-            await asyncio.sleep(30)
+            # Private Polymarket WS events wake reconciliation immediately;
+            # timeout preserves the 30-second polling fallback.
+            wake = getattr(primary_exchange, "_user_event", None)
+            if wake is None:
+                await asyncio.sleep(30)
+            else:
+                try:
+                    await asyncio.wait_for(wake.wait(), timeout=30)
+                except asyncio.TimeoutError:
+                    pass
+                wake.clear()
 
     async def _reconcile_orphaned_pending_trades(self, live_clients) -> None:
         """Resolve live trades rows stuck in status='pending'.

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -32,6 +32,8 @@ from auramaur.db.database import Database
 from auramaur.exchange.models import Fill, Market, Order, OrderResult, OrderSide, Signal
 from auramaur.exchange.protocols import ExchangeClient
 from auramaur.monitoring.display import show_order, show_order_dropped
+from auramaur.research.polymarket_strategies import DecisionTracker
+from auramaur.strategy.signals import taker_fee_rate
 from config.settings import Settings
 
 log = structlog.get_logger()
@@ -113,6 +115,7 @@ class ExecutionGateway:
         capped = await self._exceeds_market_cap(order, is_live=is_live)
         if capped is not None:
             return ExecutionResult(status="skipped", reason=capped)
+        await self._capture_decision(intent, order)
         return await self._place_and_record(
             order, strategy_source=intent.signal.strategy_source,
             signal_id=getattr(intent.signal, "id", None),
@@ -197,6 +200,30 @@ class ExecutionGateway:
             order, strategy_source=strategy_source, signal_id=None,
             exchange=exchange, exchange_name=exchange_name)
 
+    async def _capture_decision(self, intent: TradeIntent, order: Order) -> None:
+        """Persist the immutable executable decision before submission."""
+        try:
+            coefficient = 0.0 if order.post_only else taker_fee_rate(
+                order.exchange or self.exchange_name, intent.market.category)
+            fee = order.size * coefficient * order.price * (1.0 - order.price)
+            await DecisionTracker(self.db).capture(
+                market_id=order.market_id,
+                strategy_source=intent.signal.strategy_source or "llm",
+                signal_id=getattr(intent.signal, "id", None),
+                side=order.side.value,
+                fair_probability=intent.signal.claude_prob,
+                reference_price=intent.signal.market_prob,
+                executable_price=order.price,
+                best_bid=None,
+                best_ask=None,
+                requested_size=order.size * order.price,
+                fee_estimate=fee,
+            )
+        except Exception as exc:
+            # Research telemetry may never block an approved trade.
+            log.warning("gateway.decision_capture_failed",
+                        market_id=order.market_id, error=str(exc))
+
     async def submit_paired(
         self,
         a: TradeIntent,
@@ -239,6 +266,9 @@ class ExecutionGateway:
                 ExecutionResult(status="skipped", order=order_b,
                                 reason=cap_b or "paired leg blocked by market cap"),
             )
+
+        await self._capture_decision(a, order_a)
+        await self._capture_decision(b, order_b)
 
         res_a = await self._place_and_record(
             order_a, strategy_source=a.signal.strategy_source,

--- a/auramaur/broker/rebates.py
+++ b/auramaur/broker/rebates.py
@@ -1,0 +1,35 @@
+"""Polymarket maker-rebate ingestion and accounting."""
+
+from __future__ import annotations
+
+import aiohttp
+
+
+class MakerRebateSync:
+    def __init__(self, db, maker_address: str) -> None:
+        self.db = db
+        self.maker_address = maker_address
+
+    async def sync(self, date: str) -> float:
+        if not self.maker_address:
+            return 0.0
+        timeout = aiohttp.ClientTimeout(total=15)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                "https://clob.polymarket.com/rebates/current",
+                params={"date": date, "maker_address": self.maker_address},
+            ) as response:
+                response.raise_for_status()
+                rows = await response.json()
+        total = 0.0
+        for row in rows:
+            amount = float(row.get("rebated_fees_usdc", 0) or 0)
+            total += amount
+            await self.db.execute(
+                """INSERT OR REPLACE INTO maker_rebates
+                   (date, condition_id, maker_address, rebate_usdc)
+                   VALUES (?, ?, ?, ?)""",
+                (date, str(row.get("condition_id", "")), self.maker_address, amount),
+            )
+        await self.db.commit()
+        return total

--- a/auramaur/cli/kraken.py
+++ b/auramaur/cli/kraken.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 
 import click
 from rich.table import Table
@@ -78,6 +80,77 @@ def kraken_balance_cmd():
                 console.print(f"  [magenta]{a:8}[/] {v}")
         await k.close()
     asyncio.run(_run())
+
+
+@kraken.command("preflight")
+def kraken_preflight():
+    """Read-only API-key permissions/restrictions audit."""
+    async def _run():
+        from auramaur.exchange.kraken import KrakenSpotClient
+        client = KrakenSpotClient(Settings())
+        try:
+            info = await client.get_api_key_info()
+            if not info:
+                console.print("[red]Kraken key metadata unavailable.[/]")
+                return
+            permissions = set(info.get("permissions") or [])
+            ips = info.get("ipAllowlist") or []
+            dangerous = permissions & {"withdraw-funds", "add-withdraw-address", "update-withdraw-address"}
+            console.print(f"Key: {info.get('apiKeyName', 'unknown')}")
+            console.print(f"Permissions: {', '.join(sorted(permissions)) or 'none'}")
+            console.print(f"IP allowlist: {', '.join(ips) if ips else '[red]NONE[/]'}")
+            if dangerous:
+                console.print(f"[red]Trading key has transfer authority: {sorted(dangerous)}[/]")
+            else:
+                console.print("[green]No withdrawal/address-management permission detected.[/]")
+        finally:
+            await client.close()
+    asyncio.run(_run())
+
+
+@kraken.command("research")
+@click.option("--input", "input_path", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.option("--elapsed-days", default=0, type=int)
+def kraken_research(input_path: str, elapsed_days: int):
+    """Evaluate challenger books from JSON OHLC data without placing orders.
+
+    Input maps pair to rows: [ts, open, high, low, close, volume,
+    bid?, ask?, event_score?, order_imbalance?].
+    """
+    from auramaur.research.kraken_eval import (
+        Bar, PortfolioEvaluator, graduation, relative_strength_signal,
+        fit_residual_betas, residual_mean_reversion_signal,
+        volatility_breakout_signal, event_confirmation_signal,
+    )
+    raw = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    def parse(row):
+        if len(row) < 6:
+            raise click.ClickException("each OHLC row requires at least 6 fields")
+        extra = list(row[6:10]) + [None, None, 0.0, 0.0]
+        return Bar(int(row[0]), *map(float, row[1:6]),
+                   bid=None if extra[0] is None else float(extra[0]),
+                   ask=None if extra[1] is None else float(extra[1]),
+                   event_score=float(extra[2] or 0), order_imbalance=float(extra[3] or 0))
+    data = {pair: [parse(r) for r in rows] for pair, rows in raw.items()}
+    if "XBTUSDC" not in data:
+        raise click.ClickException("XBTUSDC is required as the residual market factor")
+    split = max(2, min(len(rows) for rows in data.values()) // 2)
+    training = {pair: rows[:split] for pair, rows in data.items()}
+    betas = fit_residual_betas(training)
+    evaluator = PortfolioEvaluator()
+    candidates = {
+        "relative_strength": relative_strength_signal(data),
+        "residual_mean_reversion": residual_mean_reversion_signal(data, betas),
+        "volatility_breakout": volatility_breakout_signal(),
+        "confirmed_events": event_confirmation_signal(),
+    }
+    for name, signal in candidates.items():
+        m = evaluator.run(name, data, signal)
+        gate = graduation(m, elapsed_days)
+        status = "[green]ELIGIBLE[/]" if gate["eligible"] else "[yellow]PAPER[/]"
+        console.print(f"{name:26} {status} trades={m.trades} pnl=${m.net_pnl:.2f} "
+                      f"return={m.return_pct:.1f}% dd={m.max_drawdown_pct:.1f}% "
+                      f"excess={m.excess_return_pct:.1f}%")
 
 @kraken.command("pnl")
 def kraken_pnl():

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -174,7 +174,7 @@ def graduation():
             cfg = settings.graduation
             console.print(
                 f"[bold]Graduation ladder[/] — mode [cyan]{cfg.mode}[/], "
-                f"min {cfg.min_events} events / {cfg.window_days}d window, "
+                f"min {cfg.min_markets} markets / {cfg.window_days}d window, "
                 f"probation x{cfg.probation_multiplier}"
             )
             if not cells:

--- a/auramaur/components.py
+++ b/auramaur/components.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from auramaur.exchange.paper import PaperTrader
     from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
     from auramaur.exchange.websocket import PolymarketWebSocket
+    from auramaur.exchange.websocket import PolymarketUserWebSocket
     from auramaur.monitoring.alerts import AlertManager
     from auramaur.monitoring.attribution import PerformanceAttributor
     from auramaur.nlp.analyzer import ClaudeAnalyzer
@@ -155,6 +156,9 @@ class Components(dict):
 
     @property
     def websocket(self) -> PolymarketWebSocket | None: return self.get("websocket")
+
+    @property
+    def user_websocket(self) -> PolymarketUserWebSocket | None: return self.get("user_websocket")
 
     @property
     def ensemble(self) -> EnsembleEstimator | None: return self.get("ensemble")

--- a/auramaur/composition.py
+++ b/auramaur/composition.py
@@ -504,6 +504,7 @@ async def assemble_components(
 
     # WebSocket & Ensemble (optional — only if ensemble enabled)
     ws = None
+    user_ws = None
     ensemble = None
     if s.ensemble.enabled:
         try:
@@ -516,6 +517,18 @@ async def assemble_components(
             ensemble = EnsembleEstimator(db=db)
         except ImportError:
             log.warning("optional.missing", component="EnsembleEstimator")
+
+    # Private lifecycle events wake the existing idempotent order monitor; the
+    # stream never writes fills itself, so REST reconciliation remains truth.
+    if (exchange is not None and s.is_live and s.polymarket_api_key
+            and s.polymarket_api_secret and s.polymarket_passphrase):
+        from auramaur.exchange.websocket import PolymarketUserWebSocket
+        user_ws = PolymarketUserWebSocket(
+            api_key=s.polymarket_api_key,
+            api_secret=s.polymarket_api_secret,
+            passphrase=s.polymarket_passphrase,
+            on_event=exchange.notify_user_event,
+        )
 
     # Market maker (optional, enabled by config — Polymarket only).
     # Intentionally not wired for Kalshi: the 7% fee on winnings eats
@@ -558,7 +571,7 @@ async def assemble_components(
         "depth_agent": depth_agent,
         "market_maker": market_maker,
         "alerts": alerts,
-        "websocket": ws, "ensemble": ensemble,
+        "websocket": ws, "user_websocket": user_ws, "ensemble": ensemble,
         "source_names": source_names,
         "exchange_filter": exchange_filter,
     })

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -116,6 +116,18 @@ class Database:
             await self._migrate_v25_to_v26()
         if from_version < 27:
             await self._migrate_v26_to_v27()
+        if from_version < 28:
+            await self._migrate_v27_to_v28()
+        if from_version < 29:
+            await self._migrate_v28_to_v29()
+
+    async def _migrate_v28_to_v29(self) -> None:
+        """Add immutable strategy-research and CLV accounting tables."""
+        # TABLES has already created the additive tables; only advance the
+        # version so older live databases converge without destructive DDL.
+        await self._db.execute("UPDATE schema_version SET version = 29")
+        await self._db.commit()
+        log.info("database.migrated", from_version=28, to_version=29)
 
     async def _migrate_v1_to_v2(self) -> None:
         """Add category to calibration, add new tables."""
@@ -655,6 +667,24 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 27")
         await self._db.commit()
         log.info("database.migrated", from_version=26, to_version=27)
+
+    async def _migrate_v27_to_v28(self) -> None:
+        """Add the restart-safe, wallet-independent Kraken paper book."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS kraken_paper_positions (
+                strategy TEXT NOT NULL DEFAULT 'llm', pair TEXT NOT NULL,
+                quantity REAL NOT NULL, entry_price REAL NOT NULL,
+                peak_gain_pct REAL NOT NULL DEFAULT 0,
+                opened_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (strategy, pair)
+            );
+            CREATE INDEX IF NOT EXISTS idx_kraken_paper_positions_pair
+                ON kraken_paper_positions(pair);
+        """)
+        await self._db.execute("UPDATE schema_version SET version = 28")
+        await self._db.commit()
+        log.info("database.migrated", from_version=27, to_version=28)
 
     async def _migrate_v11_to_v12(self) -> None:
         """Add strategy_source column to signals and trades for hybrid mode attribution."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 29
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -391,6 +391,62 @@ CREATE TABLE IF NOT EXISTS orderbook_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_orderbook_market_time ON orderbook_snapshots(market_id, recorded_at);
 
+-- Immutable decision-time observations used for executable-price and
+-- closing-line-value evaluation.  These are separate from mutable signals so
+-- later analysis cannot rewrite the research record.
+CREATE TABLE IF NOT EXISTS decision_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    market_id TEXT NOT NULL,
+    strategy_source TEXT NOT NULL,
+    signal_id INTEGER,
+    side TEXT NOT NULL,
+    fair_probability REAL NOT NULL,
+    reference_price REAL NOT NULL,
+    executable_price REAL,
+    best_bid REAL,
+    best_ask REAL,
+    requested_size REAL NOT NULL DEFAULT 0,
+    fee_estimate REAL NOT NULL DEFAULT 0,
+    filled INTEGER NOT NULL DEFAULT 0,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(signal_id, strategy_source)
+);
+CREATE INDEX IF NOT EXISTS idx_decision_market_time
+    ON decision_snapshots(market_id, observed_at);
+
+CREATE TABLE IF NOT EXISTS decision_marks (
+    decision_id INTEGER NOT NULL,
+    horizon_seconds INTEGER NOT NULL,
+    bid REAL,
+    ask REAL,
+    mid REAL,
+    marked_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (decision_id, horizon_seconds)
+);
+
+CREATE TABLE IF NOT EXISTS maker_rebates (
+    date TEXT NOT NULL,
+    condition_id TEXT NOT NULL,
+    maker_address TEXT NOT NULL,
+    rebate_usdc REAL NOT NULL,
+    strategy_source TEXT NOT NULL DEFAULT 'market_maker',
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (date, condition_id, maker_address)
+);
+
+CREATE TABLE IF NOT EXISTS strategy_evaluations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_source TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    mechanism TEXT NOT NULL,
+    score REAL NOT NULL,
+    expected_edge REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    is_paper INTEGER NOT NULL DEFAULT 1,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(strategy_source, market_id, mechanism, observed_at)
+);
+
 CREATE INDEX IF NOT EXISTS idx_signals_market ON signals(market_id);
 CREATE INDEX IF NOT EXISTS idx_trades_market ON trades(market_id);
 CREATE INDEX IF NOT EXISTS idx_trades_timestamp ON trades(timestamp);
@@ -567,6 +623,21 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_state (
     last_error TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Authoritative shadow book for Kraken validate-only strategies. Paper orders
+-- do not alter the real wallet, so wallet reconciliation must not own this state.
+CREATE TABLE IF NOT EXISTS kraken_paper_positions (
+    strategy TEXT NOT NULL DEFAULT 'llm',
+    pair TEXT NOT NULL,
+    quantity REAL NOT NULL,
+    entry_price REAL NOT NULL,
+    peak_gain_pct REAL NOT NULL DEFAULT 0,
+    opened_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (strategy, pair)
+);
+CREATE INDEX IF NOT EXISTS idx_kraken_paper_positions_pair
+    ON kraken_paper_positions(pair);
 
 -- Broker-qualified identities for the deterministic IBKR manifest. Discovery
 -- may refresh these rows but cannot introduce an undeclared instrument.

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import time
 import aiohttp
 from auramaur.killswitch import kill_switch_present
 
@@ -48,8 +49,8 @@ class PolymarketClient:
         # Cache of real on-chain positions: asset_id -> net token balance
         self._real_positions: dict[str, dict] = {}
         self._positions_loaded = False
-        self._geoblocked = False  # Set on first 403 geoblock; routes to paper for session
-        self._geoblock_checked = False
+        self._geoblocked = False
+        self._geoblock_checked_at = 0.0
         # market_id -> set of CLOB token ids. Initialized here (not lazily) so
         # get_sellable_token_id() can read it safely even before any market
         # tokens have been registered.
@@ -191,15 +192,13 @@ class PolymarketClient:
         """Check the two global gates (env var + config)."""
         return self._settings.is_live
 
-    async def _check_geoblock(self) -> bool:
-        """Return True only after Polymarket explicitly permits this IP.
-
-        Network errors fail closed for live entries.  The result is cached for
-        the process lifetime; exits still use their existing close path.
-        """
-        if self._geoblock_checked:
+    async def _check_geoblock(self) -> bool | None:
+        """Return frontend eligibility telemetry, refreshed on a bounded TTL."""
+        now = time.monotonic()
+        ttl = max(0, int(getattr(
+            self._settings.execution, "polymarket_geoblock_ttl_seconds", 300)))
+        if self._geoblock_checked_at and now - self._geoblock_checked_at < ttl:
             return not self._geoblocked
-        self._geoblock_checked = True
         try:
             timeout = aiohttp.ClientTimeout(total=8)
             async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -208,12 +207,14 @@ class PolymarketClient:
                         raise RuntimeError(f"geoblock HTTP {response.status}")
                     payload = await response.json()
             self._geoblocked = bool(payload.get("blocked", True))
+            self._geoblock_checked_at = now
             log.info("polymarket.geoblock_checked", blocked=self._geoblocked,
                      country=payload.get("country", ""), region=payload.get("region", ""))
         except Exception as exc:
-            self._geoblocked = True
-            log.error("polymarket.geoblock_unavailable", error=str(exc),
-                      action="live_entries_fail_closed")
+            # A transient frontend failure must not become process-lifetime state.
+            self._geoblock_checked_at = 0.0
+            log.warning("polymarket.geoblock_unavailable", error=str(exc))
+            return None
         return not self._geoblocked
 
     def _init_clob_client(self):
@@ -362,16 +363,6 @@ class PolymarketClient:
                 is_paper=True,
             )
 
-        # Geoblock: once detected, reject live intent for this session. Do not
-        # fabricate a paper fill while the operator believes live execution was
-        # requested.
-        if self._geoblocked:
-            return OrderResult(
-                order_id="GEOBLOCKED", market_id=order.market_id,
-                status="rejected", is_paper=False,
-                error_message="Polymarket geographic eligibility denied",
-            )
-
         # Paper trade if ANY gate is closed
         if order.dry_run or not self._is_live_enabled():
             result = await self._paper.execute(order)
@@ -384,14 +375,23 @@ class PolymarketClient:
             )
             return result
 
-        # Fail closed before the first live order.  A reactive 403 is too late:
-        # builders are required to check geographic eligibility explicitly.
-        if not await self._check_geoblock():
-            return OrderResult(
-                order_id="GEOBLOCKED", market_id=order.market_id,
-                status="rejected", is_paper=False,
-                error_message="Polymarket geographic eligibility denied or unavailable",
-            )
+        # The frontend probe must never strand a position. For entries it is
+        # advisory by default; operators can deliberately choose enforcement.
+        is_exit = order.source == "exit"
+        if not is_exit:
+            eligibility = await self._check_geoblock()
+            mode = getattr(self._settings.execution, "polymarket_geoblock_mode", "advisory")
+            mode = mode if mode in {"advisory", "enforce"} else "advisory"
+            if eligibility is not True:
+                log.warning("polymarket.geoblock_advisory",
+                            result="blocked" if eligibility is False else "unavailable",
+                            mode=mode)
+                if mode == "enforce":
+                    return OrderResult(
+                        order_id="GEOBLOCKED", market_id=order.market_id,
+                        status="rejected", is_paper=False,
+                        error_message="Polymarket geographic eligibility denied or unavailable",
+                    )
 
         # === LIVE ORDER PATH ===
         log.warning(
@@ -502,13 +502,12 @@ class PolymarketClient:
             err_str = str(e)
             if "restricted in your region" in err_str or "geoblock" in err_str.lower():
                 self._geoblocked = True
+                self._geoblock_checked_at = time.monotonic()
                 log.warning(
                     "order.geoblocked",
                     market_id=order.market_id,
-                    msg="Polymarket trading geoblocked — routing to paper for this session",
+                    msg="Polymarket CLOB rejected geographic eligibility",
                 )
-                order.dry_run = True
-                return await self._paper.execute(order)
             # "not enough balance / allowance" is an expected capital constraint
             # (the live book is fully deployed), not a fault — log it at warning
             # like paper.insufficient_balance, reserving error for real failures.

--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import aiohttp
 from auramaur.killswitch import kill_switch_present
 
 import structlog
@@ -48,6 +49,7 @@ class PolymarketClient:
         self._real_positions: dict[str, dict] = {}
         self._positions_loaded = False
         self._geoblocked = False  # Set on first 403 geoblock; routes to paper for session
+        self._geoblock_checked = False
         # market_id -> set of CLOB token ids. Initialized here (not lazily) so
         # get_sellable_token_id() can read it safely even before any market
         # tokens have been registered.
@@ -57,6 +59,13 @@ class PolymarketClient:
         # Deadline for any single CLOB HTTP call; instance attr so tests can
         # shrink it.
         self._call_timeout = 20.0
+        self._user_event = asyncio.Event()
+
+    async def notify_user_event(self, event: dict) -> None:
+        """Wake the authoritative order monitor after a private WS event."""
+        log.debug("clob.user_event", event_type=event.get("event_type", event.get("type", "")),
+                  order_id=event.get("order_id", event.get("id", "")))
+        self._user_event.set()
 
     async def clob_call(self, fn, *args, timeout: float | None = None, **kwargs):
         """Run a blocking py_clob_client call off the event loop, with a deadline.
@@ -181,6 +190,31 @@ class PolymarketClient:
     def _is_live_enabled(self) -> bool:
         """Check the two global gates (env var + config)."""
         return self._settings.is_live
+
+    async def _check_geoblock(self) -> bool:
+        """Return True only after Polymarket explicitly permits this IP.
+
+        Network errors fail closed for live entries.  The result is cached for
+        the process lifetime; exits still use their existing close path.
+        """
+        if self._geoblock_checked:
+            return not self._geoblocked
+        self._geoblock_checked = True
+        try:
+            timeout = aiohttp.ClientTimeout(total=8)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get("https://polymarket.com/api/geoblock") as response:
+                    if response.status != 200:
+                        raise RuntimeError(f"geoblock HTTP {response.status}")
+                    payload = await response.json()
+            self._geoblocked = bool(payload.get("blocked", True))
+            log.info("polymarket.geoblock_checked", blocked=self._geoblocked,
+                     country=payload.get("country", ""), region=payload.get("region", ""))
+        except Exception as exc:
+            self._geoblocked = True
+            log.error("polymarket.geoblock_unavailable", error=str(exc),
+                      action="live_entries_fail_closed")
+        return not self._geoblocked
 
     def _init_clob_client(self):
         """Initialize the real CLOB client. Only called for live trading."""
@@ -328,12 +362,15 @@ class PolymarketClient:
                 is_paper=True,
             )
 
-        # Geoblock: once detected, route all orders to paper for this session
+        # Geoblock: once detected, reject live intent for this session. Do not
+        # fabricate a paper fill while the operator believes live execution was
+        # requested.
         if self._geoblocked:
-            order.dry_run = True
-            result = await self._paper.execute(order)
-            log.debug("order.geoblocked_paper", market_id=order.market_id)
-            return result
+            return OrderResult(
+                order_id="GEOBLOCKED", market_id=order.market_id,
+                status="rejected", is_paper=False,
+                error_message="Polymarket geographic eligibility denied",
+            )
 
         # Paper trade if ANY gate is closed
         if order.dry_run or not self._is_live_enabled():
@@ -346,6 +383,15 @@ class PolymarketClient:
                 price=order.price,
             )
             return result
+
+        # Fail closed before the first live order.  A reactive 403 is too late:
+        # builders are required to check geographic eligibility explicitly.
+        if not await self._check_geoblock():
+            return OrderResult(
+                order_id="GEOBLOCKED", market_id=order.market_id,
+                status="rejected", is_paper=False,
+                error_message="Polymarket geographic eligibility denied or unavailable",
+            )
 
         # === LIVE ORDER PATH ===
         log.warning(

--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -289,6 +289,12 @@ class GammaClient:
                 or (uma_statuses[-1] if uma_statuses else "")
             )
 
+            fee_schedule = data.get("feeSchedule") or {}
+            if not isinstance(fee_schedule, dict):
+                fee_schedule = {}
+            raw_fee_rate = fee_schedule.get("rate", fee_schedule.get("r"))
+            raw_fee_exponent = fee_schedule.get("exponent", fee_schedule.get("e"))
+
             return Market(
                 id=str(data.get("id", data.get("conditionId", ""))),
                 exchange="polymarket",
@@ -304,6 +310,11 @@ class GammaClient:
                 volume=float(data.get("volume", 0) or 0),
                 liquidity=float(data.get("liquidity", 0) or 0),
                 spread=spread,
+                fees_enabled=(bool(data["feesEnabled"])
+                              if "feesEnabled" in data else None),
+                fee_rate=(float(raw_fee_rate) if raw_fee_rate is not None else None),
+                fee_exponent=(float(raw_fee_exponent)
+                              if raw_fee_exponent is not None else None),
                 clob_token_yes=clob_yes,
                 clob_token_no=clob_no,
                 neg_risk=neg_risk,

--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -143,9 +143,26 @@ class KrakenSpotClient:
             return None
         info = next(iter(result.values()))
         try:
-            return float(info["c"][0])  # 'c' = last trade closed [price, lot volume]
-        except (KeyError, IndexError, TypeError):
+            return float(info["c"][0])
+        except (KeyError, IndexError, TypeError, ValueError):
             return None
+
+    async def get_bid_ask(self, pair: str) -> tuple[float, float] | None:
+        """Executable top-of-book prices for shadow fills and cost checks."""
+        result = await self._public("Ticker", {"pair": pair})
+        if not result:
+            return None
+        info = next(iter(result.values()))
+        try:
+            bid, ask = float(info["b"][0]), float(info["a"][0])
+            return (bid, ask) if 0 < bid <= ask else None
+        except (KeyError, IndexError, TypeError, ValueError):
+            return None
+
+    async def get_api_key_info(self) -> dict:
+        """Return Kraken's permission/restriction metadata for startup audits."""
+        resp = await self._private("GetApiKeyInfo")
+        return {} if resp.get("error") else dict(resp.get("result") or {})
 
     async def get_pair_quote(self, pair: str) -> str | None:
         """Quote-currency asset code for a pair (e.g. PAXGUSD -> 'ZUSD')."""
@@ -213,6 +230,7 @@ class KrakenSpotClient:
         purpose: str = "treasury",
         dry_run: bool | None = None,
         max_usd: float | None = None,
+        client_order_id: str | None = None,
     ) -> OrderResult:
         """Place a spot order on Kraken.
 
@@ -255,6 +273,8 @@ class KrakenSpotClient:
         validate = bool(dry_run)
 
         params = {"pair": pair, "type": side_str, "ordertype": ordertype, "volume": str(volume)}
+        if client_order_id:
+            params["cl_ord_id"] = str(client_order_id)[:32]
         if price is not None and ordertype != "market":
             params["price"] = str(price)
         if validate:
@@ -270,7 +290,10 @@ class KrakenSpotClient:
 
         result = resp.get("result", {})
         txids = result.get("txid") or []
-        order_id = txids[0] if txids else ("VALIDATED" if validate else "unknown")
+        # Validate-only responses have no exchange txid. Preserve the caller's
+        # unique id so distinct paper fills remain independently idempotent.
+        order_id = txids[0] if txids else (
+            client_order_id or ("VALIDATED" if validate else "unknown"))
         log.info("kraken.order_placed", pair=pair, order_id=order_id, validate=validate,
                  descr=result.get("descr"))
         return OrderResult(

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -55,6 +55,11 @@ class Market(BaseModel):
     volume: float = 0
     liquidity: float = 0
     spread: float = 0
+    # Venue truth for fees. None means legacy/unknown and falls back to the
+    # conservative category schedule; False means this specific market is free.
+    fees_enabled: bool | None = None
+    fee_rate: float | None = None
+    fee_exponent: float | None = None
     clob_token_yes: str = ""
     clob_token_no: str = ""
     # NegRisk grouping: Polymarket multi-outcome events (e.g. "who wins the

--- a/auramaur/exchange/websocket.py
+++ b/auramaur/exchange/websocket.py
@@ -12,6 +12,7 @@ import structlog
 log = structlog.get_logger()
 
 POLYMARKET_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+POLYMARKET_USER_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/user"
 
 # Seconds between application-level pings. If Cloudflare half-closes the socket
 # without sending a WS CLOSE frame, the `async for` read loop would otherwise
@@ -145,3 +146,60 @@ class PolymarketWebSocket:
         if self._session and not self._session.closed:
             await self._session.close()
         log.info("websocket.closed")
+
+
+class PolymarketUserWebSocket:
+    """Authenticated, reconnecting order/trade lifecycle stream.
+
+    It observes only; accounting remains idempotent in the order monitor.  The
+    callback receives the unmodified event so the monitor can reconcile it with
+    the authoritative order id and CONFIRMED lifecycle state.
+    """
+
+    def __init__(self, *, api_key: str, api_secret: str, passphrase: str,
+                 on_event: Callable[[dict], Awaitable[None]],
+                 max_reconnect_delay: float = 60.0) -> None:
+        self._auth = {"apiKey": api_key, "secret": api_secret,
+                      "passphrase": passphrase}
+        self._on_event = on_event
+        self._markets: set[str] = set()
+        self._running = False
+        self._max_reconnect_delay = max_reconnect_delay
+
+    def subscribe(self, condition_ids: list[str]) -> None:
+        self._markets.update(x for x in condition_ids if x)
+
+    async def run(self) -> None:
+        if not all(self._auth.values()):
+            raise RuntimeError("authenticated Polymarket user stream requires L2 credentials")
+        self._running = True
+        delay = 1.0
+        async with aiohttp.ClientSession(timeout=_WS_TIMEOUT) as session:
+            while self._running:
+                try:
+                    async with session.ws_connect(
+                        POLYMARKET_USER_WS_URL, heartbeat=_WS_HEARTBEAT,
+                    ) as ws:
+                        await ws.send_json({"auth": self._auth,
+                                            "markets": sorted(self._markets),
+                                            "type": "user"})
+                        delay = 1.0
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                payload = json.loads(msg.data)
+                                events = payload if isinstance(payload, list) else [payload]
+                                for event in events:
+                                    if event.get("event_type") in ("order", "trade") or event.get("type") in ("order", "trade"):
+                                        await self._on_event(event)
+                            elif msg.type in (aiohttp.WSMsgType.ERROR,
+                                              aiohttp.WSMsgType.CLOSE,
+                                              aiohttp.WSMsgType.CLOSED):
+                                break
+                except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+                    log.warning("websocket.user_disconnected", error=str(exc))
+                if self._running:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self._max_reconnect_delay)
+
+    async def close(self) -> None:
+        self._running = False

--- a/auramaur/monitoring/books.py
+++ b/auramaur/monitoring/books.py
@@ -101,7 +101,7 @@ def render_books_panel(settings, ledger_live_total: float | None = None) -> Pane
 
     g = settings.graduation
     t.add_row("graduation", Text(g.mode, style="yellow" if g.mode == "observe" else "bold"),
-              f">= {g.min_events} events / {g.window_days}d to earn live")
+              f">= {g.min_markets} markets / {g.window_days}d to earn live")
     if ledger_live_total is not None:
         t.add_row("ledger", Text(f"${ledger_live_total:+,.2f}",
                                  style="green" if ledger_live_total >= 0 else "red"),

--- a/auramaur/research/__init__.py
+++ b/auramaur/research/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible research tools; never imported by the live execution path."""

--- a/auramaur/research/kraken_eval.py
+++ b/auramaur/research/kraken_eval.py
@@ -1,0 +1,361 @@
+"""Deterministic, portfolio-faithful Kraken research primitives."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from math import sqrt
+from statistics import mean, median, pstdev
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Bar:
+    ts: int
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+    bid: float | None = None
+    ask: float | None = None
+    event_score: float = 0.0
+    order_imbalance: float = 0.0
+
+
+@dataclass(frozen=True)
+class CostModel:
+    fee_bps: float = 26.0
+    slippage_bps: float = 5.0
+    spread_bps: float = 6.0
+    stress_multiplier: float = 1.0
+
+    def executable(self, bar: Bar, side: str) -> float:
+        half = self.spread_bps / 20_000
+        px = bar.ask if side == "buy" else bar.bid
+        if px is None:
+            px = bar.close * (1 + half if side == "buy" else 1 - half)
+        slip = self.slippage_bps / 10_000 * self.stress_multiplier
+        return px * (1 + slip if side == "buy" else 1 - slip)
+
+    def fee(self, notional: float) -> float:
+        return notional * self.fee_bps / 10_000 * self.stress_multiplier
+
+
+@dataclass
+class Decision:
+    enter: bool = False
+    exit: bool = False
+    score: float = 0.0
+    reason: str = ""
+
+
+@dataclass
+class Position:
+    pair: str
+    qty: float
+    entry: float
+    entry_fee: float
+    opened: int
+    peak: float
+
+
+Signal = Callable[[str, list[Bar], int, Position | None], Decision]
+SignalFactory = Callable[[dict[str, list[Bar]], dict[str, list[Bar]]], Signal]
+
+
+@dataclass
+class Trade:
+    pair: str
+    opened: int
+    closed: int
+    entry: float
+    exit: float
+    pnl: float
+    return_pct: float
+    reason: str
+
+
+@dataclass
+class Metrics:
+    strategy: str
+    trades: int
+    win_rate: float
+    net_pnl: float
+    return_pct: float
+    expectancy: float
+    profit_factor: float
+    max_drawdown_pct: float
+    sharpe: float
+    turnover: float
+    time_in_market_pct: float
+    benchmark_return_pct: float
+    excess_return_pct: float
+    worst_trade: float
+    by_pair: dict[str, dict] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class PortfolioEvaluator:
+    def __init__(self, initial_cash=60.0, slot_usd=30.0, costs: CostModel | None = None):
+        self.initial_cash = initial_cash
+        self.slot_usd = slot_usd
+        self.costs = costs or CostModel()
+
+    def run(self, strategy: str, data: dict[str, list[Bar]], signal: Signal,
+            trade_start_ts: int | None = None) -> Metrics:
+        self._validate(data)
+        if not data:
+            return self._metrics(strategy, [], [self.initial_cash], 0, 0, data, [])
+        timeline = sorted({b.ts for bars in data.values() for b in bars})
+        indexes = {p: {b.ts: i for i, b in enumerate(bars)} for p, bars in data.items()}
+        start = timeline[0] if trade_start_ts is None else trade_start_ts
+        cash, turnover, occupied = self.initial_cash, 0.0, 0
+        positions: dict[str, Position] = {}
+        trades: list[Trade] = []
+        equity = [cash]
+        last_marks: dict[str, float] = {}
+
+        for ts in timeline:
+            trading = ts >= start
+            for pair, idx in indexes.items():
+                if ts in idx:
+                    last_marks[pair] = data[pair][idx[ts]].close
+            if trading:
+                for pair in list(positions):
+                    i = indexes[pair].get(ts)
+                    if i is None:
+                        continue
+                    bar, pos = data[pair][i], positions[pair]
+                    pos.peak = max(pos.peak, bar.high)
+                    decision = signal(pair, data[pair], i, pos)
+                    if decision.exit:
+                        cash, trade, value = self._close(cash, pos, bar,
+                                                         decision.reason or "signal")
+                        turnover += value
+                        trades.append(trade)
+                        del positions[pair]
+
+                candidates = []
+                for pair, bars in data.items():
+                    i = indexes[pair].get(ts)
+                    if i is None or pair in positions:
+                        continue
+                    decision = signal(pair, bars, i, None)
+                    if decision.enter:
+                        candidates.append((decision.score, pair, i))
+                for _, pair, i in sorted(candidates, reverse=True):
+                    if cash < min(self.slot_usd, 5.0):
+                        break
+                    bar, spend = data[pair][i], min(self.slot_usd, cash)
+                    px, fee = self.costs.executable(bar, "buy"), self.costs.fee(spend)
+                    qty = max(0.0, (spend - fee) / px)
+                    if qty:
+                        cash -= spend
+                        turnover += spend
+                        positions[pair] = Position(pair, qty, px, fee, ts, bar.high)
+
+            if trading:
+                marked = cash + sum(pos.qty * last_marks.get(pair, pos.entry)
+                                    for pair, pos in positions.items())
+                equity.append(marked)
+                occupied += bool(positions)
+
+        for pair, pos in list(positions.items()):
+            cash, trade, value = self._close(cash, pos, data[pair][-1], "end_of_window")
+            turnover += value
+            trades.append(trade)
+        equity.append(cash)
+        trading_periods = sum(ts >= start for ts in timeline)
+        trading_timeline = [ts for ts in timeline if ts >= start]
+        return self._metrics(strategy, trades, equity, turnover, occupied, data,
+                             trading_timeline, trading_periods, start)
+
+    @staticmethod
+    def _validate(data):
+        for pair, bars in data.items():
+            if not bars:
+                raise ValueError(f"{pair}: empty bar series")
+            if any(b.close <= 0 or b.high < b.low for b in bars):
+                raise ValueError(f"{pair}: invalid OHLC data")
+            if any(bars[i].ts >= bars[i + 1].ts for i in range(len(bars) - 1)):
+                raise ValueError(f"{pair}: timestamps must be strictly increasing")
+
+    def _close(self, cash, pos, bar, reason):
+        px = self.costs.executable(bar, "sell")
+        gross, basis = pos.qty * px, pos.qty * pos.entry + pos.entry_fee
+        proceeds = gross - self.costs.fee(gross)
+        pnl = proceeds - basis
+        return cash + proceeds, Trade(pos.pair, pos.opened, bar.ts, pos.entry, px, pnl,
+                                      pnl / basis * 100 if basis else 0, reason), gross
+
+    def _benchmark(self, data, start_ts=None):
+        """Equal-dollar buy-and-hold, charged the same entry/exit costs."""
+        returns = []
+        for bars in data.values():
+            eligible = [b for b in bars if start_ts is None or b.ts >= start_ts]
+            if not eligible:
+                continue
+            buy = self.costs.executable(eligible[0], "buy")
+            allocation = 1.0
+            qty = (allocation - self.costs.fee(allocation)) / buy
+            gross = qty * self.costs.executable(eligible[-1], "sell")
+            returns.append(gross - self.costs.fee(gross) - allocation)
+        return mean(returns) * 100 if returns else 0.0
+
+    def _metrics(self, strategy, trades, equity, turnover, occupied, data,
+                 timeline, trading_periods=0, start_ts=None):
+        pnls = [t.pnl for t in trades]
+        wins, losses = [x for x in pnls if x > 0], [-x for x in pnls if x < 0]
+        peak, max_dd = equity[0], 0.0
+        for value in equity:
+            peak = max(peak, value)
+            max_dd = max(max_dd, (peak - value) / peak * 100 if peak else 0)
+        rets = [equity[i] / equity[i-1] - 1 for i in range(1, len(equity)) if equity[i-1]]
+        intervals = [timeline[i+1] - timeline[i] for i in range(len(timeline)-1)]
+        seconds = median(intervals) if intervals else 3600
+        annual = 365.25 * 86400 / max(seconds, 1)
+        sharpe = mean(rets) / pstdev(rets) * sqrt(annual) if len(rets) > 1 and pstdev(rets) else 0
+        net, benchmark = sum(pnls), self._benchmark(data, start_ts)
+        by_pair = {p: {"trades": len(xs := [t for t in trades if t.pair == p]),
+                       "pnl": round(sum(t.pnl for t in xs), 4)} for p in data}
+        ret = net / self.initial_cash * 100
+        return Metrics(strategy, len(trades), len(wins)/len(trades)*100 if trades else 0,
+                       net, ret, mean(pnls) if pnls else 0,
+                       sum(wins)/sum(losses) if losses else (float("inf") if wins else 0),
+                       max_dd, sharpe, turnover,
+                       occupied/trading_periods*100 if trading_periods else 0,
+                       benchmark, ret-benchmark, min(pnls) if pnls else 0, by_pair)
+
+
+def _ret(bars, i, n):
+    return bars[i].close / bars[i-n].close - 1 if i >= n and bars[i-n].close else 0.0
+
+
+def llm_trend_signal(probabilities, minimum=.60, exit_below=.45, trend=72):
+    def signal(pair, bars, i, position):
+        p = probabilities.get((pair, bars[i].ts), .5)
+        sma = mean(b.close for b in bars[max(0, i-trend+1):i+1])
+        return (Decision(exit=p < exit_below, reason="llm_bearish") if position else
+                Decision(enter=p >= minimum and bars[i].close > sma, score=p,
+                         reason="llm_trend"))
+    return signal
+
+
+def relative_strength_signal(universe, lookback=72):
+    maps = {p: {b.ts: i for i, b in enumerate(xs)} for p, xs in universe.items()}
+    def signal(pair, bars, i, position):
+        ts, ranked = bars[i].ts, []
+        for candidate, xs in universe.items():
+            j = maps[candidate].get(ts)
+            if j is not None and j >= lookback:
+                ranked.append((_ret(xs, j, lookback), candidate))
+        leader = max(ranked)[1] if ranked else None
+        strength = _ret(bars, i, lookback)
+        return Decision(exit=position is not None and leader != pair,
+                        enter=position is None and leader == pair and strength > 0,
+                        score=strength, reason="rank_change")
+    return signal
+
+
+def fit_residual_betas(training, benchmark_pair="XBTUSDC", lookback=1):
+    benchmark = training.get(benchmark_pair, [])
+    benchmark_returns = {benchmark[i].ts: _ret(benchmark, i, lookback)
+                         for i in range(lookback, len(benchmark))}
+    betas = {}
+    for pair, bars in training.items():
+        observations = [(_ret(bars, i, lookback), benchmark_returns[bars[i].ts])
+                        for i in range(lookback, len(bars))
+                        if bars[i].ts in benchmark_returns]
+        y = [pair_ret for pair_ret, _ in observations]
+        x = [market_ret for _, market_ret in observations]
+        mx, my = (mean(x), mean(y)) if x else (0, 0)
+        var = sum((v-mx)**2 for v in x)
+        betas[pair] = sum((a-mx)*(b-my) for a, b in zip(x, y)) / var if var else 1.0
+    return betas
+
+
+def residual_mean_reversion_signal(universe, betas, benchmark_pair="XBTUSDC",
+                                   lookback=24, entry=.035, exit_band=.005):
+    benchmark = universe[benchmark_pair]
+    bench_idx = {b.ts: i for i, b in enumerate(benchmark)}
+    def signal(pair, bars, i, position):
+        j = bench_idx.get(bars[i].ts)
+        if pair == benchmark_pair or j is None or min(i, j) < lookback:
+            return Decision()
+        residual = _ret(bars, i, lookback) - betas.get(pair, 1.0) * _ret(benchmark, j, lookback)
+        return Decision(enter=position is None and residual <= -entry, score=-residual,
+                        exit=position is not None and residual >= -exit_band,
+                        reason="residual_normalized")
+    return signal
+
+
+def volatility_breakout_signal(lookback=48, atr_n=24, stop_atr=2.0):
+    def signal(pair, bars, i, position):
+        if i < max(lookback, atr_n):
+            return Decision()
+        atr = mean(b.high-b.low for b in bars[i-atr_n:i])
+        if position:
+            return Decision(exit=bars[i].low <= position.peak-stop_atr*atr, reason="atr_trail")
+        breakout = bars[i].close > max(b.high for b in bars[i-lookback:i])
+        return Decision(enter=breakout, score=atr/bars[i].close, reason="breakout")
+    return signal
+
+
+def event_confirmation_signal(min_event=.7, confirm_return=.005):
+    def signal(pair, bars, i, position):
+        confirmed = i > 0 and _ret(bars, i, 1) >= confirm_return
+        return Decision(enter=position is None and bars[i].event_score >= min_event and confirmed,
+                        score=bars[i].event_score,
+                        exit=position is not None and bars[i].event_score < 0,
+                        reason="event_reversed")
+    return signal
+
+
+def passive_liquidity_signal(min_imbalance=.25):
+    """Research hook only; production evaluation requires queue-aware replay."""
+    def signal(pair, bars, i, position):
+        x = bars[i].order_imbalance
+        return Decision(enter=position is None and x >= min_imbalance, score=x,
+                        exit=position is not None and x <= 0, reason="imbalance_reversed")
+    return signal
+
+
+def graduation(metrics, elapsed_days, *, folds=None, stressed=None, regimes=None,
+               holdout=None, min_trades=50, min_days=90):
+    pair_pnls = [abs(v["pnl"]) for v in metrics.by_pair.values()]
+    concentration = max(pair_pnls)/sum(pair_pnls) if sum(pair_pnls) else 1.0
+    folds, regimes = folds or [], regimes or {}
+    checks = {
+        "sample": metrics.trades >= min_trades,
+        "duration": elapsed_days >= min_days,
+        "positive_expectancy": metrics.expectancy > 0,
+        "profitable_after_costs": metrics.net_pnl > 0,
+        "beats_benchmark": metrics.excess_return_pct > 0,
+        "drawdown": metrics.max_drawdown_pct <= 20,
+        "pair_concentration": concentration <= .70,
+        "walk_forward_stability": len(folds) >= 3 and sum(m.net_pnl > 0 for m in folds) > len(folds)/2,
+        "stressed_costs": stressed is not None and stressed.net_pnl > 0,
+        "regime_breadth": len(regimes) >= 2 and all(m.net_pnl > 0 for m in regimes.values()),
+        "untouched_holdout": holdout is not None and holdout.net_pnl > 0 and holdout.excess_return_pct > 0,
+    }
+    eligible = all(checks.values())
+    return {"eligible": eligible, "checks": checks,
+            "next_allocation_usd": 5.0 if eligible else 0.0}
+
+
+def walk_forward(data, signal_factory: SignalFactory, train_bars, test_bars,
+                 evaluator, name, warmup_bars=72):
+    """Fit on train only; evaluate test with non-tradable historical warm-up."""
+    n = min(len(v) for v in data.values())
+    out, start = [], train_bars
+    while start+test_bars <= n:
+        train = {p: bars[start-train_bars:start] for p, bars in data.items()}
+        context = {p: bars[max(0, start-warmup_bars):start+test_bars]
+                   for p, bars in data.items()}
+        test_start = min(xs[start].ts for xs in data.values())
+        signal = signal_factory(train, context)
+        out.append(evaluator.run(name, context, signal, trade_start_ts=test_start))
+        start += test_bars
+    return out

--- a/auramaur/research/polymarket_strategies.py
+++ b/auramaur/research/polymarket_strategies.py
@@ -1,0 +1,235 @@
+"""Paper-only, mechanism-first Polymarket strategy evaluators.
+
+These functions produce research observations, never orders.  Execution must
+remain behind the normal strategy protocol, risk manager, and graduation gate.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class OutcomeQuote:
+    market_id: str
+    outcome: str
+    bid: float
+    ask: float
+    bid_size: float
+    ask_size: float
+    taker_fee_per_share: float = 0.0
+
+
+@dataclass(frozen=True)
+class ResearchOpportunity:
+    strategy_source: str
+    market_id: str
+    mechanism: str
+    expected_edge: float
+    capacity_usd: float
+    score: float
+    details: dict
+
+
+def complete_set_arbitrage(
+    event_id: str,
+    outcomes: Iterable[OutcomeQuote],
+    *,
+    safety_buffer: float = 0.01,
+) -> list[ResearchOpportunity]:
+    """Evaluate executable buy-all and sell-all bounds for a full partition."""
+    quotes = list(outcomes)
+    if len(quotes) < 2:
+        return []
+    out: list[ResearchOpportunity] = []
+    buy_cost = sum(q.ask + q.taker_fee_per_share for q in quotes)
+    buy_capacity = min(q.ask_size for q in quotes)
+    buy_edge = 1.0 - buy_cost - safety_buffer
+    if buy_edge > 0 and buy_capacity > 0:
+        out.append(ResearchOpportunity(
+            "complete_set_arb", event_id, "buy_all_below_one", buy_edge,
+            buy_capacity * buy_cost, min(1.0, buy_edge / 0.05),
+            {"outcomes": len(quotes), "executable_cost": buy_cost},
+        ))
+    sell_proceeds = sum(q.bid - q.taker_fee_per_share for q in quotes)
+    sell_capacity = min(q.bid_size for q in quotes)
+    sell_edge = sell_proceeds - 1.0 - safety_buffer
+    if sell_edge > 0 and sell_capacity > 0:
+        out.append(ResearchOpportunity(
+            "complete_set_arb", event_id, "sell_all_above_one", sell_edge,
+            sell_capacity * sell_proceeds, min(1.0, sell_edge / 0.05),
+            {"outcomes": len(quotes), "executable_proceeds": sell_proceeds},
+        ))
+    return out
+
+
+class Relation(str, Enum):
+    A_IMPLIES_B = "a_implies_b"
+    MUTUALLY_EXCLUSIVE = "mutually_exclusive"
+    PARTITION = "partition"
+
+
+def logical_constraint_edge(
+    relationship_id: str,
+    relation: Relation,
+    probability_a: float,
+    probability_b: float,
+    *,
+    verification_confidence: float,
+    cost_buffer: float = 0.02,
+) -> ResearchOpportunity | None:
+    """Price deterministic probability bounds after semantic verification."""
+    if verification_confidence < 0.95:
+        return None
+    if relation is Relation.A_IMPLIES_B:
+        violation = probability_a - probability_b
+    elif relation is Relation.MUTUALLY_EXCLUSIVE:
+        violation = probability_a + probability_b - 1.0
+    else:
+        violation = abs(probability_a + probability_b - 1.0)
+    edge = violation - cost_buffer
+    if edge <= 0:
+        return None
+    return ResearchOpportunity(
+        "constraint_arb", relationship_id, relation.value, edge, 0.0,
+        min(1.0, edge / 0.10) * verification_confidence,
+        {"p_a": probability_a, "p_b": probability_b,
+         "verification_confidence": verification_confidence},
+    )
+
+
+def source_latency_edge(
+    market_id: str,
+    *,
+    source_age_seconds: float,
+    observed_market_move: float,
+    expected_move: float,
+    source_is_authoritative: bool,
+    max_source_age_seconds: float = 120.0,
+    cost_buffer: float = 0.02,
+) -> ResearchOpportunity | None:
+    """Admit only fresh, authoritative source changes not yet reflected in price."""
+    if not source_is_authoritative or source_age_seconds < 0:
+        return None
+    if source_age_seconds > max_source_age_seconds:
+        return None
+    residual = abs(expected_move) - abs(observed_market_move) - cost_buffer
+    if residual <= 0 or expected_move * observed_market_move < 0:
+        return None
+    freshness = 1.0 - source_age_seconds / max_source_age_seconds
+    return ResearchOpportunity(
+        "source_latency", market_id, "official_source_changed_first", residual,
+        0.0, max(0.0, min(1.0, freshness * residual / 0.10)),
+        {"source_age_seconds": source_age_seconds,
+         "observed_market_move": observed_market_move,
+         "expected_move": expected_move},
+    )
+
+
+def normal_bin_probability(
+    mean: float, standard_deviation: float, lower: float | None, upper: float | None,
+) -> float:
+    """Scheduled-release nowcast probability for an interval under a normal model."""
+    if standard_deviation <= 0:
+        raise ValueError("standard_deviation must be positive")
+    def cdf(x: float) -> float:
+        return 0.5 * (1.0 + math.erf(
+            (x - mean) / (standard_deviation * math.sqrt(2))))
+    lo = 0.0 if lower is None else cdf(lower)
+    hi = 1.0 if upper is None else cdf(upper)
+    return max(0.0, min(1.0, hi - lo))
+
+
+def maker_quote_economics(
+    market_id: str,
+    *,
+    spread_capture: float,
+    fill_probability: float,
+    expected_rebate: float,
+    adverse_selection: float,
+    inventory_cost: float,
+    cancel_failure_cost: float,
+) -> ResearchOpportunity | None:
+    """Expected maker value including rebates and stale-quote tail costs."""
+    gross = fill_probability * (spread_capture + expected_rebate)
+    edge = gross - adverse_selection - inventory_cost - cancel_failure_cost
+    if edge <= 0:
+        return None
+    return ResearchOpportunity(
+        "maker_rebate", market_id, "rebate_adjusted_passive_quote", edge, 0.0,
+        min(1.0, edge / 0.02),
+        {"fill_probability": fill_probability, "gross": gross,
+         "adverse_selection": adverse_selection,
+         "inventory_cost": inventory_cost,
+         "cancel_failure_cost": cancel_failure_cost},
+    )
+
+
+def flow_confirmation_multiplier(
+    *, base_signal_edge: float, signed_flow_z: float, same_direction: bool,
+) -> float:
+    """Use flow only as a bounded filter; it can never originate a trade."""
+    if base_signal_edge <= 0:
+        return 0.0
+    strength = min(1.0, abs(signed_flow_z) / 4.0)
+    return 1.0 + 0.25 * strength if same_direction else 1.0 - 0.75 * strength
+
+
+class ResearchRecorder:
+    """Persist immutable paper evaluations for later walk-forward scoring."""
+
+    def __init__(self, db) -> None:
+        self.db = db
+
+    async def record(self, opportunity: ResearchOpportunity) -> None:
+        await self.db.execute(
+            """INSERT INTO strategy_evaluations
+               (strategy_source, market_id, mechanism, score, expected_edge,
+                payload_json, is_paper) VALUES (?, ?, ?, ?, ?, ?, 1)""",
+            (opportunity.strategy_source, opportunity.market_id,
+             opportunity.mechanism, opportunity.score, opportunity.expected_edge,
+             json.dumps({**opportunity.details,
+                         "capacity_usd": opportunity.capacity_usd}, sort_keys=True)),
+        )
+        await self.db.commit()
+
+
+class DecisionTracker:
+    """Capture decision-time executable prices and subsequent CLV marks."""
+
+    def __init__(self, db) -> None:
+        self.db = db
+
+    async def capture(
+        self, *, market_id: str, strategy_source: str, signal_id: int | None,
+        side: str, fair_probability: float, reference_price: float,
+        executable_price: float | None, best_bid: float | None,
+        best_ask: float | None, requested_size: float, fee_estimate: float,
+        filled: bool = False,
+    ) -> None:
+        await self.db.execute(
+            """INSERT OR IGNORE INTO decision_snapshots
+               (market_id, strategy_source, signal_id, side, fair_probability,
+                reference_price, executable_price, best_bid, best_ask,
+                requested_size, fee_estimate, filled)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (market_id, strategy_source, signal_id, side, fair_probability,
+             reference_price, executable_price, best_bid, best_ask,
+             requested_size, fee_estimate, int(filled)),
+        )
+        await self.db.commit()
+
+    async def mark(self, decision_id: int, horizon_seconds: int, *,
+                   bid: float | None, ask: float | None) -> None:
+        mid = None if bid is None or ask is None else (bid + ask) / 2
+        await self.db.execute(
+            """INSERT OR REPLACE INTO decision_marks
+               (decision_id, horizon_seconds, bid, ask, mid)
+               VALUES (?, ?, ?, ?, ?)""",
+            (decision_id, horizon_seconds, bid, ask, mid),
+        )
+        await self.db.commit()

--- a/auramaur/research/polymarket_strategies.py
+++ b/auramaur/research/polymarket_strategies.py
@@ -221,6 +221,9 @@ class DecisionTracker:
              reference_price, executable_price, best_bid, best_ask,
              requested_size, fee_estimate, int(filled)),
         )
+        # Deliberately durable at the decision boundary. This path is currently
+        # low-volume; if capture moves into a high-frequency scanner, batch it
+        # behind a non-blocking writer rather than adding latency here.
         await self.db.commit()
 
     async def mark(self, decision_id: int, horizon_seconds: int, *,

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -7,12 +7,10 @@ from its measured record in the pnl_ledger, and loses it again on decay.
 
 The ladder (mode=enforce):
 
-  * cell has >= min_events LIVE realizations in the window:
-      live P&L > 0  -> LIVE, full size
-      live P&L <= 0 -> PAPER (demoted — the live record is negative)
-  * else cell has >= min_events PAPER realizations:
-      paper P&L > 0 -> LIVE on probation (size * probation_multiplier)
-      paper P&L <= 0 -> PAPER (its paper record is negative)
+  * observations are aggregated by market before evaluation
+  * cell has >= min_events independent LIVE markets in the window and its
+    one-sided mean-P&L lower confidence bound is positive -> LIVE, full size
+  * else the same evidence contract is applied to PAPER markets -> probation
   * else -> PAPER (unproven; exploration happens on paper)
 
 mode=observe computes and logs the same decision but never changes behavior —
@@ -31,6 +29,7 @@ Safety properties:
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass
 
@@ -47,7 +46,7 @@ class CellDecision:
     reason: str
 
 
-_LIVE_FULL = CellDecision(False, 1.0, "live", "live record positive")
+_LIVE_FULL = CellDecision(False, 1.0, "live", "live evidence lower bound positive")
 _EXEMPT = CellDecision(False, 1.0, "exempt", "strategy exempt from graduation")
 
 
@@ -91,22 +90,30 @@ class GraduationLadder:
     # ------------------------------------------------------------------
 
     async def _cell_stats(self, strategy: str, category: str) -> dict:
-        row = await self._db.fetchone(
-            """SELECT
-                 SUM(CASE WHEN is_paper = 0 THEN 1 ELSE 0 END) AS live_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 0 THEN pnl ELSE 0 END), 0) AS live_pnl,
-                 SUM(CASE WHEN is_paper = 1 THEN 1 ELSE 0 END) AS paper_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 1 THEN pnl ELSE 0 END), 0) AS paper_pnl
+        rows = await self._db.fetchall(
+            """SELECT market_id, is_paper, SUM(pnl) AS pnl
                FROM pnl_ledger
                WHERE strategy_source = ? AND category = ?
-                 AND realized_at >= datetime('now', ?)""",
+                 AND realized_at >= datetime('now', ?)
+               GROUP BY market_id, is_paper""",
             (strategy, category, f"-{int(self._settings.graduation.window_days)} days"),
         )
+        live = [float(r["pnl"] or 0.0) for r in rows or [] if not r["is_paper"]]
+        paper = [float(r["pnl"] or 0.0) for r in rows or [] if r["is_paper"]]
+
+        def lower_bound(values: list[float]) -> float:
+            if len(values) < 2:
+                return float("-inf")
+            mean = sum(values) / len(values)
+            variance = sum((x - mean) ** 2 for x in values) / (len(values) - 1)
+            return mean - self._settings.graduation.confidence_z * math.sqrt(
+                variance / len(values))
+
         return {
-            "live_n": int(row["live_n"] or 0) if row else 0,
-            "live_pnl": float(row["live_pnl"] or 0.0) if row else 0.0,
-            "paper_n": int(row["paper_n"] or 0) if row else 0,
-            "paper_pnl": float(row["paper_pnl"] or 0.0) if row else 0.0,
+            "live_n": len(live), "live_pnl": sum(live),
+            "live_lcb": lower_bound(live),
+            "paper_n": len(paper), "paper_pnl": sum(paper),
+            "paper_lcb": lower_bound(paper),
         }
 
     async def _paper_breadth(self) -> int:
@@ -129,19 +136,22 @@ class GraduationLadder:
         s = await self._cell_stats(strategy, category)
 
         if s["live_n"] >= cfg.min_events:
-            if s["live_pnl"] > 0:
+            if s["live_lcb"] > cfg.min_mean_pnl_lower_bound:
                 return _LIVE_FULL
             return CellDecision(
                 True, 1.0, "demoted",
-                f"live record negative (${s['live_pnl']:+.2f} over {s['live_n']} events)")
+                f"live evidence insufficient (mean-P&L LCB ${s['live_lcb']:+.3f}; "
+                f"${s['live_pnl']:+.2f} over {s['live_n']} independent markets)")
         if s["paper_n"] >= cfg.min_events:
-            if s["paper_pnl"] > 0:
+            if s["paper_lcb"] > cfg.min_mean_pnl_lower_bound:
                 return CellDecision(
                     False, cfg.probation_multiplier, "probation",
-                    f"graduated from paper (${s['paper_pnl']:+.2f} over {s['paper_n']} events)")
+                    f"graduated from paper (mean-P&L LCB ${s['paper_lcb']:+.3f}; "
+                    f"${s['paper_pnl']:+.2f} over {s['paper_n']} independent markets)")
             return CellDecision(
                 True, 1.0, "paper_negative",
-                f"paper record negative (${s['paper_pnl']:+.2f} over {s['paper_n']} events)")
+                f"paper evidence insufficient (mean-P&L LCB ${s['paper_lcb']:+.3f}; "
+                f"${s['paper_pnl']:+.2f} over {s['paper_n']} independent markets)")
         # Unproven (still exploring). Restrict the spray: if the open paper book is
         # already at the breadth cap, skip NEW unproven entries (size x0) so
         # exploration concentrates instead of spraying. Restriction only — proven/

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -8,7 +8,7 @@ from its measured record in the pnl_ledger, and loses it again on decay.
 The ladder (mode=enforce):
 
   * observations are aggregated by market before evaluation
-  * cell has >= min_events independent LIVE markets in the window and its
+  * cell has >= min_markets independent LIVE markets in the window and its
     one-sided mean-P&L lower confidence bound is positive -> LIVE, full size
   * else the same evidence contract is applied to PAPER markets -> probation
   * else -> PAPER (unproven; exploration happens on paper)
@@ -103,6 +103,8 @@ class GraduationLadder:
 
         def lower_bound(values: list[float]) -> float:
             if len(values) < 2:
+                # Sample variance is undefined below two independent markets;
+                # -inf prevents a single outcome from claiming evidence.
                 return float("-inf")
             mean = sum(values) / len(values)
             variance = sum((x - mean) ** 2 for x in values) / (len(values) - 1)
@@ -135,14 +137,14 @@ class GraduationLadder:
         cfg = self._settings.graduation
         s = await self._cell_stats(strategy, category)
 
-        if s["live_n"] >= cfg.min_events:
+        if s["live_n"] >= cfg.min_markets:
             if s["live_lcb"] > cfg.min_mean_pnl_lower_bound:
                 return _LIVE_FULL
             return CellDecision(
                 True, 1.0, "demoted",
                 f"live evidence insufficient (mean-P&L LCB ${s['live_lcb']:+.3f}; "
                 f"${s['live_pnl']:+.2f} over {s['live_n']} independent markets)")
-        if s["paper_n"] >= cfg.min_events:
+        if s["paper_n"] >= cfg.min_markets:
             if s["paper_lcb"] > cfg.min_mean_pnl_lower_bound:
                 return CellDecision(
                     False, cfg.probation_multiplier, "probation",
@@ -165,7 +167,7 @@ class GraduationLadder:
         return CellDecision(
             True, 1.0, "unproven",
             f"insufficient record (live {s['live_n']}, paper {s['paper_n']} "
-            f"< {cfg.min_events} events in {cfg.window_days}d)")
+            f"< {cfg.min_markets} markets in {cfg.window_days}d)")
 
     # ------------------------------------------------------------------
     # Reporting (CLI)

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -630,7 +630,8 @@ class CycleOrchestrationMixin:
             # percentage. Polymarket is per-category (see taker_fee_rate); this
             # is a crossing execution path so the taker rate is the right one.
             fee_rate = taker_fee_rate(
-                market.exchange or self.exchange_name, market.category, exchange_fees)
+                market.exchange or self.exchange_name, market.category, exchange_fees,
+                actual_fee_rate=market.fee_rate, fees_enabled=market.fees_enabled)
             edge = abs(raw_edge) - fee_rate * market_prob * (1.0 - market_prob)
 
             signal = Signal(

--- a/auramaur/strategy/signals.py
+++ b/auramaur/strategy/signals.py
@@ -46,6 +46,8 @@ def taker_fee_rate(
     exchange: str | None,
     category: str | None = None,
     exchange_fees: dict[str, float] | None = None,
+    actual_fee_rate: float | None = None,
+    fees_enabled: bool | None = None,
 ) -> float:
     """Per-share TAKER fee coefficient for the ``rate * p*(1-p)`` formula.
 
@@ -54,6 +56,10 @@ def taker_fee_rate(
     net a fee). Other venues use the flat per-exchange coefficient.
     """
     if (exchange or "polymarket") == "polymarket":
+        if fees_enabled is False:
+            return 0.0
+        if actual_fee_rate is not None:
+            return max(0.0, actual_fee_rate)
         return POLYMARKET_TAKER_FEES.get(
             (category or "").lower(), POLYMARKET_DEFAULT_TAKER_FEE)
     fees = exchange_fees if exchange_fees is not None else EXCHANGE_FEES
@@ -228,7 +234,9 @@ def detect_edge(
     # Crossing (taker) execution: net the per-category Polymarket taker fee (or
     # the flat per-exchange coefficient elsewhere). Maker-only strategies don't
     # reach this path, so this conservatively assumes the edge will be taken.
-    fee_rate = taker_fee_rate(market.exchange, market.category, exchange_fees)
+    fee_rate = taker_fee_rate(
+        market.exchange, market.category, exchange_fees,
+        actual_fee_rate=market.fee_rate, fees_enabled=market.fees_enabled)
     net_edge = edge - fee_rate * market_prob * (1.0 - market_prob)
 
     if net_edge <= 0:

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import math
 import time
+import uuid
 
 import structlog
 
@@ -85,6 +86,59 @@ class KrakenPillar:
     def _db(self):
         return self._bot._components.get("db") if self._bot else None
 
+    def _paper_strategy(self) -> str:
+        return "llm" if getattr(self._s.kraken, "directional_llm_enabled", False) else "momentum"
+
+    async def _save_paper_position(self, pair: str, quantity: float, entry: float) -> None:
+        db = self._db()
+        if db is None:
+            return
+        await db.execute(
+            """INSERT INTO kraken_paper_positions
+               (strategy, pair, quantity, entry_price, peak_gain_pct, opened_at, updated_at)
+               VALUES (?, ?, ?, ?, 0, datetime('now'), datetime('now'))
+               ON CONFLICT(strategy, pair) DO UPDATE SET
+                   quantity=excluded.quantity, entry_price=excluded.entry_price,
+                   peak_gain_pct=0,
+                   updated_at=excluded.updated_at""",
+            (self._paper_strategy(), pair, quantity, entry),
+        )
+        await db.commit()
+
+    async def _delete_paper_position(self, pair: str) -> None:
+        db = self._db()
+        if db is not None:
+            await db.execute(
+                "DELETE FROM kraken_paper_positions WHERE strategy=? AND pair=?",
+                (self._paper_strategy(), pair),
+            )
+            await db.commit()
+
+    async def _reconcile_paper_positions(
+        self, managed: list[str],
+    ) -> dict[str, tuple[float, float, float]]:
+        """Restore validate-only positions without consulting the real wallet."""
+        db = self._db()
+        if db is None:
+            rows = [(p, 0.0, entry) for p, entry in self._dir_long.items()]
+        else:
+            found = await db.fetchall(
+                "SELECT pair, quantity, entry_price FROM kraken_paper_positions WHERE strategy=?",
+                (self._paper_strategy(),),
+            )
+            rows = [(r["pair"], float(r["quantity"]), float(r["entry_price"])) for r in found]
+        held_prices: dict[str, tuple[float, float, float]] = {}
+        self._dir_long.clear()
+        for pair, qty, entry in rows:
+            price = await self._k.get_price(pair)
+            if price and price > 0:
+                self._dir_long[pair] = entry
+                held_prices[pair] = (entry, price, qty)
+                if pair not in managed:
+                    managed.append(pair)
+        await self._mirror_to_portfolio(held_prices, [], is_paper=True)
+        return held_prices
+
     def _in_cooldown(self, pair: str) -> bool:
         return self._cooldown_until.get(pair, 0.0) > time.monotonic()
 
@@ -101,17 +155,34 @@ class KrakenPillar:
         if db is None:
             return gain_pct
         try:
+            paper = (not self._s.is_live) or (
+                getattr(self._s.kraken, "directional_llm_enabled", False)
+                and getattr(self._s.kraken, "directional_llm_paper", True))
+            if paper:
+                await db.execute(
+                    """UPDATE kraken_paper_positions
+                       SET peak_gain_pct=MAX(peak_gain_pct, ?), updated_at=datetime('now')
+                       WHERE strategy=? AND pair=?""",
+                    (gain_pct, self._paper_strategy(), pair),
+                )
+                await db.commit()
+                row = await db.fetchone(
+                    "SELECT peak_gain_pct FROM kraken_paper_positions WHERE strategy=? AND pair=?",
+                    (self._paper_strategy(), pair),
+                )
+                return float(row["peak_gain_pct"]) if row else gain_pct
+            peak_key = f"kraken-live:{pair}"
             await db.execute(
                 """INSERT INTO position_peaks (market_id, peak_pnl_pct, updated_at)
                    VALUES (?, ?, datetime('now'))
                    ON CONFLICT(market_id) DO UPDATE SET
                        peak_pnl_pct = MAX(excluded.peak_pnl_pct, position_peaks.peak_pnl_pct),
                        updated_at = excluded.updated_at""",
-                (pair, gain_pct),
+                (peak_key, gain_pct),
             )
             await db.commit()
             row = await db.fetchone(
-                "SELECT peak_pnl_pct FROM position_peaks WHERE market_id = ?", (pair,))
+                "SELECT peak_pnl_pct FROM position_peaks WHERE market_id = ?", (peak_key,))
             return float(row["peak_pnl_pct"]) if row else gain_pct
         except Exception:  # noqa: BLE001
             return gain_pct
@@ -121,7 +192,7 @@ class KrakenPillar:
         if db is None:
             return
         try:
-            await db.execute("DELETE FROM position_peaks WHERE market_id = ?", (pair,))
+            await db.execute("DELETE FROM position_peaks WHERE market_id = ?", (f"kraken-live:{pair}",))
             await db.commit()
         except Exception:  # noqa: BLE001
             pass
@@ -248,6 +319,13 @@ class KrakenPillar:
             pnl = self._pnl_tracker()
             if pnl is not None:
                 fee_pct = (getattr(self._s.kraken, "directional_fee_pct", 0.26) or 0.0) / 100.0
+                # Last trade is not executable. Prefer top-of-book and stress it
+                # by configured adverse slippage for a less flattering shadow fill.
+                book = await self._k.get_bid_ask(pair) if hasattr(self._k, "get_bid_ask") else None
+                if book:
+                    est_price = book[1] if side == OrderSide.BUY else book[0]
+                bps = float(getattr(self._s.kraken, "directional_paper_slippage_bps", 5.0) or 0.0)
+                est_price *= 1 + bps / 10_000 if side == OrderSide.BUY else 1 - bps / 10_000
                 fill = Fill(
                     order_id=str(getattr(res, "order_id", "")) or f"paper-{pair}",
                     market_id=pair, token_id=pair, side=side, token=TokenType.YES,
@@ -557,13 +635,17 @@ class KrakenPillar:
 
     async def _mirror_to_portfolio(
         self, held_prices: dict[str, tuple[float, float, float]], closed: list[str],
+        is_paper: bool | None = None,
     ) -> None:
         db = self._bot._components.get("db") if self._bot else None
         if db is None:
             return
-        is_paper = 0 if self._s.is_live else 1
+        is_paper = (not self._s.is_live) if is_paper is None else is_paper
+        paper_strategy = self._paper_strategy()
+        is_paper = 1 if is_paper else 0
         try:
             for pair, (entry, current, qty) in held_prices.items():
+                market_id = f"kraken-paper:{paper_strategy}:{pair}" if is_paper else pair
                 await db.execute(
                     """INSERT INTO portfolio
                        (market_id, exchange, side, size, avg_price, current_price,
@@ -575,7 +657,7 @@ class KrakenPillar:
                            current_price = excluded.current_price,
                            unrealized_pnl = excluded.unrealized_pnl,
                            updated_at = excluded.updated_at""",
-                    (pair, qty, entry, current, (current - entry) * qty, pair, is_paper),
+                    (market_id, qty, entry, current, (current - entry) * qty, pair, is_paper),
                 )
             # Reconcile the mirror against WALLET truth, not in-memory state:
             # `closed` only sees pairs tracked by THIS process, so positions
@@ -587,8 +669,12 @@ class KrakenPillar:
                 "SELECT market_id FROM portfolio WHERE exchange = 'kraken' AND is_paper = ?",
                 (is_paper,),
             )
+            expected = ({f"kraken-paper:{paper_strategy}:{p}" for p in held_prices}
+                        if is_paper else set(held_prices))
+            scope = f"kraken-paper:{paper_strategy}:" if is_paper else None
             stale = [r["market_id"] for r in (rows or [])
-                     if r["market_id"] not in held_prices]
+                     if r["market_id"] not in expected
+                     and (scope is None or r["market_id"].startswith(scope))]
             for pair in stale:
                 await db.execute(
                     "DELETE FROM portfolio WHERE market_id = ? AND exchange = 'kraken' AND is_paper = ?",
@@ -602,6 +688,9 @@ class KrakenPillar:
 
     async def _directional(self) -> None:
         kcfg = self._s.kraken
+        llm_on = bool(getattr(kcfg, "directional_llm_enabled", False))
+        llm_paper = llm_on and bool(getattr(kcfg, "directional_llm_paper", True))
+        effective_paper = (not self._s.is_live) or llm_paper
         # Free (tradable) balances: total minus anything reserved by open orders.
         # Sizing exits/entries off the free amount avoids requesting more than is
         # actually sellable/spendable (which Kraken rejects as insufficient funds).
@@ -611,7 +700,11 @@ class KrakenPillar:
         # Evaluate the UNION of configured pairs and everything we actually hold,
         # so a position whose pair was pruned/de-configured still gets exited.
         managed = self._managed_pairs(bal)
-        held_prices = await self._reconcile_positions(bal, managed)
+        # Test/minimal embeddings without a DB retain legacy in-memory behavior;
+        # production paper mode uses the durable shadow book exclusively.
+        held_prices = (await self._reconcile_paper_positions(managed)
+                       if effective_paper and self._db() is not None
+                       else await self._reconcile_positions(bal, managed))
         valid_set = set(self._valid_pairs or kcfg.directional_pairs)
         liquidate_orphans = getattr(kcfg, "directional_liquidate_orphans", True)
 
@@ -625,9 +718,6 @@ class KrakenPillar:
         # paper-forced: orders go in validate-only and positions are simulated +
         # booked as paper fills, so `kraken pnl` measures it without risking
         # capital even when the bot runs live for other venues.
-        llm_on = bool(getattr(kcfg, "directional_llm_enabled", False))
-        llm_paper = llm_on and bool(getattr(kcfg, "directional_llm_paper", True))
-        effective_paper = (not self._s.is_live) or llm_paper
 
         # LLM-eligible pairs (those the news/LLM pipeline can reason about).
         # Drives both the calibration feedback loop and the conviction-weighted
@@ -699,7 +789,8 @@ class KrakenPillar:
                 res = await self._k.place_spot_order(
                     pair, OrderSide.SELL, volume=vol, ordertype="market",
                     purpose="directional", max_usd=max(notional, kcfg.max_order_usd) * 1.1,
-                    dry_run=True if effective_paper else None)
+                    dry_run=True if effective_paper else None,
+                    client_order_id=f"aur-s-{uuid.uuid4().hex}"[:32])
                 placed = res.order_id not in ("ERROR", "BLOCKED")
                 fill_price = None
                 if placed:
@@ -719,6 +810,8 @@ class KrakenPillar:
                 closed = placed and (effective_paper or fill_price is not None)
                 if closed:
                     self._dir_long.pop(pair, None)
+                    if effective_paper:
+                        await self._delete_paper_position(pair)
                     await self._clear_peak(pair)
                     self._set_cooldown(pair)   # damp whipsaw re-entry
                 elif placed:   # live, but the fill never confirmed
@@ -808,7 +901,8 @@ class KrakenPillar:
                         continue
                 res = await self._k.place_spot_order(
                     pair, OrderSide.BUY, volume=vol, ordertype="market", purpose="directional",
-                    dry_run=True if effective_paper else None)
+                    dry_run=True if effective_paper else None,
+                    client_order_id=f"aur-b-{uuid.uuid4().hex}"[:32])
                 if res.order_id not in ("ERROR", "BLOCKED"):
                     # Record the fill and anchor the entry to the actual fill price
                     # so cost basis + the stops use real numbers. Paper books a
@@ -819,7 +913,9 @@ class KrakenPillar:
                         await self._paper_comparator.record_shadow_fill(
                             pair, OrderSide.BUY, vol)
                     if effective_paper:
-                        self._dir_long[pair] = price          # paper: simulate the entry
+                        basis = fill_price or price
+                        self._dir_long[pair] = basis
+                        await self._save_paper_position(pair, vol, basis)
                     elif fill_price is not None:
                         self._dir_long[pair] = fill_price     # live: track only a CONFIRMED buy
                     else:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -109,7 +109,7 @@ risk:
   mispricing_audit_ttl_hours: 12.0
 
 kelly:
-  fraction: 0.30
+  fraction: 0.10
 
 graduation:
   # Graduation ladder: every (strategy x category) cell EARNS live capital
@@ -128,8 +128,10 @@ graduation:
   # ledger; arbitrage/market_maker stay live (exempt). Entries only — open
   # positions are never stranded (exits bypass the risk manager).
   mode: "enforce"
-  min_events: 20
+  min_events: 100
   window_days: 90
+  confidence_z: 1.645
+  min_mean_pnl_lower_bound: 0.0
   probation_multiplier: 0.5
   cache_seconds: 300
   # Structural/two-sided strategies bypass the ladder.
@@ -396,6 +398,8 @@ kraken:
   # 0W/7L: every position decayed back into a momentum/stop loss. This re-enables
   # profit-taking so the book can actually close trades green.
   directional_take_profit_pct: 4.0
+  # Adverse fill adjustment on top of executable bid/ask in the shadow book.
+  directional_paper_slippage_bps: 5.0
   # Paper exposure ceiling: at most two $30 simulated positions. This is a
   # measurement budget, not authorization to deploy live capital.
   directional_budget_usd: 60.0

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -11,6 +11,11 @@ execution:
   # flipping this to true alone never arms real orders — but the tracked
   # default must match the docs (README: paper is default).
   live: false
+  # The frontend geoblock endpoint is telemetry, not authoritative CLOB
+  # eligibility. Set to "enforce" only as an explicit operator policy.
+  # Exits always bypass it.
+  polymarket_geoblock_mode: "advisory"
+  polymarket_geoblock_ttl_seconds: 300
   paper_initial_balance: 111.0
   limit_order_ttl_seconds: 120
   # Max cents above the reference price the router may pay to lift the ask;
@@ -109,18 +114,18 @@ risk:
   mispricing_audit_ttl_hours: 12.0
 
 kelly:
-  fraction: 0.10
+  fraction: 0.30
 
 graduation:
   # Graduation ladder: every (strategy x category) cell EARNS live capital
-  # from its measured pnl_ledger record (>= min_events in window_days, P&L
+  # from its measured pnl_ledger record (>= min_markets in window_days, P&L
   # positive), and is demoted back to paper on decay. Entries only — exits
   # never pass through the risk manager, so demotion can't strand positions.
-  # ROLLOUT: "observe" logs what enforce would do without changing behavior.
-  # Read `auramaur graduation`, then flip to "enforce" deliberately. NOTE:
-  # on current data enforce would paper-force most of the llm book (cells
-  # are unproven at n<20 or negative) — that is the redesign's intent, but
-  # flip it consciously.
+  # "observe" logs what enforce would do without changing behavior. This
+  # deployment intentionally remains enforce: raising the evidence contract
+  # to 100 independent markets plus a positive lower confidence bound can
+  # immediately demote cells that met the old 20-market/positive-total rule.
+  # Operators should inspect `auramaur graduation` before changing this bar.
   # FLIPPED to enforce 2026-06-15: the ledger showed an unproven, 0-for-15
   # (-$3.86 live) news_speed cell sizing a $40 live entry under observe. No
   # directional cell has a proven positive live record yet, so enforce
@@ -128,7 +133,7 @@ graduation:
   # ledger; arbitrage/market_maker stay live (exempt). Entries only — open
   # positions are never stranded (exits bypass the risk manager).
   mode: "enforce"
-  min_events: 100
+  min_markets: 100
   window_days: 90
   confidence_z: 1.645
   min_mean_pnl_lower_bound: 0.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -178,7 +178,8 @@ class RiskConfig(BaseModel):
 
 
 class KellyConfig(BaseModel):
-    fraction: float = 0.25
+    # Forecast error dominates theoretical Kelly in prediction markets.
+    fraction: float = 0.10
 
 
 class IntervalsConfig(BaseModel):
@@ -972,8 +973,10 @@ class GraduationConfig(BaseModel):
     """
 
     mode: str = "observe"
-    min_events: int = 20
+    min_events: int = 100
     window_days: int = 90
+    confidence_z: float = 1.645
+    min_mean_pnl_lower_bound: float = 0.0
     probation_multiplier: float = 0.5
     cache_seconds: int = 300
     exempt_strategies: list[str] = ["arbitrage", "market_maker", "order_monitor"]
@@ -1309,6 +1312,7 @@ class KrakenConfig(BaseModel):
     # paper/validate fills and is folded into the take-profit threshold so a TP
     # only fires once the move clears costs. Live fills use the actual fee.
     directional_fee_pct: float = 0.26
+    directional_paper_slippage_bps: float = 5.0
     # Take-profit: exit a winner up this much from entry, NET of round-trip fees.
     # 0 disables it (winners ride, protected only by the trailing stop) — but with
     # a wide trailing_stop a sub-(trailing)% rally can never be banked, so winners

--- a/config/settings.py
+++ b/config/settings.py
@@ -51,6 +51,11 @@ _DEFAULTS = _load_defaults()
 
 class ExecutionConfig(BaseModel):
     live: bool = False
+    # The public frontend eligibility endpoint is not authoritative for CLOB
+    # access. Advisory records its answer and lets the authenticated API decide;
+    # enforce blocks new entries. Explicit exits always bypass this check.
+    polymarket_geoblock_mode: Literal["advisory", "enforce"] = "advisory"
+    polymarket_geoblock_ttl_seconds: int = 300
     # Paper book capital. Sized for headroom, not realism: the provisional
     # paper-forced strategies must hold enough concurrent positions across
     # (strategy x category) cells to accrue the graduation sample. Sized so
@@ -178,8 +183,7 @@ class RiskConfig(BaseModel):
 
 
 class KellyConfig(BaseModel):
-    # Forecast error dominates theoretical Kelly in prediction markets.
-    fraction: float = 0.10
+    fraction: float = 0.25
 
 
 class IntervalsConfig(BaseModel):
@@ -973,7 +977,7 @@ class GraduationConfig(BaseModel):
     """
 
     mode: str = "observe"
-    min_events: int = 100
+    min_markets: int = 100
     window_days: int = 90
     confidence_z: float = 1.645
     min_mean_pnl_lower_bound: float = 0.0

--- a/docs/KRAKEN_RESEARCH_PLAN.md
+++ b/docs/KRAKEN_RESEARCH_PLAN.md
@@ -1,0 +1,41 @@
+# Kraken research and graduation plan
+
+Kraken directional trading remains paper-forced. The live wallet and the
+validate-only shadow book are intentionally separate: `kraken_paper_positions`
+is authoritative for paper positions and survives restarts.
+
+## Evaluation contract
+
+Every candidate uses the same `PortfolioEvaluator`: one shared $60 portfolio,
+$30 slots, executable bid/ask estimates, fees, adverse slippage, forced final
+liquidation, drawdown, turnover, time-in-market, per-pair attribution and an
+equal-weight buy-and-hold benchmark. Parameter selection must happen only on a
+training window; reported results come from sequential untouched test windows.
+Warm-up bars are visible to indicators but explicitly non-tradable. The
+equal-weight benchmark uses equal dollars per asset and pays the same modeled
+spread, slippage, and fees as each challenger.
+
+The registered challengers are LLM plus trend confirmation, cross-sectional
+relative strength, residual mean reversion, volatility breakout, confirmed
+events, and a passive-liquidity research hook. Passive liquidity is not valid
+without order-book replay and queue-aware fills.
+
+## Graduation
+
+`graduation()` fails closed and requires at least 50 closed trades, 90 elapsed
+days, positive cost-adjusted expectancy and PnL, benchmark outperformance,
+drawdown no greater than 20%, and no pair contributing over 70% of absolute
+pair PnL. It also requires a majority of at least three profitable walk-forward
+folds, positive stressed-cost results, positive results in at least two declared
+regimes, and a positive untouched holdout that beats its benchmark. Passing
+authorizes only a $5 canary proposal; it does not change live configuration.
+
+`auramaur kraken research --input FILE` accepts rows shaped as
+`[ts, open, high, low, close, volume, bid?, ask?, event_score?,
+order_imbalance?]`. `XBTUSDC` is required as the common market factor for
+beta-adjusted residual returns. Missing optional fields are neutral rather than
+fabricated.
+
+API keys should be IP-restricted and least-privilege. Use Kraken's key-info
+preflight to inspect permissions; withdrawal authority belongs on a separate
+key and remains governed by the transfer gate.

--- a/docs/POLYMARKET_RESEARCH.md
+++ b/docs/POLYMARKET_RESEARCH.md
@@ -1,0 +1,41 @@
+# Polymarket research and graduation contract
+
+All new mechanisms in `auramaur/research/polymarket_strategies.py` are
+paper-only evaluators. They create `strategy_evaluations`; they do not place an
+order or bypass the execution gateway.
+
+## Evaluation standard
+
+- Collapse repeated signals and ledger rows to one observation per market;
+  cluster related markets by event when event-group metadata is available.
+- Freeze parameters before each test window.
+- Use chronological expanding walk-forward folds and retain a final untouched
+  holdout.
+- Evaluate executable bid/ask prices, actual per-market fees, partial fills,
+  maker fill rates, rebates, and locked-capital time.
+- Require at least 100 independent resolved markets and a positive one-sided
+  95% lower confidence bound on mean cost-adjusted P&L.
+- Forecast strategies must improve Brier score or log loss over the
+  contemporaneous market and show positive executable closing-line value.
+- Maker and taker variants are separate strategy cells.
+
+`decision_snapshots` records the order price before submission. The runtime
+adds 1-minute, 5-minute, 1-hour, and 24-hour bid/ask marks to
+`decision_marks`. Rejected and unfilled decisions remain in the dataset so
+fill-selection bias can be measured.
+
+## Evaluators
+
+- `complete_set_arb`: full-partition buy-all/sell-all executable bounds.
+- `constraint_arb`: implication, mutual-exclusion, and partition violations;
+  semantic verification confidence must be at least 95%.
+- `source_latency`: fresh authoritative-source transitions not yet incorporated
+  into the CLOB price.
+- `normal_bin_probability`: source-native scheduled-release nowcasts.
+- `maker_rebate`: spread plus rebate less adverse selection, inventory, and
+  cancellation-failure costs.
+- `flow_confirmation_multiplier`: bounded confirmation or veto only; flow can
+  never originate a position.
+
+Live startup performs Polymarket's geographic eligibility check and fails
+closed when eligibility cannot be confirmed. Do not bypass that control.

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -20,9 +20,9 @@ from auramaur.risk.graduation import GraduationLadder
 from config.settings import GraduationConfig
 
 
-def _settings(mode="enforce", min_events=5, **kw):
+def _settings(mode="enforce", min_markets=5, **kw):
     s = MagicMock()
-    s.graduation = GraduationConfig(mode=mode, min_events=min_events, **kw)
+    s.graduation = GraduationConfig(mode=mode, min_markets=min_markets, **kw)
     return s
 
 
@@ -72,7 +72,7 @@ def test_ladder_states():
         d = await ladder.decide("s_new", "tech")
         assert d.force_paper is True and d.status == "unproven"
 
-        # live wins over paper when both have >= min_events
+        # live wins over paper when both have >= min_markets
         await _seed(db, "s_mixed", "tech", n=5, pnl_each=-1.0, is_paper=0)
         await _seed(db, "s_mixed", "tech", n=5, pnl_each=1.0, is_paper=1)
         d = await ladder.decide("s_mixed", "tech")
@@ -142,7 +142,7 @@ def test_risk_manager_integration():
         await db.connect()
 
         settings = _make_settings()
-        settings.graduation = GraduationConfig(mode="enforce", min_events=5)
+        settings.graduation = GraduationConfig(mode="enforce", min_markets=5)
 
         with patch("auramaur.risk.manager.check_kill_switch") as mock_kill:
             mock_kill.return_value = CheckResult(
@@ -278,7 +278,7 @@ async def test_ladder_cell_uses_classified_category_when_label_missing():
     await db.connect()
 
     settings = _make_settings()
-    settings.graduation = GraduationConfig(mode="enforce", min_events=5)
+    settings.graduation = GraduationConfig(mode="enforce", min_markets=5)
     # 'crypto' is on the default live allowlist in _make_settings-land;
     # earn probation for llm x crypto on paper.
     await _seed(db, "llm", "crypto", n=5, pnl_each=1.0, is_paper=1)

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -4,6 +4,7 @@ import aiosqlite
 import pytest
 
 from auramaur.db.database import Database
+from auramaur.db.models import SCHEMA_VERSION
 
 
 @pytest.mark.asyncio
@@ -31,7 +32,7 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
     version = await db.fetchone("SELECT version FROM schema_version")
     position_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
     fill_columns = await db.fetchall("PRAGMA table_info(ibkr_paper_fills)")
-    assert version["version"] == 27
+    assert version["version"] == SCHEMA_VERSION
     assert {row["name"] for row in position_columns} >= {
         "price_source", "instrument_spec_json", "stop_price", "initial_risk_usd"}
     assert "price_source" in {row["name"] for row in fill_columns}

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -43,6 +43,29 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_v27_migrates_directly_through_v29(tmp_path):
+    path = tmp_path / "v27.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(
+        """CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (27);
+        """)
+    raw.close()
+
+    db = Database(str(path))
+    await db.connect()
+    version = await db.fetchone("SELECT version FROM schema_version")
+    kraken = await db.fetchone(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='kraken_paper_positions'")
+    decisions = await db.fetchone(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='decision_snapshots'")
+    assert version["version"] == 29
+    assert kraken["name"] == "kraken_paper_positions"
+    assert decisions["name"] == "decision_snapshots"
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_v23_migration_does_not_stamp_version_after_busy_error():
     db = Database(":memory:")
     await db.connect()

--- a/tests/test_kraken_research.py
+++ b/tests/test_kraken_research.py
@@ -1,0 +1,175 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from auramaur.components import Components
+from auramaur.db.database import Database
+from auramaur.exchange.kraken import KrakenSpotClient
+from auramaur.exchange.models import OrderSide
+from auramaur.research.kraken_eval import (
+    Bar, CostModel, Decision, Metrics, PortfolioEvaluator,
+    fit_residual_betas, graduation, residual_mean_reversion_signal,
+    volatility_breakout_signal, walk_forward,
+)
+from auramaur.treasury.kraken_pillar import KrakenPillar
+
+
+def bars(prices, start=0):
+    return [Bar(start+i*3600, p, p*1.01, p*.99, p, 100) for i, p in enumerate(prices)]
+
+
+@pytest.mark.asyncio
+async def test_ticker_price_and_bid_ask_parse_distinct_fields():
+    client = KrakenSpotClient(SimpleNamespace())
+    client._public = AsyncMock(return_value={"XXBTZUSD": {
+        "c": ["101.0", "1"], "b": ["100.0", "1", "1"], "a": ["102.0", "1", "1"]}})
+    assert await client.get_price("XBTUSD") == 101.0
+    assert await client.get_bid_ask("XBTUSD") == (100.0, 102.0)
+
+
+def test_balance_cli_runs_coroutine_once():
+    import sys
+    import types
+    if "fcntl" not in sys.modules:
+        fcntl = types.ModuleType("fcntl")
+        fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN = 2, 4, 8
+        fcntl.flock = lambda *args: None
+        sys.modules["fcntl"] = fcntl
+    from auramaur.cli.kraken import kraken
+    client = MagicMock()
+    client.get_balance = AsyncMock(return_value={"USDC": 12.0})
+    client.close = AsyncMock()
+    with patch("auramaur.exchange.kraken.KrakenSpotClient", return_value=client):
+        result = CliRunner().invoke(kraken, ["balance"])
+    assert result.exit_code == 0, result.output
+    client.get_balance.assert_awaited_once()
+    client.close.assert_awaited_once()
+
+
+def test_research_cli_accepts_event_and_orderbook_fields(tmp_path):
+    from auramaur.cli.kraken import kraken
+    rows = [[i, 100+i, 101+i, 99+i, 100+i, 10, 99.5+i, 100.5+i,
+             .8 if i == 2 else 0, .3] for i in range(5)]
+    path = tmp_path / "ohlc.json"
+    path.write_text(json.dumps({"XBTUSDC": rows, "ETHUSDC": rows}), encoding="utf-8")
+    result = CliRunner().invoke(kraken, ["research", "--input", str(path)])
+    assert result.exit_code == 0, result.output
+    assert "confirmed_events" in result.output
+
+
+def test_forced_close_costs_and_equal_weight_benchmark():
+    data = {"CHEAP": bars([1, 2]), "EXPENSIVE": bars([1000, 1000])}
+    def signal(pair, xs, i, position):
+        return Decision(enter=i == 0 and position is None)
+    result = PortfolioEvaluator(costs=CostModel()).run("long", data, signal)
+    assert result.trades == 2
+    assert 45 < result.benchmark_return_pct < 50
+
+
+def test_warmup_is_excluded_from_benchmark_and_sharpe_curve():
+    data = {"A": bars([1, 100, 100])}
+    result = PortfolioEvaluator().run("warm", data, lambda *args: Decision(),
+                                      trade_start_ts=data["A"][1].ts)
+    assert -2 < result.benchmark_return_pct < 0
+    assert result.return_pct == 0
+
+
+def test_shared_budget_limits_concurrent_entries():
+    data = {"A": bars([10, 11]), "B": bars([10, 11]), "C": bars([10, 11])}
+    def signal(pair, xs, i, position):
+        return Decision(enter=i == 0 and position is None, score=1)
+    assert PortfolioEvaluator(60, 30).run("slots", data, signal).trades == 2
+
+
+def test_residual_signal_removes_market_factor():
+    market = bars([100, 110, 121, 133.1])
+    clone = bars([50, 55, 60.5, 66.55])
+    weak = bars([50, 55, 54, 53])
+    data = {"XBTUSDC": market, "CLONE": clone, "WEAK": weak}
+    signal = residual_mean_reversion_signal(data, fit_residual_betas(data),
+                                            lookback=1, entry=.03)
+    assert signal("CLONE", clone, 3, None).enter is False
+    assert signal("WEAK", weak, 3, None).enter is True
+
+
+def test_atr_trail_uses_post_entry_peak():
+    xs = [Bar(i, p, h, p-1, p) for i, (p, h) in enumerate([
+        (10, 11), (11, 12), (13, 14), (15, 16), (12, 13)])]
+    signal = volatility_breakout_signal(lookback=2, atr_n=2, stop_atr=1)
+    assert signal("A", xs, 4, SimpleNamespace(peak=16)).exit is True
+
+
+def test_walk_forward_has_warmup_but_never_trades_it():
+    data = {"A": bars(list(range(10, 30))), "B": bars(list(range(20, 40)))}
+    train_ends, first_seen = [], []
+    def factory(train, context):
+        train_ends.append(train["A"][-1].ts)
+        seen = False
+        def signal(pair, xs, i, position):
+            nonlocal seen
+            if not seen:
+                first_seen.append(xs[i].ts)
+                seen = True
+            return Decision(enter=position is None)
+        return signal
+    folds = walk_forward(data, factory, 8, 4, PortfolioEvaluator(), "wf", warmup_bars=3)
+    assert len(folds) == 3
+    assert all(first > end for first, end in zip(first_seen, train_ends))
+
+
+def metric(name="m", pnl=10, excess=2):
+    return Metrics(name, 60, 60, pnl, 20, .2, 1.5, 10, 1, 100, 50,
+                   18, excess, -1, {"A": {"pnl": 6}, "B": {"pnl": 4}})
+
+
+def test_graduation_requires_all_evidence_and_then_passes():
+    base = metric()
+    assert graduation(base, 100)["eligible"] is False
+    folds = [metric(str(i)) for i in range(3)]
+    gate = graduation(base, 100, folds=folds, stressed=metric("stress"),
+                      regimes={"bull": metric(), "bear": metric()}, holdout=metric("holdout"))
+    assert gate["eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_paper_basis_peak_restart_and_delete_are_isolated():
+    db = Database(":memory:")
+    await db.connect()
+    cfg = SimpleNamespace(directional_llm_enabled=True, directional_llm_paper=True,
+                          directional_pairs=["XBTUSDC"])
+    settings = SimpleNamespace(kraken=cfg, is_live=True)
+    client = SimpleNamespace(get_price=AsyncMock(return_value=110.0))
+    bot = SimpleNamespace(_components=Components({"db": db}))
+    pillar = KrakenPillar(settings, client, bot=bot)
+    await pillar._save_paper_position("XBTUSDC", .25, 102.5)
+    assert await pillar._update_and_get_peak("XBTUSDC", 7.3) == 7.3
+    held = await KrakenPillar(settings, client, bot=bot)._reconcile_paper_positions(["XBTUSDC"])
+    assert held["XBTUSDC"] == (102.5, 110.0, .25)
+    assert await db.fetchone("SELECT * FROM position_peaks WHERE market_id='XBTUSDC'") is None
+    await pillar._delete_paper_position("XBTUSDC")
+    assert await db.fetchone("SELECT * FROM kraken_paper_positions") is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_two_paper_buys_have_independent_fill_ids_and_basis():
+    db = Database(":memory:")
+    await db.connect()
+    cfg = SimpleNamespace(directional_llm_enabled=True, directional_llm_paper=True,
+                          directional_fee_pct=.26, directional_paper_slippage_bps=5)
+    settings = SimpleNamespace(kraken=cfg, is_live=True)
+    client = SimpleNamespace(get_bid_ask=AsyncMock(side_effect=[(99, 101), (199, 201)]))
+    pillar = KrakenPillar(settings, client,
+        bot=SimpleNamespace(_components=Components({"db": db})))
+    a = await pillar._record_directional_fill("XBTUSDC", OrderSide.BUY,
+        SimpleNamespace(order_id="paper-a"), 100, .1, paper=True)
+    b = await pillar._record_directional_fill("ETHUSDC", OrderSide.BUY,
+        SimpleNamespace(order_id="paper-b"), 200, .1, paper=True)
+    assert a == pytest.approx(101 * 1.0005)
+    assert b == pytest.approx(201 * 1.0005)
+    rows = await db.fetchall("SELECT DISTINCT order_id FROM fills")
+    assert {r["order_id"] for r in rows} == {"paper-a", "paper-b"}
+    await db.close()

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -51,7 +51,12 @@ def mock_paper():
 
 @pytest.fixture
 def client(mock_settings, mock_paper):
-    return PolymarketClient(settings=mock_settings, paper_trader=mock_paper)
+    client = PolymarketClient(settings=mock_settings, paper_trader=mock_paper)
+    # Geographic eligibility is tested in test_triple_gate; lifecycle tests
+    # isolate the CLOB accounting path and must not call the real endpoint.
+    client._geoblock_checked = True
+    client._geoblocked = False
+    return client
 
 
 async def _place_live_buy(client, size=10, price=0.5):

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -54,7 +54,7 @@ def client(mock_settings, mock_paper):
     client = PolymarketClient(settings=mock_settings, paper_trader=mock_paper)
     # Geographic eligibility is tested in test_triple_gate; lifecycle tests
     # isolate the CLOB accounting path and must not call the real endpoint.
-    client._geoblock_checked = True
+    client._geoblock_checked_at = float("inf")
     client._geoblocked = False
     return client
 

--- a/tests/test_polymarket_research.py
+++ b/tests/test_polymarket_research.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from auramaur.backtest.walk_forward import expanding_walk_forward
+from auramaur.research.polymarket_strategies import (
+    DecisionTracker,
+    OutcomeQuote,
+    Relation,
+    complete_set_arbitrage,
+    flow_confirmation_multiplier,
+    logical_constraint_edge,
+    maker_quote_economics,
+    normal_bin_probability,
+    source_latency_edge,
+)
+
+
+def test_complete_set_uses_executable_prices_fees_and_depth():
+    quotes = [
+        OutcomeQuote("a", "A", .40, .42, 100, 50, .005),
+        OutcomeQuote("b", "B", .50, .52, 100, 20, .005),
+    ]
+    opportunities = complete_set_arbitrage("event", quotes, safety_buffer=.01)
+    assert len(opportunities) == 1
+    assert opportunities[0].mechanism == "buy_all_below_one"
+    assert opportunities[0].expected_edge == pytest.approx(.04)
+    assert opportunities[0].capacity_usd == pytest.approx(19.0)
+
+
+def test_constraint_requires_strict_semantic_verification():
+    assert logical_constraint_edge("r", Relation.A_IMPLIES_B, .7, .5,
+                                   verification_confidence=.90) is None
+    result = logical_constraint_edge("r", Relation.A_IMPLIES_B, .7, .5,
+                                     verification_confidence=.99)
+    assert result is not None and result.expected_edge == pytest.approx(.18)
+
+
+def test_source_latency_is_authoritative_fresh_and_same_direction():
+    assert source_latency_edge(
+        "m", source_age_seconds=10, observed_market_move=.01,
+        expected_move=.08, source_is_authoritative=True,
+    ) is not None
+    assert source_latency_edge(
+        "m", source_age_seconds=10, observed_market_move=-.01,
+        expected_move=.08, source_is_authoritative=True,
+    ) is None
+
+
+def test_release_nowcast_and_maker_economics():
+    assert normal_bin_probability(0, 1, None, 0) == pytest.approx(.5)
+    assert maker_quote_economics(
+        "m", spread_capture=.02, fill_probability=.5, expected_rebate=.005,
+        adverse_selection=.005, inventory_cost=.002, cancel_failure_cost=.001,
+    ) is not None
+
+
+def test_flow_never_originates_signal_and_is_bounded():
+    assert flow_confirmation_multiplier(base_signal_edge=0, signed_flow_z=5,
+                                        same_direction=True) == 0
+    assert flow_confirmation_multiplier(base_signal_edge=.1, signed_flow_z=10,
+                                        same_direction=True) == 1.25
+    assert flow_confirmation_multiplier(base_signal_edge=.1, signed_flow_z=10,
+                                        same_direction=False) == .25
+
+
+def test_walk_forward_is_chronological_and_event_unique():
+    start = datetime(2026, 1, 1)
+    rows = [{"event": str(i // 2), "at": start + timedelta(days=i)}
+            for i in range(12)]
+    folds = expanding_walk_forward(
+        rows, timestamp=lambda x: x["at"], event_key=lambda x: x["event"],
+        min_train=3, test_size=2,
+    )
+    assert len(folds) == 2
+    assert len(folds[0].train) == 3
+    assert {x["event"] for x in folds[0].train}.isdisjoint(
+        {x["event"] for x in folds[0].test})
+
+
+@pytest.mark.asyncio
+async def test_decision_tracker_persists_immutable_snapshot(tmp_path):
+    from auramaur.db.database import Database
+
+    db = Database(str(tmp_path / "research.db"))
+    await db.connect()
+    tracker = DecisionTracker(db)
+    kwargs = dict(market_id="m", strategy_source="llm", signal_id=7,
+                  side="BUY", fair_probability=.6, reference_price=.5,
+                  executable_price=.51, best_bid=.49, best_ask=.51,
+                  requested_size=10, fee_estimate=.1)
+    await tracker.capture(**kwargs)
+    await tracker.capture(**{**kwargs, "executable_price": .99})
+    row = await db.fetchone("SELECT executable_price FROM decision_snapshots")
+    assert row["executable_price"] == pytest.approx(.51)
+    await db.close()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -60,7 +60,7 @@ def test_default_risk_params():
     # Kalshi gets a lower candidate liquidity floor than Polymarket (thinner book)
     assert s.risk.min_liquidity == 1000.0
     assert s.risk.kalshi_min_liquidity == 300.0
-    assert s.kelly.fraction == 0.30
+    assert s.kelly.fraction == 0.10
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -60,7 +60,7 @@ def test_default_risk_params():
     # Kalshi gets a lower candidate liquidity floor than Polymarket (thinner book)
     assert s.risk.min_liquidity == 1000.0
     assert s.risk.kalshi_min_liquidity == 300.0
-    assert s.kelly.fraction == 0.10
+    assert s.kelly.fraction == 0.30
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -189,3 +189,11 @@ def test_taker_fee_rate_per_category_and_venue():
     # Non-poly venues use the flat coefficient from the fees map.
     assert taker_fee_rate("kalshi", "crypto") == 0.07
     assert taker_fee_rate("kalshi", None, {"kalshi": 0.03}) == 0.03
+
+
+def test_polymarket_market_level_fee_truth_overrides_category_fallback():
+    from auramaur.strategy.signals import taker_fee_rate
+
+    assert taker_fee_rate("polymarket", "crypto", fees_enabled=False) == 0.0
+    assert taker_fee_rate("polymarket", "other", actual_fee_rate=0.031,
+                          fees_enabled=True) == pytest.approx(0.031)

--- a/tests/test_triple_gate.py
+++ b/tests/test_triple_gate.py
@@ -25,6 +25,8 @@ def _make_settings(auramaur_live: bool = False, execution_live: bool = False) ->
     settings = MagicMock()
     settings.auramaur_live = auramaur_live
     settings.execution.live = execution_live
+    settings.execution.polymarket_geoblock_mode = "advisory"
+    settings.execution.polymarket_geoblock_ttl_seconds = 300
     settings.kill_switch_active = False
     # is_live requires both env + config and no kill switch
     settings.is_live = auramaur_live and execution_live
@@ -162,8 +164,9 @@ async def test_all_gates_open_attempts_live(paper_trader):
 
 
 @pytest.mark.asyncio
-async def test_live_order_fails_closed_when_geoblock_denies(paper_trader):
+async def test_live_order_enforces_geoblock_when_operator_opts_in(paper_trader):
     settings = _make_settings(auramaur_live=True, execution_live=True)
+    settings.execution.polymarket_geoblock_mode = "enforce"
     client = PolymarketClient(settings, paper_trader)
     order = _make_order(dry_run=False)
     with patch.object(client, "_check_geoblock", return_value=False):
@@ -172,6 +175,61 @@ async def test_live_order_fails_closed_when_geoblock_denies(paper_trader):
     assert result.is_paper is False
     assert result.status == "rejected"
     assert result.order_id == "GEOBLOCKED"
+
+
+@pytest.mark.asyncio
+async def test_live_order_treats_frontend_geoblock_as_advisory(paper_trader):
+    settings = _make_settings(auramaur_live=True, execution_live=True)
+    client = PolymarketClient(settings, paper_trader)
+    order = _make_order(dry_run=False)
+    order.token_id = "0xabc123"
+    mock_clob = MagicMock()
+    mock_clob.create_and_post_order.return_value = {"orderID": "LIVE-advisory"}
+    client._clob_client = mock_clob
+    with patch.object(client, "_check_geoblock", return_value=False):
+        result = await client.place_order(order)
+    paper_trader.execute.assert_not_awaited()
+    assert result.order_id == "LIVE-advisory"
+    assert result.is_paper is False
+
+
+@pytest.mark.asyncio
+async def test_live_exit_bypasses_geoblock_even_when_enforced(paper_trader):
+    settings = _make_settings(auramaur_live=True, execution_live=True)
+    settings.execution.polymarket_geoblock_mode = "enforce"
+    client = PolymarketClient(settings, paper_trader)
+    order = _make_order(dry_run=False)
+    order.side = OrderSide.SELL
+    order.source = "exit"
+    order.token_id = "0xabc123"
+    mock_clob = MagicMock()
+    mock_clob.create_and_post_order.return_value = {"orderID": "LIVE-exit"}
+    client._clob_client = mock_clob
+    client._approved_tokens = {order.token_id}
+    with patch.object(client, "_check_geoblock", return_value=False) as check:
+        result = await client.place_order(order)
+    check.assert_not_awaited()
+    assert result.order_id == "LIVE-exit"
+    assert result.is_paper is False
+
+
+@pytest.mark.asyncio
+async def test_geoblock_cache_expires_and_transient_failure_is_retryable(paper_trader):
+    settings = _make_settings()
+    client = PolymarketClient(settings, paper_trader)
+    client._geoblocked = True
+    client._geoblock_checked_at = 100.0
+
+    with patch("auramaur.exchange.client.time.monotonic", return_value=200.0), \
+         patch("auramaur.exchange.client.aiohttp.ClientSession") as session:
+        assert await client._check_geoblock() is False
+        session.assert_not_called()
+
+    with patch("auramaur.exchange.client.time.monotonic", return_value=500.0), \
+         patch("auramaur.exchange.client.aiohttp.ClientSession",
+               side_effect=RuntimeError("frontend unavailable")):
+        assert await client._check_geoblock() is None
+    assert client._geoblock_checked_at == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triple_gate.py
+++ b/tests/test_triple_gate.py
@@ -151,14 +151,27 @@ async def test_all_gates_open_attempts_live(paper_trader):
         mock_clob = MagicMock()
         mock_clob.create_and_post_order.return_value = {"orderID": "LIVE-xyz"}
         client._clob_client = mock_clob
-
-        result = await client.place_order(order)
+        with patch.object(client, "_check_geoblock", return_value=True):
+            result = await client.place_order(order)
 
     # Paper trader must NOT have been called
     paper_trader.execute.assert_not_awaited()
     assert result.is_paper is False
     assert result.order_id == "LIVE-xyz"
     assert result.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_live_order_fails_closed_when_geoblock_denies(paper_trader):
+    settings = _make_settings(auramaur_live=True, execution_live=True)
+    client = PolymarketClient(settings, paper_trader)
+    order = _make_order(dry_run=False)
+    with patch.object(client, "_check_geoblock", return_value=False):
+        result = await client.place_order(order)
+    paper_trader.execute.assert_not_awaited()
+    assert result.is_paper is False
+    assert result.status == "rejected"
+    assert result.order_id == "GEOBLOCKED"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make Kraken validate-only positions restart-safe, strategy-isolated, and cost-basis consistent
- add executable bid/ask paper fills, unique client order IDs, API-key preflight, and research CLI tooling
- add portfolio-faithful Kraken evaluation with equal-dollar benchmarks, walk-forward warm-up isolation, beta-adjusted residuals, ATR trailing exits, stressed-cost/holdout graduation gates, and event/order-flow inputs
- add shared walk-forward and Polymarket research infrastructure, immutable decision snapshots, CLV/rebate accounting, and execution-quality hooks
- document Kraken and Polymarket research/graduation contracts

## Review follow-up

- make the public Polymarket frontend geoblock probe advisory by default; operators can explicitly select `execution.polymarket_geoblock_mode: enforce`
- refresh eligibility telemetry on a 300-second TTL, retry transient failures, and always bypass the probe for explicit exits
- keep authenticated CLOB geographic rejections as real live rejections rather than fabricating paper fills
- restore the established portfolio-wide Kelly default of 30%; this PR no longer changes global sizing
- rename the graduation evidence threshold to `min_markets` and document that the enforced 100-independent-market, positive-LCB bar intentionally may demote cells that passed the former 20-market/positive-total contract
- document decision-capture commit behavior and add direct schema 27→29 migration coverage

## Safety

- Kraken directional trading remains paper-forced by default
- Polymarket frontend eligibility is telemetry unless enforcement is explicitly configured; exits remain attemptable in either mode
- the stricter graduation contract remains enforced intentionally; structural/two-sided exempt strategies are unchanged
- live and paper position/peak state are isolated
- no new live strategy gate is enabled by this change

## Verification

- `python -m ruff check .`: passed
- focused review regression suite: **71 passed**
- final geoblock regression suite: **19 passed**
- full suite: **1244 passed, 2 skipped**
- `git diff --check`: passed
