### PR TITLE
Harden IBKR research evaluation and controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,12 +77,12 @@ AURAMAUR_LIVE=false
 # arm them explicitly on the final host only after verification.
 AURAMAUR_CONTAINER_LIVE=false
 AURAMAUR_CONTAINER_ENABLE_TRANSFERS=false
-# The dedicated IBKR live login is a read-only quote source. Port 4002 is an
-# intentional deployment-local choice; local paper execution remains separate.
-IBKR_QUOTE_ENVIRONMENT=live
+# IBKR is opt-in. Start with a paper Gateway/login; the socket stays read-only
+# and strategy fills remain in local paper ledgers.
+IBKR_QUOTE_ENVIRONMENT=paper
 IBKR_QUOTE_PORT=4002
-IBKR_ENABLED=true
-IBKR_MULTIASSET_PAPER_ENABLED=true
+IBKR_ENABLED=false
+IBKR_MULTIASSET_PAPER_ENABLED=false
 # 1=live. Multi-asset paper fills fail closed for 2/3/4.
 IBKR_MARKET_DATA_TYPE=1
 # Stable private addresses make the Gateway Trusted IP entry survive restarts.

--- a/auramaur/backtest/walk_forward.py
+++ b/auramaur/backtest/walk_forward.py
@@ -1,9 +1,10 @@
-"""Leakage-resistant walk-forward helpers for strategy research."""
+"""Leakage-resistant walk-forward helpers and metrics for strategy research."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
+import math
 from typing import Callable, Sequence, TypeVar
 
 T = TypeVar("T")
@@ -13,6 +14,30 @@ T = TypeVar("T")
 class WalkForwardFold:
     train: tuple
     test: tuple
+
+
+@dataclass(frozen=True)
+class StrategyObservation:
+    timestamp: datetime
+    equity: float
+    net_pnl: float | None = None
+    turnover: float = 0.0
+    gross_exposure: float = 0.0
+
+
+@dataclass(frozen=True)
+class StrategyEvaluation:
+    observations: int
+    cagr: float | None
+    annualized_volatility: float
+    sharpe: float
+    sortino: float
+    max_drawdown: float
+    turnover: float
+    profit_factor: float | None
+    hit_rate: float | None
+    tail_loss: float
+    average_gross_exposure: float
 
 
 def event_unique(rows: Sequence[T], event_key: Callable[[T], str]) -> list[T]:
@@ -28,24 +53,87 @@ def event_unique(rows: Sequence[T], event_key: Callable[[T], str]) -> list[T]:
 
 
 def expanding_walk_forward(
-    rows: Sequence[T], *, timestamp: Callable[[T], datetime],
-    event_key: Callable[[T], str], min_train: int = 100,
+    rows: Sequence[T],
+    *,
+    timestamp: Callable[[T], datetime],
+    event_key: Callable[[T], str],
+    min_train: int = 100,
     test_size: int = 25,
+    event_end: Callable[[T], datetime] | None = None,
+    embargo: timedelta = timedelta(0),
 ) -> list[WalkForwardFold]:
     """Chronological expanding-window folds with event-disjoint test sets."""
     if min_train < 1 or test_size < 1:
         raise ValueError("min_train and test_size must be positive")
+    if embargo < timedelta(0):
+        raise ValueError("embargo must be non-negative")
     ordered = event_unique(sorted(rows, key=timestamp), event_key)
     folds: list[WalkForwardFold] = []
     cursor = min_train
     while cursor < len(ordered):
-        test = ordered[cursor:cursor + test_size]
+        test = ordered[cursor : cursor + test_size]
         if not test:
             break
         train = ordered[:cursor]
+        if event_end is not None:
+            cutoff = timestamp(test[0]) - embargo
+            train = [x for x in train if event_end(x) < cutoff]
         train_events = {event_key(x) for x in train}
         test = [x for x in test if event_key(x) not in train_events]
         if test:
             folds.append(WalkForwardFold(tuple(train), tuple(test)))
         cursor += test_size
     return folds
+
+
+def evaluate_strategy(
+    observations: Sequence[StrategyObservation],
+    *,
+    annual_periods: int = 252,
+    risk_free_rate: float = 0.0,
+    tail_probability: float = 0.05,
+) -> StrategyEvaluation:
+    """Calculate generic portfolio metrics from chronological net observations."""
+    if annual_periods < 1:
+        raise ValueError("annual_periods must be positive")
+    if not 0 < tail_probability <= 1:
+        raise ValueError("tail_probability must be in (0, 1]")
+    points = sorted(observations, key=lambda x: x.timestamp)
+    if any(not math.isfinite(p.equity) or p.equity <= 0 for p in points):
+        raise ValueError("equity must be finite and positive")
+    if any(p.turnover < 0 or p.gross_exposure < 0 for p in points):
+        raise ValueError("turnover and gross_exposure must be non-negative")
+    returns = [points[i].equity / points[i - 1].equity - 1 for i in range(1, len(points))]
+    cagr = None
+    if len(points) >= 2:
+        years = (points[-1].timestamp - points[0].timestamp).total_seconds() / (365.2425 * 86400)
+        if years > 0:
+            cagr = (points[-1].equity / points[0].equity) ** (1 / years) - 1
+    mean = sum(returns) / len(returns) if returns else 0.0
+    variance = (
+        sum((x - mean) ** 2 for x in returns) / (len(returns) - 1) if len(returns) >= 2 else 0.0
+    )
+    std = math.sqrt(variance)
+    vol = std * math.sqrt(annual_periods)
+    rf = (1 + risk_free_rate) ** (1 / annual_periods) - 1
+    sharpe = (mean - rf) / std * math.sqrt(annual_periods) if std else 0.0
+    down = [min(0.0, x - rf) for x in returns]
+    dev = math.sqrt(sum(x * x for x in down) / len(down)) if down else 0.0
+    sortino = (mean - rf) / dev * math.sqrt(annual_periods) if dev else 0.0
+    peak = max_dd = 0.0
+    for p in points:
+        peak = max(peak, p.equity)
+        max_dd = max(max_dd, (peak - p.equity) / peak)
+    pnls = [p.net_pnl for p in points if p.net_pnl is not None]
+    gains = sum(x for x in pnls if x > 0)
+    losses = -sum(x for x in pnls if x < 0)
+    pf = gains / losses if losses else (math.inf if gains else None)
+    hit = sum(x > 0 for x in pnls) / len(pnls) if pnls else None
+    avg = sum(p.equity for p in points) / len(points) if points else 0.0
+    turnover = sum(p.turnover for p in points) / avg if avg else 0.0
+    exposure = sum(p.gross_exposure / p.equity for p in points) / len(points) if points else 0.0
+    n = max(1, int(len(returns) * tail_probability)) if returns else 0
+    tail = max(0.0, -sum(sorted(returns)[:n]) / n) if n else 0.0
+    return StrategyEvaluation(
+        len(points), cagr, vol, sharpe, sortino, max_dd, turnover, pf, hit, tail, exposure
+    )

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -675,6 +675,7 @@ class AuramaurBot(
         """OpenAI intelligence-cap A/B over the paper-only ETF mandate."""
         from auramaur.exchange.ibkr_equity import IBKREquityClient
         from auramaur.nlp.openai_etf import OpenAIETFAnalyzer
+        from auramaur.strategy.ibkr_etf_controls import MomentumETFAnalyzer
         from auramaur.strategy.ibkr_etf_paper import IBKRETFPaperPillar
 
         client = IBKREquityClient(self.settings, force_paper_readonly=True)
@@ -692,6 +693,10 @@ class AuramaurBot(
             self._components.get("cache"), model_alias=spec.alias,
             evidence_cache=evidence_cache)
             for spec, analyzer in zip(self.settings.ibkr.etf_models, analyzers)]
+        pillars.append(IBKRETFPaperPillar(
+            self.settings, client, self._components.get("db"), None,
+            MomentumETFAnalyzer(), self._components.get("cache"),
+            model_alias="momentum_control"))
         try:
             while self._running:
                 if await self._check_kill_switch():

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -120,6 +120,43 @@ class Database:
             await self._migrate_v27_to_v28()
         if from_version < 29:
             await self._migrate_v28_to_v29()
+        if from_version < 30:
+            await self._migrate_v29_to_v30()
+
+    async def _migrate_v29_to_v30(self) -> None:
+        """Add cost-adjusted IBKR round-trip observations."""
+        for column in (
+            "entry_commission_usd REAL NOT NULL DEFAULT 0",
+            "entry_fill_ref TEXT NOT NULL DEFAULT ''",
+        ):
+            try:
+                await self._db.execute(
+                    f"ALTER TABLE ibkr_paper_positions ADD COLUMN {column}")
+            except aiosqlite.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS ibkr_paper_round_trips (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                book TEXT NOT NULL, instrument_key TEXT NOT NULL,
+                entry_fill_ref TEXT NOT NULL DEFAULT '',
+                exit_fill_ref TEXT NOT NULL UNIQUE,
+                gross_pnl_usd REAL NOT NULL,
+                entry_commission_usd REAL NOT NULL DEFAULT 0,
+                exit_commission_usd REAL NOT NULL DEFAULT 0,
+                financing_usd REAL NOT NULL DEFAULT 0,
+                borrow_usd REAL NOT NULL DEFAULT 0,
+                roll_cost_usd REAL NOT NULL DEFAULT 0,
+                intelligence_cost_usd REAL NOT NULL DEFAULT 0,
+                net_pnl_usd REAL NOT NULL, opened_at TEXT NOT NULL,
+                closed_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_ibkr_round_trips_book_closed
+                ON ibkr_paper_round_trips(book, closed_at);
+        """)
+        await self._db.execute("UPDATE schema_version SET version = 30")
+        await self._db.commit()
+        log.info("database.migrated", from_version=29, to_version=30)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 29
+SCHEMA_VERSION = 30
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -578,6 +578,8 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_positions (
     unrealized_pnl_usd REAL NOT NULL DEFAULT 0,
     stop_price REAL NOT NULL DEFAULT 0,
     initial_risk_usd REAL NOT NULL DEFAULT 0,
+    entry_commission_usd REAL NOT NULL DEFAULT 0,
+    entry_fill_ref TEXT NOT NULL DEFAULT '',
     price_source TEXT NOT NULL DEFAULT 'ibkr_unknown',
     instrument_spec_json TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -614,6 +616,25 @@ CREATE TABLE IF NOT EXISTS ibkr_paper_ledger (
 );
 CREATE INDEX IF NOT EXISTS idx_ibkr_paper_ledger_book_day
     ON ibkr_paper_ledger(book, realized_at);
+
+CREATE TABLE IF NOT EXISTS ibkr_paper_round_trips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book TEXT NOT NULL, instrument_key TEXT NOT NULL,
+    entry_fill_ref TEXT NOT NULL DEFAULT '',
+    exit_fill_ref TEXT NOT NULL UNIQUE,
+    gross_pnl_usd REAL NOT NULL,
+    entry_commission_usd REAL NOT NULL DEFAULT 0,
+    exit_commission_usd REAL NOT NULL DEFAULT 0,
+    financing_usd REAL NOT NULL DEFAULT 0,
+    borrow_usd REAL NOT NULL DEFAULT 0,
+    roll_cost_usd REAL NOT NULL DEFAULT 0,
+    intelligence_cost_usd REAL NOT NULL DEFAULT 0,
+    net_pnl_usd REAL NOT NULL,
+    opened_at TEXT NOT NULL,
+    closed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ibkr_round_trips_book_closed
+    ON ibkr_paper_round_trips(book, closed_at);
 
 CREATE TABLE IF NOT EXISTS ibkr_paper_state (
     book TEXT PRIMARY KEY,

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -12,6 +12,7 @@ import structlog
 from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
 from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
 from auramaur.exchange.ibkr_registry import record_validation
+from auramaur.risk.ibkr_evidence import evaluate_ibkr_evidence
 
 log = structlog.get_logger()
 
@@ -115,7 +116,8 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
         add("isolation", "OK", "read-only client exposes no broker order method")
 
     required = {"ibkr_paper_positions", "ibkr_paper_fills",
-                "ibkr_paper_ledger", "ibkr_paper_state", "ibkr_contract_registry"}
+                "ibkr_paper_ledger", "ibkr_paper_round_trips",
+                "ibkr_paper_state", "ibkr_contract_registry"}
     rows = await db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
     missing = required - {row["name"] for row in rows}
     add("database", "BLOCK" if missing else "OK",
@@ -177,20 +179,25 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
             "OK" if set(counts) <= {"eligible"} else "WARN",
             ", ".join(f"{status}={count}" for status, count in counts.items()))
 
-        edge = await db.fetchone(
-            """SELECT SUM(CASE WHEN kind = 'trade' THEN 1 ELSE 0 END) AS n,
-                      COALESCE(SUM(pnl_usd), 0) AS pnl,
-                      COALESCE(SUM(CASE WHEN pnl_usd > 0 THEN pnl_usd ELSE 0 END), 0) AS gains,
-                      ABS(COALESCE(SUM(CASE WHEN pnl_usd < 0 THEN pnl_usd ELSE 0 END), 0)) AS losses
-                 FROM ibkr_paper_ledger WHERE book = ?""",
-            (book.value,))
-        n, pnl = int(edge["n"] or 0), float(edge["pnl"] or 0)
-        gains, losses = float(edge["gains"] or 0), float(edge["losses"] or 0)
+        observations = await db.fetchall(
+            "SELECT net_pnl_usd FROM ibkr_paper_round_trips "
+            "WHERE book = ? ORDER BY closed_at, id", (book.value,))
+        pnls = [float(row["net_pnl_usd"]) for row in observations]
+        age = await db.fetchone(
+            "SELECT CAST(julianday('now') - julianday(MIN(opened_at)) AS INTEGER) "
+            "AS elapsed FROM ibkr_paper_round_trips WHERE book = ?", (book.value,))
+        elapsed_days = max(0, int(age["elapsed"] or 0))
+        evidence = evaluate_ibkr_evidence(
+            pnls, elapsed_days=elapsed_days, budget_usd=book_cfg.budget_usd)
+        gains = sum(pnl for pnl in pnls if pnl > 0)
+        losses = abs(sum(pnl for pnl in pnls if pnl < 0))
         profit_factor = gains / losses if losses else (float("inf") if gains else 0.0)
-        proven = n >= 30 and pnl > 0 and profit_factor > 1.1
-        add(f"{book.value}:edge", "OK" if proven else "WARN",
-            f"forward paper evidence: {n} exits, ${pnl:.2f} net P&L, "
-            f"profit factor {profit_factor:.2f}")
+        status = "graduated" if evidence.ready else "not graduated"
+        reasons = "; ".join(evidence.reasons) if evidence.reasons else "contract passed"
+        add(f"{book.value}:edge", "OK" if evidence.ready else "WARN",
+            f"{status}: {evidence.observations} cost-adjusted round trips over "
+            f"{evidence.elapsed_days} days, ${evidence.net_pnl_usd:.2f} net P&L, "
+            f"profit factor {profit_factor:.2f}; {reasons}")
     if own_client:
         await client.close()
     return MultiAssetPreflightReport(tuple(results))

--- a/auramaur/research/ibkr_signals.py
+++ b/auramaur/research/ibkr_signals.py
@@ -1,0 +1,239 @@
+"""Pure, point-in-time signal primitives for IBKR strategy research.
+
+These functions do not fetch data, size positions, or place orders.  Callers must
+provide an explicit ``as_of`` time and already-known observations.  Invalid,
+future-dated, stale, or insufficient inputs raise :class:`SignalInputError`, so
+an evaluator cannot silently turn incomplete data into a tradable signal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import math
+from statistics import fmean, pstdev
+from typing import Sequence
+
+
+class SignalInputError(ValueError):
+    """Input is unsafe or insufficient for a point-in-time signal."""
+
+
+@dataclass(frozen=True)
+class PricePoint:
+    observed_at: datetime
+    value: float
+
+
+@dataclass(frozen=True)
+class CurvePoint:
+    expiry: datetime
+    price: float
+
+
+@dataclass(frozen=True)
+class ResearchSignal:
+    """A research direction: -1 short, 0 flat, or 1 long."""
+
+    direction: int
+    score: float
+    rationale: str
+
+    def __post_init__(self) -> None:
+        if self.direction not in (-1, 0, 1):
+            raise ValueError("direction must be -1, 0, or 1")
+        if not math.isfinite(self.score):
+            raise ValueError("score must be finite")
+
+
+def _utc(value: datetime, name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise SignalInputError(f"{name} must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _positive(value: float, name: str) -> float:
+    if not math.isfinite(value) or value <= 0:
+        raise SignalInputError(f"{name} must be finite and positive")
+    return float(value)
+
+
+def _finite(value: float, name: str) -> float:
+    if not math.isfinite(value):
+        raise SignalInputError(f"{name} must be finite")
+    return float(value)
+
+
+def _prices(
+    points: Sequence[PricePoint],
+    *,
+    as_of: datetime,
+    minimum: int,
+    max_age: timedelta | None,
+    name: str,
+) -> list[float]:
+    cutoff = _utc(as_of, "as_of")
+    if len(points) < minimum:
+        raise SignalInputError(f"{name} requires at least {minimum} observations")
+    times = [_utc(point.observed_at, f"{name}.observed_at") for point in points]
+    if any(right <= left for left, right in zip(times, times[1:])):
+        raise SignalInputError(f"{name} timestamps must be strictly increasing")
+    if times[-1] > cutoff:
+        raise SignalInputError(f"{name} contains data after as_of")
+    if max_age is not None:
+        if max_age <= timedelta(0):
+            raise SignalInputError("max_age must be positive")
+        if cutoff - times[-1] > max_age:
+            raise SignalInputError(f"{name} latest observation is stale")
+    return [_positive(point.value, f"{name}.value") for point in points]
+
+
+def _zscore(current: float, history: Sequence[float], name: str) -> float:
+    sigma = pstdev(history)
+    if sigma <= 0 or not math.isfinite(sigma):
+        raise SignalInputError(f"{name} history has zero variance")
+    return (current - fmean(history)) / sigma
+
+
+def short_term_mean_reversion(
+    closes: Sequence[PricePoint],
+    *,
+    as_of: datetime,
+    return_lookback: int = 20,
+    trend_lookback: int = 60,
+    entry_z: float = 2.0,
+    max_age: timedelta | None = None,
+) -> ResearchSignal:
+    """Fade an abnormal one-period move only in the prevailing price trend.
+
+    The current log return is compared with the *preceding* return window.  A
+    negative shock above ``entry_z`` is long only above the trailing trend mean;
+    a positive shock is short only below it.  This separation avoids including
+    the decision observation in its own normalization baseline.
+    """
+    if return_lookback < 2 or trend_lookback < 2:
+        raise SignalInputError("lookbacks must be at least 2")
+    entry_z = _positive(entry_z, "entry_z")
+    needed = max(return_lookback + 2, trend_lookback + 1)
+    values = _prices(closes, as_of=as_of, minimum=needed, max_age=max_age, name="closes")
+    returns = [math.log(b / a) for a, b in zip(values, values[1:])]
+    z = _zscore(returns[-1], returns[-return_lookback - 1 : -1], "return")
+    trend_mean = fmean(values[-trend_lookback - 1 : -1])
+    if z <= -entry_z and values[-1] > trend_mean:
+        return ResearchSignal(1, -z, "negative shock within an uptrend")
+    if z >= entry_z and values[-1] < trend_mean:
+        return ResearchSignal(-1, z, "positive shock within a downtrend")
+    return ResearchSignal(0, abs(z), "shock or trend filter not satisfied")
+
+
+def relative_value_residual_zscore(
+    dependent: Sequence[PricePoint],
+    independent: Sequence[PricePoint],
+    *,
+    as_of: datetime,
+    hedge_beta: float,
+    intercept: float = 0.0,
+    lookback: int = 60,
+    entry_z: float = 2.0,
+    max_age: timedelta | None = None,
+) -> ResearchSignal:
+    """Return the mean-reversion direction of a pre-fitted log-price spread.
+
+    ``hedge_beta`` and ``intercept`` must have been fitted before ``as_of``.
+    Direction describes the dependent leg; the independent leg has exposure
+    ``-direction * hedge_beta``.  Both series must have identical timestamps.
+    """
+    if lookback < 2:
+        raise SignalInputError("lookback must be at least 2")
+    beta = _finite(hedge_beta, "hedge_beta")
+    alpha = _finite(intercept, "intercept")
+    entry_z = _positive(entry_z, "entry_z")
+    needed = lookback + 1
+    ys = _prices(dependent, as_of=as_of, minimum=needed, max_age=max_age, name="dependent")
+    xs = _prices(independent, as_of=as_of, minimum=needed, max_age=max_age, name="independent")
+    y_times = [_utc(point.observed_at, "dependent.observed_at") for point in dependent]
+    x_times = [_utc(point.observed_at, "independent.observed_at") for point in independent]
+    if y_times != x_times:
+        raise SignalInputError("pair observations must have identical timestamps")
+    residuals = [math.log(y) - alpha - beta * math.log(x) for y, x in zip(ys, xs)]
+    z = _zscore(residuals[-1], residuals[-lookback - 1 : -1], "residual")
+    direction = -1 if z >= entry_z else 1 if z <= -entry_z else 0
+    return ResearchSignal(direction, abs(z), "residual mean reversion")
+
+
+def futures_carry_trend(
+    curve: Sequence[CurvePoint],
+    closes: Sequence[PricePoint],
+    *,
+    as_of: datetime,
+    trend_lookback: int = 60,
+    min_annualized_carry: float = 0.0,
+    max_age: timedelta | None = None,
+) -> ResearchSignal:
+    """Combine front/back futures curve carry with trailing price trend.
+
+    Positive carry denotes backwardation (near price above far price).  A signal
+    is emitted only when carry and trailing log-price trend agree.
+    """
+    if trend_lookback < 1:
+        raise SignalInputError("trend_lookback must be positive")
+    threshold = _finite(min_annualized_carry, "min_annualized_carry")
+    if threshold < 0:
+        raise SignalInputError("min_annualized_carry cannot be negative")
+    cutoff = _utc(as_of, "as_of")
+    if len(curve) < 2:
+        raise SignalInputError("curve requires at least two contracts")
+    expiries = [_utc(point.expiry, "curve.expiry") for point in curve]
+    if any(right <= left for left, right in zip(expiries, expiries[1:])):
+        raise SignalInputError("curve expiries must be strictly increasing")
+    if expiries[0] <= cutoff:
+        raise SignalInputError("curve contains an expired front contract")
+    near = _positive(curve[0].price, "curve.near.price")
+    far = _positive(curve[-1].price, "curve.far.price")
+    years = (expiries[-1] - expiries[0]).total_seconds() / (365.25 * 86400)
+    if years <= 0:
+        raise SignalInputError("curve tenor must be positive")
+    carry = math.log(near / far) / years
+    values = _prices(
+        closes, as_of=as_of, minimum=trend_lookback + 1, max_age=max_age, name="closes"
+    )
+    trend = math.log(values[-1] / values[-trend_lookback - 1])
+    carry_side = 1 if carry > threshold else -1 if carry < -threshold else 0
+    trend_side = 1 if trend > 0 else -1 if trend < 0 else 0
+    direction = carry_side if carry_side == trend_side else 0
+    return ResearchSignal(
+        direction, min(abs(carry), abs(trend)), f"annualized_carry={carry:.6f}; trend={trend:.6f}"
+    )
+
+
+def fx_carry_trend(
+    closes: Sequence[PricePoint],
+    *,
+    as_of: datetime,
+    base_rate: float,
+    quote_rate: float,
+    trend_lookback: int = 60,
+    min_rate_spread: float = 0.0,
+    max_age: timedelta | None = None,
+) -> ResearchSignal:
+    """Combine BASE/QUOTE interest carry with spot trend.
+
+    Rates are annual decimal yields known at ``as_of``.  Long BASE/QUOTE earns
+    approximately ``base_rate - quote_rate`` before broker financing costs.
+    """
+    if trend_lookback < 1:
+        raise SignalInputError("trend_lookback must be positive")
+    spread = _finite(base_rate, "base_rate") - _finite(quote_rate, "quote_rate")
+    threshold = _finite(min_rate_spread, "min_rate_spread")
+    if threshold < 0:
+        raise SignalInputError("min_rate_spread cannot be negative")
+    values = _prices(
+        closes, as_of=as_of, minimum=trend_lookback + 1, max_age=max_age, name="closes"
+    )
+    trend = math.log(values[-1] / values[-trend_lookback - 1])
+    carry_side = 1 if spread > threshold else -1 if spread < -threshold else 0
+    trend_side = 1 if trend > 0 else -1 if trend < 0 else 0
+    direction = carry_side if carry_side == trend_side else 0
+    return ResearchSignal(
+        direction, min(abs(spread), abs(trend)), f"rate_spread={spread:.6f}; trend={trend:.6f}"
+    )

--- a/auramaur/strategy/ibkr_etf_controls.py
+++ b/auramaur/strategy/ibkr_etf_controls.py
@@ -1,0 +1,79 @@
+"""Deterministic, leakage-resistant controls for the IBKR ETF experiment."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+from statistics import fmean
+from auramaur.nlp.openai_etf import ETFAnalysis
+from auramaur.risk.ibkr_math import annualized_volatility, normalized_momentum
+
+
+def completed_closes(bars, as_of: str) -> list[float]:
+    return [float(c) for day, c in bars if day < as_of and c and float(c) > 0]
+
+
+def dual_momentum_score(closes, cash_closes) -> float | None:
+    asset, cash = normalized_momentum(closes), normalized_momentum(cash_closes)
+    return None if asset is None or cash is None or asset <= 0 else asset - cash
+
+
+def cross_sectional_winners(histories, top_n: int = 3) -> list[str]:
+    ranked = [
+        (s, k) for k, v in histories.items() if (s := normalized_momentum(v)) is not None and s > 0
+    ]
+    return [k for _, k in sorted(ranked, reverse=True)[:top_n]]
+
+
+def regime_allows_risk(closes, *, max_annual_vol: float = 0.30) -> bool:
+    vol = annualized_volatility(closes)
+    return bool(
+        vol is not None
+        and vol <= max_annual_vol
+        and len(closes) >= 201
+        and closes[-1] > fmean(closes[-200:])
+    )
+
+
+class MomentumETFAnalyzer:
+    model = "deterministic_momentum_v1"
+
+    async def analyze_symbol(self, client, symbol: str, as_of: str | None = None):
+        closes = completed_closes(
+            await client.get_adjusted_daily_closes(symbol), as_of or date.today().isoformat()
+        )
+        score = normalized_momentum(closes)
+        if score is None:
+            return None
+        return ETFAnalysis(
+            0.70 if score > 0 else 0.30,
+            "HIGH",
+            f"deterministic normalized momentum={score:.4f}",
+            (),
+        )
+
+
+@dataclass(frozen=True)
+class ControlReturn:
+    cash: float
+    buy_hold: float
+    momentum: float
+    placebo: float
+
+
+def compare_controls(
+    closes, *, warmup: int = 120, placebo_rate: float = 0.5, seed: str = "ibkr-etf-v1"
+) -> ControlReturn:
+    """Walk-forward returns with decisions made before each scored return."""
+    if len(closes) <= warmup or not 0 <= placebo_rate <= 1:
+        raise ValueError("controls require sufficient closes and a valid placebo rate")
+    buy_hold = momentum = placebo = 1.0
+    for i in range(warmup, len(closes)):
+        ret = closes[i] / closes[i - 1]
+        buy_hold *= ret
+        if (normalized_momentum(closes[:i]) or 0) > 0:
+            momentum *= ret
+        digest = hashlib.sha256(f"{seed}:{i}".encode()).digest()
+        if int.from_bytes(digest[:8], "big") / (2**64 - 1) < placebo_rate:
+            placebo *= ret
+    return ControlReturn(0.0, buy_hold - 1, momentum - 1, placebo - 1)

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -96,6 +96,14 @@ class IBKRETFPaperPillar:
             return cached[1], cached[2]
         if not allow_refresh:
             return (cached[1], cached[2]) if cached else None
+        deterministic = getattr(self._analyzer, "analyze_symbol", None)
+        if deterministic is not None:
+            analysis = await deterministic(self._client, symbol)
+            if analysis is None:
+                return None
+            view = (float(analysis.probability), str(analysis.confidence))
+            self._views[symbol] = (time.time(), *view)
+            return view
         call_count = await self._db.fetchone(
             """SELECT COUNT(*) AS n FROM ibkr_etf_openai_attempts
                WHERE model_alias = ? AND date(started_at) = date('now')""",

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -167,16 +167,34 @@ class IBKRMultiAssetPaperBook:
                 """INSERT INTO ibkr_paper_positions
                    (book, instrument_key, con_id, currency, quantity, multiplier,
                     fx_to_usd, avg_cost, current_price, price_source,
-                    instrument_spec_json, stop_price, initial_risk_usd)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    instrument_spec_json, stop_price, initial_risk_usd,
+                    entry_commission_usd, entry_fill_ref)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (self.book.value, spec.key, quote.con_id, spec.currency, quantity,
                  quote.multiplier, fx, price, price, quote.source,
-                 self._serialize_spec(spec), stop_price, initial_risk_usd))
+                 self._serialize_spec(spec), stop_price, initial_risk_usd, fee,
+                 fill_ref))
         else:
             pnl = (price - float(entry_price)) * quantity * quote.multiplier * fx
             await self._db.execute(
                 "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) VALUES (?, 'trade', ?, ?)",
                 (self.book.value, pnl, f"{fill_ref}:trade"))
+            position = await self._db.fetchone(
+                "SELECT entry_commission_usd, entry_fill_ref, opened_at "
+                "FROM ibkr_paper_positions "
+                "WHERE book = ? AND instrument_key = ?",
+                (self.book.value, spec.key))
+            entry_fee = float(position["entry_commission_usd"] or 0) if position else 0.0
+            entry_fill_ref = str(position["entry_fill_ref"] or "") if position else ""
+            opened_at = position["opened_at"] if position else datetime.now(timezone.utc).isoformat()
+            await self._db.execute(
+                """INSERT INTO ibkr_paper_round_trips
+                   (book, instrument_key, entry_fill_ref, exit_fill_ref, gross_pnl_usd,
+                    entry_commission_usd, exit_commission_usd, net_pnl_usd,
+                    opened_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (self.book.value, spec.key, entry_fill_ref, fill_ref, pnl, entry_fee, fee,
+                 pnl - entry_fee - fee, opened_at))
             await self._db.execute(
                 "DELETE FROM ibkr_paper_positions WHERE book = ? AND instrument_key = ?",
                 (self.book.value, spec.key))

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -186,9 +186,16 @@ class IBKRMultiAssetPaperBook:
                 (self.book.value, spec.key))
             entry_fee = float(position["entry_commission_usd"] or 0) if position else 0.0
             entry_fill_ref = str(position["entry_fill_ref"] or "") if position else ""
+            if position is None:
+                # Understates elapsed_days for the evidence contract; loud so a
+                # recurring miss is investigated rather than absorbed.
+                log.warning("ibkr_multiasset.round_trip_missing_entry",
+                            book=self.book.value, instrument=spec.key)
             opened_at = position["opened_at"] if position else datetime.now(timezone.utc).isoformat()
+            # OR IGNORE: exit_fill_ref is UNIQUE, so a crash-replayed exit books
+            # the round trip once instead of failing the cycle.
             await self._db.execute(
-                """INSERT INTO ibkr_paper_round_trips
+                """INSERT OR IGNORE INTO ibkr_paper_round_trips
                    (book, instrument_key, entry_fill_ref, exit_fill_ref, gross_pnl_usd,
                     entry_commission_usd, exit_commission_usd, net_pnl_usd,
                     opened_at)

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,20 +28,20 @@ services:
       # The dedicated live account supplies quotes only. Auramaur execution
       # remains in its local paper ledger until the independent gates above
       # are deliberately armed at graduation.
-      AURAMAUR_IBKR_ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
+      AURAMAUR_IBKR_ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-paper}
       AURAMAUR_IBKR_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__HOST: ibgateway
-      IBKR__ENABLED: ${IBKR_ENABLED:-true}
+      IBKR__ENABLED: ${IBKR_ENABLED:-false}
       IBKR__OPTIONS_ENABLED: "false"
       # Paper books reject delayed/frozen prices; request native live data.
       IBKR__MARKET_DATA_TYPE: ${IBKR_MARKET_DATA_TYPE:-1}
-      IBKR__ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-live}
+      IBKR__ENVIRONMENT: ${IBKR_QUOTE_ENVIRONMENT:-paper}
       IBKR__PAPER_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__LIVE_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__ETF_QUOTE_PORT: ${IBKR_QUOTE_PORT:-4002}
       IBKR__READONLY: "true"
       IBKR__PAPER_TRADE: "true"
