### PR TITLE
feat(fx): reachable evidence contract, ranked entries, carry research

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -716,8 +716,15 @@ class AuramaurBot(
         from auramaur.strategy.ibkr_multiasset_paper import IBKRMultiAssetPaperBook
 
         client = IBKRReadOnlyMarketData(self.settings)
+        rates_provider = None
+        if self.settings.fred_api_key:
+            from auramaur.data_sources.fred import FREDSource
+            from auramaur.research.fx_rates import FredRatesProvider
+            rates_provider = FredRatesProvider(
+                FREDSource(api_key=self.settings.fred_api_key))
         books = [IBKRMultiAssetPaperBook(
-            self.settings, client, self._components.get("db"), book)
+            self.settings, client, self._components.get("db"), book,
+            rates_provider=rates_provider)
             for book in IBKRBook
             if self.settings.ibkr.multiasset_books[book.value].enabled]
         try:

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -132,6 +132,8 @@ class Database:
             await self._migrate_v30_to_v31()
         if from_version < 32:
             await self._migrate_v31_to_v32()
+        if from_version < 33:
+            await self._migrate_v32_to_v33()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -211,6 +213,30 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 32")
         await self._db.commit()
         log.info("database.migrated", from_version=31, to_version=32)
+
+    async def _migrate_v32_to_v33(self) -> None:
+        """Daily marks + research signal recordings (new tables only)."""
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS ibkr_paper_daily_marks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                book TEXT NOT NULL, mark_date TEXT NOT NULL,
+                equity_usd REAL NOT NULL,
+                realized_cum_usd REAL NOT NULL DEFAULT 0,
+                unrealized_usd REAL NOT NULL DEFAULT 0,
+                marked_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(book, mark_date))""")
+        await self._db.execute(
+            """CREATE TABLE IF NOT EXISTS ibkr_research_signals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instrument_key TEXT NOT NULL, signal_date TEXT NOT NULL,
+                signal_name TEXT NOT NULL, direction INTEGER NOT NULL,
+                strength REAL NOT NULL DEFAULT 0,
+                detail TEXT NOT NULL DEFAULT '',
+                recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(instrument_key, signal_date, signal_name))""")
+        await self._db.execute("UPDATE schema_version SET version = 33")
+        await self._db.commit()
+        log.info("database.migrated", from_version=32, to_version=33)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 32
+SCHEMA_VERSION = 33
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -752,6 +752,33 @@ CREATE INDEX IF NOT EXISTS idx_kalshi_execution_samples_market_time
 
 -- Interim-manager proposal queue: operator-proposed entries awaiting the
 -- pillar's charter/risk/ladder gauntlet. Terminal rows are the audit log.
+-- Daily marked-to-market equity per IBKR paper book: the observation
+-- stream for the daily evidence contract (evaluate_ibkr_daily_evidence).
+CREATE TABLE IF NOT EXISTS ibkr_paper_daily_marks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book TEXT NOT NULL,
+    mark_date TEXT NOT NULL,
+    equity_usd REAL NOT NULL,
+    realized_cum_usd REAL NOT NULL DEFAULT 0,
+    unrealized_usd REAL NOT NULL DEFAULT 0,
+    marked_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(book, mark_date)
+);
+
+-- Execution-free research signal recordings (fx carry+trend et al) so the
+-- comparative record accrues before anything is wired into entries.
+CREATE TABLE IF NOT EXISTS ibkr_research_signals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    instrument_key TEXT NOT NULL,
+    signal_date TEXT NOT NULL,
+    signal_name TEXT NOT NULL,
+    direction INTEGER NOT NULL,
+    strength REAL NOT NULL DEFAULT 0,
+    detail TEXT NOT NULL DEFAULT '',
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(instrument_key, signal_date, signal_name)
+);
+
 CREATE TABLE IF NOT EXISTS manager_proposals (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     venue TEXT NOT NULL,

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -12,7 +12,8 @@ import structlog
 from auramaur.exchange.ibkr_instruments import BY_BOOK, IBKRBook
 from auramaur.exchange.ibkr_market_data import IBKRReadOnlyMarketData
 from auramaur.exchange.ibkr_registry import record_validation
-from auramaur.risk.ibkr_evidence import evaluate_ibkr_evidence
+from auramaur.risk.ibkr_evidence import (evaluate_ibkr_daily_evidence,
+                                         evaluate_ibkr_evidence)
 
 log = structlog.get_logger()
 
@@ -179,24 +180,40 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
             "OK" if set(counts) <= {"eligible"} else "WARN",
             ", ".join(f"{status}={count}" for status, count in counts.items()))
 
+        # PRIMARY contract (pre-registered 2026-07-20): daily marked-to-market
+        # returns. The round-trip count is a SECONDARY cost-realism check —
+        # slow-turnover books physically cannot produce 200 trips in 180 days,
+        # and holding brackets must never be shortened to manufacture them.
+        marks = await db.fetchall(
+            "SELECT equity_usd FROM ibkr_paper_daily_marks "
+            "WHERE book = ? ORDER BY mark_date", (book.value,))
+        equities = [float(row["equity_usd"]) for row in marks]
+        daily = [b - a for a, b in zip(equities, equities[1:])]
+        mark_age = await db.fetchone(
+            "SELECT CAST(julianday('now') - julianday(MIN(mark_date)) AS INTEGER) "
+            "AS elapsed FROM ibkr_paper_daily_marks WHERE book = ?", (book.value,))
+        elapsed_days = max(0, int(mark_age["elapsed"] or 0))
+        evidence = evaluate_ibkr_daily_evidence(
+            daily, elapsed_days=elapsed_days, budget_usd=book_cfg.budget_usd)
+
         observations = await db.fetchall(
             "SELECT net_pnl_usd FROM ibkr_paper_round_trips "
             "WHERE book = ? ORDER BY closed_at, id", (book.value,))
         pnls = [float(row["net_pnl_usd"]) for row in observations]
-        age = await db.fetchone(
-            "SELECT CAST(julianday('now') - julianday(MIN(opened_at)) AS INTEGER) "
-            "AS elapsed FROM ibkr_paper_round_trips WHERE book = ?", (book.value,))
-        elapsed_days = max(0, int(age["elapsed"] or 0))
-        evidence = evaluate_ibkr_evidence(
-            pnls, elapsed_days=elapsed_days, budget_usd=book_cfg.budget_usd)
+        trips = evaluate_ibkr_evidence(
+            pnls, elapsed_days=elapsed_days, budget_usd=book_cfg.budget_usd,
+            min_observations=30)
         gains = sum(pnl for pnl in pnls if pnl > 0)
         losses = abs(sum(pnl for pnl in pnls if pnl < 0))
         profit_factor = gains / losses if losses else (float("inf") if gains else 0.0)
-        status = "graduated" if evidence.ready else "not graduated"
-        reasons = "; ".join(evidence.reasons) if evidence.reasons else "contract passed"
-        add(f"{book.value}:edge", "OK" if evidence.ready else "WARN",
-            f"{status}: {evidence.observations} cost-adjusted round trips over "
-            f"{evidence.elapsed_days} days, ${evidence.net_pnl_usd:.2f} net P&L, "
+        ready = evidence.ready and trips.ready
+        status = "graduated" if ready else "not graduated"
+        reasons = "; ".join(evidence.reasons + trips.reasons) or "contract passed"
+        add(f"{book.value}:edge", "OK" if ready else "WARN",
+            f"{status}: {evidence.observations} daily marks over "
+            f"{evidence.elapsed_days} days (mean lower bound "
+            f"${evidence.mean_lower_95_usd:.2f}/day), {len(pnls)} cost-adjusted "
+            f"round trips, ${trips.net_pnl_usd:.2f} trip P&L, "
             f"profit factor {profit_factor:.2f}; {reasons}")
     if own_client:
         await client.close()

--- a/auramaur/research/fx_rates.py
+++ b/auramaur/research/fx_rates.py
@@ -1,0 +1,57 @@
+"""G10 short-rate provider for the FX carry research recorder.
+
+OECD "immediate rate" series mirrored on FRED, one per currency the FX book
+trades. Monthly and lagged one to two months — acceptable for the SIGN and
+rough magnitude of carry in a research recording (the recorder stores the
+detail string, so the staleness is auditable). Rates are cached for a day;
+a missing series or absent FRED key degrades to None and the recorder simply
+skips the carry signal for that pair (trend-only still records).
+"""
+
+from __future__ import annotations
+
+import time
+
+import structlog
+
+log = structlog.get_logger()
+
+FRED_RATE_SERIES: dict[str, str] = {
+    "USD": "DFF",                 # effective federal funds, daily
+    "EUR": "ECBDFR",              # ECB deposit facility, daily
+    "GBP": "IUDSOIA",             # SONIA, daily
+    "JPY": "IRSTCI01JPM156N",     # OECD immediate rate, monthly
+    "CAD": "IRSTCI01CAM156N",
+    "CHF": "IR3TIB01CHM156N",     # 3m interbank (SNB policy proxy)
+    "AUD": "IRSTCI01AUM156N",
+    "NZD": "IRSTCI01NZM156N",
+}
+
+_CACHE_SECONDS = 86_400.0
+
+
+class FredRatesProvider:
+    """Daily-cached ``currency -> annual decimal rate`` lookups."""
+
+    def __init__(self, fred_source) -> None:
+        self._fred = fred_source
+        self._cache: dict[str, tuple[float, float | None]] = {}
+
+    async def rate(self, currency: str) -> float | None:
+        series = FRED_RATE_SERIES.get(currency.upper())
+        if series is None or self._fred is None:
+            return None
+        hit = self._cache.get(currency)
+        now = time.monotonic()
+        if hit is not None and now - hit[0] < _CACHE_SECONDS:
+            return hit[1]
+        value: float | None = None
+        try:
+            obs = await self._fred.get_observations(series, n=1)
+            if obs:
+                value = float(obs[-1][1]) / 100.0  # FRED quotes percent
+        except Exception as e:  # noqa: BLE001 — research-only, never fatal
+            log.debug("fx_rates.fetch_failed", currency=currency,
+                      series=series, error=str(e)[:100])
+        self._cache[currency] = (now, value)
+        return value

--- a/auramaur/risk/ibkr_evidence.py
+++ b/auramaur/risk/ibkr_evidence.py
@@ -68,3 +68,46 @@ def evaluate_ibkr_evidence(
         n, elapsed_days, sum(net_trade_pnls), mean, lower, drawdown,
         brier, baseline, not reasons, tuple(reasons),
     )
+
+
+def evaluate_ibkr_daily_evidence(
+    daily_pnls_usd: list[float], *, elapsed_days: int, budget_usd: float,
+    min_observations: int = 120, min_elapsed_days: int = 180,
+    max_drawdown_pct: float = 10.0,
+) -> IBKREvidence:
+    """Pre-registered contract over DAILY marked-to-market P&L.
+
+    Adopted 2026-07-20 (docs/ibkr_multiasset_paper.md, "Evidence contract"):
+    the round-trip contract is arithmetically unreachable for slow-turnover
+    books — an FX book holding 2-6 weeks across 4 slots produces ~15-50
+    round trips in 180 days against a 200-trip bar. Daily marks give ~130
+    observations over the same window with identical cost realism (marks
+    are net of the simulated fills'' spreads/slippage/commissions), so the
+    statistical bar stays high while the clock actually runs. Round trips
+    remain a SECONDARY realism check (see the preflight), and holding
+    brackets must never be shortened merely to manufacture observations.
+    """
+    n = len(daily_pnls_usd)
+    mean = fmean(daily_pnls_usd) if n else 0.0
+    se = pstdev(daily_pnls_usd) / math.sqrt(n) if n > 1 else math.inf
+    lower = mean - 1.96 * se
+    drawdown = _max_drawdown(daily_pnls_usd)
+    reasons = []
+    if n < min_observations:
+        reasons.append(f"{n}/{min_observations} daily observations")
+    if elapsed_days < min_elapsed_days:
+        reasons.append(f"{elapsed_days}/{min_elapsed_days} elapsed days")
+    if n and lower <= 0:
+        reasons.append(
+            f"daily mean lower bound ${lower:.2f} not positive")
+    if budget_usd > 0 and drawdown > budget_usd * max_drawdown_pct / 100:
+        reasons.append(
+            f"max drawdown ${drawdown:.2f} exceeds {max_drawdown_pct:.0f}% of budget")
+    return IBKREvidence(
+        observations=n, elapsed_days=elapsed_days,
+        net_pnl_usd=sum(daily_pnls_usd), mean_pnl_usd=mean,
+        mean_lower_95_usd=lower if n > 1 else 0.0,
+        max_drawdown_usd=drawdown, brier_score=None,
+        baseline_brier_score=None, ready=not reasons,
+        reasons=tuple(reasons),
+    )

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -28,12 +28,14 @@ class IBKRMultiAssetPaperBook:
 
     execution_mode = ExecutionMode.PAPER_SIMULATED
 
-    def __init__(self, settings, client, db, book: IBKRBook):
+    def __init__(self, settings, client, db, book: IBKRBook,
+                 rates_provider=None):
         self._settings = settings
         self._client = client
         self._db = db
         self.book = book
         self.name = f"ibkr_{book.value}_paper"
+        self._rates_provider = rates_provider
 
     @property
     def config(self):
@@ -246,6 +248,7 @@ class IBKRMultiAssetPaperBook:
         unmarked_positions = set(positions)
         entries = 0
         error = ""
+        candidates: list = []
         for spec in selected:
             try:
                 held = positions.get(spec.key)
@@ -300,12 +303,24 @@ class IBKRMultiAssetPaperBook:
                 annual_vol = annualized_volatility(closes)
                 if momentum is None or annual_vol is None:
                     continue
+                if momentum < self._settings.ibkr.multiasset_min_normalized_momentum:
+                    continue
+                # Qualifiers are COLLECTED, not entered: with more qualifying
+                # signals than slots, entry order must be strongest-first, not
+                # rotation-cursor order (audit 2026-07-20).
+                candidates.append((momentum, spec, quote, fx, annual_vol))
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)[:300]
+                log.warning("ibkr_multiasset.instrument_error", book=self.book.value,
+                            key=spec.key, error=error)
+
+        candidates.sort(key=lambda item: -item[0])
+        for momentum, spec, quote, fx, annual_vol in candidates:
+            try:
                 loss_exposure = await self._loss_exposure()
                 if (unmarked_positions or loss_exposure <= -cfg.daily_loss_limit_usd
                         or len(positions) >= cfg.max_positions):
-                    continue
-                if momentum < self._settings.ibkr.multiasset_min_normalized_momentum:
-                    continue
+                    break
                 deployed = sum(
                     float(row["quantity"]) * self._capital_per_unit(
                         held_specs.get(key) or BY_KEY[key],
@@ -356,7 +371,104 @@ class IBKRMultiAssetPaperBook:
                  last_error=excluded.last_error, updated_at=datetime('now')""",
             (self.book.value, next_cursor, error))
         await self._db.commit()
