### PR TITLE
fix(kraken): pin the directional read to the reserved Claude slice

### DIFF
--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -223,6 +223,8 @@ class ClaudeAnalyzer:
         self,
         market: Market,
         evidence: list[NewsItem],
+        *,
+        pin_claude: bool = False,
     ) -> AnalysisResult:
         """Call Claude (primary) to estimate the probability."""
         evidence_text = format_evidence(evidence)
@@ -233,7 +235,8 @@ class ClaudeAnalyzer:
             evidence=evidence_text,
         )
 
-        raw = await self._call_llm(prompt, effort=self._settings.nlp.effort_primary)
+        raw = await self._call_llm(prompt, effort=self._settings.nlp.effort_primary,
+                                   pin_claude=pin_claude)
         parsed = _parse_claude_json(raw)
         return AnalysisResult(**parsed)
 
@@ -262,8 +265,16 @@ class ClaudeAnalyzer:
         market: Market,
         evidence: list[NewsItem],
         cache: NLPCache,
+        *,
+        pin_claude: bool = False,
     ) -> AnalysisResult:
-        """Full analysis pipeline: cache -> primary -> second opinion -> cache."""
+        """Full analysis pipeline: cache -> primary -> second opinion -> cache.
+
+        ``pin_claude=True`` pins the PRIMARY estimate to Claude against the
+        reserved budget slice (see _call_llm) — for callers whose signal is
+        worthless on fallback models (measured: the kraken directional read
+        flatlines at 0.5 on Gemini). The second opinion still routes freely.
+        """
         digest = _evidence_digest(evidence)
         cache_key = make_cache_key(market.question, digest)
 
@@ -278,7 +289,8 @@ class ClaudeAnalyzer:
         # 2. Primary estimate
         show_claude_thinking(market.id, "primary")
         try:
-            primary = await self.estimate_probability(market, evidence)
+            primary = await self.estimate_probability(
+                market, evidence, pin_claude=pin_claude)
         except Exception as e:
             log.warning("analyze.primary_failed", market_id=market.id, error=str(e))
             return AnalysisResult(

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -1042,7 +1042,13 @@ class KrakenPillar:
                     if it.id not in seen:
                         seen.add(it.id)
                         evidence.append(it)
-            analysis = await analyzer.analyze(market, evidence, cache)
+            # pin_claude: the directional read is the trial's entire signal and
+            # flatlines at 0.5 on fallback models (2026-07-19: 114/114 gate
+            # evaluations in [0.50, 0.51] while the non-reserved budget was
+            # exhausted and everything routed to Gemini). Same treatment as the
+            # resolution lens: never let bulk consumers starve it.
+            analysis = await analyzer.analyze(market, evidence, cache,
+                                              pin_claude=True)
         except Exception as e:
             log.warning("kraken.llm_view_error", pair=pair, error=str(e))
             return None

--- a/tests/test_kraken_llm_signal.py
+++ b/tests/test_kraken_llm_signal.py
@@ -88,6 +88,26 @@ def test_llm_view_returns_and_throttles():
     asyncio.run(run())
 
 
+def test_llm_view_pins_primary_to_claude():
+    """The directional read is worthless on fallback models (flatlines at 0.5),
+    so the pillar must request the pinned/reserved Claude path explicitly."""
+    agg = MagicMock()
+    agg.gather = AsyncMock(return_value=[])
+    analysis = SimpleNamespace(probability=0.61, confidence="HIGH", skipped_reason=None)
+    analyzer = MagicMock()
+    analyzer.analyze = AsyncMock(return_value=analysis)
+    bot = SimpleNamespace(_components=Components({
+        "aggregator": agg, "analyzer": analyzer, "cache": None, "calibration": None,
+    }))
+    p = _pillar(bot=bot)
+
+    async def run():
+        await p._llm_view("SOLUSDC")
+        assert analyzer.analyze.await_args.kwargs.get("pin_claude") is True
+
+    asyncio.run(run())
+
+
 def test_llm_view_unknown_pair_returns_none():
     bot = SimpleNamespace(_components=Components({}))
     p = _pillar(bot=bot)


### PR DESCRIPTION
## Summary
- The Kraken paper trial (armed Jul 18) was silently measuring fallback noise: the non-reserved Claude budget was exhausted (`150/175, paced`), every directional view routed to Gemini, and the read flatlined at 0.5 — 114/114 gate evaluations in [0.50, 0.51], so the calibrated gate correctly never fired and zero evidence accrued. The June resolution-lens postmortem documented the identical collapse and its fix: pin the signal to the reserved Claude slice.
- Thread `pin_claude` through `analyzer.analyze` → `estimate_probability` (keyword-only, default off) and request it from the kraken directional view. Second opinions still route freely; only the primary read is pinned.
- Cost: at the deployed 8h/pair refresh this is ~9 reserved calls/day; the operator config raises the refresh cadence and budget separately.

## Testing
- New test pins the contract: `_llm_view` must call `analyze(pin_claude=True)`.
- Kraken signal + gate + LLM-efficiency suites (27 tests) and ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)