-      IBKR__MULTIASSET_PAPER_ENABLED: ${IBKR_MULTIASSET_PAPER_ENABLED:-true}
+      IBKR__MULTIASSET_PAPER_ENABLED: ${IBKR_MULTIASSET_PAPER_ENABLED:-false}
       IBKR__ETF_PAPER_ENABLED: "false"
       KALSHI_PRIVATE_KEY_PATH: /run/auramaur-kalshi-private.pem
       HOME: /home/auramaur

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -218,9 +218,9 @@ cryptodotcom:
   environment: "sandbox"
 
 ibkr:
-  # Shared IBKR operational defaults remain unchanged. The ETF experiment below
-  # forces its own paper-port, read-only quote connection in code, so it cannot
-  # silently alter or arm the independently configured options/odd-lot paths.
+  # Shared IBKR operational defaults are inert. The ETF experiment below forces
+  # its own paper-port, read-only quote connection in code, so it cannot silently
+  # alter or arm the independently configured options/odd-lot paths.
   #
   # PRE-REGISTERED EXPERIMENT (2026-06-09, Phase 6 of the edge-first redesign).
   # IBKR is an experiment, not a commitment. Criteria fixed BEFORE activation
@@ -237,7 +237,9 @@ ibkr:
   # NOTE: before scaling beyond the starter budget, expose the isolated IBKR
   # ledgers through a report that calls the evidence contract above.
   # Ports: TWS 7497 paper / 7496 live; IB Gateway 4002 / 4001.