+        await self._record_daily_mark()
+        await self._record_research_signals()
         loss_exposure = await self._loss_exposure()
         log.info("ibkr_multiasset.cycle", book=self.book.value, entries=entries,
                  positions=len(positions), loss_exposure=round(loss_exposure, 2))
         return entries
+
+    async def _record_daily_mark(self) -> None:
+        """Upsert the current UTC date's marked-to-market equity.
+
+        Idempotent per (book, date); the last cycle of the day wins, so the
+        mark reflects end-of-day state without any scheduler. This is the
+        observation stream for evaluate_ibkr_daily_evidence.
+        """
+        if self._db is None:
+            return
+        try:
+            realized = await self._db.fetchone(
+                "SELECT COALESCE(SUM(pnl_usd), 0) AS pnl FROM ibkr_paper_ledger "
+                "WHERE book = ?", (self.book.value,))
+            unrealized = await self._db.fetchone(
+                "SELECT COALESCE(SUM(unrealized_pnl_usd), 0) AS pnl "
+                "FROM ibkr_paper_positions WHERE book = ?", (self.book.value,))
+            r = float(realized["pnl"] or 0)
+            u = float(unrealized["pnl"] or 0)
+            await self._db.execute(
+                """INSERT INTO ibkr_paper_daily_marks
+                   (book, mark_date, equity_usd, realized_cum_usd, unrealized_usd)
+                   VALUES (?, date('now'), ?, ?, ?)
+                   ON CONFLICT(book, mark_date) DO UPDATE SET
+                     equity_usd=excluded.equity_usd,
+                     realized_cum_usd=excluded.realized_cum_usd,
+                     unrealized_usd=excluded.unrealized_usd,
+                     marked_at=datetime('now')""",
+                (self.book.value, r + u, r, u))
+            await self._db.commit()
+        except Exception as e:  # noqa: BLE001 - bookkeeping must not break the cycle
+            log.debug("ibkr_multiasset.mark_error", book=self.book.value,
+                      error=str(e)[:120])
+
+    async def _record_research_signals(self) -> None:
+        """Once daily for the FX book: record execution-free comparator signals.
+
+        Records carry+trend (when a rates provider is wired and both legs
+        resolve) beside the live book's own trend signal, so the comparative
+        record exists BEFORE anything is wired into entries — the
+        pre-registered upgrade path (docs/ibkr_multiasset_paper.md).
+        """
+        if self._db is None or self.book is not IBKRBook.FX:
+            return
+        try:
+            row = await self._db.fetchone(
+                "SELECT 1 AS x FROM ibkr_research_signals "
+                "WHERE signal_date = date('now') LIMIT 1")
+            if row is not None:
+                return  # today already recorded
+            from datetime import datetime, timedelta, timezone
+
+            from auramaur.research.ibkr_signals import PricePoint, fx_carry_trend
+            now = datetime.now(timezone.utc)
+            for spec in BY_BOOK[self.book]:
+                try:
+                    bars = await self._client.get_daily_bars(spec)
+                    closes = closes_from_bars(bars)
+                    momentum = normalized_momentum(closes)
+                    if momentum is not None:
+                        await self._db.execute(
+                            """INSERT OR IGNORE INTO ibkr_research_signals
+                               (instrument_key, signal_date, signal_name,
+                                direction, strength, detail)
+                               VALUES (?, date('now'), 'trend_normalized', ?, ?, ?)""",
+                            (spec.key,
+                             1 if momentum > 0 else -1 if momentum < 0 else 0,
+                             abs(momentum), f"normalized_momentum={momentum:.4f}"))
+                    if self._rates_provider is None or len(spec.key) < 6:
+                        continue
+                    base_rate = await self._rates_provider.rate(spec.key[:3])
+                    quote_rate = await self._rates_provider.rate(spec.key[3:6])
+                    if base_rate is None or quote_rate is None:
+                        continue
+                    window = closes[-121:]
+                    points = [
+                        PricePoint(
+                            observed_at=now - timedelta(days=len(window) - 1 - i),
+                            value=c)
+                        for i, c in enumerate(window)]
+                    signal = fx_carry_trend(points, as_of=now, base_rate=base_rate,
+                                            quote_rate=quote_rate)
+                    await self._db.execute(
+                        """INSERT OR IGNORE INTO ibkr_research_signals
+                           (instrument_key, signal_date, signal_name,
+                            direction, strength, detail)
+                           VALUES (?, date('now'), 'fx_carry_trend', ?, ?, ?)""",
+                        (spec.key, signal.direction, signal.score,
+                         signal.rationale[:200]))
+                except Exception as e:  # noqa: BLE001 - one pair must not stop the sweep
+                    log.debug("ibkr_multiasset.research_signal_error",
+                              key=spec.key, error=str(e)[:100])
+            await self._db.commit()
+        except Exception as e:  # noqa: BLE001 - research-only
+            log.debug("ibkr_multiasset.research_error", error=str(e)[:120])

