### PR TITLE
fix(trading): harden conditional arb and Kraken nonces

### DIFF
--- a/auramaur/bot_arb.py
+++ b/auramaur/bot_arb.py
@@ -60,6 +60,23 @@ class ArbExecutionMixin(ArbTradeExecutionMixin, ArbScanLoopMixin):
             log.debug("arbitrage.no_engine", buy=buy_exchange, sell=sell_exchange)
             return
 
+        # Fail closed before risk evaluation or order construction when a
+        # reconstructed Polymarket leg lacks the CLOB token required for its
+        # side. This prevents a malformed relative-value pair reaching the
+        # execution gateway even if upstream persistence regresses.
+        missing_tokens = []
+        if buy_exchange == "polymarket" and not buy_market.clob_token_yes:
+            missing_tokens.append((buy_market.id, "YES"))
+        if sell_exchange == "polymarket" and not sell_market.clob_token_no:
+            missing_tokens.append((sell_market.id, "NO"))
+        if missing_tokens:
+            log.error(
+                "arbitrage.missing_execution_metadata",
+                type=opp.get("type"),
+                missing_tokens=missing_tokens,
+            )
+            return
+
         alerts: AlertManager = self._components.alerts
 
         # Risk checks on both legs using exchange-local cash for sizing.

--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -49,6 +49,8 @@ class KrakenSpotClient:
         self._settings = settings
         self._session: aiohttp.ClientSession | None = None
         self._sem = asyncio.Semaphore(_RATE_LIMIT)
+        self._private_lock = asyncio.Lock()
+        self._last_nonce = 0
         self._quote_rate_cache: dict[str, float] = {}  # quote asset -> USD rate
         self._pair_quote_cache: dict[str, str] = {}     # pair -> quote asset code
 
@@ -86,21 +88,28 @@ class KrakenSpotClient:
         if not key or not secret:
             return {"error": ["EAuramaur:No Kraken credentials"]}
         path = f"/0/private/{method}"