-  enabled: true
+  # Deliberate operator opt-in only. A fresh checkout must not connect to IBKR
+  # or start an experiment merely because TWS/Gateway is reachable.
+  enabled: false
   # Master switch above just connects. The two books are gated independently
   # (both also need enabled:true): options_enabled = the option-chain scanner
   # (needs OPRA data; off = no Error 200/10091 scan spam); the odd-lot
@@ -258,7 +260,7 @@ ibkr:
   paper_budget_usd: 5000.0
   # Structurally paper-only ETF book. The quote session may use a live TWS
   # login, but the API connection stays read-only and fills remain local-only.
-  etf_paper_enabled: true
+  etf_paper_enabled: false
   # TWS is logged into the live account but exposes this read-only API socket.
   etf_quote_port: 7497
   # Six isolated local paper books. TWS supplies read-only market data only.

--- a/docs/IBKR_PIPELINE.md
+++ b/docs/IBKR_PIPELINE.md
@@ -2,18 +2,19 @@
 
 The IBKR account holds real capital and two strategy families want to earn
 their way onto it. This is the ordered checklist from today's state
-(venue disabled, no API listener) to "a graduated strategy can trade it".
+(venue and experiments disabled by default) to "a graduated strategy can trade it".
 Everything below the operator steps is already built and tested.
 
