### PR TITLE
feat(manager): auto-proposals — operationalized confidence, same gauntlet

### DIFF
--- a/auramaur/cli/manager.py
+++ b/auramaur/cli/manager.py
@@ -120,12 +120,15 @@ def list_proposals(show_all: bool) -> None:
                 f"SELECT * FROM manager_proposals {where} "
                 "ORDER BY created_at DESC LIMIT 50")
             table = Table(title="interim-manager proposals")
-            for col in ("id", "venue", "market", "side", "fair", "stake",
+            for col in ("id", "by", "venue", "market", "side", "fair", "stake",
                         "status", "reason", "created"):
                 table.add_column(col)
             for r in rows or []:
-                table.add_row(str(r["id"]), r["venue"], r["market_id"], r["side"],
-                              f"{r['fair_prob']:.2f}", f"{r['stake_usd']:.2f}",
+                keys = r.keys()
+                by = r["proposer"] if "proposer" in keys else "operator"
+                table.add_row(str(r["id"]), by, r["venue"], r["market_id"],
+                              r["side"], f"{r['fair_prob']:.2f}",
+                              f"{r['stake_usd']:.2f}",
                               r["status"], (r["reason"] or "")[:50],
                               str(r["created_at"])[:16])
             console.print(table)
@@ -166,7 +169,7 @@ def report() -> None:
         db = await _db()
         try:
             rows = await db.fetchall(
-                """SELECT mp.thesis_class AS cls,
+                """SELECT mp.proposer || ':' || mp.thesis_class AS cls,
                           COUNT(*) AS proposals,
                           SUM(mp.status = 'executed') AS executed,
                           SUM(mp.status = 'skipped') AS skipped,
@@ -177,7 +180,7 @@ def report() -> None:
                        ON led.market_id = mp.market_id
                       AND led.strategy_source = 'interim_manager'
                     GROUP BY mp.thesis_class ORDER BY proposals DESC""")
-            table = Table(title="interim-manager scorecard (by thesis class)")
+            table = Table(title="interim-manager scorecard (by proposer:class)")
             for col in ("class", "proposals", "executed", "skipped",
                         "avg robust edge", "realized P&L"):
                 table.add_column(col)

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -134,6 +134,8 @@ class Database:
             await self._migrate_v31_to_v32()
         if from_version < 33:
             await self._migrate_v32_to_v33()
+        if from_version < 34:
+            await self._migrate_v33_to_v34()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -237,6 +239,18 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 33")
         await self._db.commit()
         log.info("database.migrated", from_version=32, to_version=33)
+
+    async def _migrate_v33_to_v34(self) -> None:
+        """Tag manager proposals with their author (operator vs auto)."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE manager_proposals ADD COLUMN "
+                "proposer TEXT NOT NULL DEFAULT 'operator'")
+        except Exception:  # noqa: BLE001 — column already present
+            pass
+        await self._db.execute("UPDATE schema_version SET version = 34")
+        await self._db.commit()
+        log.info("database.migrated", from_version=33, to_version=34)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 33
+SCHEMA_VERSION = 34
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -800,7 +800,10 @@ CREATE TABLE IF NOT EXISTS manager_proposals (
     invalidation TEXT NOT NULL DEFAULT '',
     sunset_at TEXT,
     robust_edge REAL,
-    decision_price REAL
+    decision_price REAL,
+    -- v34: who authored the thesis — 'operator' (CLI) or 'auto' (the
+    -- manager's own signal-derived proposals). Scored separately.
+    proposer TEXT NOT NULL DEFAULT 'operator'
 );
 CREATE INDEX IF NOT EXISTS idx_manager_proposals_status
     ON manager_proposals(status, created_at);

--- a/auramaur/strategy/interim_manager.py
+++ b/auramaur/strategy/interim_manager.py
@@ -80,6 +80,7 @@ class InterimManagerPillar:
 
         owned_categories = {category: strategy
                            for strategy, category in graduated}
+        await self._auto_propose(owned_categories)
         pending = await self._db.fetchall(
             """SELECT * FROM manager_proposals WHERE status = 'pending'
                ORDER BY created_at LIMIT ?""",
@@ -284,3 +285,85 @@ class InterimManagerPillar:
             return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
         except ValueError:
             return None
+
+    async def _auto_propose(self, owned: dict[str, str]) -> None:
+        """Author queue entries from strong calibrated signals (charter
+        amendment 2026-07-20). Confidence is operationalized: HIGH-confidence
+        source signal, calibrated edge above the floor, category not owned by
+        a graduate, market not already held or proposed. The proposal then
+        faces the identical gauntlet as an operator proposal — the CI width
+        is a configured, deliberately honest haircut, and the robust-edge
+        gate remains the arbiter. Capped per day; scored separately via the
+        proposer tag.
+        """
+        cfg = self._settings.interim_manager
+        if not cfg.auto_propose or self._calibration is None:
+            return
+        try:
+            row = await self._db.fetchone(
+                """SELECT COUNT(*) AS n FROM manager_proposals
+                   WHERE proposer = 'auto' AND created_at >= date('now')""")
+            if int(row["n"] or 0) >= cfg.auto_daily_cap:
+                return
+            budget = cfg.auto_daily_cap - int(row["n"] or 0)
+            signals = await self._db.fetchall(
+                """SELECT s.market_id, s.exchange, s.claude_prob, s.market_prob,
+                          s.evidence_summary, s.strategy_source,
+                          COALESCE(m.category, '') AS category
+                   FROM signals s LEFT JOIN markets m ON m.id = s.market_id
+                   WHERE s.claude_confidence = ?
+                     AND s.timestamp >= datetime('now', '-6 hours')
+                     AND s.market_id NOT IN
+                         (SELECT market_id FROM manager_proposals
+                           WHERE created_at >= datetime('now', '-48 hours'))
+                     AND s.market_id NOT IN
+                         (SELECT market_id FROM portfolio WHERE size > 0)
+                   ORDER BY s.timestamp DESC LIMIT 25""",
+                (cfg.auto_min_confidence,))
+            for sig in signals or []:
+                if budget <= 0:
+                    break
+                category = sig["category"] or ""
+                if category in owned:
+                    continue
+                exempt = set(self._settings.graduation.exempt_strategies)
+                if (sig["strategy_source"] or "") in exempt:
+                    continue  # structural strategies place their own orders
+                calibrated = await self._calibration.adjust(
+                    float(sig["claude_prob"]), category)
+                market_p = float(sig["market_prob"] or 0)
+                if not (0.0 < market_p < 1.0):
+                    continue
+                edge = calibrated - market_p
+                if abs(edge) < cfg.auto_min_calibrated_edge:
+                    continue
+                half = cfg.auto_ci_width / 2.0
+                lo = max(0.01, calibrated - half)
+                hi = min(0.99, calibrated + half)
+                side = "BUY" if edge > 0 else "SELL"
+                thesis = (
+                    f"[auto] Source {sig['strategy_source'] or 'llm'} HIGH-confidence "
+                    f"signal: raw {float(sig['claude_prob']):.2f} -> calibrated "
+                    f"{calibrated:.2f} vs market {market_p:.2f} "
+                    f"(edge {edge:+.2f} after Platt scaling on category "
+                    f"'{category or 'global'}'). Mechanism per source evidence: "
+                    f"{(sig['evidence_summary'] or '')[:200]}")
+                await self._db.execute(
+                    """INSERT INTO manager_proposals
+                       (venue, market_id, side, fair_prob, stake_usd, thesis,
+                        thesis_class, confidence_lo, confidence_hi,
+                        sunset_at, proposer)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                               datetime('now', '+24 hours'), 'auto')""",
+                    (sig["exchange"] or "polymarket", sig["market_id"], side,
+                     round(calibrated, 4), cfg.auto_stake_usd, thesis,
+                     "forecast_divergence" if category in ("weather", "economics")
+                     else "unclassified", round(lo, 4), round(hi, 4)))
+                budget -= 1
+                log.info("interim_manager.auto_proposed",
+                         market_id=sig["market_id"], side=side,
+                         calibrated=round(calibrated, 3),
+                         market=round(market_p, 3), category=category)
+            await self._db.commit()
+        except Exception as e:  # noqa: BLE001 — authorship must not break the cycle
+            log.warning("interim_manager.auto_propose_error", error=str(e)[:150])

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -569,6 +569,15 @@ interim_manager:
   # liquidity - correlation must clear this. Conservative about apparent
   # edges built on weak estimates (docs/INTERIM_MANAGER.md).
   min_robust_edge: 0.05
+  # Auto-proposals: OFF by tracked default; arm deliberately in the local
+  # overrides. Confidence is operationalized (HIGH source signal + calibrated
+  # edge floor) and every auto proposal faces the identical gauntlet.
+  auto_propose: false
+  auto_min_confidence: "HIGH"
+  auto_min_calibrated_edge: 0.10
+  auto_ci_width: 0.10
+  auto_daily_cap: 3
+  auto_stake_usd: 10.0
   default_uncertainty_buffer: 0.04
   slippage_buffer: 0.01
   thin_liquidity_usd: 200.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -749,6 +749,18 @@ class InterimManagerConfig(BaseModel):
     # Robust-edge gate (docs/INTERIM_MANAGER.md "decision rule"): the edge that
     # must survive after subtracting every cost and uncertainty haircut.
     min_robust_edge: float = 0.05
+    # Auto-proposals (charter amendment 2026-07-20): the manager may author
+    # its OWN queue entries from strong calibrated signals. Confidence is
+    # operationalized, not judged: HIGH-confidence source signal, calibrated
+    # edge >= auto_min_calibrated_edge, and then the SAME gauntlet as every
+    # operator proposal (CI haircut from auto_ci_width, robust edge, risk
+    # gateway, delegation, sunset). Scored separately via the proposer tag.
+    auto_propose: bool = False
+    auto_min_confidence: str = "HIGH"
+    auto_min_calibrated_edge: float = 0.10
+    auto_ci_width: float = 0.10
+    auto_daily_cap: int = 3
+    auto_stake_usd: float = 10.0
     # Haircut when no confidence interval is supplied (else CI half-width).
     default_uncertainty_buffer: float = 0.04
     slippage_buffer: float = 0.01

--- a/docs/INTERIM_MANAGER.md
+++ b/docs/INTERIM_MANAGER.md
@@ -109,6 +109,28 @@ The mandate, compiled: **find short-lived, falsifiable probability
 discrepancies with an external anchor, an explainable mispricing mechanism,
 and enough robust edge to survive uncertainty and execution costs.**
 
+## Auto-proposals (charter amendment, 2026-07-20)
+
+The operator amended the "no autonomous signal generation" clause: when
+`auto_propose` is armed, the manager may author its own queue entries.
+Confidence is OPERATIONALIZED, never judged:
+
+- source signal must carry `auto_min_confidence` (default HIGH) from a
+  non-exempt strategy, be fresh (≤6h), for a market neither held nor
+  proposed in the last 48h;
+- the raw probability is Platt-calibrated per category, and the calibrated
+  edge must clear `auto_min_calibrated_edge` (default 0.10);
+- the proposal's confidence interval is the configured `auto_ci_width` —
+  a deliberately honest haircut the robust-edge gate then charges;
+- capped at `auto_daily_cap` per day, `auto_stake_usd` per entry, 24h
+  sunset, and the category-delegation rule applies before authorship.
+
+Every auto proposal then faces the IDENTICAL gauntlet as an operator
+proposal — nothing about the gates changes with authorship. The `proposer`
+tag separates human and auto theses in the scorecard, so the evaluation
+contract judges each author on its own record. Tracked default: OFF; arming
+is a dated operator override.
+
 ## Evaluation contract (pre-registered)
 
 - `strategy_source = "interim_manager"`; **not** in `exempt_strategies` — the

--- a/tests/test_interim_manager.py
+++ b/tests/test_interim_manager.py
@@ -276,3 +276,85 @@ def test_startup_migrates_an_existing_v31_database(tmp_path):
         assert idx is not None
         await db.close()
     asyncio.run(run())
+
+
+# ---- auto-proposals (charter amendment 2026-07-20) -------------------------
+
+class _FlatteringCalibration:
+    async def adjust(self, raw, category=""):
+        return min(0.99, raw + 0.05)
+
+    async def record_prediction(self, *a, **k):
+        return None
+
+
+async def _seed_signal(db, market_id="M9", confidence="HIGH", prob=0.62,
+                       market_prob=0.40, strategy="llm"):
+    await db.execute(
+        """INSERT OR IGNORE INTO markets (id, exchange, question, category,
+           outcome_yes_price, outcome_no_price, volume, last_updated)
+           VALUES (?, 'kalshi', 'Q?', 'economics', ?, ?, 0, datetime('now'))""",
+        (market_id, market_prob, 1 - market_prob))
+    await db.execute(
+        """INSERT INTO signals (market_id, exchange, claude_prob,
+           claude_confidence, market_prob, edge, evidence_summary,
+           strategy_source)
+           VALUES (?, 'kalshi', ?, ?, ?, 0, 'stale prices vs fresh print', ?)""",
+        (market_id, prob, confidence, market_prob, strategy))
+    await db.commit()
+
+
+def test_auto_propose_authors_from_high_confidence_calibrated_edge():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        pillar._settings.interim_manager.auto_propose = True
+        pillar._calibration = _FlatteringCalibration()
+        await _seed_signal(db)
+        await pillar._auto_propose({})
+        row = await db.fetchone(
+            "SELECT * FROM manager_proposals WHERE proposer='auto'")
+        assert row is not None
+        assert row["side"] == "BUY"
+        assert row["fair_prob"] == pytest.approx(0.67)  # 0.62 + 0.05
+        assert row["confidence_lo"] < row["fair_prob"] < row["confidence_hi"]
+        assert row["sunset_at"] is not None
+        assert len(row["thesis"]) >= 40 and row["thesis"].startswith("[auto]")
+        await db.close()
+    asyncio.run(run())
+
+
+def test_auto_propose_respects_daily_cap_and_confidence_floor():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        cfg = pillar._settings.interim_manager
+        cfg.auto_propose = True
+        cfg.auto_daily_cap = 1
+        pillar._calibration = _FlatteringCalibration()
+        await _seed_signal(db, "A1")
+        await _seed_signal(db, "A2")
+        await _seed_signal(db, "A3", confidence="MEDIUM")
+        await pillar._auto_propose({})
+        rows = await db.fetchall(
+            "SELECT market_id FROM manager_proposals WHERE proposer='auto'")
+        assert len(rows) == 1  # cap, and the MEDIUM one never qualifies
+        await db.close()
+    asyncio.run(run())
+
+
+def test_auto_propose_stands_down_in_delegated_categories():
+    async def run():
+        pillar, db, gateway, _ = await _pillar()
+        pillar._settings.interim_manager.auto_propose = True
+        pillar._calibration = _FlatteringCalibration()
+        await _seed_signal(db)
+        await pillar._auto_propose({"economics": "econ_indicator"})
+        row = await db.fetchone(
+            "SELECT 1 AS x FROM manager_proposals WHERE proposer='auto'")
+        assert row is None
+        await db.close()
+    asyncio.run(run())
+
+
+def test_auto_propose_disabled_by_tracked_default():
+    s = Settings()
+    assert s.interim_manager.auto_propose is False


### PR DESCRIPTION
## Summary
Charter amendment per operator instruction: the interim manager may place trades on its own initiative **when it is confident — with confidence operationalized, never judged**:

- Candidate = fresh (≤6h) `HIGH`-confidence signal from a non-exempt strategy, market neither held nor proposed in 48h, category not delegated to a graduate.
- The raw probability is **Platt-calibrated per category** (`calibration.adjust`), and the calibrated edge must clear `auto_min_calibrated_edge` (default 0.10).
- The authored proposal carries a **configured honest CI** (`auto_ci_width` 0.10 → a 0.05 uncertainty haircut the robust-edge gate charges), a 24h sunset, `auto_stake_usd` (default $10), and at most `auto_daily_cap` (default 3) per day.
- **Nothing about the gates changes with authorship**: every auto proposal faces the identical gauntlet — delegation, max-entry, robust edge with full haircut breakdown, and all risk checks.
- Schema v34 adds the `proposer` tag; `manager list` shows it and `manager report` splits the scorecard by `proposer:class`, so the evaluation contract scores the auto author on its own record, separable from the human''s.
- Tracked default **OFF** (`auto_propose: false`); arming is a dated operator override in the local config.

## Safety
- Additive only; no gate weakened. The exempt structural strategies are excluded as sources (they place their own orders). Authorship failures never break the manager cycle.

## Testing
- 4 new tests: authors from a qualifying calibrated signal (side, CI bracket, sunset, thesis form), daily cap + confidence floor enforced, delegated-category stand-down, tracked-default-off contract. Full manager+migrations+settings run: 50 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)