### PR TITLE
feat(manager): thesis compiler — structured proposals + robust-edge gate

### DIFF
--- a/auramaur/cli/manager.py
+++ b/auramaur/cli/manager.py
@@ -33,8 +33,28 @@ async def _db() -> Database:
               show_default=True, help="Stake in USD (risk sizing may shrink it).")
 @click.option("--thesis", required=True,
               help="The nameable mispricing mechanism (charter rule 1; >= 40 chars).")
+@click.option("--thesis-class", "thesis_class",
+              type=click.Choice(["forecast_divergence", "cross_venue",
+                                 "conditional_inconsistency", "timeline",
+                                 "base_rate", "resolution_language",
+                                 "information_lag", "exclusive_basket",
+                                 "unclassified"]),
+              default="unclassified", show_default=True,
+              help="Which anchor class the thesis belongs to (evaluated per class).")
+@click.option("--ci", default=None,
+              help="Fair-probability confidence interval, e.g. 0.33,0.47 "
+                   "(half-width becomes the uncertainty haircut).")
+@click.option("--max-entry", "max_entry", type=click.FloatRange(0.01, 0.99),
+              default=None, help="Max price PAID for the side taken; protects the edge.")
+@click.option("--catalyst", default="", help="What resolves or closes the gap.")
+@click.option("--invalidation", default="",
+              help="Observable condition that kills the thesis.")
+@click.option("--sunset", default=None,
+              help="ISO time after which the thesis is stale, e.g. 2026-07-20T12:00Z.")
 def propose(venue: str, market_id: str, side: str, fair_prob: float,
-            stake: float, thesis: str) -> None:
+            stake: float, thesis: str, thesis_class: str, ci: str | None,
+            max_entry: float | None, catalyst: str, invalidation: str,
+            sunset: str | None) -> None:
     """Queue a proposal. The pillar executes it only after the charter rules,
     the full risk gateway, and the graduation ladder (paper-forced until the
     manager earns live)."""
