### PR TITLE
chore(kalshi): review follow-ups for the hardening PR

### DIFF
--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -321,6 +321,10 @@ class ExitExecutionMixin:
 
         # Never sell more than we hold
         order.size = min(order.size, pos.size)
+        if not market.fractional_trading_enabled:
+            # Legacy holdings can carry fractional sizes; a non-fractional
+            # market rejects a fractional count at the API, stranding the exit.
+            order.size = float(int(order.size))
         minimum = 0.01 if market.fractional_trading_enabled else 1.0
         if order.size < minimum:
             return False

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -116,7 +116,7 @@ class KalshiClient:
         the worker thread (body included), so a stall blocks only that thread,
         not the event loop.
         """
-        await self._throttle_read()
+        await self._throttle()
         async with self._semaphore:
             return await asyncio.to_thread(fn, *args, **kwargs)
 
@@ -138,12 +138,12 @@ class KalshiClient:
         def _run():
             return fn(*args, **kwargs).data
 
-        await self._throttle_read()
+        await self._throttle()
         async with self._semaphore:
             return await asyncio.to_thread(_run)
 
-    async def _throttle_read(self) -> None:
-        """Enforce a real per-second read budget."""
+    async def _throttle(self) -> None:
+        """Enforce a real per-second request budget (reads and writes)."""
         # A few protocol tests and lightweight adapters construct the client
         # with __new__; initialize these defensively without weakening runtime.
         if not hasattr(self, "_rate_lock"):
@@ -600,7 +600,7 @@ class KalshiClient:
                 )
                 return resp.read()
 
-            await self._throttle_read()
+            await self._throttle()
             async with self._semaphore:
                 raw = await asyncio.to_thread(_post)
             data = json.loads(raw) if raw else {}
@@ -786,7 +786,7 @@ class KalshiClient:
             )
 
         try:
-            await self._throttle_read()
+            await self._throttle()
             async with self._semaphore:
                 await asyncio.to_thread(_delete)
             log.info("order.cancelled", exchange="kalshi", order_id=order_id, via="v2")

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -79,9 +79,11 @@ class Market(BaseModel):
     strike_type: str = ""
     floor_strike: float | None = None
     cap_strike: float | None = None
-    # Kalshi fixed-point execution metadata.
+    # Kalshi fixed-point execution metadata. Range values are strings in the
+    # current API but tolerate numeric drift — a typing mismatch here would
+    # fail Market validation and silently drop the whole market.
     price_level_structure: str = "linear_cent"
-    price_ranges: list[dict[str, str]] = Field(default_factory=list)
+    price_ranges: list[dict[str, str | int | float]] = Field(default_factory=list)
     fractional_trading_enabled: bool = False
     # Polymarket UMA optimistic-oracle resolution state, surfaced by Gamma.
     # `uma_status` is the current stage ("" → no proposal yet, "proposed" →

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -202,6 +202,10 @@ class EconIndicatorPillar:
             log.warning("econ_indicator.order_rejected", market_id=market.id,
                         status=res.status, error=res.reason)
             return False
+        # A resting live order is deliberately NOT recorded here: the order
+        # monitor books its confirmed fill and the next sync_positions venue
+        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
+        # "Fill booking for resting live orders").
         if res.status != "pending" and res.result.filled_size > 0:
             await self._record_position(signal, market, res.order, res.result)
         log.info("econ_indicator.entered", market_id=market.id, side=side.value,

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -183,6 +183,10 @@ class InformedFlowPillar:
                         status=res.status, error=res.reason)
             return False
 
+        # A resting live order is deliberately NOT recorded here: the order
+        # monitor books its confirmed fill and the next sync_positions venue
+        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
+        # "Fill booking for resting live orders").
         if res.status != "pending" and res.result.filled_size > 0:
             await self._record_position(signal, market, res.order, res.result)
         log.info("informed_flow.entered", market_id=market.id,

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -298,6 +298,10 @@ class LongHorizonPillar:
                         status=res.status, error=res.reason)
             return False
 
+        # A resting live order is deliberately NOT recorded here: the order
+        # monitor books its confirmed fill and the next sync_positions venue
+        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
+        # "Fill booking for resting live orders").
         if res.status != "pending" and res.result.filled_size > 0:
             await self._record_position(signal, market, res.order, res.result)
         log.info("long_horizon.entered", market_id=market.id,

--- a/docs/KALSHI_HARDENING.md
+++ b/docs/KALSHI_HARDENING.md
@@ -4,6 +4,24 @@ Kalshi remains paper-first. Live orders still require the environment gate,
 configuration gate, and per-order `dry_run=False`; the kill switch and risk
 gateway remain authoritative.
 
+## Endpoints
+
+Production uses `https://external-api.kalshi.com/trade-api/v2`, Kalshi's
+current API domain (migrated 2026-07 from `api.elections.kalshi.com`, which
+serves identical responses and remains a valid fallback). The demo host is
+unchanged: `https://demo-api.kalshi.co/trade-api/v2`. If Kalshi retires a
+domain, the host literal lives in `KalshiClient._init_api`.
+
+## Fill booking for resting live orders
+
+A live order that rests (`pending`) is not recorded as a position by the
+entering strategy. The single-booking contract is: the order monitor records
+the confirmed fill (`pnl_tracker.record_fill` → fills / cost basis), and the
+next `sync_positions` venue snapshot materializes the `portfolio` row from
+venue truth. Strategy-level re-entry is prevented meanwhile by the `signals`
+table guard. Do not "fix" the entry gates to record pending orders — that
+reintroduces phantom positions.
+
 ## Execution contract
 
 - Current fixed-point (`*_fp`, `*_dollars`) fields are canonical. Legacy fields

--- a/tests/test_prepare_order.py
+++ b/tests/test_prepare_order.py
@@ -107,6 +107,19 @@ class TestKalshiPrepareOrder:
         order = client.prepare_order(_make_signal(OrderSide.BUY), market, 10, False)
         assert order.price == pytest.approx(0.062)
 
+    def test_numeric_price_range_values_do_not_drop_the_market(self):
+        """Kalshi sends strings today; numeric drift must not fail validation."""
+        from auramaur.exchange.kalshi import KalshiClient
+        market = _make_market(yes_price=0.041)
+        market.spread = 0.002
+        market.exchange = "kalshi"
+        market.ticker = market.id
+        market.price_ranges = [{"start": 0, "end": 0.1, "step": 0.001}]
+        assert Market.model_validate(market.model_dump()).price_ranges
+        client = KalshiClient.__new__(KalshiClient)
+        order = client.prepare_order(_make_signal(OrderSide.BUY), market, 10, False)
+        assert order.price == pytest.approx(0.062)
+
     @pytest.mark.asyncio
     async def test_fresh_book_caps_paper_size_to_executable_depth(self):
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary
Follow-ups requested in the #314 review:
- **Endpoints documented**: the production host migration to `external-api.kalshi.com` (verified byte-identical to the old host) and the unchanged demo host now live in `KALSHI_HARDENING.md`.
- **Single-booking invariant written down**: comments at all three pillar entry gates + a doc section explain that a resting live order is booked by the order monitor (fill/cost-basis) and materialized into `portfolio` by the next `sync_positions` venue snapshot — with the `signals` guard preventing re-entry meanwhile. This was verified against `bot_order_monitor.py` and `sync_positions` before writing it down.
- **Exit hardening**: non-fractional markets now get integral exit counts in `bot_exits` (legacy fractional holdings would strand at the API).
- **Schema tolerance**: `Market.price_ranges` accepts numeric values so Kalshi-side type drift degrades gracefully instead of silently dropping markets (regression test included).
- **Rename**: `_throttle_read` → `_throttle` (it correctly budgets writes too).

## Testing
- Kalshi suites (46 tests) and `ruff check .` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)