-## Current state (verified 2026-07-18)
+## Tracked default state (verified 2026-07-19)
 
 - IBKR Desktop installed (~/Applications); `~/Jts` config exists from the
   June sessions; `ib_async` in the venv; equity client connects lazily
   (a down Gateway degrades gracefully, no crash loop).
-- `ibkr.enabled: false` — the venue is parked. No API port listening.
+- `ibkr.enabled: false` — Auramaur does not connect to the venue. A separately
+  launched TWS/Gateway may still listen, but no IBKR strategy task starts.
 - IBKR-bound strategies: `oddlot_tender` (paper, EDGAR-scan, manual
-  tendering by design) and the `ibkr_etf` paper experiment (#289 — ships
-  disabled; OpenAI-armed, cost-in-ledger, isolated tables).
+  tendering by design), the `ibkr_etf` paper experiment, and the multi-asset
+  paper books. All tracked strategy gates ship disabled.
 
 ## Operator steps (in order — each gates the next)
 
@@ -25,11 +26,15 @@ Everything below the operator steps is already built and tested.
    June CAD-hold and OPRA market-data subscription. Options stay off
    (`options_enabled: false`) until OPRA is active — without it the
    option scanner spams errors by design.
-3. **Enable the venue** in `config/defaults.local.yaml`:
-   `ibkr: {enabled: true}` (environment stays paper).
-4. **Smoke-test**: `python scripts/preflight_venues.py` (has an IBKR
-   probe) and, for the ETF experiment, `auramaur ibkr-etf-preflight`.
-5. Restart via `./scripts/restart_live.sh`.
+3. **Enable only the venue** in `config/defaults.local.yaml`:
+   `ibkr: {enabled: true}` (environment stays paper). In Docker, set
+   `IBKR_ENABLED=true`; do not change `IBKR_QUOTE_ENVIRONMENT` from `paper`.
+4. **Smoke-test**: `python scripts/preflight_venues.py` (has an IBKR probe),
+   then run the relevant `auramaur ibkr-etf-preflight` or
+   `auramaur ibkr-multiasset-preflight` command.
+5. **Enable exactly one paper experiment** in the local override
+   (`etf_paper_enabled: true` or `multiasset_paper_enabled: true`). For Docker,
+   use `IBKR_MULTIASSET_PAPER_ENABLED=true` only after preflight. Restart.
 
 ## The graduation paths
 