--- a/docs/ibkr_multiasset_paper.md
+++ b/docs/ibkr_multiasset_paper.md
@@ -144,3 +144,29 @@ separate design and review. At minimum, a book needs 30 closed paper positions,
 positive net trade P&L after modeled commissions, profit factor above 1.1, fresh
 native quotes for every traded instrument, and asset-specific reconciliation.
 No book graduates another book.
+
+
+## Evidence contract (amended, pre-registered 2026-07-20)
+
+The 200-round-trip / 180-day contract is arithmetically unreachable for
+slow-turnover books: an FX book holding 2-6 weeks across 4 slots produces
+roughly 15-50 round trips in 180 days. Amended BEFORE any FX evidence
+existed:
+
+- **Primary**: `evaluate_ibkr_daily_evidence` over daily marked-to-market
+  book P&L (`ibkr_paper_daily_marks`, written idempotently by each cycle) —
+  at least 120 daily observations across at least 180 days, positive 95%
+  lower confidence bound on the daily mean, drawdown within 10% of budget.
+- **Secondary (cost realism)**: at least 30 cost-adjusted round trips with
+  their own positive lower bound.
+- **Anti-gaming clause**: holding brackets (stops, take-profits, momentum
+  exits) must never be shortened merely to manufacture observations; a
+  cadence change requires its own pre-registration with rationale.
+- **Entry ordering**: when more signals qualify than slots remain, entries
+  are taken strongest-normalized-momentum first (not universe order).
+- **Carry upgrade path**: `fx_carry_trend` and the book's own trend signal
+  are recorded daily, execution-free, to `ibkr_research_signals` (rates via
+  FRED OECD immediate-rate series; monthly, lagged — auditable in the
+  detail column). Wiring carry into entry RANKING (never gating alone) is
+  permitted only after ≥60 recorded days show the blend would not have
+  degraded the realized book, and requires its own pre-registered change.

