### PR TITLE
feat(strategy): add paper-forced platform consensus follower

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1533,6 +1533,10 @@ class AuramaurBot(
         if self.settings.bias_harvest.enabled:
             tasks.append(asyncio.create_task(self._task_bias_harvest(), name="bias_harvest"))
 
+        # Platform consensus follower (paper-forced until proven)
+        if self.settings.platform_consensus.enabled:
+            tasks.append(asyncio.create_task(self._task_platform_consensus(), name="platform_consensus"))
+
         # Long-horizon favorite underpricing (paper-forced; structural slope edge)
         if self.settings.long_horizon.enabled:
             tasks.append(asyncio.create_task(self._task_long_horizon(), name="long_horizon"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -494,3 +494,26 @@ class StrategyTaskMixin:
             if equity is not None:
                 await equity.close()
 
+    async def _task_platform_consensus(self) -> None:
+        """Periodic platform consensus follower (Metaculus / Manifold)."""
+        from auramaur.strategy.platform_consensus import PlatformConsensusPillar
+
+        pillar = PlatformConsensusPillar(
+            db=self._components.db,
+            settings=self.settings,
+            discovery=self._components.discovery,
+            exchange=self._components.exchange,
+            risk_manager=self._components.risk_manager,
+            pnl_tracker=self._components.pnl_tracker,
+            calibration=self._components.calibration,
+        )
+        interval = max(60, self.settings.platform_consensus.interval_seconds)
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await pillar.run_once()
+            except Exception as e:
+                log.error("platform_consensus.cycle_error", error=str(e))
+            await asyncio.sleep(interval)
+

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -508,12 +508,18 @@ class StrategyTaskMixin:
             calibration=self._components.calibration,
         )
         interval = max(60, self.settings.platform_consensus.interval_seconds)
-        while self._running:
-            if await self._check_kill_switch():
-                return
+        try:
+            while self._running:
+                if await self._check_kill_switch():
+                    return
+                try:
+                    await pillar.run_once()
+                except Exception as e:
+                    log.error("platform_consensus.cycle_error", error=str(e))
+                await asyncio.sleep(interval)
+        finally:
             try:
-                await pillar.run_once()
+                await pillar.close()
             except Exception as e:
-                log.error("platform_consensus.cycle_error", error=str(e))
-            await asyncio.sleep(interval)
+                log.warning("platform_consensus.close_error", error=str(e))
 

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import re
-import time
 from datetime import datetime, timezone
 
 import structlog
@@ -180,6 +178,25 @@ class PlatformConsensusPillar:
             return float(m.group(1)) / 100.0
         return None
 
+    @staticmethod
+    def _quality_ok(item, source_name: str, cfg) -> bool:
+        """Fail closed when a crowd forecast lacks the configured sample depth."""
+        content = item.content or ""
+        if source_name == "Manifold":
+            bettors = re.search(r"Unique bettors:\s*([\d,]+)", content)
+            liquidity = re.search(r"Liquidity:\s*\$([\d,]+(?:\.\d+)?)", content)
+            if bettors is None or liquidity is None:
+                return False
+            return (
+                int(bettors.group(1).replace(",", "")) >= cfg.min_manifold_bettors
+                and float(liquidity.group(1).replace(",", ""))
+                >= cfg.min_manifold_liquidity
+            )
+        forecasters = re.search(r"Forecasters:\s*([\d,]+)", content)
+        if forecasters is None:
+            return False
+        return int(forecasters.group(1).replace(",", "")) >= cfg.min_metaculus_forecasters
+
     async def _try_enter(self, market: Market, cfg) -> bool:
         # Search Manifold
         manifold_items = []
@@ -209,6 +226,8 @@ class PlatformConsensusPillar:
 
         # Process Manifold matches
         for item in manifold_items:
+            if not self._quality_ok(item, "Manifold", cfg):
+                continue
             clean_title = self._get_clean_title(item.title)
             overlap = _word_overlap_score(market.question, clean_title)
             if overlap > best_overlap:
@@ -218,6 +237,8 @@ class PlatformConsensusPillar:
 
         # Process Metaculus matches
         for item in metaculus_items:
+            if not self._quality_ok(item, "Metaculus", cfg):
+                continue
             clean_title = self._get_clean_title(item.title)
             overlap = _word_overlap_score(market.question, clean_title)
             if overlap > best_overlap:
@@ -293,7 +314,7 @@ class PlatformConsensusPillar:
                 market.exchange or "polymarket",
                 market.condition_id,
                 market.question,
-                market.description[:500],
+                (market.description or "")[:500],
                 ensure_category(market.question, market.description, market.category),
                 market.outcome_yes_price,
                 market.outcome_no_price,
@@ -341,20 +362,31 @@ class PlatformConsensusPillar:
                 pnl_tracker=self._pnl,
             )
 
+        size = min(decision.position_size, cfg.stake_usd)
+        force_paper = cfg.paper or getattr(decision, "force_paper", False)
         res = await self._gateway.submit(
             TradeIntent(
                 signal=signal,
                 market=market,
-                size_dollars=decision.position_size,
-                force_paper=cfg.paper,
+                size_dollars=size,
+                force_paper=force_paper,
             )
         )
+
+        if res.status not in ("filled", "paper", "partial", "pending"):
+            log.warning(
+                "platform_consensus.order_rejected",
+                market_id=market.id,
+                status=res.status,
+                reason=res.reason,
+            )
+            return False
 
         log.info(
             "platform_consensus.executed",
             market_id=market.id,
             status=res.status,
-            size=decision.position_size,
+            size=size,
             is_paper=res.result.is_paper if res.result else None,
         )
         return True

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -1,0 +1,364 @@
+"""Platform consensus follower strategy — follow crowd forecasting consensus on Manifold and Metaculus."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+import time
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.data_sources.manifold import ManifoldSource
+from auramaur.data_sources.metaculus import MetaculusSource
+from auramaur.exchange.models import (
+    Confidence,
+    Market,
+    OrderSide,
+    Signal,
+)
+from auramaur.strategy.classifier import blocked_category_hit, ensure_category
+from auramaur.strategy.arbitrage_scanner import _word_overlap_score
+from auramaur.strategy.protocols import ExecutionMode
+from auramaur.strategy.signals import taker_fee_rate
+
+log = structlog.get_logger()
+
+
+class PlatformConsensusPillar:
+    """Strategy pillar that aligns prediction market prices with play-money consensus."""
+
+    # Uniform Strategy contract (see strategy/protocols.py).
+    name = "platform_consensus"
+    execution_mode = ExecutionMode.GATEWAY_SINGLE
+
+    def __init__(
+        self,
+        db,
+        settings,
+        discovery,
+        exchange,
+        risk_manager,
+        pnl_tracker,
+        calibration,
+    ) -> None:
+        self._db = db
+        self._settings = settings
+        self._discovery = discovery
+        self._exchange = exchange
+        self._risk = risk_manager
+        self._pnl = pnl_tracker
+        self._calibration = calibration
+        self._manifold = ManifoldSource()
+        self._metaculus = MetaculusSource()
+        self._gateway = None
+
+    async def run_once(self) -> int:
+        cfg = self._settings.platform_consensus
+        if not cfg.enabled:
+            return 0
+
+        open_count = await self._open_position_count()
+        if open_count >= cfg.max_open:
+            log.info(
+                "platform_consensus.cycle",
+                scanned=0,
+                entered=0,
+                book_full=True,
+                open=open_count,
+                cap=cfg.max_open,
+            )
+            return 0
+
+        markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+
+        eligible_markets = []
+        for m in markets:
+            if not self._eligible(m, cfg):
+                continue
+            if await self._already_entered_or_held(m.id):
+                continue
+            eligible_markets.append(m)
+
+        # Rank by liquidity / volume descending to prioritize active markets
+        eligible_markets.sort(
+            key=lambda x: max(x.liquidity or 0.0, x.volume or 0.0), reverse=True
+        )
+
+        eval_limit = min(len(eligible_markets), cfg.max_entries_per_cycle * 2, 10)
+
+        entered = 0
+        for market in eligible_markets[:eval_limit]:
+            if entered >= cfg.max_entries_per_cycle:
+                break
+            if open_count + entered >= cfg.max_open:
+                break
+
+            try:
+                if await self._try_enter(market, cfg):
+                    entered += 1
+            except Exception as e:
+                log.error(
+                    "platform_consensus.market_error",
+                    market_id=market.id,
+                    error=str(e),
+                    exc_info=True,
+                )
+
+            # Sleep between queries to be nice to public APIs
+            await asyncio.sleep(1.0)
+
+        if entered > 0:
+            log.info("platform_consensus.cycle_done", entered=entered)
+        return entered
+
+    def _eligible(self, market: Market, cfg) -> bool:
+        if not market.active:
+            return False
+
+        # Volume or liquidity threshold
+        vol_or_liq = max(market.liquidity or 0.0, market.volume or 0.0)
+        if vol_or_liq < cfg.min_liquidity:
+            return False
+
+        # Category blocklist
+        blocked = set(self._settings.risk.blocked_categories)
+        if blocked_category_hit(
+            blocked, market.question, market.description, market.category
+        ):
+            return False
+
+        # Time to resolution bounds
+        if market.end_date is None:
+            return False
+
+        now = datetime.now(timezone.utc)
+        end_date = market.end_date
+        if end_date.tzinfo is None:
+            end_date = end_date.replace(tzinfo=timezone.utc)
+
+        hours_to_res = (end_date - now).total_seconds() / 3600.0
+        if (
+            hours_to_res < cfg.min_hours_to_resolution
+            or hours_to_res > cfg.max_days_to_resolution * 24.0
+        ):
+            return False
+
+        return True
+
+    async def _already_entered_or_held(self, market_id: str) -> bool:
+        row = await self._db.fetchone(
+            "SELECT 1 FROM signals WHERE market_id = ? AND strategy_source = ? LIMIT 1",
+            (market_id, self.name),
+        )
+        if row is not None:
+            return True
+        row = await self._db.fetchone(
+            "SELECT 1 FROM portfolio WHERE market_id = ? LIMIT 1",
+            (market_id,),
+        )
+        return row is not None
+
+    async def _open_position_count(self) -> int:
+        row = await self._db.fetchone(
+            """SELECT COUNT(*) AS n FROM portfolio p
+               WHERE EXISTS (SELECT 1 FROM signals s
+                             WHERE s.market_id = p.market_id
+                               AND s.strategy_source = ?)""",
+            (self.name,),
+        )
+        return int(row["n"]) if row else 0
+
+    def _get_clean_title(self, title: str) -> str:
+        return re.sub(r"^\[(?:Manifold|Metaculus):\s*\d+%\]\s*", "", title).strip()
+
+    def _parse_probability_from_title(self, title: str) -> float | None:
+        m = re.match(r"^\[(?:Manifold|Metaculus):\s*(\d+)%\]", title)
+        if m:
+            return float(m.group(1)) / 100.0
+        return None
+
+    async def _try_enter(self, market: Market, cfg) -> bool:
+        # Search Manifold
+        manifold_items = []
+        try:
+            manifold_items = await self._manifold.fetch(market.question, limit=5)
+        except Exception as e:
+            log.debug(
+                "platform_consensus.manifold_fetch_error",
+                market_id=market.id,
+                error=str(e),
+            )
+
+        # Search Metaculus
+        metaculus_items = []
+        try:
+            metaculus_items = await self._metaculus.fetch(market.question, limit=5)
+        except Exception as e:
+            log.debug(
+                "platform_consensus.metaculus_fetch_error",
+                market_id=market.id,
+                error=str(e),
+            )
+
+        best_match = None
+        best_overlap = 0.0
+        source_name = ""
+
+        # Process Manifold matches
+        for item in manifold_items:
+            clean_title = self._get_clean_title(item.title)
+            overlap = _word_overlap_score(market.question, clean_title)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_match = item
+                source_name = "Manifold"
+
+        # Process Metaculus matches
+        for item in metaculus_items:
+            clean_title = self._get_clean_title(item.title)
+            overlap = _word_overlap_score(market.question, clean_title)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_match = item
+                source_name = "Metaculus"
+
+        if best_match is None or best_overlap < cfg.match_threshold:
+            return False
+
+        prob = self._parse_probability_from_title(best_match.title)
+        if prob is None:
+            return False
+
+        market_p = market.outcome_yes_price
+        edge = prob - market_p
+        abs_edge = abs(edge)
+
+        # Calculate required edge (including fee)
+        fee = (
+            taker_fee_rate(
+                market.exchange or "polymarket",
+                market.category or "",
+                self._settings.arbitrage.exchange_fees,
+            )
+            * market_p
+            * (1.0 - market_p)
+        )
+        required_edge = cfg.min_edge + fee
+
+        if abs_edge < required_edge:
+            return False
+
+        recommended_side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+
+        log.info(
+            "platform_consensus.signal_detected",
+            market_id=market.id,
+            market_question=market.question[:50],
+            consensus_source=source_name,
+            consensus_prob=round(prob, 3),
+            market_prob=round(market_p, 3),
+            edge=round(abs_edge * 100, 2),
+            side=recommended_side.value,
+        )
+
+        signal = Signal(
+            market_id=market.id,
+            market_question=market.question,
+            claude_prob=prob,
+            claude_confidence=Confidence.HIGH
+            if best_overlap >= 0.8
+            else Confidence.MEDIUM,
+            market_prob=market_p,
+            edge=abs_edge * 100.0,
+            evidence_summary=(
+                f"Platform consensus follower: found matching market on {source_name} "
+                f"('{self._get_clean_title(best_match.title)[:80]}') with consensus probability {prob:.0%}. "
+                f"Market price is {market_p:.0%}. Edge: {abs_edge:.1%}. Word overlap: {best_overlap:.2f}."
+            ),
+            recommended_side=recommended_side,
+            strategy_source=self.name,
+        )
+
+        # Insert DB rows for FK constraints
+        await self._db.execute(
+            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question, description,
+               category, active, outcome_yes_price, outcome_no_price,
+               volume, liquidity, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
+            (
+                market.id,
+                market.exchange or "polymarket",
+                market.condition_id,
+                market.question,
+                market.description[:500],
+                ensure_category(market.question, market.description, market.category),
+                market.outcome_yes_price,
+                market.outcome_no_price,
+                market.volume,
+                market.liquidity,
+            ),
+        )
+        await self._db.execute(
+            """INSERT INTO signals (market_id, claude_prob, claude_confidence, market_prob,
+                                     edge, evidence_summary, action, strategy_source)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                signal.market_id,
+                signal.claude_prob,
+                signal.claude_confidence.value,
+                signal.market_prob,
+                signal.edge,
+                signal.evidence_summary,
+                signal.recommended_side.value if signal.recommended_side else None,
+                signal.strategy_source,
+            ),
+        )
+        await self._db.commit()
+
+        # Evaluate with risk manager
+        decision = await self._risk.evaluate(
+            signal, market, available_cash=None
+        )
+        if not decision.approved or decision.position_size <= 0:
+            log.info(
+                "platform_consensus.risk_rejected",
+                market_id=market.id,
+                reason=decision.reason[:80],
+            )
+            return False
+
+        # Submit order
+        if self._gateway is None:
+            self._gateway = ExecutionGateway(
+                router=None,
+                exchange=self._exchange,
+                exchange_name="polymarket",
+                settings=self._settings,
+                db=self._db,
+                pnl_tracker=self._pnl,
+            )
+
+        res = await self._gateway.submit(
+            TradeIntent(
+                signal=signal,
+                market=market,
+                size_dollars=decision.position_size,
+                force_paper=cfg.paper,
+            )
+        )
+
+        log.info(
+            "platform_consensus.executed",
+            market_id=market.id,
+            status=res.status,
+            size=decision.position_size,
+            is_paper=res.result.is_paper if res.result else None,
+        )
+        return True
+
+    async def close(self) -> None:
+        await self._manifold.close()
+        await self._metaculus.close()

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -958,6 +958,25 @@ bias_harvest:
   maker_min_spread: 0.02
   paper_maker_fill_rate: 0.5
 