--- a/docs/ibkr-research-signals.md
+++ b/docs/ibkr-research-signals.md
@@ -1,0 +1,21 @@
+# IBKR research signal primitives
+
+`auramaur.research.ibkr_signals` contains pure research-only candidates for:
+
+- short-horizon price-shock mean reversion with a longer trend filter;
+- pre-fitted pair residual mean reversion;
+- futures curve carry confirmed by trend; and
+- FX interest-rate carry confirmed by trend.
+
+Every call requires an explicit timezone-aware `as_of`. Price observations must
+be positive, finite, strictly ordered, no later than `as_of`, and optionally no
+older than `max_age`. Pair observations must be timestamp-aligned. Futures curve
+inputs must be unexpired and expiry-ordered. Invalid or insufficient data raises
+`SignalInputError`; evaluators should treat that as **no decision**, never as
+permission to trade.
+
+The module performs no fetching, contract selection, sizing, cost modeling, or
+execution. Hedge coefficients and interest rates must be point-in-time values
+known at `as_of`. Backtests must lag revised macro data, fit pair coefficients on
+training data only, construct continuous futures without future roll knowledge,
+and apply commissions, spread, slippage, financing, borrow, and roll costs.

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -110,7 +110,9 @@ fresh BBOs, at least 21 daily bars, quote provenance, and per-book forward
 evidence. Run it during each venue's session when diagnosing BBO availability;
 closed venues are expected to lack executable quotes.
 