--- a/tests/test_ibkr_evidence.py
+++ b/tests/test_ibkr_evidence.py
@@ -23,3 +23,29 @@ def test_drawdown_and_uncertainty_fail_closed():
         [5.0] * 210 + [-100.0] * 10, elapsed_days=220, budget_usd=1_000)
     assert not evidence.ready
     assert evidence.max_drawdown_usd == 1_000
+
+
+# ---- daily-marks contract (pre-registered 2026-07-20) ----------------------
+
+def test_daily_evidence_reachable_for_slow_turnover_books():
+    from auramaur.risk.ibkr_evidence import evaluate_ibkr_daily_evidence
+    # 180 days of steady small positive daily P&L: exactly the profile a
+    # 2-6 week-hold FX book can produce but the 200-trip contract cannot see.
+    daily = [3.0 + (0.5 if i % 3 else -0.5) for i in range(130)]
+    out = evaluate_ibkr_daily_evidence(daily, elapsed_days=185, budget_usd=5000)
+    assert out.ready, out.reasons
+    assert out.observations == 130
+
+
+def test_daily_evidence_rejects_short_windows_and_weak_means():
+    from auramaur.risk.ibkr_evidence import evaluate_ibkr_daily_evidence
+    thin = evaluate_ibkr_daily_evidence([5.0] * 50, elapsed_days=60,
+                                        budget_usd=5000)
+    assert not thin.ready
+    assert any("50/120" in r for r in thin.reasons)
+    assert any("60/180" in r for r in thin.reasons)
+    noisy = evaluate_ibkr_daily_evidence(
+        [100.0 if i % 2 else -99.0 for i in range(130)],
+        elapsed_days=185, budget_usd=5000)
+    assert not noisy.ready
+    assert any("lower bound" in r for r in noisy.reasons)

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -340,3 +340,92 @@ async def test_broker_calendar_honours_holiday_and_split_sessions():
         spec, now=datetime(2026, 7, 21, 16, tzinfo=timezone.utc))
     assert await client.is_market_open(
         spec, now=datetime(2026, 7, 21, 18, tzinfo=timezone.utc))
