### PR TITLE
feat(manager): interim manager — operator proposals, ladder-evaluated

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1556,6 +1556,10 @@ class AuramaurBot(
         if self.settings.econ_indicator.enabled:
             tasks.append(asyncio.create_task(self._task_econ_indicator(), name="econ_indicator"))
 
+        # Operator-proposed interim book management (ladder-evaluated; default off).
+        if self.settings.interim_manager.enabled:
+            tasks.append(asyncio.create_task(self._task_interim_manager(), name="interim_manager"))
+
         # Settlement-lag / known-outcome arb (FRED-first). Paper-forced; default off.
         if self.settings.settlement_arb.enabled:
             tasks.append(asyncio.create_task(self._task_settlement_arb(), name="settlement_arb"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -271,6 +271,29 @@ class StrategyTaskMixin:
                 log.error("econ_indicator.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_interim_manager(self) -> None:
+        """Operator-proposed interim entries (docs/INTERIM_MANAGER.md)."""
+        from auramaur.strategy.interim_manager import InterimManagerPillar
+
+        pillar = InterimManagerPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discoveries=self._components.discoveries,
+            exchanges=self._components.exchanges,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(60, self.settings.interim_manager.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("interim_manager.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_settlement_arb(self) -> None:
         """Settlement-lag / known-outcome arb over Polymarket econ markets,
         resolved deterministically against FRED (paper-forced, default off)."""

--- a/auramaur/cli/__init__.py
+++ b/auramaur/cli/__init__.py
@@ -12,7 +12,7 @@ from auramaur.cli._base import console, log, main  # noqa: F401
 
 # Importing these registers their commands onto `main` (side effect).
 from auramaur.cli import (  # noqa: E402,F401
-    diagnostics, intel, kraken, maintenance, redeem, reporting, run,
+    diagnostics, intel, kraken, maintenance, manager, redeem, reporting, run,
 )
 
 if __name__ == "__main__":

--- a/auramaur/cli/manager.py
+++ b/auramaur/cli/manager.py
@@ -1,0 +1,113 @@
+"""Auramaur CLI — interim-manager proposal queue (docs/INTERIM_MANAGER.md)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+from rich.table import Table
+
+from auramaur.cli._base import console, main
+from auramaur.db.database import Database
+from auramaur.runtime import db_path
+
+
+@main.group()
+def manager():
+    """Interim-manager proposals: manual entries, ladder-evaluated."""
+
+
+async def _db() -> Database:
+    db = Database(str(db_path()))
+    await db.connect()
+    return db
+
+
+@manager.command()
+@click.option("--venue", type=click.Choice(["polymarket", "kalshi"]), required=True)
+@click.option("--market", "market_id", required=True, help="Market id / ticker.")
+@click.option("--side", type=click.Choice(["buy", "sell"]), required=True)
+@click.option("--fair-prob", type=click.FloatRange(0.01, 0.99), required=True,
+              help="Your calibrated fair probability for YES.")
+@click.option("--stake", type=click.FloatRange(1.0, 25.0), default=10.0,
+              show_default=True, help="Stake in USD (risk sizing may shrink it).")
+@click.option("--thesis", required=True,
+              help="The nameable mispricing mechanism (charter rule 1; >= 40 chars).")
+def propose(venue: str, market_id: str, side: str, fair_prob: float,
+            stake: float, thesis: str) -> None:
+    """Queue a proposal. The pillar executes it only after the charter rules,
+    the full risk gateway, and the graduation ladder (paper-forced until the
+    manager earns live)."""
+    if len(thesis.strip()) < 40:
+        console.print("[red]Thesis too short — name the mispricing mechanism "
+                      "(charter rule 1; >= 40 chars).[/]")
+        raise SystemExit(1)
+
+    async def run() -> None:
+        db = await _db()
+        try:
+            await db.execute(
+                """INSERT INTO manager_proposals
+                   (venue, market_id, side, fair_prob, stake_usd, thesis)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (venue, market_id, side.upper(), fair_prob, stake, thesis.strip()))
+            await db.commit()
+            row = await db.fetchone("SELECT last_insert_rowid() AS id")
+            console.print(f"[green]Proposal {row['id']} queued[/] — "
+                          f"{side.upper()} {market_id} on {venue} "
+                          f"(fair {fair_prob:.2f}, ${stake:.2f}).")
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+@manager.command("list")
+@click.option("--all", "show_all", is_flag=True, help="Include decided proposals.")
+def list_proposals(show_all: bool) -> None:
+    """Show the proposal queue and its decisions (the audit log)."""
+
+    async def run() -> None:
+        db = await _db()
+        try:
+            where = "" if show_all else "WHERE status = 'pending'"
+            rows = await db.fetchall(
+                f"SELECT * FROM manager_proposals {where} "
+                "ORDER BY created_at DESC LIMIT 50")
+            table = Table(title="interim-manager proposals")
+            for col in ("id", "venue", "market", "side", "fair", "stake",
+                        "status", "reason", "created"):
+                table.add_column(col)
+            for r in rows or []:
+                table.add_row(str(r["id"]), r["venue"], r["market_id"], r["side"],
+                              f"{r['fair_prob']:.2f}", f"{r['stake_usd']:.2f}",
+                              r["status"], (r["reason"] or "")[:50],
+                              str(r["created_at"])[:16])
+            console.print(table)
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+@manager.command()
+@click.argument("proposal_id", type=int)
+def cancel(proposal_id: int) -> None:
+    """Cancel a pending proposal."""
+
+    async def run() -> None:
+        db = await _db()
+        try:
+            cur = await db.execute(
+                """UPDATE manager_proposals SET status = 'cancelled',
+                   reason = 'operator cancel', decided_at = datetime('now')
+                   WHERE id = ? AND status = 'pending'""", (proposal_id,))
+            await db.commit()
+            if cur.rowcount:
+                console.print(f"[yellow]Proposal {proposal_id} cancelled.[/]")
+            else:
+                console.print(f"[red]No pending proposal {proposal_id}.[/]")
+        finally:
+            await db.close()
+
+    asyncio.run(run())

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -122,6 +122,8 @@ class Database:
             await self._migrate_v28_to_v29()
         if from_version < 30:
             await self._migrate_v29_to_v30()
+        if from_version < 31:
+            await self._migrate_v30_to_v31()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -157,6 +159,29 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 30")
         await self._db.commit()
         log.info("database.migrated", from_version=29, to_version=30)
+
+    async def _migrate_v30_to_v31(self) -> None:
+        """Add the interim-manager proposal queue."""
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS manager_proposals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venue TEXT NOT NULL,
+                market_id TEXT NOT NULL,
+                side TEXT NOT NULL,
+                fair_prob REAL NOT NULL,
+                stake_usd REAL NOT NULL,
+                thesis TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'pending',
+                reason TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                decided_at TEXT
+            )""")
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_proposals_status "
+            "ON manager_proposals(status, created_at)")
+        await self._db.execute("UPDATE schema_version SET version = 31")
+        await self._db.commit()
+        log.info("database.migrated", from_version=30, to_version=31)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 30
+SCHEMA_VERSION = 31
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -749,6 +749,24 @@ CREATE TABLE IF NOT EXISTS kalshi_execution_samples (
 );
 CREATE INDEX IF NOT EXISTS idx_kalshi_execution_samples_market_time
     ON kalshi_execution_samples(market_id, observed_at);
+
+-- Interim-manager proposal queue: operator-proposed entries awaiting the
+-- pillar's charter/risk/ladder gauntlet. Terminal rows are the audit log.
+CREATE TABLE IF NOT EXISTS manager_proposals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    venue TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    side TEXT NOT NULL,
+    fair_prob REAL NOT NULL,
+    stake_usd REAL NOT NULL,
+    thesis TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',
+    reason TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    decided_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_manager_proposals_status
+    ON manager_proposals(status, created_at);
 
 CREATE TABLE IF NOT EXISTS redemptions (
     condition_id TEXT PRIMARY KEY,

--- a/auramaur/strategy/interim_manager.py
+++ b/auramaur/strategy/interim_manager.py
@@ -1,0 +1,222 @@
+"""Interim manager — operator-proposed entries, ladder-evaluated.
+
+The disciplined channel for manual balance deployment while the strategy
+book earns its graduation records (docs/INTERIM_MANAGER.md is the charter).
+Proposals arrive via ``auramaur manager propose``; this pillar validates
+each one against the charter's mechanical rules, the risk gateway, and the
+graduation ladder, then executes and books it under
+``strategy_source = "interim_manager"`` so the ladder judges the manager
+like any other strategy.
+
+Two rules make it self-retiring:
+
+  * DELEGATION — a category where any non-exempt strategy holds a live or
+    probation cell belongs to that strategy; manager proposals there are
+    skipped permanently.
+  * SUNSET — once ``sunset_after_live_cells`` non-exempt strategy cells have
+    graduated, the manager stops executing and expires its queue.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.exchange.models import Confidence, OrderSide, Signal
+from auramaur.risk.graduation import GraduationLadder
+from auramaur.strategy.classifier import ensure_category
+from auramaur.strategy.protocols import ExecutionMode
+
+log = structlog.get_logger()
+
+_GRADUATED = {"live", "probation"}
+_MIN_THESIS_CHARS = 40
+
+
+class InterimManagerPillar:
+    """Executes queued operator proposals through the standard rails."""
+
+    name = "interim_manager"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
+
+    def __init__(self, db, settings, discoveries, exchanges,
+                 risk_manager, pnl_tracker, calibration) -> None:
+        self._db = db
+        self._settings = settings
+        self._discoveries = discoveries or {}
+        self._exchanges = exchanges or {}
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._ladder = GraduationLadder(db, settings)
+        self._gateways: dict[str, ExecutionGateway] = {}
+
+    def _gateway(self, venue: str) -> ExecutionGateway | None:
+        if venue not in self._gateways:
+            exchange = self._exchanges.get(venue)
+            if exchange is None:
+                return None
+            self._gateways[venue] = ExecutionGateway(
+                router=None, exchange=exchange, exchange_name=venue,
+                settings=self._settings, db=self._db, pnl_tracker=self._pnl,
+            )
+        return self._gateways.get(venue)
+
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> int:
+        cfg = self._settings.interim_manager
+        if not cfg.enabled:
+            return 0
+
+        graduated = await self._graduated_cells()
+        if len(graduated) >= cfg.sunset_after_live_cells:
+            await self._expire_pending(
+                f"sunset: {len(graduated)} graduated strategy cells")
+            log.info("interim_manager.sunset", graduated=len(graduated))
+            return 0
+
+        owned_categories = {category: strategy
+                           for strategy, category in graduated}
+        pending = await self._db.fetchall(
+            """SELECT * FROM manager_proposals WHERE status = 'pending'
+               ORDER BY created_at LIMIT ?""",
+            (max(1, cfg.max_entries_per_cycle),))
+        executed = 0
+        for row in pending or []:
+            try:
+                if await self._decide_one(dict(row), owned_categories):
+                    executed += 1
+            except Exception as e:  # noqa: BLE001 — one proposal must not kill the cycle
+                log.error("interim_manager.proposal_error",
+                          proposal_id=row["id"], error=str(e))
+                await self._resolve(row["id"], "skipped", f"error: {e}"[:200])
+        return executed
+
+    async def _graduated_cells(self) -> list[tuple[str, str]]:
+        """(strategy, category) pairs holding live/probation cells, excluding
+        exempt strategies and the manager itself."""
+        exempt = set(self._settings.graduation.exempt_strategies) | {self.name}
+        cells = []
+        for cell in await self._ladder.report():
+            status = str(cell.get("status", ""))
+            # observe-mode statuses look like "observe:<status>".
+            status = status.split(":", 1)[-1] if ":" in status else status
+            if status in _GRADUATED and cell.get("strategy") not in exempt:
+                cells.append((cell["strategy"], cell.get("category") or ""))
+        return cells
+
+    # ------------------------------------------------------------------
+
+    async def _decide_one(self, p: dict, owned: dict[str, str]) -> bool:
+        cfg = self._settings.interim_manager
+        pid = p["id"]
+
+        created = self._parse_ts(p.get("created_at"))
+        if created is not None and datetime.now(timezone.utc) - created > timedelta(
+                hours=cfg.proposal_ttl_hours):
+            await self._resolve(pid, "expired", "proposal ttl elapsed")
+            return False
+
+        thesis = (p.get("thesis") or "").strip()
+        if len(thesis) < _MIN_THESIS_CHARS:
+            await self._resolve(pid, "skipped",
+                                "charter: no nameable mispricing mechanism")
+            return False
+
+        venue = p["venue"]
+        discovery = self._discoveries.get(venue)
+        gateway = self._gateway(venue)
+        if discovery is None or gateway is None:
+            await self._resolve(pid, "skipped", f"venue {venue} not composed")
+            return False
+
+        market = await discovery.get_market(p["market_id"])
+        if market is None or not (0.0 < market.outcome_yes_price < 1.0):
+            await self._resolve(pid, "skipped", "market missing or no live mid")
+            return False
+
+        category = ensure_category(market.question, market.description,
+                                   market.category)
+        if category in owned:
+            await self._resolve(pid, "skipped", f"delegated to {owned[category]}")
+            return False
+
+        open_now = await self._open_positions()
+        if open_now >= cfg.max_open_positions:
+            log.info("interim_manager.position_cap", open=open_now)
+            return False  # stays pending; retried next cycle
+
+        side = OrderSide.BUY if str(p["side"]).upper() == "BUY" else OrderSide.SELL
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=max(0.01, min(0.99, float(p["fair_prob"]))),
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=market.outcome_yes_price,
+            edge=abs(float(p["fair_prob"]) - market.outcome_yes_price) * 100.0,
+            evidence_summary=f"[interim_manager proposal {pid}] {thesis}"[:500],
+            recommended_side=side,
+            strategy_source=self.name,
+        )
+        decision = await self._risk.evaluate(signal, market)
+        if not decision.approved or decision.position_size <= 0:
+            await self._resolve(pid, "skipped", f"risk: {decision.reason}"[:200])
+            return False
+
+        size = min(decision.position_size, cfg.stake_usd, float(p["stake_usd"]))
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        res = await gateway.submit(TradeIntent(
+            signal=signal, market=market, size_dollars=size,
+            force_paper=force_paper))
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            await self._resolve(pid, "skipped", f"order: {res.reason}"[:200])
+            return False
+
+        await self._resolve(pid, "executed",
+                            f"{'paper' if res.result.is_paper else 'LIVE'} "
+                            f"${size:.2f} @ {res.order.price}")
+        log.info("interim_manager.entered", proposal_id=pid,
+                 market_id=market.id, side=side.value, size=size,
+                 paper=res.result.is_paper)
+        try:
+            await self._calibration.record_prediction(
+                market.id, signal.claude_prob, category)
+        except Exception as e:  # noqa: BLE001 — bookkeeping only
+            log.debug("interim_manager.calibration_error", error=str(e))
+        return True
+
+    # ------------------------------------------------------------------
+
+    async def _open_positions(self) -> int:
+        row = await self._db.fetchone(
+            """SELECT COUNT(DISTINCT s.market_id) AS n FROM signals s
+               JOIN portfolio p ON p.market_id = s.market_id AND p.size > 0
+               WHERE s.strategy_source = ?""", (self.name,))
+        return int(row["n"] or 0) if row else 0
+
+    async def _expire_pending(self, reason: str) -> None:
+        await self._db.execute(
+            """UPDATE manager_proposals SET status = 'expired', reason = ?,
+               decided_at = datetime('now') WHERE status = 'pending'""",
+            (reason,))
+        await self._db.commit()
+
+    async def _resolve(self, proposal_id: int, status: str, reason: str) -> None:
+        await self._db.execute(
+            """UPDATE manager_proposals SET status = ?, reason = ?,
+               decided_at = datetime('now') WHERE id = ?""",
+            (status, reason, proposal_id))
+        await self._db.commit()
+
+    @staticmethod
+    def _parse_ts(raw) -> datetime | None:
+        if not raw:
+            return None
+        try:
+            ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -549,6 +549,23 @@ entailment_arb:
   # per-series; violations must clear BOTH legs' Kalshi taker fees + buffer.
   kalshi_ladders_enabled: true
 
+interim_manager:
+  # Operator-proposed interim book management (docs/INTERIM_MANAGER.md).
+  # The disciplined channel for deploying idle balance while strategies earn
+  # graduation: proposals via `auramaur manager propose`, executed only after
+  # the charter rules, full risk gateway, and the graduation ladder (which
+  # paper-forces the manager until it earns live like everyone else).
+  # Delegates per category to graduated cells; sunsets once
+  # sunset_after_live_cells non-exempt strategy cells are live/probation.
+  enabled: false
+  paper: true
+  interval_seconds: 900
+  stake_usd: 10.0
+  max_entries_per_cycle: 2
+  max_open_positions: 10
+  proposal_ttl_hours: 48.0
+  sunset_after_live_cells: 3
+
 econ_indicator:
   # Data-driven Kalshi econ-indicator bin pricing: price "Above X" ladders from
   # FRED history (random-walk nowcast + change-vol, sigma floored), trade bins

--- a/config/settings.py
+++ b/config/settings.py
@@ -694,6 +694,25 @@ class VolAnchorConfig(BaseModel):
     exclude_categories: list[str] = []
 
 
+class InterimManagerConfig(BaseModel):
+    """Operator-proposed interim book management (strategy/interim_manager.py).
+
+    Disabled and paper-forced by default; the graduation ladder additionally
+    paper-forces unproven cells regardless. Delegates per category to any
+    graduated strategy cell and sunsets outright once enough cells graduate.
+    See docs/INTERIM_MANAGER.md for the charter and evaluation contract.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    interval_seconds: int = 900
+    stake_usd: float = 10.0
+    max_entries_per_cycle: int = 2
+    max_open_positions: int = 10
+    proposal_ttl_hours: float = 48.0
+    sunset_after_live_cells: int = 3
+
+
 class EconIndicatorConfig(BaseModel):
     """Data-driven Kalshi economic-indicator bin pricing (strategy/econ_indicator.py).
 
@@ -1586,6 +1605,7 @@ class Settings(BaseSettings):
             **_DEFAULTS.get("information_graduation", {})))
     entailment_arb: EntailmentArbConfig = Field(default_factory=lambda: EntailmentArbConfig(**_DEFAULTS.get("entailment_arb", {})))
     cross_venue_arb: CrossVenueArbConfig = Field(default_factory=lambda: CrossVenueArbConfig(**_DEFAULTS.get("cross_venue_arb", {})))
+    interim_manager: InterimManagerConfig = Field(default_factory=lambda: InterimManagerConfig(**_DEFAULTS.get("interim_manager", {})))
     econ_indicator: EconIndicatorConfig = Field(default_factory=lambda: EconIndicatorConfig(**_DEFAULTS.get("econ_indicator", {})))
     long_horizon: LongHorizonConfig = Field(default_factory=lambda: LongHorizonConfig(**_DEFAULTS.get("long_horizon", {})))
     agent_trader: AgentTraderConfig = Field(default_factory=lambda: AgentTraderConfig(**_DEFAULTS.get("agent_trader", {})))

--- a/docs/INTERIM_MANAGER.md
+++ b/docs/INTERIM_MANAGER.md
@@ -1,0 +1,97 @@
+# Interim manager — operator-proposed book management, ladder-evaluated
+
+The graduation ladder correctly paper-forces nearly every strategy while it
+earns its record, which leaves live balance idle in the interim. The interim
+manager is the disciplined channel for deploying that balance **manually**
+(operator or assistant sessions) without abandoning measurement: every
+proposal passes the same gauntlet as any strategy entry, books under its own
+`strategy_source`, and the ladder judges the manager exactly like the
+strategies it stands in for. It is scaffolding with a demolition date built
+in.
+
+## What it is
+
+A proposal queue plus a pillar. `auramaur manager propose` records a manual
+trade thesis; the pillar validates each pending proposal against the charter
+rules below, the risk gateway (all checks), and the graduation ladder (which
+paper-forces the manager until IT has earned live), then executes and books
+it under `strategy_source = "interim_manager"`. No autonomous signal
+generation, no LLM budget consumption, no exemptions.
+
+## The charter — accumulated learnings this manager must obey
+
+Distilled from the project ledger and incidents through 2026-07-19. The
+mechanical rules below are enforced in code; the judgment rules bind whoever
+writes proposals.
+
+1. **No nameable mispricing mechanism, no trade.** Unexplained disagreement
+   with the market defers to the market. Enforced: a proposal must carry a
+   thesis of substance, and the thesis is stored immutably beside the fill
+   for post-mortem.
+2. **Raw model probabilities are compressed and mis-centered.** Six weeks of
+   Kraken reads lived in [0.42, 0.56] while resolving 29 points wide; the
+   calibrated view, not the raw number, is what a probability means.
+   Judgment rule: state fair value AFTER calibration awareness, not model
+   output verbatim.
+3. **A neutral read from a degraded model is absence of signal, not signal.**
+   The 2026-07-19 Gemini-fallback incident produced 114 consecutive 0.5
+   reads; the June resolution-lens collapse was the same failure. Never
+   propose on analysis produced by fallback routing.
+4. **Fees and executable depth decide marginal trades.** Settlement fees,
+   taker fees on both venues, deci-cent tick structures, and thin books all
+   materially changed recorded P&L this quarter. Enforced: the risk gateway's
+   fee-cleared edge requirement and depth-capped sizing apply to every
+   proposal; small notionals in thin books.
+5. **Mid-band divergence is adverse selection.** The 10–20% divergence bucket
+   realized −$5.90/market at 22% win; strong divergence with high confidence
+   or no trade.
+6. **Respect the ledger's category verdicts.** Do not re-fight a category a
+   strategy has already proven negative in with the same class of reasoning
+   (news_speed, technical momentum, weather_temp were all retired on
+   evidence). The ledger outranks conviction.
+7. **Long-dated markets are unresearchable; very short-dated leave no time to
+   be right.** The engine's resolution-window filters exist for measured
+   reasons; proposals inherit them via the risk gateway.
+8. **Venue truth outranks local assumption.** Positions are what the venue
+   snapshot says; fills are what the venue confirms; a pending order is not
+   a position. Reconcile before acting on state.
+9. **Size for information while unproven.** Until the manager's own cells
+   graduate, stakes are evidence-gathering stakes (config-capped), not
+   P&L-maximizing stakes.
+
+## Evaluation contract (pre-registered)
+
+- `strategy_source = "interim_manager"`; **not** in `exempt_strategies` — the
+  ladder paper-forces it until each (manager × category) cell clears the same
+  bar as everyone: `min_markets` independent markets in the window with a
+  positive mean-P&L lower confidence bound. No special thresholds.
+- Proposals the pillar skips (delegation, sunset, thesis, expiry, risk
+  rejection) are recorded with their reason — the queue is an auditable
+  decision log, not just an order channel.
+- Review cadence: alongside the normal graduation review. The manager's
+  record is compared per category against the strategies it stands in for;
+  if a manager cell and a strategy cell both hold records in a category, the
+  strategy's takes precedence at equal evidence.
+
+## Delegation and sunset (enforced in code)
+
+- **Delegation:** before executing any proposal, the pillar checks the
+  ladder report. If ANY non-exempt strategy other than the manager holds a
+  `live` or `probation` cell in the proposal's category, the proposal is
+  skipped with reason `delegated to <strategy>` — the graduate owns the
+  category, and the manager stands down there permanently.
+- **Sunset:** when the number of graduated (live/probation) non-exempt
+  strategy cells reaches `sunset_after_live_cells`, the manager stops
+  executing entirely and expires its queue. The interim is over; the
+  strategies have the book.
+- Open positions are never stranded by either rule: exits flow through the
+  engine's position-based exit paths, which the ladder never touches.
+
+## Configuration
+
+`interim_manager` in config (tracked default `enabled: false`; arm it in the
+operator's `defaults.local.yaml` with the usual dated rationale block):
+`stake_usd` per-proposal cap, `max_entries_per_cycle`, `max_open_positions`,
+`proposal_ttl_hours`, `sunset_after_live_cells`, `interval_seconds`, and
+`paper` (tracked default `true`; the ladder additionally paper-forces
+unproven cells regardless).

--- a/tests/test_interim_manager.py
+++ b/tests/test_interim_manager.py
@@ -1,0 +1,152 @@
+"""Interim manager: charter rules, delegation, sunset, and ladder humility."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market
+from auramaur.strategy.interim_manager import InterimManagerPillar
+from config.settings import Settings
+
+THESIS = ("Resolution fine print prices NO events as YES; venue mid ignores "
+          "the settlement source's published revision schedule.")
+
+
+def _market(mid="M1", price=0.40, category="economics"):
+    return Market(id=mid, question="Will X happen?", description="",
+                  category=category, outcome_yes_price=price,
+                  outcome_no_price=1 - price, volume=1000, liquidity=500,
+                  exchange="kalshi")
+
+
+async def _pillar(tmp_proposals=(), ladder_cells=(), risk_approves=True):
+    db = Database(":memory:")
+    await db.connect()
+    for p in tmp_proposals:
+        await db.execute(
+            """INSERT INTO manager_proposals
+               (venue, market_id, side, fair_prob, stake_usd, thesis, status)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending')""", p)
+    await db.commit()
+
+    settings = Settings()
+    settings.interim_manager.enabled = True
+
+    discovery = MagicMock()
+    discovery.get_market = AsyncMock(return_value=_market())
+    exchange = MagicMock()
+    risk = MagicMock()
+    risk.evaluate = AsyncMock(return_value=SimpleNamespace(
+        approved=risk_approves, position_size=10.0, reason="",
+        force_paper=True))
+    calibration = MagicMock()
+    calibration.record_prediction = AsyncMock()
+
+    pillar = InterimManagerPillar(
+        db=db, settings=settings,
+        discoveries={"kalshi": discovery}, exchanges={"kalshi": exchange},
+        risk_manager=risk, pnl_tracker=None, calibration=calibration)
+    pillar._ladder = MagicMock()
+    pillar._ladder.report = AsyncMock(return_value=list(ladder_cells))
+
+    order = SimpleNamespace(price=0.41, market_id="M1",
+                            token=SimpleNamespace(value="YES"))
+    result = SimpleNamespace(is_paper=True, filled_size=10.0, filled_price=0.41)
+    gateway = MagicMock()
+    gateway.submit = AsyncMock(return_value=SimpleNamespace(
+        status="paper", order=order, result=result, reason=""))
+    pillar._gateways = {"kalshi": gateway}
+    return pillar, db, gateway, risk
+
+
+PROPOSAL = ("kalshi", "M1", "BUY", 0.55, 10.0, THESIS)
+
+
+def test_executes_valid_proposal_paper_forced():
+    async def run():
+        pillar, db, gateway, risk = await _pillar(tmp_proposals=[PROPOSAL])
+        assert await pillar.run_once() == 1
+        intent = gateway.submit.await_args.args[0]
+        assert intent.signal.strategy_source == "interim_manager"
+        assert intent.force_paper is True
+        row = await db.fetchone("SELECT status FROM manager_proposals")
+        assert row["status"] == "executed"
+        await db.close()
+    asyncio.run(run())
+
+
+def test_thin_thesis_is_skipped_by_charter():
+    async def run():
+        pillar, db, gateway, _ = await _pillar(
+            tmp_proposals=[("kalshi", "M1", "BUY", 0.55, 10.0, "just vibes")])
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "skipped"
+        assert "mechanism" in row["reason"]
+        await db.close()
+    asyncio.run(run())
+
+
+def test_delegates_category_to_graduated_strategy_cell():
+    async def run():
+        pillar, db, gateway, _ = await _pillar(
+            tmp_proposals=[PROPOSAL],
+            ladder_cells=[{"strategy": "econ_indicator",
+                           "category": "economics", "status": "probation"}])
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "skipped"
+        assert "delegated to econ_indicator" in row["reason"]
+        await db.close()
+    asyncio.run(run())
+
+
+def test_exempt_strategies_do_not_trigger_delegation_or_sunset():
+    async def run():
+        pillar, db, gateway, _ = await _pillar(
+            tmp_proposals=[PROPOSAL],
+            ladder_cells=[{"strategy": "arbitrage", "category": "economics",
+                           "status": "live"},
+                          {"strategy": "market_maker", "category": "economics",
+                           "status": "live"}])
+        assert await pillar.run_once() == 1
+        await db.close()
+    asyncio.run(run())
+
+
+def test_sunset_expires_queue_once_enough_cells_graduate():
+    async def run():
+        cells = [{"strategy": f"s{i}", "category": f"c{i}", "status": "live"}
+                 for i in range(3)]
+        pillar, db, gateway, _ = await _pillar(
+            tmp_proposals=[PROPOSAL], ladder_cells=cells)
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "expired"
+        assert "sunset" in row["reason"]
+        await db.close()
+    asyncio.run(run())
+
+
+def test_risk_rejection_is_recorded_not_silently_dropped():
+    async def run():
+        pillar, db, gateway, risk = await _pillar(
+            tmp_proposals=[PROPOSAL], risk_approves=False)
+        assert await pillar.run_once() == 0
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "skipped"
+        assert row["reason"].startswith("risk:")
+        await db.close()
+    asyncio.run(run())
+
+
+def test_disabled_by_default_in_tracked_config():
+    s = Settings()
+    assert s.interim_manager.enabled is False
+    assert s.interim_manager.paper is True
+    assert "interim_manager" not in set(s.graduation.exempt_strategies)


### PR DESCRIPTION
## Summary
- **What**: a disciplined channel for manually deploying the idle live balance while the strategy book earns graduation — a proposal queue (`auramaur manager propose / list / cancel`) plus a pillar that executes each proposal only after (1) the charter''s mechanical rules, (2) the full risk gateway, and (3) the graduation ladder, booking under `strategy_source = "interim_manager"`.
- **Evaluated like everyone**: not in `exempt_strategies`; the ladder paper-forces the manager until its own cells clear the `min_markets`/positive-LCB bar. Skipped proposals are recorded with reasons — the queue doubles as an auditable decision log.
- **Self-retiring**: per-category **delegation** (a live/probation cell by any non-exempt strategy owns the category; manager proposals there are skipped as `delegated to <strategy>`) and **sunset** (once `sunset_after_live_cells` non-exempt cells graduate, the queue expires and the manager stops).
- **Charter** (`docs/INTERIM_MANAGER.md`) distills the accumulated project learnings: no nameable mispricing mechanism → no trade (enforced: thesis required); calibrated views over raw model output; fallback-model neutrality is absence of signal; fees/depth decide marginal trades; mid-band divergence is adverse selection; the ledger''s category verdicts outrank conviction; venue truth over local assumption; size for information while unproven.
- Schema v31: `manager_proposals` + migration with direct coverage. Tracked defaults: `enabled: false`, `paper: true`.

## Safety
- No new live authority: triple gate, kill switch, risk gateway, and ladder all unchanged and all upstream of every proposal.
- Zero LLM budget consumption — proposals are operator-authored; the pillar is purely mechanical.
- Disabled by default; arming is an explicit operator override in `defaults.local.yaml`.

## Testing
- 7 new tests: execute-through-gauntlet (paper-forced, correct strategy_source), thin-thesis charter rejection, delegation to a graduated cell, exempt strategies neither delegate nor sunset, sunset queue expiry, risk-rejection audit trail, disabled-by-default contract.
- Full local run: interim-manager + triple-gate + settings + migrations (56 tests) and `ruff check .` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)