-Set `IBKR_MARKET_DATA_TYPE=1` in the compose environment. Values 2–4 may still
+Set `IBKR_MARKET_DATA_TYPE=1` in the compose environment. Keep
+`IBKR_QUOTE_ENVIRONMENT=paper`; using a live-account quote login is a separate,
+explicit operational review. Values 2–4 may still
 qualify contracts and expose delayed/frozen data for diagnostics, but registry
 status becomes `qualified_no_live_data` and the runtime will not open risk.
 

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -230,9 +230,8 @@ class TestIBKRConfig:
     def test_ibkr_config_defaults(self):
         from config.settings import Settings
         s = Settings()
-        # Ready-but-quiet: configured for the live port + paper-trade prep, but
-        # enabled stays false until OPRA data + funds land (~2026-06-08).
-        assert s.ibkr.enabled is True
+        # Fail-closed by default; operators explicitly enable the paper setup.
+        assert s.ibkr.enabled is False
         assert s.ibkr.environment == "paper"
         assert s.ibkr.readonly is True
         assert s.ibkr.paper_trade is True
@@ -249,6 +248,6 @@ class TestIBKRConfig:
         with open(defaults_path) as f:
             raw = yaml.safe_load(f)
 
-        assert raw["ibkr"]["enabled"] is True
+        assert raw["ibkr"]["enabled"] is False
         assert raw["ibkr"]["environment"] == "paper"
         assert raw["ibkr"]["paper_trade"] is True