+
+
+# ---- FX audit follow-ups (2026-07-20) --------------------------------------
+
+class RankedFakeMarketData(FakeMarketData):
+    """Distinct momentum per instrument so entry ordering is observable."""
+
+    def __init__(self, momenta):
+        self._momenta = momenta
+
+    async def get_daily_bars(self, spec, duration="3 M"):
+        # Construct a price path whose normalized momentum ordering follows
+        # the configured per-key slope: later closes grow by slope per step.
+        slope = self._momenta.get(spec.key, 0.0)
+        return [(f"s-{d:03d}", 100 * (1 + slope) ** d) for d in range(121)]
+
+
+@pytest.mark.asyncio
+async def test_entries_rank_strongest_momentum_first():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
+    settings.ibkr.multiasset_refreshes_per_cycle = 12
+    cfg = settings.ibkr.multiasset_books["fx"]
+    cfg.enabled = True
+    cfg.max_positions = 1  # one slot: the strongest signal must win it
+    cfg.max_position_pct = 40
+    cfg.max_deployment_pct = 60
+    momenta = {spec.key: 0.001 for spec in BY_BOOK[IBKRBook.FX]}
+    momenta["GBPJPY"] = 0.004  # clearly strongest trend
+    pillar = IBKRMultiAssetPaperBook(
+        settings, RankedFakeMarketData(momenta), db, IBKRBook.FX)
+    pillar.market_open = lambda now=None: True
+    assert await pillar.run_once() == 1
+    row = await db.fetchone(
+        "SELECT instrument_key FROM ibkr_paper_positions WHERE book='fx'")
+    assert row["instrument_key"] == "GBPJPY"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_daily_mark_upserts_one_row_per_day():
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
+    settings.ibkr.multiasset_refreshes_per_cycle = 1
+    settings.ibkr.multiasset_books["futures"].max_position_pct = 40
+    pillar = IBKRMultiAssetPaperBook(
+        settings, FakeMarketData(), db, IBKRBook.FUTURES)
+    pillar.market_open = lambda now=None: True
+    await pillar.run_once()
+    await pillar.run_once()  # same day: must update, not duplicate
+    rows = await db.fetchall(
+        "SELECT * FROM ibkr_paper_daily_marks WHERE book='futures'")
+    assert len(rows) == 1
+    assert rows[0]["equity_usd"] == pytest.approx(
+        rows[0]["realized_cum_usd"] + rows[0]["unrealized_usd"])
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fx_research_recorder_records_trend_and_carry_once_daily():
+    class Rates:
+        async def rate(self, currency):
+            return {"GBP": 0.05, "JPY": 0.001}.get(currency, 0.03)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
+    pillar = IBKRMultiAssetPaperBook(
+        settings, RankedFakeMarketData({s.key: 0.002 for s in BY_BOOK[IBKRBook.FX]}),
+        db, IBKRBook.FX, rates_provider=Rates())
+    await pillar._record_research_signals()
+    await pillar._record_research_signals()  # second call same day: no-op
+    trend = await db.fetchall(
+        "SELECT * FROM ibkr_research_signals WHERE signal_name='trend_normalized'")
+    carry = await db.fetchall(
+        "SELECT * FROM ibkr_research_signals WHERE signal_name='fx_carry_trend'")
+    assert len(trend) == len(BY_BOOK[IBKRBook.FX])
+    assert len(carry) == len(BY_BOOK[IBKRBook.FX])
+    gbpjpy = next(r for r in carry if r["instrument_key"] == "GBPJPY")
+    assert gbpjpy["direction"] == 1  # positive carry + uptrend agree
+    await db.close()

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -212,9 +212,9 @@ async def test_edge_evidence_is_net_of_commissions_and_financing():
     report = await preflight(settings, db, client=ReadyClient())
     edge = next(result for result in report.results if result.book == "global_etf:edge")
     assert "1 cost-adjusted round trips" in edge.detail