@@ -42,20 +62,45 @@ def propose(venue: str, market_id: str, side: str, fair_prob: float,
         console.print("[red]Thesis too short — name the mispricing mechanism "
                       "(charter rule 1; >= 40 chars).[/]")
         raise SystemExit(1)
+    lo = hi = None
+    if ci:
+        try:
+            lo, hi = (float(x) for x in ci.split(","))
+        except ValueError:
+            console.print("[red]--ci must be 'lo,hi', e.g. 0.33,0.47[/]")
+            raise SystemExit(1) from None
+        if not (0.0 < lo <= fair_prob <= hi < 1.0):
+            console.print("[red]--ci must bracket --fair-prob inside (0, 1).[/]")
+            raise SystemExit(1)
+    if sunset:
+        from datetime import datetime
+        try:
+            datetime.fromisoformat(sunset.replace("Z", "+00:00"))
+        except ValueError:
+            console.print("[red]--sunset must be ISO 8601, e.g. 2026-07-20T12:00Z[/]")
+            raise SystemExit(1) from None
 
     async def run() -> None:
         db = await _db()
         try:
             await db.execute(
                 """INSERT INTO manager_proposals
-                   (venue, market_id, side, fair_prob, stake_usd, thesis)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (venue, market_id, side.upper(), fair_prob, stake, thesis.strip()))
+                   (venue, market_id, side, fair_prob, stake_usd, thesis,
+                    thesis_class, confidence_lo, confidence_hi, max_entry_price,
+                    catalyst, invalidation, sunset_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (venue, market_id, side.upper(), fair_prob, stake, thesis.strip(),
+                 thesis_class, lo, hi, max_entry, catalyst.strip(),
+                 invalidation.strip(),
+                 sunset.replace("Z", "+00:00") if sunset else None))
             await db.commit()
             row = await db.fetchone("SELECT last_insert_rowid() AS id")
             console.print(f"[green]Proposal {row['id']} queued[/] — "
                           f"{side.upper()} {market_id} on {venue} "
-                          f"(fair {fair_prob:.2f}, ${stake:.2f}).")
+                          f"(fair {fair_prob:.2f}, class {thesis_class}, "
+                          f"${stake:.2f}"
+                          + (f", limit {max_entry:.2f}" if max_entry else "")
+                          + ").")
         finally:
             await db.close()
 
@@ -107,6 +152,45 @@ def cancel(proposal_id: int) -> None:
                 console.print(f"[yellow]Proposal {proposal_id} cancelled.[/]")
             else:
                 console.print(f"[red]No pending proposal {proposal_id}.[/]")
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+@manager.command()
+def report() -> None:
+    """Per-thesis-class scorecard: was the reasoning good, not just the P&L?"""
+
+    async def run() -> None:
+        db = await _db()
+        try:
+            rows = await db.fetchall(
+                """SELECT mp.thesis_class AS cls,
+                          COUNT(*) AS proposals,
+                          SUM(mp.status = 'executed') AS executed,
+                          SUM(mp.status = 'skipped') AS skipped,
+                          AVG(mp.robust_edge) AS avg_edge,
+                          COALESCE(SUM(led.pnl), 0) AS realized
+                     FROM manager_proposals mp
+                     LEFT JOIN pnl_ledger led
+                       ON led.market_id = mp.market_id
+                      AND led.strategy_source = 'interim_manager'
+                    GROUP BY mp.thesis_class ORDER BY proposals DESC""")
+            table = Table(title="interim-manager scorecard (by thesis class)")
+            for col in ("class", "proposals", "executed", "skipped",
+                        "avg robust edge", "realized P&L"):
+                table.add_column(col)
+            for r in rows or []:
+                table.add_row(r["cls"], str(r["proposals"]), str(r["executed"] or 0),
+                              str(r["skipped"] or 0),
+                              f"{(r['avg_edge'] or 0):+.3f}",
+                              f"${(r['realized'] or 0):+.2f}")
+            console.print(table)
+            console.print(
+                "[dim]Full audit per proposal: manager list --all. Calibration "
+                "of fair-prob vs outcomes: the standard calibration report "
+                "(predictions are recorded per executed proposal).[/]")
         finally:
             await db.close()
 

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -124,6 +124,8 @@ class Database:
             await self._migrate_v29_to_v30()
         if from_version < 31:
             await self._migrate_v30_to_v31()
+        if from_version < 32:
+            await self._migrate_v31_to_v32()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -182,6 +184,27 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 31")
         await self._db.commit()
         log.info("database.migrated", from_version=30, to_version=31)
+
+    async def _migrate_v31_to_v32(self) -> None:
+        """Structured thesis columns for the interim-manager compiler contract."""
+        for column in (
+            "thesis_class TEXT NOT NULL DEFAULT 'unclassified'",
+            "confidence_lo REAL", "confidence_hi REAL", "max_entry_price REAL",
+            "catalyst TEXT NOT NULL DEFAULT ''",
+            "invalidation TEXT NOT NULL DEFAULT ''",
+            "sunset_at TEXT", "robust_edge REAL", "decision_price REAL",
+        ):
+            try:
+                await self._db.execute(
+                    f"ALTER TABLE manager_proposals ADD COLUMN {column}")
+            except Exception:  # noqa: BLE001 — column already present
+                pass
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_proposals_class "
+            "ON manager_proposals(thesis_class, status)")
+        await self._db.execute("UPDATE schema_version SET version = 32")
+        await self._db.commit()
+        log.info("database.migrated", from_version=31, to_version=32)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 31
+SCHEMA_VERSION = 32
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -763,10 +763,22 @@ CREATE TABLE IF NOT EXISTS manager_proposals (
     status TEXT NOT NULL DEFAULT 'pending',
     reason TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    decided_at TEXT
+    decided_at TEXT,
+    -- Structured thesis (v32): the compiler contract. See docs/INTERIM_MANAGER.md.
+    thesis_class TEXT NOT NULL DEFAULT 'unclassified',
+    confidence_lo REAL,
+    confidence_hi REAL,
+    max_entry_price REAL,
+    catalyst TEXT NOT NULL DEFAULT '',
+    invalidation TEXT NOT NULL DEFAULT '',
+    sunset_at TEXT,
+    robust_edge REAL,
+    decision_price REAL
 );
 CREATE INDEX IF NOT EXISTS idx_manager_proposals_status
     ON manager_proposals(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_manager_proposals_class
+    ON manager_proposals(thesis_class, status);
 
 CREATE TABLE IF NOT EXISTS redemptions (
     condition_id TEXT PRIMARY KEY,

--- a/auramaur/strategy/interim_manager.py
+++ b/auramaur/strategy/interim_manager.py
@@ -144,12 +144,43 @@ class InterimManagerPillar:
             await self._resolve(pid, "skipped", f"delegated to {owned[category]}")
             return False
 
+        # Machine-checkable sunset: an information/time bound the proposer set.
+        sunset = self._parse_ts(p.get("sunset_at"))
+        if sunset is not None and datetime.now(timezone.utc) >= sunset:
+            await self._resolve(pid, "expired", "thesis sunset reached")
+            return False
+
         open_now = await self._open_positions()
         if open_now >= cfg.max_open_positions:
             log.info("interim_manager.position_cap", open=open_now)
             return False  # stays pending; retried next cycle
 
         side = OrderSide.BUY if str(p["side"]).upper() == "BUY" else OrderSide.SELL
+
+        # Entry-price limit: the mechanical guard that protects the edge.
+        # Expressed as the max price PAID for the side taken (BUY pays the
+        # YES price; SELL pays the NO price).
+        entry_price = (market.outcome_yes_price if side == OrderSide.BUY
+                       else 1.0 - market.outcome_yes_price)
+        max_entry = p.get("max_entry_price")
+        if max_entry is not None and entry_price > float(max_entry) + 1e-9:
+            await self._resolve(
+                pid, "skipped",
+                f"entry {entry_price:.3f} above limit {float(max_entry):.3f}")
+            return False
+
+        # Robust-edge gate: the edge must survive every haircut. Conservative
+        # about apparent edges built on weak estimates (charter decision rule).
+        robust, detail = await self._robust_edge(p, market, category, side)
+        await self._db.execute(
+            "UPDATE manager_proposals SET robust_edge = ?, decision_price = ? "
+            "WHERE id = ?", (round(robust, 4), entry_price, pid))
+        await self._db.commit()
+        if robust < cfg.min_robust_edge:
+            await self._resolve(
+                pid, "skipped",
+                f"robust edge {robust:+.3f} < {cfg.min_robust_edge:.3f} ({detail})")
+            return False
         signal = Signal(
             market_id=market.id,
             market_question=market.question,
@@ -189,6 +220,39 @@ class InterimManagerPillar:
         return True
 
     # ------------------------------------------------------------------
+
+    async def _robust_edge(self, p: dict, market, category: str,
+                           side: OrderSide) -> tuple[float, str]:
+        """fair − executable − uncertainty − fees − slippage − liquidity −
+        correlation. Returns (edge, haircut breakdown for the audit trail)."""
+        from auramaur.strategy.signals import taker_fee_rate
+        cfg = self._settings.interim_manager
+        fair = float(p["fair_prob"])
+        mid = market.outcome_yes_price
+        gross = (fair - mid) if side == OrderSide.BUY else (mid - fair)
+
+        lo, hi = p.get("confidence_lo"), p.get("confidence_hi")
+        if lo is not None and hi is not None and float(hi) >= float(lo):
+            uncertainty = (float(hi) - float(lo)) / 2.0
+        else:
+            uncertainty = cfg.default_uncertainty_buffer
+        fee = taker_fee_rate(market.exchange or "kalshi", category) * mid * (1.0 - mid)
+        liq = (cfg.liquidity_penalty
+               if float(market.liquidity or 0) < cfg.thin_liquidity_usd else 0.0)
+        corr = (cfg.correlation_penalty_per_position
+                * await self._open_positions_in_category(category))
+        edge = gross - uncertainty - fee - cfg.slippage_buffer - liq - corr
+        detail = (f"gross {gross:+.3f} − unc {uncertainty:.3f} − fee {fee:.3f} "
+                  f"− slip {cfg.slippage_buffer:.3f} − liq {liq:.3f} − corr {corr:.3f}")
+        return edge, detail
+
+    async def _open_positions_in_category(self, category: str) -> int:
+        row = await self._db.fetchone(
+            """SELECT COUNT(DISTINCT s.market_id) AS n FROM signals s
+               JOIN portfolio p ON p.market_id = s.market_id AND p.size > 0
+               WHERE s.strategy_source = ? AND p.category = ?""",
+            (self.name, category))
+        return int(row["n"] or 0) if row else 0
 
     async def _open_positions(self) -> int:
         row = await self._db.fetchone(

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -565,6 +565,15 @@ interim_manager:
   max_open_positions: 10
   proposal_ttl_hours: 48.0
   sunset_after_live_cells: 3
+  # Robust-edge gate: fair - executable - uncertainty - fees - slippage -
+  # liquidity - correlation must clear this. Conservative about apparent
+  # edges built on weak estimates (docs/INTERIM_MANAGER.md).
+  min_robust_edge: 0.05
+  default_uncertainty_buffer: 0.04
+  slippage_buffer: 0.01
+  thin_liquidity_usd: 200.0
+  liquidity_penalty: 0.02
+  correlation_penalty_per_position: 0.01
 
 econ_indicator:
   # Data-driven Kalshi econ-indicator bin pricing: price "Above X" ladders from

--- a/config/settings.py
+++ b/config/settings.py
@@ -711,6 +711,17 @@ class InterimManagerConfig(BaseModel):
     max_open_positions: int = 10
     proposal_ttl_hours: float = 48.0
     sunset_after_live_cells: int = 3
+    # Robust-edge gate (docs/INTERIM_MANAGER.md "decision rule"): the edge that
+    # must survive after subtracting every cost and uncertainty haircut.
+    min_robust_edge: float = 0.05
+    # Haircut when no confidence interval is supplied (else CI half-width).
+    default_uncertainty_buffer: float = 0.04
+    slippage_buffer: float = 0.01
+    # Markets with less liquidity than this get the thin-liquidity haircut.
+    thin_liquidity_usd: float = 200.0
+    liquidity_penalty: float = 0.02
+    # Haircut per already-open manager position in the same category.
+    correlation_penalty_per_position: float = 0.01
 
 
 class EconIndicatorConfig(BaseModel):

--- a/docs/INTERIM_MANAGER.md
+++ b/docs/INTERIM_MANAGER.md
@@ -59,6 +59,56 @@ writes proposals.
    graduate, stakes are evidence-gathering stakes (config-capped), not
    P&L-maximizing stakes.
 
+## The generalized decision rule (enforced)
+
+The manager's trade condition is not `fair > market`. It is:
+
+    robust_edge = fair_probability
+                  − executable_probability
+                  − uncertainty_buffer      (CI half-width, or the default)
+                  − taker_fees
+                  − slippage_buffer
+                  − thin_liquidity_penalty
+                  − correlation_penalty     (per open manager position in category)
+
+    execute only if robust_edge ≥ min_robust_edge
+                 and entry price ≤ the proposal's max_entry_price
+                 and the thesis sunset has not passed
+                 and (charter, human-judged) the thesis is falsifiable,
+                     resolution is objective, and a catalyst exists
+
+The arithmetic gates are computed and recorded per proposal (`robust_edge`,
+`decision_price`, and the full haircut breakdown in the skip reason) — the
+manager is deliberately conservative about apparent edges built on weak
+estimates. Falsifiability and resolution-objectivity remain human judgments;
+the schema records catalyst, invalidation, and sunset so post-mortems can
+score whether the judgment was honest.
+
+## Thesis classes (evaluated separately)
+
+Every proposal declares its anchor class; `auramaur manager report` scores
+each class independently, because a manager that only picks good classes is
+learnable even when individual trades lose:
+
+| class | independent anchor | typical divergence cause |
+|---|---|---|
+| forecast_divergence | weather/polling/econ forecasts | stale prices, headline anchoring |
+| cross_venue | equivalent contracts elsewhere | fragmented liquidity |
+| conditional_inconsistency | related markets' implied probabilities | contracts priced independently |
+| timeline | known process and deadlines | procedural-timing confusion |
+| base_rate | historical reference class | vivid-recent-event attention |
+| resolution_language | contract rules vs public reading | ambiguous wording |
+| information_lag | newly released official data | slow repricing |
+| exclusive_basket | sum of outcome probabilities | bucket-level imbalance |
+
+Priority for the interim period: forecast_divergence,
+conditional_inconsistency, exclusive_basket — legible evidence, useful
+feedback even in losses.
+
+The mandate, compiled: **find short-lived, falsifiable probability
+discrepancies with an external anchor, an explainable mispricing mechanism,
+and enough robust edge to survive uncertainty and execution costs.**
+
 ## Evaluation contract (pre-registered)
 
 - `strategy_source = "interim_manager"`; **not** in `exempt_strategies` — the
@@ -68,6 +118,11 @@ writes proposals.
 - Proposals the pillar skips (delegation, sunset, thesis, expiry, risk
   rejection) are recorded with their reason — the queue is an auditable
   decision log, not just an order channel.
+- The scorecard judges reasoning, not only money: fair-value calibration
+  (every executed proposal records its prediction), whether the claimed
+  mechanism was real, whether invalidation occurred before execution,
+  whether the price limit protected the edge, and whether the manager
+  selected good thesis classes — variance and bad reasoning are separable.
 - Review cadence: alongside the normal graduation review. The manager's
   record is compared per category against the strategies it stands in for;
   if a manager cell and a strategy cell both hold records in a category, the

--- a/tests/test_interim_manager.py
+++ b/tests/test_interim_manager.py
@@ -2,6 +2,8 @@
 
 import asyncio
 from types import SimpleNamespace
+
+import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 
@@ -150,3 +152,90 @@ def test_disabled_by_default_in_tracked_config():
     assert s.interim_manager.enabled is False
     assert s.interim_manager.paper is True
     assert "interim_manager" not in set(s.graduation.exempt_strategies)
+
+
+# ---- v2: the generalized decision rule ----
+
+async def _propose_row(db, **overrides):
+    fields = dict(venue="kalshi", market_id="M1", side="BUY", fair_prob=0.55,
+                  stake_usd=10.0, thesis=THESIS, status="pending",
+                  thesis_class="forecast_divergence")
+    fields.update(overrides)
+    cols = ", ".join(fields)
+    marks = ", ".join("?" for _ in fields)
+    await db.execute(
+        f"INSERT INTO manager_proposals ({cols}) VALUES ({marks})",
+        tuple(fields.values()))
+    await db.commit()
+
+
+def test_max_entry_price_gate_blocks_expensive_fills():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        await _propose_row(db, max_entry_price=0.35)  # market mid is 0.40
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "skipped"
+        assert "above limit" in row["reason"]
+        await db.close()
+    asyncio.run(run())
+
+
+def test_robust_edge_gate_rejects_thin_edges():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        # fair 0.47 vs mid 0.40: gross 0.07 − default buffers ≈ below 0.05 gate
+        await _propose_row(db, fair_prob=0.47)
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone(
+            "SELECT status, reason, robust_edge FROM manager_proposals")
+        assert row["status"] == "skipped"
+        assert "robust edge" in row["reason"]
+        assert row["robust_edge"] is not None
+        await db.close()
+    asyncio.run(run())
+
+
+def test_wide_robust_edge_executes_and_records_decision_price():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        # fair 0.72 vs mid 0.40 with a tight CI: survives every haircut
+        await _propose_row(db, fair_prob=0.72, confidence_lo=0.70,
+                           confidence_hi=0.74)
+        assert await pillar.run_once() == 1
+        row = await db.fetchone(
+            "SELECT status, robust_edge, decision_price FROM manager_proposals")
+        assert row["status"] == "executed"
+        assert row["robust_edge"] > 0.05
+        assert row["decision_price"] == pytest.approx(0.40)
+        await db.close()
+    asyncio.run(run())
+
+
+def test_thesis_sunset_expires_before_execution():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        await _propose_row(db, fair_prob=0.72, sunset_at="2020-01-01T00:00:00+00:00")
+        assert await pillar.run_once() == 0
+        gateway.submit.assert_not_awaited()
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "expired"
+        assert "sunset" in row["reason"]
+        await db.close()
+    asyncio.run(run())
+
+
+def test_ci_half_width_is_the_uncertainty_haircut():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        # A modest edge with a sloppy CI (±0.15) must die where the same
+        # edge with a tight CI would survive — the haircut is the CI width.
+        await _propose_row(db, fair_prob=0.55, confidence_lo=0.40,
+                           confidence_hi=0.70)
+        assert await pillar.run_once() == 0
+        row = await db.fetchone("SELECT status, reason FROM manager_proposals")
+        assert row["status"] == "skipped" and "robust edge" in row["reason"]
+        await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
v2 of the interim manager, per the operator''s design: proposals become a structured, machine-checkable thesis contract rather than free text.

- **Generalized decision rule, enforced in code**: `robust_edge = fair − executable − uncertainty − fees − slippage − liquidity_penalty − correlation_penalty`, executed only if `≥ min_robust_edge` AND entry price ≤ the proposal''s `max_entry_price` AND the thesis `sunset_at` has not passed. The uncertainty haircut is the CI half-width when supplied (a sloppy interval kills what a tight one allows) or a conservative default when not.
- **Structured schema (v32)**: thesis_class, confidence interval, max entry price, catalyst, invalidation condition, sunset — plus the *recorded decision*: computed `robust_edge`, `decision_price`, and the full haircut breakdown in every skip reason. The queue is now a falsifiable audit trail.
- **Thesis classes**: eight anchor classes (forecast_divergence, cross_venue, conditional_inconsistency, timeline, base_rate, resolution_language, information_lag, exclusive_basket); `auramaur manager report` scores each class separately — the manager is evaluated on whether it picks good classes and calibrates well, not merely on P&L.
- **Charter updated** with the decision rule, the taxonomy, the reasoning-quality evaluation dimensions, and the compiled mandate.
- Falsifiability and resolution-objectivity remain human judgments by design — the schema records catalyst/invalidation/sunset so post-mortems can score whether the judgment was honest.

## Safety
- Purely additive tightening: every existing gate (risk gateway, delegation, sunset, stake caps, thesis requirement) remains; the robust-edge rule only REJECTS more.
- Schema migration 31→32 is additive columns with direct test coverage.

## Testing
- 5 new tests: max-entry gate, thin-edge rejection with recorded robust_edge, wide-edge execution with recorded decision_price, thesis-sunset expiry, CI-width-as-haircut contrast. Full manager+migrations+settings run: 42 passed; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)