--- a/tests/test_ibkr_default_safety.py
+++ b/tests/test_ibkr_default_safety.py
@@ -1,0 +1,48 @@
+"""Regression tests for deliberate, paper-only IBKR activation."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_tracked_ibkr_defaults_are_inert_and_paper_only():
+    defaults = yaml.safe_load((ROOT / "config" / "defaults.yaml").read_text())
+    ibkr = defaults["ibkr"]
+
+    assert ibkr["enabled"] is False
+    assert ibkr["environment"] == "paper"
+    assert ibkr["readonly"] is True
+    assert ibkr["paper_trade"] is True
+    assert ibkr["options_enabled"] is False
+    assert ibkr["etf_paper_enabled"] is False
+    assert ibkr["multiasset_paper_enabled"] is False
+
+
+def test_compose_ibkr_fallbacks_require_explicit_paper_activation():
+    compose = yaml.safe_load((ROOT / "compose.yaml").read_text())
+    environment = compose["services"]["auramaur"]["environment"]
+
+    assert environment["IBKR__ENABLED"] == "${IBKR_ENABLED:-false}"
+    assert environment["IBKR__ENVIRONMENT"] == "${IBKR_QUOTE_ENVIRONMENT:-paper}"
+    assert environment["AURAMAUR_IBKR_ENVIRONMENT"] == "${IBKR_QUOTE_ENVIRONMENT:-paper}"
+    assert environment["IBKR__MULTIASSET_PAPER_ENABLED"] == (
+        "${IBKR_MULTIASSET_PAPER_ENABLED:-false}"
+    )
+    assert environment["IBKR__ETF_PAPER_ENABLED"] == "false"
+    assert environment["IBKR__READONLY"] == "true"
+    assert environment["IBKR__PAPER_TRADE"] == "true"
+
+
+def test_example_environment_does_not_arm_ibkr():
+    values = {}
+    for line in (ROOT / ".env.example").read_text().splitlines():
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+
+    assert values["IBKR_ENABLED"] == "false"
+    assert values["IBKR_MULTIASSET_PAPER_ENABLED"] == "false"
+    assert values["IBKR_QUOTE_ENVIRONMENT"] == "paper"

--- a/tests/test_ibkr_etf_controls.py
+++ b/tests/test_ibkr_etf_controls.py
@@ -1,0 +1,46 @@
+import pytest
+from auramaur.strategy.ibkr_etf_controls import (
+    MomentumETFAnalyzer,
+    compare_controls,
+    completed_closes,
+    cross_sectional_winners,
+    dual_momentum_score,
+    regime_allows_risk,
+)
+
+
+def _trend(n=260, rate=0.001):
+    return [100 * (1 + rate) ** i for i in range(n)]
+
+
+def test_completed_closes_excludes_cutoff_and_future():
+    bars = [("2026-07-17", 100), ("2026-07-18", 500), ("2026-07-19", 999)]
+    assert completed_closes(bars, "2026-07-18") == [100.0]
+
+
+@pytest.mark.asyncio
+async def test_momentum_analyzer_excludes_as_of_return():
+    class Client:
+        async def get_adjusted_daily_closes(self, symbol):
+            return [
+                (f"2025-{i // 28 + 1:02d}-{i % 28 + 1:02d}", x) for i, x in enumerate(_trend(120))
+            ] + [("2026-07-19", 1.0)]
+
+    result = await MomentumETFAnalyzer().analyze_symbol(Client(), "SPY", "2026-07-19")
+    assert result is not None and result.probability == 0.70
+
+
+def test_walk_forward_and_placebo_are_stable():
+    base = _trend(180)
+    assert (
+        compare_controls(base + [base[-1] * 2]).momentum
+        > compare_controls(base + [base[-1] * 0.5]).momentum
+    )
+    assert compare_controls(base) == compare_controls(base)
+
+
+def test_research_challenger_primitives():
+    up, down = _trend(), _trend(rate=-0.001)
+    assert dual_momentum_score(up, down) > 0
+    assert cross_sectional_winners({"UP": up, "DOWN": down}, 1) == ["UP"]
+    assert regime_allows_risk(up) and not regime_allows_risk(down)

--- a/tests/test_ibkr_etf_paper.py
+++ b/tests/test_ibkr_etf_paper.py
@@ -108,7 +108,7 @@ def test_default_profile_is_small_readonly_paper_book():
     settings = Settings()
     assert {"SPY", "QQQ", "IWM", "TLT", "GLD", "VEA"}.issubset(
         settings.ibkr.etf_symbols)
-    assert settings.ibkr.etf_paper_enabled is True
+    assert settings.ibkr.etf_paper_enabled is False
     assert settings.ibkr.etf_paper_budget_usd == 5_000.0
     assert settings.ibkr.etf_max_entry_usd == 250.0
     assert settings.ibkr.etf_max_deployment_pct == 50.0

--- a/tests/test_ibkr_migrations.py
+++ b/tests/test_ibkr_migrations.py
@@ -43,7 +43,7 @@ async def test_v23_migration_adds_verified_columns(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_v27_migrates_directly_through_v29(tmp_path):
+async def test_v27_migrates_directly_through_latest(tmp_path):
     path = tmp_path / "v27.db"
     raw = sqlite3.connect(path)
     raw.executescript(
@@ -59,9 +59,34 @@ async def test_v27_migrates_directly_through_v29(tmp_path):
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kraken_paper_positions'")
     decisions = await db.fetchone(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='decision_snapshots'")
-    assert version["version"] == 29
+    assert version["version"] == SCHEMA_VERSION
     assert kraken["name"] == "kraken_paper_positions"
     assert decisions["name"] == "decision_snapshots"
+    round_trips = await db.fetchone(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='ibkr_paper_round_trips'")
+    assert round_trips["name"] == "ibkr_paper_round_trips"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v29_adds_round_trip_lineage_columns(tmp_path):
+    path = tmp_path / "v29.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(
+        """CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (29);
+        CREATE TABLE ibkr_paper_positions (
+          book TEXT, instrument_key TEXT, PRIMARY KEY (book, instrument_key));
+        """)
+    raw.close()
+    db = Database(str(path))
+    await db.connect()
+    columns = await db.fetchall("PRAGMA table_info(ibkr_paper_positions)")
+    assert {"entry_commission_usd", "entry_fill_ref"} <= {
+        row["name"] for row in columns}
+    version = await db.fetchone("SELECT version FROM schema_version")
+    assert version["version"] == SCHEMA_VERSION
     await db.close()
 
 

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -109,6 +109,36 @@ async def test_intracycle_commission_tightens_loss_gate():
 
 
 @pytest.mark.asyncio
+async def test_completed_position_records_one_net_round_trip():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    book = IBKRMultiAssetPaperBook(
+        settings, FakeMarketData(), db, IBKRBook.GLOBAL_ETF)
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    buy = MarketDataQuote(spec.key, 99.0, 100.0, time.time(), 42,
+                          spec.currency, spec.multiplier)
+    await book._fill(spec, buy, "BUY", 1, 1.0, stop_price=95,
+                     initial_risk_usd=5)
+    position = await db.fetchone(
+        "SELECT * FROM ibkr_paper_positions WHERE book='global_etf'")
+    sell = MarketDataQuote(spec.key, 110.0, 111.0, time.time(), 42,
+                           spec.currency, spec.multiplier)
+    await book._fill(spec, sell, "SELL", 1, 1.0,
+                     entry_price=float(position["avg_cost"]))
+    result = await db.fetchone("SELECT * FROM ibkr_paper_round_trips")
+    assert result is not None
+    assert result["entry_fill_ref"]
+    assert result["exit_fill_ref"] != result["entry_fill_ref"]
+    assert result["net_pnl_usd"] == pytest.approx(
+        result["gross_pnl_usd"] - result["entry_commission_usd"]
+        - result["exit_commission_usd"])
+    assert (await db.fetchone(
+        "SELECT COUNT(*) AS n FROM ibkr_paper_round_trips"))["n"] == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_asset_class_risk_cap_bounds_correlated_entries():
     db = Database(":memory:")
     await db.connect()

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -199,11 +199,38 @@ async def test_edge_evidence_is_net_of_commissions_and_financing():
         "('global_etf', 'trade', 10, 'trade-1'), "
         "('global_etf', 'commission', -1.5, 'fee-1'), "
         "('global_etf', 'financing', -0.5, 'finance-1')")
+    await db.execute(
+        """INSERT INTO ibkr_paper_round_trips
+           (book, instrument_key, exit_fill_ref, gross_pnl_usd,
+            entry_commission_usd, exit_commission_usd, financing_usd,
+            net_pnl_usd, opened_at)
+           VALUES ('global_etf', 'SPY', 'exit-1', 10, 1, .5, .5, 8,
+                   datetime('now', '-10 days'))""")
     await db.commit()
     settings = Settings()
     settings.ibkr.enabled = True
     report = await preflight(settings, db, client=ReadyClient())
     edge = next(result for result in report.results if result.book == "global_etf:edge")
-    assert "1 exits" in edge.detail
+    assert "1 cost-adjusted round trips" in edge.detail
     assert "$8.00 net P&L" in edge.detail
+    assert "not graduated" in edge.detail
+    assert "1/200 cost-adjusted observations" in edge.detail
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_edge_ignores_ambiguous_legacy_ledger_events():
+    db = Database(":memory:")
+    await db.connect()
+    await db.execute(
+        "INSERT INTO ibkr_paper_ledger (book, kind, pnl_usd, source_ref) "
+        "VALUES ('global_etf', 'trade', 999, 'legacy-trade'), "
+        "('global_etf', 'commission', -1, 'legacy-fee')")
+    await db.commit()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    report = await preflight(settings, db, client=ReadyClient())
+    edge = next(result for result in report.results if result.book == "global_etf:edge")
+    assert "0 cost-adjusted round trips" in edge.detail
+    assert "$0.00 net P&L" in edge.detail
     await db.close()

--- a/tests/test_ibkr_research_signals.py
+++ b/tests/test_ibkr_research_signals.py
@@ -1,0 +1,147 @@
+from datetime import datetime, timedelta, timezone
+import math
+
+import pytest
+
+from auramaur.research.ibkr_signals import (
+    CurvePoint,
+    PricePoint,
+    SignalInputError,
+    futures_carry_trend,
+    fx_carry_trend,
+    relative_value_residual_zscore,
+    short_term_mean_reversion,
+)
+
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def prices(values):
+    start = NOW - timedelta(days=len(values) - 1)
+    return [PricePoint(start + timedelta(days=i), value) for i, value in enumerate(values)]
+
+
+def test_short_term_mean_reversion_requires_shock_and_uptrend():
+    values = [100 + i for i in range(24)] + [118]
+    signal = short_term_mean_reversion(
+        prices(values), as_of=NOW, return_lookback=10, trend_lookback=20, entry_z=2
+    )
+    assert signal.direction == 1
+    assert signal.score >= 2
+
+
+def test_short_term_mean_reversion_trend_filter_can_leave_flat():
+    values = [100 - i for i in range(24)] + [72]
+    signal = short_term_mean_reversion(
+        prices(values), as_of=NOW, return_lookback=10, trend_lookback=20, entry_z=2
+    )
+    assert signal.direction == 0
+
+
+def test_relative_value_uses_prefit_residual_and_gives_leg_direction():
+    xs = [100 + i for i in range(21)]
+    ys = [x * (1.001 if i % 2 else 0.999) for i, x in enumerate(xs)]
+    ys[-1] = 150
+    signal = relative_value_residual_zscore(
+        prices(ys), prices(xs), as_of=NOW, hedge_beta=1, lookback=20, entry_z=2
+    )
+    assert signal.direction == -1
+    assert signal.score > 2
+
+
+def test_relative_value_rejects_misaligned_pair_timestamps():
+    left, right = prices(range(100, 106)), prices(range(100, 106))
+    right[-1] = PricePoint(right[-1].observed_at - timedelta(hours=1), right[-1].value)
+    with pytest.raises(SignalInputError, match="identical timestamps"):
+        relative_value_residual_zscore(left, right, as_of=NOW, hedge_beta=1, lookback=5)
+
+
+def test_futures_carry_and_trend_must_agree():
+    curve = [
+        CurvePoint(NOW + timedelta(days=30), 110),
+        CurvePoint(NOW + timedelta(days=120), 100),
+    ]
+    assert (
+        futures_carry_trend(curve, prices([100, 105, 110]), as_of=NOW, trend_lookback=2).direction
+        == 1
+    )
+    assert (
+        futures_carry_trend(curve, prices([110, 105, 100]), as_of=NOW, trend_lookback=2).direction
+        == 0
+    )
+
+
+def test_futures_curve_rejects_expired_contract_and_bad_price():
+    with pytest.raises(SignalInputError, match="expired"):
+        futures_carry_trend(
+            [CurvePoint(NOW, 100), CurvePoint(NOW + timedelta(days=30), 101)],
+            prices([99, 100]),
+            as_of=NOW,
+            trend_lookback=1,
+        )
+    with pytest.raises(SignalInputError, match="positive"):
+        futures_carry_trend(
+            [
+                CurvePoint(NOW + timedelta(days=1), math.nan),
+                CurvePoint(NOW + timedelta(days=30), 101),
+            ],
+            prices([99, 100]),
+            as_of=NOW,
+            trend_lookback=1,
+        )
+
+
+def test_fx_carry_and_trend_agreement_and_disagreement():
+    rising = prices([1.0, 1.05, 1.1])
+    assert (
+        fx_carry_trend(
+            rising, as_of=NOW, base_rate=0.05, quote_rate=0.02, trend_lookback=2
+        ).direction
+        == 1
+    )
+    assert (
+        fx_carry_trend(
+            rising, as_of=NOW, base_rate=0.01, quote_rate=0.04, trend_lookback=2
+        ).direction
+        == 0
+    )
+
+
+@pytest.mark.parametrize("bad_as_of", [NOW.replace(tzinfo=None)])
+def test_point_in_time_validation_rejects_naive_as_of(bad_as_of):
+    with pytest.raises(SignalInputError, match="timezone-aware"):
+        fx_carry_trend(
+            prices([1, 2]),
+            as_of=bad_as_of,
+            base_rate=0.02,
+            quote_rate=0.01,
+            trend_lookback=1,
+        )
+
+
+def test_point_in_time_validation_rejects_future_stale_and_unsorted_data():
+    with pytest.raises(SignalInputError, match="after as_of"):
+        fx_carry_trend(
+            [PricePoint(NOW, 1), PricePoint(NOW + timedelta(seconds=1), 1.1)],
+            as_of=NOW,
+            base_rate=0.02,
+            quote_rate=0.01,
+            trend_lookback=1,
+        )
+    with pytest.raises(SignalInputError, match="stale"):
+        fx_carry_trend(
+            prices([1, 1.1]),
+            as_of=NOW + timedelta(days=2),
+            base_rate=0.02,
+            quote_rate=0.01,
+            trend_lookback=1,
+            max_age=timedelta(days=1),
+        )
+    with pytest.raises(SignalInputError, match="strictly increasing"):
+        short_term_mean_reversion(
+            list(reversed(prices(range(100, 125)))),
+            as_of=NOW,
+            return_lookback=10,
+            trend_lookback=20,
+        )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -176,7 +176,9 @@ def test_yaml_defaults_safe():
     assert raw["coinbase"]["paper_enabled"] is True
 
     ibkr = raw["ibkr"]
-    assert ibkr["etf_paper_enabled"] is True
+    assert ibkr["enabled"] is False
+    assert ibkr["etf_paper_enabled"] is False
+    assert ibkr["multiasset_paper_enabled"] is False
     assert ibkr["options_enabled"] is False
     assert ibkr["auto_fx_enabled"] is False
     assert {"SPY", "QQQ", "IWM", "TLT", "GLD", "VEA"}.issubset(

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+import math
+import pytest
+from auramaur.backtest.walk_forward import (
+    StrategyObservation,
+    evaluate_strategy,
+    expanding_walk_forward,
+)
+
+
+def test_purge_overlap_and_embargo():
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    rows = [
+        {
+            "id": str(i),
+            "start": start + timedelta(days=i),
+            "end": start + timedelta(days=i + (5 if i == 2 else 0)),
+        }
+        for i in range(8)
+    ]
+    folds = expanding_walk_forward(
+        rows,
+        timestamp=lambda x: x["start"],
+        event_end=lambda x: x["end"],
+        event_key=lambda x: x["id"],
+        min_train=4,
+        test_size=2,
+        embargo=timedelta(days=1),
+    )
+    assert [x["id"] for x in folds[0].train] == ["0", "1"]
+    assert [x["id"] for x in folds[0].test] == ["4", "5"]
+
+
+def test_negative_embargo_rejected():
+    with pytest.raises(ValueError, match="embargo"):
+        expanding_walk_forward(
+            [], timestamp=lambda x: x, event_key=str, embargo=timedelta(seconds=-1)
+        )
+
+
+def test_strategy_metrics_and_edges():
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    points = [
+        StrategyObservation(start, 100, 0),
+        StrategyObservation(start + timedelta(days=1), 110, 10, 100, 50),
+        StrategyObservation(start + timedelta(days=2), 99, -11, 50, 99),
+        StrategyObservation(start + timedelta(days=3), 108.9, 9.9, 25, 54.45),
+    ]
+    result = evaluate_strategy(points, tail_probability=0.34)
+    assert result.max_drawdown == pytest.approx(0.1)
+    assert result.profit_factor == pytest.approx(19.9 / 11)
+    assert result.hit_rate == pytest.approx(0.5)
+    assert result.tail_loss == pytest.approx(0.1)
+    assert result.annualized_volatility > 0 and result.cagr is not None
+    one = evaluate_strategy([StrategyObservation(start, 100, 2)])
+    assert one.cagr is None and math.isinf(one.profit_factor)
+    with pytest.raises(ValueError, match="equity"):
+        evaluate_strategy([StrategyObservation(start, 0)])


### PR DESCRIPTION
## Summary
- make IBKR, ETF paper, and multi-asset paper experiments explicit opt-ins across tracked config, Compose, and operator docs
- add schema v30 cost-adjusted IBKR round trips with entry/exit fill lineage and use the strict 200-observation / 180-day evidence contract in preflight
- add a deterministic momentum ETF control plus cash, buy-and-hold, and seeded-placebo comparisons
- add purged/embargoed walk-forward evaluation and portfolio metrics
- add execution-free research primitives for mean reversion, relative value, futures carry+trend, and FX carry+trend

## Safety
- IBKR remains disabled by default
- multi-asset and ETF experiments remain paper-only and opt-in
- advanced signals expose no broker, sizing, or execution surface
- options and bonds remain disabled

## Verification
- combined IBKR suite: 121 passed
- full suite: 1267 passed, 2 skipped
- `python -m ruff check .`
- `git diff --check`