-    assert "$8.00 net P&L" in edge.detail
+    assert "$8.00 trip P&L" in edge.detail
     assert "not graduated" in edge.detail
-    assert "1/200 cost-adjusted observations" in edge.detail
+    assert "1/30 cost-adjusted observations" in edge.detail
     await db.close()
 
 
@@ -232,5 +232,5 @@ async def test_edge_ignores_ambiguous_legacy_ledger_events():
     report = await preflight(settings, db, client=ReadyClient())
     edge = next(result for result in report.results if result.book == "global_etf:edge")
     assert "0 cost-adjusted round trips" in edge.detail
-    assert "$0.00 net P&L" in edge.detail
+    assert "$0.00 trip P&L" in edge.detail
     await db.close()


### PR DESCRIPTION
## Summary
FX book audit follow-ups, items 1–4, pre-registered before any FX evidence exists (the book reached `eligible` only hours ago — the contract is being fixed while the slate is clean).

1. **Reachable evidence contract**: the 200-trip/180-day bar misses this book''s physics by 4–10× (2–6 week holds × 4 slots ≈ 15–50 trips/180d). New `evaluate_ibkr_daily_evidence` judges **daily marked-to-market P&L** (≥120 observations, ≥180 days, positive 95% LCB on the daily mean, drawdown ≤10% of budget); the preflight now runs it as PRIMARY with round trips demoted to a secondary cost-realism check at ≥30. Schema v33 adds `ibkr_paper_daily_marks` (idempotent per book/date; last cycle of the day wins — no scheduler needed; migration + base DDL follow the #321 index rule).
2. **Anti-gaming clause** in `docs/ibkr_multiasset_paper.md`: brackets must never be shortened to manufacture observations; cadence changes need their own pre-registration.
3. **Carry research accrual**: `fx_carry_trend` + the live trend signal recorded once daily per pair to `ibkr_research_signals`, execution-free; rates from FRED OECD immediate-rate series via a daily-cached `FredRatesProvider` (absent key → trend-only, never fatal; staleness auditable in the detail column). Carry may enter entry RANKING only after ≥60 recorded days show the blend wouldn''t have degraded the realized book — its own pre-registered change.
4. **Ranked entries**: qualifiers are collected then entered strongest-momentum-first (today''s live screen: 6 qualifiers, 4 slots — ordering is material; GBPJPY 0.776 now wins a slot over GBPUSD 0.309).

## Testing
- New: ranked-entry test (one slot → strongest wins), daily-mark idempotency (+equity identity), research recorder (trend+carry recorded once daily, carry agreement direction), daily-evidence math (reachable slow-turnover profile passes; short windows and noisy means fail with the right reasons).
- Full IBKR + settings suites: 74 passed; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)