-        data = dict(data or {})
-        data["nonce"] = int(time.time() * 1000)
-        body = urllib.parse.urlencode(data)
-        async with self._sem:
-            session = await self._get_session()
-            async with session.post(
-                _API + path,
-                data=body,
-                headers={
-                    "API-Key": key,
-                    "API-Sign": self._sign(path, data),
-                    "Content-Type": "application/x-www-form-urlencoded",
-                },
-            ) as r:
-                return await r.json()
+        # Kraken requires strictly increasing nonces per API key. Serialize
+        # private requests as well as allocation so network scheduling cannot
+        # deliver a later nonce before an earlier one. Microseconds also move
+        # safely beyond this client's former millisecond nonce range.
+        async with self._private_lock:
+            data = dict(data or {})
+            nonce = max(time.time_ns() // 1_000, self._last_nonce + 1)
+            self._last_nonce = nonce
+            data["nonce"] = nonce
+            body = urllib.parse.urlencode(data)
+            async with self._sem:
+                session = await self._get_session()
+                async with session.post(
+                    _API + path,
+                    data=body,
+                    headers={
+                        "API-Key": key,
+                        "API-Sign": self._sign(path, data),
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                ) as r:
+                    return await r.json()
 
     # ------------------------------------------------------------------
     # Read-only

--- a/auramaur/strategy/arbitrage.py
+++ b/auramaur/strategy/arbitrage.py
@@ -133,7 +133,9 @@ class ArbitrageExecutor:
 
         return Market(
             id=row["id"],
+            exchange=row["exchange"] or "polymarket",
             condition_id=row["condition_id"],
+            ticker=row["ticker"] or "",
             question=row["question"],
             description=row["description"] or "",
             category=row["category"] or "",
@@ -143,4 +145,6 @@ class ArbitrageExecutor:
             outcome_no_price=row["outcome_no_price"] or 0.5,
             volume=row["volume"] or 0,
             liquidity=row["liquidity"] or 0,
+            clob_token_yes=row["clob_token_yes"] or "",
+            clob_token_no=row["clob_token_no"] or "",
         )

--- a/auramaur/strategy/correlation.py
+++ b/auramaur/strategy/correlation.py
@@ -142,7 +142,8 @@ If no relationships found, return []. Only return the JSON array, no other text.
         P(X wins primary) = 60% but P(X wins general) = 70%.
         """
         rows = await self._db.fetchall(
-            """SELECT mr.*, m1.outcome_yes_price as price_a, m2.outcome_yes_price as price_b
+            """SELECT mr.*, m1.outcome_yes_price as price_a, m2.outcome_yes_price as price_b,
+                      m1.question as question_a, m2.question as question_b
                FROM market_relationships mr
                JOIN markets m1 ON mr.market_id_a = m1.id
                JOIN markets m2 ON mr.market_id_b = m2.id
@@ -167,9 +168,14 @@ If no relationships found, return []. Only return the JSON array, no other text.
                         "description": row["description"],
                     })
 
-            # Same event: prices should be close
+            # ``same_event`` means the markets concern the same underlying
+            # event, not that they express the same proposition. Distinct
+            # outcomes in a multi-outcome event can legitimately have very
+            # different prices, so only identical questions are fungible.
             if row["relationship_type"] == "same_event":
-                if abs(price_a - price_b) > 0.05:
+                question_a = " ".join((row["question_a"] or "").casefold().split())
+                question_b = " ".join((row["question_b"] or "").casefold().split())
+                if question_a and question_a == question_b and abs(price_a - price_b) > 0.05:
                     opportunities.append({
                         "type": "price_divergence",
                         "market_a": row["market_id_a"],

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -85,7 +85,7 @@ class TestArbitrageExecutor:
         ), event_loop)
         run(db.execute(
             """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price, last_updated)
-               VALUES ('expensive', 'c2', 'Same event?', 1, 0.55, 0.45, datetime('now'))"""
+               VALUES ('expensive', 'c2', 'Event?', 1, 0.55, 0.45, datetime('now'))"""
         ), event_loop)
         run(db.execute(
             """INSERT INTO market_relationships
@@ -99,6 +99,46 @@ class TestArbitrageExecutor:
         buy_sig, sell_sig, _ = pairs[0]
         assert buy_sig.market_id == "cheap"
         assert sell_sig.market_id == "expensive"
+
+    def test_distinct_outcomes_in_same_event_are_not_arbitrage(self, executor, event_loop):
+        db = executor._db
+        for mid, question, price in (
+            ("actor-a", "Will Timothee be the #1 searched actor?", 0.08),
+            ("actor-b", "Will Zendaya be the #1 searched actor?", 0.31),
+        ):
+            run(db.execute(
+                """INSERT INTO markets (id, condition_id, question, active,
+                       outcome_yes_price, outcome_no_price, last_updated)
+                   VALUES (?, ?, ?, 1, ?, ?, datetime('now'))""",
+                (mid, mid, question, price, 1 - price),
+            ), event_loop)
+        run(db.execute(
+            """INSERT INTO market_relationships
+               (market_id_a, market_id_b, relationship_type, strength, description, detected_at)
+               VALUES ('actor-a', 'actor-b', 'same_event', 0.95, 'Same search event', datetime('now'))"""
+        ), event_loop)
+        run(db.commit(), event_loop)
+
+        assert run(executor.generate_arb_signals(), event_loop) == []
+
+    def test_load_market_preserves_execution_metadata(self, executor, event_loop):
+        db = executor._db
+        run(db.execute(
+            """INSERT INTO markets
+               (id, exchange, condition_id, ticker, question, active,
+                outcome_yes_price, outcome_no_price, clob_token_yes,
+                clob_token_no, last_updated)
+               VALUES ('meta', 'polymarket', 'c1', 'ticker-1', 'Event?', 1,
+                       0.4, 0.6, 'yes-token', 'no-token', datetime('now'))"""
+        ), event_loop)
+        run(db.commit(), event_loop)
+
+        market = run(executor._load_market("meta"), event_loop)
+        assert market is not None
+        assert market.exchange == "polymarket"
+        assert market.ticker == "ticker-1"
+        assert market.clob_token_yes == "yes-token"
+        assert market.clob_token_no == "no-token"
 
     def test_missing_market_skipped(self, executor, event_loop):
         """Opportunities with missing markets should be skipped."""
@@ -148,6 +188,28 @@ def test_arb_category_gate_filters_blocked_and_non_allowlisted():
         allowed_categories_live=None)
     assert [m.id for m in [kbo, labeled, unknown, crypto]
             if paper._category_ok(m)] == ["unk", "cry"]
+
+
+@pytest.mark.asyncio
+async def test_conditional_arb_fails_closed_without_clob_tokens():
+    """Missing venue metadata must stop both legs before risk or placement."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from auramaur.bot_arb import ArbExecutionMixin
+    from auramaur.exchange.models import Market
+
+    mixin = ArbExecutionMixin.__new__(ArbExecutionMixin)
+    market = Market(id="missing-token", question="Will X?", exchange="polymarket")
+    risk = MagicMock()
+    risk.evaluate = AsyncMock()
+
+    await mixin._execute_conditional_arb(
+        MagicMock(), MagicMock(), market, market,
+        {"type": "price_divergence"}, risk,
+        {"polymarket": MagicMock()},
+    )
+
+    risk.evaluate.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -1,14 +1,47 @@
 """Tests for the Kraken directional spot pillar — asymmetric long bias."""
 
 from auramaur.components import Components
+import asyncio
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
+import urllib.parse
 
 import pytest
 
 from auramaur.treasury.kraken_pillar import KrakenPillar
 from auramaur.exchange.kraken import KrakenSpotClient
 from auramaur.exchange.models import OrderResult, OrderSide
+
+
+@pytest.mark.asyncio
+async def test_private_requests_use_strictly_increasing_serialized_nonces():
+    settings = MagicMock()
+    settings.kraken_api_key = "key"
+    settings.kraken_api_secret = "c2VjcmV0"
+    observed = []
+
+    class Response:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_args):
+            return None
+        async def json(self):
+            return {"error": [], "result": {}}
+
+    class Session:
+        closed = False
+        def post(self, _url, *, data, headers):
+            del headers
+            observed.append(int(urllib.parse.parse_qs(data)["nonce"][0]))
+            return Response()
+
+    client = KrakenSpotClient(settings)
+    client._session = Session()
+    with patch("auramaur.exchange.kraken.time.time_ns", return_value=1_000_000):
+        await asyncio.gather(*(client._private("Balance") for _ in range(5)))
+
+    assert observed == sorted(observed)
+    assert len(set(observed)) == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prevent distinct outcomes from the same underlying event from being treated as fungible price-divergence arbitrage
- preserve exchange, ticker, and Polymarket CLOB tokens when reconstructing markets for conditional-arb execution
- fail closed before risk sizing or placement if a required Polymarket leg token is absent
- serialize Kraken private requests and issue strictly increasing microsecond nonces

## Runtime evidence
Today's audit traced 72 \order.live_error: No CLOB token_id\ events to conditional-arb attempts on distinct #1 searched actor outcomes. The database held the tokens, but \ArbitrageExecutor._load_market\ discarded them. Kraken logs separately showed \EAPI:Invalid nonce\ under concurrent private calls.

No malformed arb order was accepted by the venue.

## Verification
- \python -m pytest tests/test_arbitrage.py tests/test_kraken_directional.py -q\: 25 passed
- targeted Ruff: passed
- \git diff --check\: passed
- full Linux suite: 1307 passed, 2 skipped, 1 environment-only failure because WSL cannot resolve the Windows linked-worktree Git pointer in \	est_committed_defaults_yaml_is_not_live\`n
## Scope note
The database-contention remediation already exists as a larger dependent patch series on another branch and is intentionally not duplicated in this focused runtime-safety PR.