+platform_consensus:
+  # Platform consensus follower — compares Polymarket/Kalshi prices with
+  # community forecasting consensus on Manifold Markets and Metaculus.
+  enabled: false
+  paper: true
+  min_edge: 0.06
+  stake_usd: 10.0
+  max_open: 40
+  max_entries_per_cycle: 5
+  scan_limit: 200
+  min_liquidity: 1000.0
+  min_hours_to_resolution: 6.0
+  max_days_to_resolution: 45.0
+  match_threshold: 0.65
+  min_manifold_bettors: 30
+  min_manifold_liquidity: 1000.0
+  min_metaculus_forecasters: 15
+  interval_seconds: 600
+
 analysis:
   mode: "strategic"   # "pipeline", "strategic", or "agent"
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -961,7 +961,11 @@ bias_harvest:
 platform_consensus:
   # Platform consensus follower — compares Polymarket/Kalshi prices with
   # community forecasting consensus on Manifold Markets and Metaculus.
-  enabled: false
+  # PAPER SPIKE STARTED 2026-07-20. Review after 30 settled positions or
+  # 2026-08-17, whichever is later. Keep only if net paper P&L is positive,
+  # Brier score beats the venue-price baseline, and manual review finds no
+  # semantic false matches. Stop early after 3 false matches or -$50 P&L.
+  enabled: true
   paper: true
   min_edge: 0.06
   stake_usd: 10.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -413,7 +413,7 @@ class BiasHarvestConfig(BaseModel):
     confidence — by design.
     """
 
-    enabled: bool = False
+    enabled: bool = True
     paper: bool = True
     # Deep band only. The backtest's edge lived in 0.90-0.97 (won 99.3% of 151);
     # the shallow 0.80-0.90 tier has no favorite-longshot edge in practice — paper

--- a/config/settings.py
+++ b/config/settings.py
@@ -465,6 +465,33 @@ class BiasHarvestConfig(BaseModel):
     paper_maker_fill_rate: float = 0.5
 
 
+class PlatformConsensusConfig(BaseModel):
+    """Platform consensus follower (strategy/platform_consensus.py).
+
+    Compares Polymarket and Kalshi prices against the community consensus
+    probabilities on Manifold Markets and Metaculus.
+
+    PAPER-FORCED by default: goes through the paper ledger to validate the edge.
+    """
+
+    enabled: bool = False
+    paper: bool = True
+    min_edge: float = 0.06
+    stake_usd: float = 10.0
+    max_open: int = 40
+    max_entries_per_cycle: int = 5
+    scan_limit: int = 200
+    min_liquidity: float = 1000.0
+    min_hours_to_resolution: float = 6.0
+    max_days_to_resolution: float = 45.0
+    match_threshold: float = 0.65
+    min_manifold_bettors: int = 30
+    min_manifold_liquidity: float = 1000.0
+    min_metaculus_forecasters: int = 15
+    interval_seconds: int = 600
+
+
+
 class InformedFlowConfig(BaseModel):
     """Informed-flow follower over Kalshi (strategy/informed_flow_pillar.py).
 
