### PR TITLE
fix(config): yaml defaults become a settings SOURCE so env deep-merges

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
 
 def _deep_merge(base: dict, over: dict) -> dict:
@@ -47,6 +47,41 @@ def _load_defaults() -> dict:
 
 
 _DEFAULTS = _load_defaults()
+
+
+class _YamlDefaultsSource(PydanticBaseSettingsSource):
+    """Lowest-priority settings source serving the merged YAML defaults.
+
+    Without this, the YAML sections only reach nested models through each
+    field's ``default_factory`` — and pydantic-settings ignores a field
+    default the moment ANY source (e.g. one ``IBKR__*`` env var) supplies
+    part of that field. In production, compose always sets IBKR env vars,
+    so the entire ``ibkr:`` YAML section (tracked and local) was silently
+    discarded for months (discovered 2026-07-20: ``7203.T`` never disabled
+    in-container, options/bonds books never config-off).
+
+    As a SOURCE, the YAML participates in pydantic-settings' cross-source
+    deep merge instead: env vars override exactly the keys they name, and
+    every other YAML key survives. Reads the module global at call time so
+    tests can monkeypatch ``_DEFAULTS``.
+    """
+
+    def get_field_value(self, field, field_name):  # pragma: no cover - unused
+        return None, field_name, False
+
+    def __call__(self) -> dict:
+        import copy
+
+        fields = self.settings_cls.model_fields
+        return {k: copy.deepcopy(v) for k, v in _current_defaults().items()
+                if k in fields}
+
+
+def _current_defaults() -> dict:
+    """Indirection so tests can monkeypatch config.settings._DEFAULTS."""
+    import config.settings as _m
+    return _m._DEFAULTS
+
 
 
 class ExecutionConfig(BaseModel):
@@ -1650,6 +1685,18 @@ class Settings(BaseSettings):
         # unrelated stray var shouldn't crash Settings on startup.
         "extra": "ignore",
     }
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings,
+                                   env_settings, dotenv_settings,
+                                   file_secret_settings):
+        # Order = priority (first wins). YAML defaults sit BELOW every other
+        # source: env/dotenv/init override exactly the keys they name and
+        # deep-merge with the rest of the YAML section (see
+        # _YamlDefaultsSource). Field default_factories remain as the final
+        # fallback for sections absent from every source.
+        return (init_settings, env_settings, dotenv_settings,
+                file_secret_settings, _YamlDefaultsSource(settings_cls))
 
     def model_post_init(self, __context) -> None:
         """Export pass-through tokens to the process environment.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -243,3 +243,54 @@ def test_ibkr_etf_model_effort_is_strict():
     with pytest.raises(ValidationError):
         IBKRConfig(etf_models=[
             {"alias": "test", "model": "gpt-test", "effort": "maximum"}])
+
+
+# ---- YAML x env deep-merge (2026-07-20 regression) -------------------------
+# One IBKR__* env var used to make pydantic-settings discard the ENTIRE yaml
+# ibkr section (field default_factory skipped once any source supplies part
+# of the field). The _YamlDefaultsSource must instead deep-merge: env wins on
+# exactly the keys it names, yaml survives everywhere else.
+
+def _with_yaml_ibkr(monkeypatch, **env):
+    import config.settings as m
+    merged = dict(m._DEFAULTS)
+    merged["ibkr"] = {
+        **m._DEFAULTS.get("ibkr", {}),
+        "multiasset_paper_enabled": False,
+        "multiasset_disabled_instruments": ["7203.T"],
+        "multiasset_books": {
+            **m._DEFAULTS.get("ibkr", {}).get("multiasset_books", {}),
+            "fx": {"enabled": False, "budget_usd": 5000, "max_positions": 4,
+                   "max_position_pct": 10, "max_deployment_pct": 40,
+                   "daily_loss_limit_usd": 75, "stop_loss_pct": 2,
+                   "take_profit_pct": 4, "max_spread_bps": 15},
+        },
+    }
+    monkeypatch.setattr(m, "_DEFAULTS", merged)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return m.Settings()
+
+
+def test_env_var_no_longer_discards_the_yaml_ibkr_section(monkeypatch):
+    s = _with_yaml_ibkr(monkeypatch, IBKR__MULTIASSET_PAPER_ENABLED="true")
+    # env wins on the key it names…
+    assert s.ibkr.multiasset_paper_enabled is True
+    # …and the rest of the yaml section SURVIVES (this was lost pre-fix):
+    assert s.ibkr.multiasset_disabled_instruments == ["7203.T"]
+    assert s.ibkr.multiasset_books["fx"].enabled is False
+
+
+def test_nested_env_deep_merges_into_yaml_books(monkeypatch):
+    s = _with_yaml_ibkr(monkeypatch,
+                        IBKR__MULTIASSET_PAPER_ENABLED="true",
+                        IBKR__MULTIASSET_BOOKS__FX__ENABLED="true")
+    assert s.ibkr.multiasset_books["fx"].enabled is True
+    # yaml-carried sibling keys of the same book survive the nested override:
+    assert s.ibkr.multiasset_books["fx"].daily_loss_limit_usd == 75
+
+
+def test_yaml_alone_still_applies_without_env(monkeypatch):
+    s = _with_yaml_ibkr(monkeypatch)
+    assert s.ibkr.multiasset_paper_enabled is False
+    assert s.ibkr.multiasset_disabled_instruments == ["7203.T"]


### PR DESCRIPTION
## Summary
- **The bug (live-verified this morning)**: any `IBKR__*` env var caused pydantic-settings to build the whole `ibkr` field from env + class defaults, silently discarding the yaml section — field `default_factory` is skipped once ANY source supplies part of a field. Compose has always set IBKR env vars, so every `ibkr:` block in tracked and local yaml has been a dead letter inside the container. Discovered when per-book gating in `defaults.local.yaml` didn''t apply; collateral findings: `multiasset_disabled_instruments: ["7203.T"]` never applied in-container, and options/bonds books were never config-off (only the master env flag kept them dormant).
- **The fix**: `_YamlDefaultsSource`, a lowest-priority `PydanticBaseSettingsSource` serving the merged yaml `_DEFAULTS` (filtered to declared fields, deep-copied, read at call time so tests can monkeypatch). Yaml now participates in pydantic-settings'' cross-source deep merge: env/dotenv/init win on exactly the keys they name; the rest of the yaml survives. `default_factory` remains the fallback for sections absent from every source — no-env behavior (CI, fresh clones) is byte-identical.
- **Restores the documented contract** the whole `defaults.local.yaml` operator workflow assumes.

## Deployment note
The production `compose.override.yaml` currently pins all six book enables via nested env as containment — those pins stay correct after this merges (env still wins on named keys) and become redundant rather than load-bearing; they can be trimmed at leisure once this deploys.

## Testing
- 3 regression tests; **2 fail on pre-fix code** (the yaml-alone one passes pre-fix, as that path always worked — asserting the fix changes only what was broken).
- Full settings + triple-gate suites green; full local suite 1217 passed with only the 3 known Windows-local failures (fail identically with the change stashed; Linux CI is authoritative for those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)