### PR TITLE
fix(db): create migration-dependent indexes after migrations, not in DDL

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -60,6 +60,12 @@ class Database:
             current_version = row[0] if isinstance(row[0], int) else row["version"]
             if current_version < SCHEMA_VERSION:
                 await self._run_migrations(current_version)
+        # Indexes on migration-added columns must be created HERE, after both
+        # paths guarantee the column exists (fresh DDL or just-run migration) —
+        # never in TABLES, which executes before migrations.
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_proposals_class "
+            "ON manager_proposals(thesis_class, status)")
         await self._db.commit()
 
     async def _run_migrations(self, from_version: int) -> None:

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -777,8 +777,9 @@ CREATE TABLE IF NOT EXISTS manager_proposals (
 );
 CREATE INDEX IF NOT EXISTS idx_manager_proposals_status
     ON manager_proposals(status, created_at);
-CREATE INDEX IF NOT EXISTS idx_manager_proposals_class
-    ON manager_proposals(thesis_class, status);
+-- idx_manager_proposals_class is created in _init_schema AFTER migrations:
+-- it indexes a v32-added column, and this DDL runs before migrations on
+-- existing databases (the 2026-07-19 v32 rollout crashed startup this way).
 
 CREATE TABLE IF NOT EXISTS redemptions (
     condition_id TEXT PRIMARY KEY,

--- a/tests/test_interim_manager.py
+++ b/tests/test_interim_manager.py
@@ -239,3 +239,40 @@ def test_ci_half_width_is_the_uncertainty_haircut():
         assert row["status"] == "skipped" and "robust edge" in row["reason"]
         await db.close()
     asyncio.run(run())
+
+
+def test_startup_migrates_an_existing_v31_database(tmp_path):
+    """The v32 rollout crashed production: the base DDL indexed a column the
+    pre-migration table lacked. Startup against a v31 DB must succeed."""
+    import sqlite3 as sq
+
+    db_file = tmp_path / "v31.db"
+    conn = sq.connect(db_file)
+    conn.executescript(
+        """CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+           INSERT INTO schema_version (version) VALUES (31);
+           CREATE TABLE manager_proposals (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               venue TEXT NOT NULL, market_id TEXT NOT NULL, side TEXT NOT NULL,
+               fair_prob REAL NOT NULL, stake_usd REAL NOT NULL,
+               thesis TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'pending',
+               reason TEXT NOT NULL DEFAULT '',
+               created_at TEXT NOT NULL DEFAULT (datetime('now')),
+               decided_at TEXT);""")
+    conn.commit()
+    conn.close()
+
+    async def run():
+        db = Database(str(db_file))
+        await db.connect()  # crashed before the fix
+        row = await db.fetchone("SELECT version FROM schema_version")
+        assert row["version"] >= 32
+        cols = {r["name"] for r in await db.fetchall(
+            "SELECT name FROM pragma_table_info('manager_proposals')")}
+        assert "thesis_class" in cols and "robust_edge" in cols
+        idx = await db.fetchone(
+            "SELECT 1 AS x FROM sqlite_master WHERE type='index' "
+            "AND name='idx_manager_proposals_class'")
+        assert idx is not None
+        await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- **Incident**: the #320 deploy crashed bot startup on the production DB. `TABLES` gained `idx_manager_proposals_class` on `thesis_class` — a v32-added column — but `_init_schema` runs the DDL **before** migrations, so the pre-migration table lacked the column and `executescript` raised. Fresh/`:memory:` databases create the full v32 table in the same DDL, which is why the entire test suite stayed green while production broke: the missing coverage was *startup against an existing old-version database file*.
- **Fix**: the index moves out of `TABLES` into `_init_schema` after version handling (idempotent `CREATE INDEX IF NOT EXISTS`), where both the fresh path (DDL created the column) and the upgrade path (migration just added it) guarantee the column exists. A comment in both files marks the rule for future migration authors.
- **Regression test**: constructs a real v31-shaped database file and asserts `Database.connect()` succeeds, lands at ≥32, has the new columns, and builds the index — this test fails on the pre-fix code.
- Production was healed in place with the equivalent manual ALTERs (~15 minutes of degraded trading loop); this PR makes every other checkout take the safe path.

## Testing
- New v31-startup regression + interim-manager + migration suites: 17 passed; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)