@@ -1657,6 +1684,7 @@ class Settings(BaseSettings):
     market_maker: MarketMakerConfig = Field(default_factory=lambda: MarketMakerConfig(**_DEFAULTS.get("market_maker", {})))
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))
     bias_harvest: BiasHarvestConfig = Field(default_factory=lambda: BiasHarvestConfig(**_DEFAULTS.get("bias_harvest", {})))
+    platform_consensus: PlatformConsensusConfig = Field(default_factory=lambda: PlatformConsensusConfig(**_DEFAULTS.get("platform_consensus", {})))
     graduation: GraduationConfig = Field(default_factory=lambda: GraduationConfig(**_DEFAULTS.get("graduation", {})))
     information_graduation: InformationGraduationConfig = Field(
         default_factory=lambda: InformationGraduationConfig(

--- a/tests/test_platform_consensus.py
+++ b/tests/test_platform_consensus.py
@@ -1,0 +1,374 @@
+"""Tests for the Platform Consensus follower pillar."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auramaur.broker.pnl import PnLTracker
+from auramaur.db.database import Database
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderResult,
+    OrderSide,
+    OrderType,
+    TokenType,
+)
+from auramaur.data_sources.base import NewsItem
+from auramaur.strategy.platform_consensus import PlatformConsensusPillar
+from config.settings import Settings
+
+
+def _market(mid="M1", question="Will SpaceX launch Starship in July?", yes=0.50, liquidity=5000.0, active=True, days_out=10.0) -> Market:
+    return Market(
+        id=mid,
+        exchange="polymarket",
+        question=question,
+        category="science",
+        active=active,
+        outcome_yes_price=yes,
+        outcome_no_price=round(1 - yes, 2),
+        liquidity=liquidity,
+        volume=10000.0,
+        end_date=datetime.now(timezone.utc) + timedelta(days=days_out),
+        clob_token_yes="ty",
+        clob_token_no="tn",
+        condition_id="cond-1",
+        description="SpaceX Starship orbital flight test",
+    )
+
+
+def _settings(**overrides) -> Settings:
+    s = Settings()
+    s.platform_consensus.enabled = True
+    s.platform_consensus.paper = True
+    s.platform_consensus.min_edge = 0.05
+    for k, v in overrides.items():
+        setattr(s.platform_consensus, k, v)
+    return s
+
+
+def _exchange(filled=True):
+    ex = MagicMock()
+
+    def prepare_order(signal, market, size, is_live):
+        token = TokenType.NO if signal.recommended_side == OrderSide.SELL else TokenType.YES
+        price = market.outcome_yes_price if token == TokenType.YES else 1 - market.outcome_yes_price
+        return Order(
+            market_id=market.id,
+            token_id="tok",
+            side=OrderSide.BUY,
+            token=token,
+            size=round(size / price, 2),
+            price=round(price, 2),
+            order_type=OrderType.LIMIT,
+            dry_run=not is_live,
+        )
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(
+        side_effect=lambda order: OrderResult(
+            order_id="ord-1",
+            market_id=order.market_id,
+            status="paper" if order.dry_run else "filled",
+            filled_size=order.size if filled else 0,
+            filled_price=order.price,
+            is_paper=order.dry_run,
+        )
+    )
+    return ex
+
+
+def _risk(approved=True, size=8.0):
+    rm = MagicMock()
+    d = MagicMock()
+    d.approved = approved
+    d.position_size = size if approved else 0.0
+    d.reason = "" if approved else "blocked"
+    d.force_paper = False
+    rm.evaluate = AsyncMock(return_value=d)
+    return rm
+
+
+@pytest.mark.asyncio
+async def test_platform_consensus_triggers_buy_yes():
+    db = await Database.connect(":memory:", ensure_schema=True)
+    try:
+        # Create schema for signals and portfolio
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS signals (
+                id INTEGER PRIMARY KEY,
+                market_id TEXT,
+                claude_prob REAL,
+                claude_confidence TEXT,
+                market_prob REAL,
+                edge REAL,
+                second_opinion_prob REAL,
+                divergence REAL,
+                evidence_summary TEXT,
+                action TEXT,
+                strategy_source TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS portfolio (
+                market_id TEXT PRIMARY KEY,
+                side TEXT,
+                size REAL,
+                avg_price REAL,
+                current_price REAL,
+                category TEXT,
+                token TEXT,
+                token_id TEXT,
+                is_paper INTEGER DEFAULT 1
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS markets (
+                id TEXT PRIMARY KEY,
+                exchange TEXT,
+                condition_id TEXT,
+                question TEXT,
+                description TEXT,
+                category TEXT,
+                active INTEGER,
+                outcome_yes_price REAL,
+                outcome_no_price REAL,
+                volume REAL,
+                liquidity REAL,
+                last_updated TEXT
+            )"""
+        )
+        await db.commit()
+
+        # Target: Market YES price is 0.50. Consensus forecasts YES is 0.75.
+        # Edge is 0.25 > 0.05 min_edge + fee.
+        # It should trigger BUY YES.
+        market = _market(yes=0.50)
+        settings = _settings()
+        ex = _exchange()
+        rm = _risk()
+        disc = MagicMock()
+        disc.get_markets = AsyncMock(return_value=[market])
+
+        pillar = PlatformConsensusPillar(
+            db=db,
+            settings=settings,
+            discovery=disc,
+            exchange=ex,
+            risk_manager=rm,
+            pnl_tracker=PnLTracker(db, settings),
+            calibration=MagicMock(),
+        )
+
+        manifold_news = NewsItem(
+            id="man-1",
+            source="manifold",
+            title="[Manifold: 75%] Will SpaceX launch Starship in July?",
+            content="Community forecast is 75%",
+            url="https://manifold.markets/space",
+        )
+
+        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
+             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
+            entered = await pillar.run_once()
+
+            assert entered == 1
+            # Check DB signals
+            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+            assert sig_row is not None
+            assert sig_row["claude_prob"] == 0.75
+            assert sig_row["action"] == "BUY"
+            assert sig_row["strategy_source"] == "platform_consensus"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_platform_consensus_triggers_buy_no():
+    db = await Database.connect(":memory:", ensure_schema=True)
+    try:
+        # Create tables
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS signals (
+                id INTEGER PRIMARY KEY,
+                market_id TEXT,
+                claude_prob REAL,
+                claude_confidence TEXT,
+                market_prob REAL,
+                edge REAL,
+                second_opinion_prob REAL,
+                divergence REAL,
+                evidence_summary TEXT,
+                action TEXT,
+                strategy_source TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS portfolio (
+                market_id TEXT PRIMARY KEY,
+                side TEXT,
+                size REAL,
+                avg_price REAL,
+                current_price REAL,
+                category TEXT,
+                token TEXT,
+                token_id TEXT,
+                is_paper INTEGER DEFAULT 1
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS markets (
+                id TEXT PRIMARY KEY,
+                exchange TEXT,
+                condition_id TEXT,
+                question TEXT,
+                description TEXT,
+                category TEXT,
+                active INTEGER,
+                outcome_yes_price REAL,
+                outcome_no_price REAL,
+                volume REAL,
+                liquidity REAL,
+                last_updated TEXT
+            )"""
+        )
+        await db.commit()
+
+        # Target: Market YES price is 0.50. Consensus forecasts YES is 0.25 (No is 0.75).
+        # Edge is 0.25 > 0.05 min_edge + fee.
+        # It should trigger BUY NO (which is recommended_side=OrderSide.SELL)
+        market = _market(yes=0.50)
+        settings = _settings()
+        ex = _exchange()
+        rm = _risk()
+        disc = MagicMock()
+        disc.get_markets = AsyncMock(return_value=[market])
+
+        pillar = PlatformConsensusPillar(
+            db=db,
+            settings=settings,
+            discovery=disc,
+            exchange=ex,
+            risk_manager=rm,
+            pnl_tracker=PnLTracker(db, settings),
+            calibration=MagicMock(),
+        )
+
+        metaculus_news = NewsItem(
+            id="meta-1",
+            source="metaculus",
+            title="[Metaculus: 25%] Will SpaceX launch Starship in July?",
+            content="Community forecast is 25%",
+            url="https://metaculus.com/space",
+        )
+
+        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[])), \
+             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[metaculus_news])):
+            entered = await pillar.run_once()
+
+            assert entered == 1
+            # Check DB signals
+            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+            assert sig_row is not None
+            assert sig_row["claude_prob"] == 0.25
+            assert sig_row["action"] == "SELL"
+            assert sig_row["strategy_source"] == "platform_consensus"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_platform_consensus_insufficient_edge():
+    db = await Database.connect(":memory:", ensure_schema=True)
+    try:
+        # Create tables
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS signals (
+                id INTEGER PRIMARY KEY,
+                market_id TEXT,
+                claude_prob REAL,
+                claude_confidence TEXT,
+                market_prob REAL,
+                edge REAL,
+                second_opinion_prob REAL,
+                divergence REAL,
+                evidence_summary TEXT,
+                action TEXT,
+                strategy_source TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS portfolio (
+                market_id TEXT PRIMARY KEY,
+                side TEXT,
+                size REAL,
+                avg_price REAL,
+                current_price REAL,
+                category TEXT,
+                token TEXT,
+                token_id TEXT,
+                is_paper INTEGER DEFAULT 1
+            )"""
+        )
+        await db.execute(
+            """CREATE TABLE IF NOT EXISTS markets (
+                id TEXT PRIMARY KEY,
+                exchange TEXT,
+                condition_id TEXT,
+                question TEXT,
+                description TEXT,
+                category TEXT,
+                active INTEGER,
+                outcome_yes_price REAL,
+                outcome_no_price REAL,
+                volume REAL,
+                liquidity REAL,
+                last_updated TEXT
+            )"""
+        )
+        await db.commit()
+
+        # Target: Market YES price is 0.50. Consensus is 0.52. Edge is 0.02 < 0.05 min_edge.
+        market = _market(yes=0.50)
+        settings = _settings()
+        ex = _exchange()
+        rm = _risk()
+        disc = MagicMock()
+        disc.get_markets = AsyncMock(return_value=[market])
+
+        pillar = PlatformConsensusPillar(
+            db=db,
+            settings=settings,
+            discovery=disc,
+            exchange=ex,
+            risk_manager=rm,
+            pnl_tracker=PnLTracker(db, settings),
+            calibration=MagicMock(),
+        )
+
+        manifold_news = NewsItem(
+            id="man-1",
+            source="manifold",
+            title="[Manifold: 52%] Will SpaceX launch Starship in July?",
+            content="Community forecast is 52%",
+            url="https://manifold.markets/space",
+        )
+
+        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
+             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
+            entered = await pillar.run_once()
+
+            assert entered == 0
+            # DB should have no signal
+            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+            assert sig_row is None
+    finally:
+        await db.close()

--- a/tests/test_platform_consensus.py
+++ b/tests/test_platform_consensus.py
@@ -6,8 +6,6 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from auramaur.broker.pnl import PnLTracker
 from auramaur.db.database import Database
 from auramaur.exchange.models import (
@@ -94,281 +92,290 @@ def _risk(approved=True, size=8.0):
     return rm
 
 
-@pytest.mark.asyncio
-async def test_platform_consensus_triggers_buy_yes():
-    db = await Database.connect(":memory:", ensure_schema=True)
-    try:
-        # Create schema for signals and portfolio
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS signals (
-                id INTEGER PRIMARY KEY,
-                market_id TEXT,
-                claude_prob REAL,
-                claude_confidence TEXT,
-                market_prob REAL,
-                edge REAL,
-                second_opinion_prob REAL,
-                divergence REAL,
-                evidence_summary TEXT,
-                action TEXT,
-                strategy_source TEXT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS portfolio (
-                market_id TEXT PRIMARY KEY,
-                side TEXT,
-                size REAL,
-                avg_price REAL,
-                current_price REAL,
-                category TEXT,
-                token TEXT,
-                token_id TEXT,
-                is_paper INTEGER DEFAULT 1
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS markets (
-                id TEXT PRIMARY KEY,
-                exchange TEXT,
-                condition_id TEXT,
-                question TEXT,
-                description TEXT,
-                category TEXT,
-                active INTEGER,
-                outcome_yes_price REAL,
-                outcome_no_price REAL,
-                volume REAL,
-                liquidity REAL,
-                last_updated TEXT
-            )"""
-        )
-        await db.commit()
+def test_platform_consensus_triggers_buy_yes():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # Create schema for signals and portfolio
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS signals (
+                    id INTEGER PRIMARY KEY,
+                    market_id TEXT,
+                    claude_prob REAL,
+                    claude_confidence TEXT,
+                    market_prob REAL,
+                    edge REAL,
+                    second_opinion_prob REAL,
+                    divergence REAL,
+                    evidence_summary TEXT,
+                    action TEXT,
+                    strategy_source TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS portfolio (
+                    market_id TEXT PRIMARY KEY,
+                    side TEXT,
+                    size REAL,
+                    avg_price REAL,
+                    current_price REAL,
+                    category TEXT,
+                    token TEXT,
+                    token_id TEXT,
+                    is_paper INTEGER DEFAULT 1
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS markets (
+                    id TEXT PRIMARY KEY,
+                    exchange TEXT,
+                    condition_id TEXT,
+                    question TEXT,
+                    description TEXT,
+                    category TEXT,
+                    active INTEGER,
+                    outcome_yes_price REAL,
+                    outcome_no_price REAL,
+                    volume REAL,
+                    liquidity REAL,
+                    last_updated TEXT
+                )"""
+            )
+            await db.commit()
 
-        # Target: Market YES price is 0.50. Consensus forecasts YES is 0.75.
-        # Edge is 0.25 > 0.05 min_edge + fee.
-        # It should trigger BUY YES.
-        market = _market(yes=0.50)
-        settings = _settings()
-        ex = _exchange()
-        rm = _risk()
-        disc = MagicMock()
-        disc.get_markets = AsyncMock(return_value=[market])
+            # Target: Market YES price is 0.50. Consensus forecasts YES is 0.75.
+            # Edge is 0.25 > 0.05 min_edge + fee.
+            # It should trigger BUY YES.
+            market = _market(yes=0.50)
+            settings = _settings()
+            ex = _exchange()
+            rm = _risk()
+            disc = MagicMock()
+            disc.get_markets = AsyncMock(return_value=[market])
 
-        pillar = PlatformConsensusPillar(
-            db=db,
-            settings=settings,
-            discovery=disc,
-            exchange=ex,
-            risk_manager=rm,
-            pnl_tracker=PnLTracker(db, settings),
-            calibration=MagicMock(),
-        )
+            pillar = PlatformConsensusPillar(
+                db=db,
+                settings=settings,
+                discovery=disc,
+                exchange=ex,
+                risk_manager=rm,
+                pnl_tracker=PnLTracker(db, settings),
+                calibration=MagicMock(),
+            )
 
-        manifold_news = NewsItem(
-            id="man-1",
-            source="manifold",
-            title="[Manifold: 75%] Will SpaceX launch Starship in July?",
-            content="Community forecast is 75%",
-            url="https://manifold.markets/space",
-        )
+            manifold_news = NewsItem(
+                id="man-1",
+                source="manifold",
+                title="[Manifold: 75%] Will SpaceX launch Starship in July?",
+                content="Community forecast is 75%",
+                url="https://manifold.markets/space",
+            )
 
-        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
-             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
-            entered = await pillar.run_once()
+            with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
+                 patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
+                entered = await pillar.run_once()
 
-            assert entered == 1
-            # Check DB signals
-            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
-            assert sig_row is not None
-            assert sig_row["claude_prob"] == 0.75
-            assert sig_row["action"] == "BUY"
-            assert sig_row["strategy_source"] == "platform_consensus"
-    finally:
-        await db.close()
+                assert entered == 1
+                # Check DB signals
+                sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+                assert sig_row is not None
+                assert sig_row["claude_prob"] == 0.75
+                assert sig_row["action"] == "BUY"
+                assert sig_row["strategy_source"] == "platform_consensus"
+        finally:
+            await db.close()
 
-
-@pytest.mark.asyncio
-async def test_platform_consensus_triggers_buy_no():
-    db = await Database.connect(":memory:", ensure_schema=True)
-    try:
-        # Create tables
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS signals (
-                id INTEGER PRIMARY KEY,
-                market_id TEXT,
-                claude_prob REAL,
-                claude_confidence TEXT,
-                market_prob REAL,
-                edge REAL,
-                second_opinion_prob REAL,
-                divergence REAL,
-                evidence_summary TEXT,
-                action TEXT,
-                strategy_source TEXT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS portfolio (
-                market_id TEXT PRIMARY KEY,
-                side TEXT,
-                size REAL,
-                avg_price REAL,
-                current_price REAL,
-                category TEXT,
-                token TEXT,
-                token_id TEXT,
-                is_paper INTEGER DEFAULT 1
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS markets (
-                id TEXT PRIMARY KEY,
-                exchange TEXT,
-                condition_id TEXT,
-                question TEXT,
-                description TEXT,
-                category TEXT,
-                active INTEGER,
-                outcome_yes_price REAL,
-                outcome_no_price REAL,
-                volume REAL,
-                liquidity REAL,
-                last_updated TEXT
-            )"""
-        )
-        await db.commit()
-
-        # Target: Market YES price is 0.50. Consensus forecasts YES is 0.25 (No is 0.75).
-        # Edge is 0.25 > 0.05 min_edge + fee.
-        # It should trigger BUY NO (which is recommended_side=OrderSide.SELL)
-        market = _market(yes=0.50)
-        settings = _settings()
-        ex = _exchange()
-        rm = _risk()
-        disc = MagicMock()
-        disc.get_markets = AsyncMock(return_value=[market])
-
-        pillar = PlatformConsensusPillar(
-            db=db,
-            settings=settings,
-            discovery=disc,
-            exchange=ex,
-            risk_manager=rm,
-            pnl_tracker=PnLTracker(db, settings),
-            calibration=MagicMock(),
-        )
-
-        metaculus_news = NewsItem(
-            id="meta-1",
-            source="metaculus",
-            title="[Metaculus: 25%] Will SpaceX launch Starship in July?",
-            content="Community forecast is 25%",
-            url="https://metaculus.com/space",
-        )
-
-        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[])), \
-             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[metaculus_news])):
-            entered = await pillar.run_once()
-
-            assert entered == 1
-            # Check DB signals
-            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
-            assert sig_row is not None
-            assert sig_row["claude_prob"] == 0.25
-            assert sig_row["action"] == "SELL"
-            assert sig_row["strategy_source"] == "platform_consensus"
-    finally:
-        await db.close()
+    asyncio.run(run())
 
 
-@pytest.mark.asyncio
-async def test_platform_consensus_insufficient_edge():
-    db = await Database.connect(":memory:", ensure_schema=True)
-    try:
-        # Create tables
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS signals (
-                id INTEGER PRIMARY KEY,
-                market_id TEXT,
-                claude_prob REAL,
-                claude_confidence TEXT,
-                market_prob REAL,
-                edge REAL,
-                second_opinion_prob REAL,
-                divergence REAL,
-                evidence_summary TEXT,
-                action TEXT,
-                strategy_source TEXT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS portfolio (
-                market_id TEXT PRIMARY KEY,
-                side TEXT,
-                size REAL,
-                avg_price REAL,
-                current_price REAL,
-                category TEXT,
-                token TEXT,
-                token_id TEXT,
-                is_paper INTEGER DEFAULT 1
-            )"""
-        )
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS markets (
-                id TEXT PRIMARY KEY,
-                exchange TEXT,
-                condition_id TEXT,
-                question TEXT,
-                description TEXT,
-                category TEXT,
-                active INTEGER,
-                outcome_yes_price REAL,
-                outcome_no_price REAL,
-                volume REAL,
-                liquidity REAL,
-                last_updated TEXT
-            )"""
-        )
-        await db.commit()
+def test_platform_consensus_triggers_buy_no():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # Create tables
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS signals (
+                    id INTEGER PRIMARY KEY,
+                    market_id TEXT,
+                    claude_prob REAL,
+                    claude_confidence TEXT,
+                    market_prob REAL,
+                    edge REAL,
+                    second_opinion_prob REAL,
+                    divergence REAL,
+                    evidence_summary TEXT,
+                    action TEXT,
+                    strategy_source TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS portfolio (
+                    market_id TEXT PRIMARY KEY,
+                    side TEXT,
+                    size REAL,
+                    avg_price REAL,
+                    current_price REAL,
+                    category TEXT,
+                    token TEXT,
+                    token_id TEXT,
+                    is_paper INTEGER DEFAULT 1
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS markets (
+                    id TEXT PRIMARY KEY,
+                    exchange TEXT,
+                    condition_id TEXT,
+                    question TEXT,
+                    description TEXT,
+                    category TEXT,
+                    active INTEGER,
+                    outcome_yes_price REAL,
+                    outcome_no_price REAL,
+                    volume REAL,
+                    liquidity REAL,
+                    last_updated TEXT
+                )"""
+            )
+            await db.commit()
 
-        # Target: Market YES price is 0.50. Consensus is 0.52. Edge is 0.02 < 0.05 min_edge.
-        market = _market(yes=0.50)
-        settings = _settings()
-        ex = _exchange()
-        rm = _risk()
-        disc = MagicMock()
-        disc.get_markets = AsyncMock(return_value=[market])
+            # Target: Market YES price is 0.50. Consensus forecasts YES is 0.25 (No is 0.75).
+            # Edge is 0.25 > 0.05 min_edge + fee.
+            # It should trigger BUY NO (which is recommended_side=OrderSide.SELL)
+            market = _market(yes=0.50)
+            settings = _settings()
+            ex = _exchange()
+            rm = _risk()
+            disc = MagicMock()
+            disc.get_markets = AsyncMock(return_value=[market])
 
-        pillar = PlatformConsensusPillar(
-            db=db,
-            settings=settings,
-            discovery=disc,
-            exchange=ex,
-            risk_manager=rm,
-            pnl_tracker=PnLTracker(db, settings),
-            calibration=MagicMock(),
-        )
+            pillar = PlatformConsensusPillar(
+                db=db,
+                settings=settings,
+                discovery=disc,
+                exchange=ex,
+                risk_manager=rm,
+                pnl_tracker=PnLTracker(db, settings),
+                calibration=MagicMock(),
+            )
 
-        manifold_news = NewsItem(
-            id="man-1",
-            source="manifold",
-            title="[Manifold: 52%] Will SpaceX launch Starship in July?",
-            content="Community forecast is 52%",
-            url="https://manifold.markets/space",
-        )
+            metaculus_news = NewsItem(
+                id="meta-1",
+                source="metaculus",
+                title="[Metaculus: 25%] Will SpaceX launch Starship in July?",
+                content="Community forecast is 25%",
+                url="https://metaculus.com/space",
+            )
 
-        with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
-             patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
-            entered = await pillar.run_once()
+            with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[])), \
+                 patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[metaculus_news])):
+                entered = await pillar.run_once()
 
-            assert entered == 0
-            # DB should have no signal
-            sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
-            assert sig_row is None
-    finally:
-        await db.close()
+                assert entered == 1
+                # Check DB signals
+                sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+                assert sig_row is not None
+                assert sig_row["claude_prob"] == 0.25
+                assert sig_row["action"] == "SELL"
+                assert sig_row["strategy_source"] == "platform_consensus"
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_platform_consensus_insufficient_edge():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # Create tables
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS signals (
+                    id INTEGER PRIMARY KEY,
+                    market_id TEXT,
+                    claude_prob REAL,
+                    claude_confidence TEXT,
+                    market_prob REAL,
+                    edge REAL,
+                    second_opinion_prob REAL,
+                    divergence REAL,
+                    evidence_summary TEXT,
+                    action TEXT,
+                    strategy_source TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS portfolio (
+                    market_id TEXT PRIMARY KEY,
+                    side TEXT,
+                    size REAL,
+                    avg_price REAL,
+                    current_price REAL,
+                    category TEXT,
+                    token TEXT,
+                    token_id TEXT,
+                    is_paper INTEGER DEFAULT 1
+                )"""
+            )
+            await db.execute(
+                """CREATE TABLE IF NOT EXISTS markets (
+                    id TEXT PRIMARY KEY,
+                    exchange TEXT,
+                    condition_id TEXT,
+                    question TEXT,
+                    description TEXT,
+                    category TEXT,
+                    active INTEGER,
+                    outcome_yes_price REAL,
+                    outcome_no_price REAL,
+                    volume REAL,
+                    liquidity REAL,
+                    last_updated TEXT
+                )"""
+            )
+            await db.commit()
+
+            # Target: Market YES price is 0.50. Consensus is 0.52. Edge is 0.02 < 0.05 min_edge.
+            market = _market(yes=0.50)
+            settings = _settings()
+            ex = _exchange()
+            rm = _risk()
+            disc = MagicMock()
+            disc.get_markets = AsyncMock(return_value=[market])
+
+            pillar = PlatformConsensusPillar(
+                db=db,
+                settings=settings,
+                discovery=disc,
+                exchange=ex,
+                risk_manager=rm,
+                pnl_tracker=PnLTracker(db, settings),
+                calibration=MagicMock(),
+            )
+
+            manifold_news = NewsItem(
+                id="man-1",
+                source="manifold",
+                title="[Manifold: 52%] Will SpaceX launch Starship in July?",
+                content="Community forecast is 52%",
+                url="https://manifold.markets/space",
+            )
+
+            with patch.object(pillar._manifold, "fetch", AsyncMock(return_value=[manifold_news])), \
+                 patch.object(pillar._metaculus, "fetch", AsyncMock(return_value=[])):
+                entered = await pillar.run_once()
+
+                assert entered == 0
+                # DB should have no signal
+                sig_row = await db.fetchone("SELECT * FROM signals WHERE market_id = ?", (market.id,))
+                assert sig_row is None
+        finally:
+            await db.close()
+
+    asyncio.run(run())

--- a/tests/test_platform_consensus.py
+++ b/tests/test_platform_consensus.py
@@ -169,7 +169,7 @@ def test_platform_consensus_triggers_buy_yes():
                 id="man-1",
                 source="manifold",
                 title="[Manifold: 75%] Will SpaceX launch Starship in July?",
-                content="Community forecast is 75%",
+                content="Community forecast is 75%\nUnique bettors: 80\nLiquidity: $5,000",
                 url="https://manifold.markets/space",
             )
 
@@ -267,7 +267,7 @@ def test_platform_consensus_triggers_buy_no():
                 id="meta-1",
                 source="metaculus",
                 title="[Metaculus: 25%] Will SpaceX launch Starship in July?",
-                content="Community forecast is 25%",
+                content="Community forecast is 25%\nForecasters: 40",
                 url="https://metaculus.com/space",
             )
 
@@ -363,7 +363,7 @@ def test_platform_consensus_insufficient_edge():
                 id="man-1",
                 source="manifold",
                 title="[Manifold: 52%] Will SpaceX launch Starship in July?",
-                content="Community forecast is 52%",
+                content="Community forecast is 52%\nUnique bettors: 80\nLiquidity: $5,000",
                 url="https://manifold.markets/space",
             )
 
@@ -379,3 +379,24 @@ def test_platform_consensus_insufficient_edge():
             await db.close()
 
     asyncio.run(run())
+
+
+def test_platform_consensus_quality_thresholds_fail_closed():
+    cfg = _settings().platform_consensus
+    thin = NewsItem(
+        id="thin",
+        source="manifold",
+        title="[Manifold: 75%] Example",
+        content="Unique bettors: 2\nLiquidity: $20",
+        url="https://example.test",
+    )
+    missing = NewsItem(
+        id="missing",
+        source="metaculus",
+        title="[Metaculus: 75%] Example",
+        content="Community probability: 75%",
+        url="https://example.test",
+    )
+
+    assert not PlatformConsensusPillar._quality_ok(thin, "Manifold", cfg)
+    assert not PlatformConsensusPillar._quality_ok(missing, "Metaculus", cfg)

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -29,6 +29,7 @@ from auramaur.strategy.protocols import ExecutionMode, NO_DIRECT_PLACE_MODES
 from auramaur.strategy.resolution_lens import ResolutionLensPillar
 from auramaur.strategy.arbitrage_scanner import ArbitrageScanner
 from auramaur.strategy.weather_temp import WeatherTempPillar
+from auramaur.strategy.platform_consensus import PlatformConsensusPillar
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -47,6 +48,7 @@ PILLARS = [
     (ArbitrageScanner, "auramaur/strategy/arbitrage_scanner.py"),
     (OddLotTenderPillar, "auramaur/strategy/oddlot_tender.py"),
     (IBKRETFPaperPillar, "auramaur/strategy/ibkr_etf_paper.py"),
+    (PlatformConsensusPillar, "auramaur/strategy/platform_consensus.py"),
 ]
 
 # NO_DIRECT_PLACE_MODES (single source of truth in protocols.py): the pillar must


### PR DESCRIPTION
## Summary
- add a platform-consensus pillar that compares venue prices with qualified Manifold and Metaculus crowd forecasts
- route every entry through the standard risk manager and ExecutionGateway
- cap stake, enforce source-depth thresholds, honor graduation paper forcing, and fail closed on rejected submissions
- start a dated paper-only measurement spike with pre-registered review and stop criteria

## Safety
- paper: true remains structurally forced for this strategy
- no live gates are changed
- blocked categories, liquidity, resolution horizon, fee-adjusted edge, position caps, and the global kill switch remain enforced

## Evaluation contract
Review after 30 settled positions or 2026-08-17, whichever is later. Retain only with positive net paper P&L, Brier improvement over venue price, and zero material semantic-match problems. Stop early after 3 false matches or - paper P&L.

## Validation
- Ruff: clean
- focused strategy/protocol/settings suite: 49 passed, 1 skipped
- exact CI dependency set under Linux/WSL: 1305 passed, 1 skipped; one environment-only failure because a Windows linked-worktree .git pointer is not valid inside WSL. GitHub CI uses a normal Linux clone and is not subject to that path issue.