### PR TITLE
feat(research): add intelligence exploration evaluation

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1627,6 +1627,11 @@ class AuramaurBot(
         if self.settings.agent_trader.enabled:
             tasks.append(asyncio.create_task(self._task_agent_trader(), name="agent_trader"))
 
+        if (self.settings.intelligence_eval.enabled
+                and self.settings.local_llm.enabled):
+            tasks.append(asyncio.create_task(
+                self._task_intelligence_eval(), name="intelligence_eval"))
+
         # Deadline-ladder curve reader (paper-forced; amortized reading edge)
         if self.settings.term_structure.enabled:
             tasks.append(asyncio.create_task(self._task_term_structure(), name="term_structure"))

--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -111,6 +111,25 @@ class StrategyTaskMixin:
                 log.error("agent_trader.cycle_error", error=str(e))
             await asyncio.sleep(interval)
 
+    async def _task_intelligence_eval(self) -> None:
+        """Prospective local-model evaluation; shadow-only and order-free."""
+        from auramaur.evaluation.service import IntelligenceEvalService
+        from auramaur.nlp import local_llm
+
+        service = IntelligenceEvalService(
+            self._components.db, self.settings, self._components.discovery,
+            local_llm.get_client(self.settings, self._components.db),
+        )
+        interval = self.settings.intelligence_eval.interval_seconds
+        while self._running:
+            if await self._check_kill_switch():
+                return
+            try:
+                await service.run_once()
+            except Exception as exc:  # noqa: BLE001 — shadow task fails isolated
+                log.error("intelligence_eval.cycle_error", error=str(exc))
+            await asyncio.sleep(interval)
+
     async def _task_term_structure(self) -> None:
         """Periodic deadline-ladder curve reader (paper-forced; one LLM read
         prices a whole family of strikes)."""

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -14,6 +14,33 @@ from config.settings import Settings
 
 from auramaur.cli._base import console, main
 
+
+@main.command("intelligence-eval")
+def intelligence_eval_report():
+    """Show the resolved, market-relative shadow evaluation scorecard."""
+    async def _run():
+        from auramaur.evaluation.store import EvaluationStore
+        db = Database()
+        await db.connect(ensure_schema=False)
+        try:
+            rows = await EvaluationStore(db).summary()
+            table = Table(title="Intelligence × Exploration Evaluation")
+            table.add_column("Arm")
+            table.add_column("Model")
+            table.add_column("N", justify="right")
+            table.add_column("Brier", justify="right")
+            table.add_column("Market", justify="right")
+            table.add_column("Δ vs market", justify="right")
+            for row in rows:
+                brier, market = float(row["brier"]), float(row["market_brier"])
+                table.add_row(row["arm_name"], row["model"], str(row["forecasts"]),
+                              f"{brier:.4f}", f"{market:.4f}",
+                              f"{market - brier:+.4f}")
+            console.print(table)
+        finally:
+            await db.close()
+    asyncio.run(_run())
+
 @main.command()
 @click.argument("query")
 @click.option("--limit", default=20, help="Number of markets to show")

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -20,8 +20,12 @@ def intelligence_eval_report():
     """Show the resolved, market-relative shadow evaluation scorecard."""
     async def _run():
         from auramaur.evaluation.store import EvaluationStore
-        db = Database()
-        await db.connect(ensure_schema=False)
+        from auramaur.web.db import ReadOnlyDatabase
+
+        # Pure report: mode=ro + query_only makes writes impossible at SQLite,
+        # and avoids Database.connect()'s write PRAGMAs/DDL on the live file.
+        db = ReadOnlyDatabase()
+        await db.connect()
         try:
             rows = await EvaluationStore(db).summary()
             table = Table(title="Intelligence × Exploration Evaluation")

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -233,6 +233,8 @@ class Database:
             await self._migrate_v33_to_v34()
         if from_version < 35:
             await self._migrate_v34_to_v35()
+        if from_version < 36:
+            await self._migrate_v35_to_v36()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -357,6 +359,12 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 35")
         await self._db.commit()
         log.info("database.migrated", from_version=34, to_version=35)
+
+    async def _migrate_v35_to_v36(self) -> None:
+        """Prospective intelligence-evaluation tables (additive only)."""
+        await self._db.execute("UPDATE schema_version SET version = 36")
+        await self._db.commit()
+        log.info("database.migrated", from_version=35, to_version=36)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 35
+SCHEMA_VERSION = 36
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -875,4 +875,63 @@ CREATE TABLE IF NOT EXISTS local_llm_calls (
 );
 CREATE INDEX IF NOT EXISTS idx_local_llm_calls_day
     ON local_llm_calls(purpose, created_at);
+
+-- Prospective, execution-free intelligence x exploration evaluation. Episodes
+-- are immutable content-addressed snapshots; every arm sees the same hash.
+CREATE TABLE IF NOT EXISTS evaluation_episodes (
+    episode_hash TEXT PRIMARY KEY,
+    venue TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    event_family TEXT NOT NULL DEFAULT '',
+    observed_at TEXT NOT NULL,
+    market_prob_yes REAL NOT NULL,
+    snapshot_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_evaluation_episodes_family_time
+    ON evaluation_episodes(event_family, observed_at);
+
+CREATE TABLE IF NOT EXISTS evaluation_runs (
+    run_id TEXT PRIMARY KEY,
+    arm_name TEXT NOT NULL,
+    model TEXT NOT NULL,
+    quantization TEXT NOT NULL DEFAULT '',
+    exploration_policy TEXT NOT NULL,
+    seed INTEGER NOT NULL DEFAULT 0,
+    prompt_version TEXT NOT NULL,
+    output_schema_version TEXT NOT NULL,
+    status TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    tool_calls INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    compute_seconds REAL NOT NULL DEFAULT 0,
+    error TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,
+    completed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS evaluation_forecasts (
+    forecast_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    episode_hash TEXT NOT NULL,
+    prob_yes REAL NOT NULL,
+    action TEXT NOT NULL,
+    min_acceptable_price REAL,
+    max_acceptable_price REAL,
+    thesis TEXT NOT NULL DEFAULT '',
+    uncertainty REAL,
+    evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(run_id, episode_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_evaluation_forecasts_episode
+    ON evaluation_forecasts(episode_hash);
+
+CREATE TABLE IF NOT EXISTS evaluation_outcomes (
+    episode_hash TEXT PRIMARY KEY,
+    outcome INTEGER NOT NULL CHECK(outcome IN (0, 1)),
+    resolved_at TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT ''
+);
 """

--- a/auramaur/evaluation/__init__.py
+++ b/auramaur/evaluation/__init__.py
@@ -1,0 +1,40 @@
+"""Shadow evaluation primitives for intelligence and exploration experiments."""
+
+from .runner import (
+    AdapterResponse,
+    ArmSpec,
+    Episode,
+    ExplorationPolicy,
+    Forecast,
+    ForecastAttempt,
+    GenerationRequest,
+    IntelligenceEvalRunner,
+    TreatmentResult,
+    TreatmentSpec,
+)
+from .domain import (
+    EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun, RunStatus,
+)
+from .scoring import ForecastScore, score_forecast
+from .store import EvaluationStore
+
+__all__ = [
+    "AdapterResponse",
+    "ArmSpec",
+    "Episode",
+    "ExplorationPolicy",
+    "Forecast",
+    "ForecastAttempt",
+    "GenerationRequest",
+    "IntelligenceEvalRunner",
+    "TreatmentResult",
+    "TreatmentSpec",
+    "EpisodeSnapshot",
+    "EvaluationForecast",
+    "EvaluationOutcome",
+    "EvaluationRun",
+    "RunStatus",
+    "ForecastScore",
+    "score_forecast",
+    "EvaluationStore",
+]

--- a/auramaur/evaluation/domain.py
+++ b/auramaur/evaluation/domain.py
@@ -1,0 +1,108 @@
+"""Immutable domain records for prospective intelligence evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class FrozenRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+class EpisodeSnapshot(FrozenRecord):
+    venue: str
+    market_id: str
+    event_family: str = ""
+    observed_at: datetime
+    market_prob_yes: float = Field(ge=0, le=1)
+    question: str
+    rules: str = ""
+    yes_bid: float | None = Field(default=None, ge=0, le=1)
+    yes_ask: float | None = Field(default=None, ge=0, le=1)
+    bid_depth: float = Field(default=0, ge=0)
+    ask_depth: float = Field(default=0, ge=0)
+    evidence_cutoff: datetime
+    evidence_ids: tuple[str, ...] = ()
+    context: dict[str, Any] = Field(default_factory=dict)
+
+    _observed_utc = field_validator("observed_at")(_utc)
+    _cutoff_utc = field_validator("evidence_cutoff")(_utc)
+
+    def canonical_json(self) -> str:
+        def normalize(value: Any) -> Any:
+            if isinstance(value, datetime):
+                return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+            if isinstance(value, dict):
+                return {key: normalize(item) for key, item in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [normalize(item) for item in value]
+            return value
+        return json.dumps(normalize(self.model_dump()), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @property
+    def episode_hash(self) -> str:
+        return hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
+
+
+class RunStatus(str, Enum):
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class EvaluationRun(FrozenRecord):
+    run_id: str
+    arm_name: str
+    model: str
+    quantization: str = ""
+    exploration_policy: str
+    seed: int = 0
+    prompt_version: str
+    output_schema_version: str
+    status: RunStatus = RunStatus.RUNNING
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    tool_calls: int = Field(default=0, ge=0)
+    duration_ms: int = Field(default=0, ge=0)
+    compute_seconds: float = Field(default=0, ge=0)
+    error: str = ""
+    started_at: datetime
+    completed_at: datetime | None = None
+
+    _started_utc = field_validator("started_at")(_utc)
+    _completed_utc = field_validator("completed_at")(
+        lambda value: None if value is None else _utc(value))
+
+
+class EvaluationForecast(FrozenRecord):
+    forecast_id: str
+    run_id: str
+    episode_hash: str
+    prob_yes: float = Field(ge=0, le=1)
+    action: Literal["YES", "NO", "ABSTAIN"]
+    min_acceptable_price: float | None = Field(default=None, ge=0, le=1)
+    max_acceptable_price: float | None = Field(default=None, ge=0, le=1)
+    thesis: str = ""
+    uncertainty: float | None = Field(default=None, ge=0, le=1)
+    evidence_ids: tuple[str, ...] = ()
+
+
+class EvaluationOutcome(FrozenRecord):
+    episode_hash: str
+    outcome: Literal[0, 1]
+    resolved_at: datetime
+    source: str = ""
+
+    _resolved_utc = field_validator("resolved_at")(_utc)

--- a/auramaur/evaluation/portfolio.py
+++ b/auramaur/evaluation/portfolio.py
@@ -1,0 +1,246 @@
+"""Pure deterministic counterfactual portfolio domain logic.
+
+No broker, exchange, risk, database, or live-order modules are imported here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+import math
+from typing import Protocol
+
+
+class ForecastLike(Protocol):
+    action: str
+
+
+class Side(str, Enum):
+    YES = "yes"
+    NO = "no"
+
+
+@dataclass(frozen=True)
+class MarketSnapshot:
+    market_id: str
+    category: str
+    timestamp: datetime
+    yes_bid: float
+    yes_ask: float
+    no_bid: float
+    no_ask: float
+    yes_bid_depth: float = math.inf
+    yes_ask_depth: float = math.inf
+    no_bid_depth: float = math.inf
+    no_ask_depth: float = math.inf
+
+
+@dataclass(frozen=True)
+class SimulationPolicy:
+    initial_cash: float = 1_000.0
+    order_notional: float = 100.0
+    fee_rate: float = 0.0
+    slippage_bps: float = 0.0
+    max_positions: int = 10
+    max_position_notional: float = 100.0
+    max_total_exposure: float = 1_000.0
+    max_category_exposure: float = 500.0
+
+    def __post_init__(self) -> None:
+        values = (self.initial_cash, self.order_notional, self.fee_rate,
+                  self.slippage_bps, self.max_position_notional,
+                  self.max_total_exposure, self.max_category_exposure)
+        if any(not math.isfinite(v) or v < 0 for v in values) or self.max_positions < 0:
+            raise ValueError("policy limits must be finite and non-negative")
+
+
+@dataclass
+class Position:
+    market_id: str
+    category: str
+    side: Side
+    quantity: float
+    entry_price: float
+    entry_fee: float
+    opened_at: datetime
+    mark_price: float
+
+    @property
+    def notional(self) -> float:
+        return self.quantity * self.entry_price
+
+
+@dataclass(frozen=True)
+class Fill:
+    market_id: str
+    side: Side
+    quantity: float
+    price: float
+    fee: float
+    timestamp: datetime
+    opening: bool
+
+
+@dataclass(frozen=True)
+class PortfolioMetrics:
+    cash: float
+    locked_capital: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    total_pnl: float
+    max_drawdown: float
+    turnover: float
+    requested_orders: int
+    filled_orders: int
+    fill_rate: float
+    capital_hours: float
+    return_on_capital_time: float
+
+
+@dataclass
+class VirtualPortfolio:
+    """Independent arm state; there is intentionally no global market registry."""
+    arm_id: str
+    policy: SimulationPolicy
+    cash: float = field(init=False)
+    positions: dict[str, Position] = field(default_factory=dict, init=False)
+    fills: list[Fill] = field(default_factory=list, init=False)
+    realized_pnl: float = field(default=0.0, init=False)
+    turnover: float = field(default=0.0, init=False)
+    requested_orders: int = field(default=0, init=False)
+    capital_hours: float = field(default=0.0, init=False)
+    _last_time: datetime | None = field(default=None, init=False)
+    _peak: float = field(init=False)
+    _drawdown: float = field(default=0.0, init=False)
+
+    def __post_init__(self) -> None:
+        self.cash = self.policy.initial_cash
+        self._peak = self.cash
+
+    @property
+    def locked_capital(self) -> float:
+        return sum(p.notional + p.entry_fee for p in self.positions.values())
+
+    def _advance(self, timestamp: datetime) -> None:
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError("timestamp must be timezone-aware")
+        if self._last_time is not None:
+            hours = (timestamp - self._last_time).total_seconds() / 3600
+            if hours < 0:
+                raise ValueError("events must be chronological")
+            self.capital_hours += self.locked_capital * hours
+        self._last_time = timestamp
+
+    @staticmethod
+    def _valid(price: float, depth: float) -> bool:
+        return math.isfinite(price) and 0 < price < 1 and depth > 0 and not math.isnan(depth)
+
+    def enter(self, snapshot: MarketSnapshot, forecast: ForecastLike) -> Fill | None:
+        self._advance(snapshot.timestamp)
+        action = str(forecast.action).lower()
+        if action == "abstain":
+            return None
+        self.requested_orders += 1
+        if action not in ("yes", "no") or snapshot.market_id in self.positions:
+            return None
+        if len(self.positions) >= self.policy.max_positions:
+            return None
+        side = Side(action)
+        ask, depth = ((snapshot.yes_ask, snapshot.yes_ask_depth) if side is Side.YES
+                      else (snapshot.no_ask, snapshot.no_ask_depth))
+        price = ask * (1 + self.policy.slippage_bps / 10_000)
+        if not self._valid(price, depth):
+            return None
+        category_used = sum(p.notional for p in self.positions.values() if p.category == snapshot.category)
+        total_used = sum(p.notional for p in self.positions.values())
+        budget = min(self.policy.order_notional, self.policy.max_position_notional,
+                     self.policy.max_total_exposure - total_used,
+                     self.policy.max_category_exposure - category_used,
+                     self.cash / (1 + self.policy.fee_rate))
+        if budget <= 0:
+            return None
+        quantity = min(budget / price, depth)
+        notional = quantity * price
+        fee = notional * self.policy.fee_rate
+        if quantity <= 0 or notional + fee > self.cash + 1e-9:
+            return None
+        self.cash -= notional + fee
+        position = Position(snapshot.market_id, snapshot.category, side, quantity,
+                            price, fee, snapshot.timestamp, price)
+        self.positions[snapshot.market_id] = position
+        fill = Fill(snapshot.market_id, side, quantity, price, fee, snapshot.timestamp, True)
+        self.fills.append(fill)
+        self.turnover += notional
+        self._track_drawdown()
+        return fill
+
+    def mark(self, snapshot: MarketSnapshot) -> None:
+        self._advance(snapshot.timestamp)
+        p = self.positions.get(snapshot.market_id)
+        if p:
+            bid, depth = ((snapshot.yes_bid, snapshot.yes_bid_depth) if p.side is Side.YES
+                          else (snapshot.no_bid, snapshot.no_bid_depth))
+            if self._valid(bid, depth):
+                p.mark_price = bid
+        self._track_drawdown()
+
+    def exit(self, snapshot: MarketSnapshot) -> Fill | None:
+        self._advance(snapshot.timestamp)
+        p = self.positions.get(snapshot.market_id)
+        if not p:
+            return None
+        self.requested_orders += 1
+        bid, depth = ((snapshot.yes_bid, snapshot.yes_bid_depth) if p.side is Side.YES
+                      else (snapshot.no_bid, snapshot.no_bid_depth))
+        price = bid * (1 - self.policy.slippage_bps / 10_000)
+        if not self._valid(price, depth):
+            return None
+        old_qty = p.quantity
+        qty = min(old_qty, depth)
+        proceeds, fee = qty * price, qty * price * self.policy.fee_rate
+        basis, entry_fee = qty * p.entry_price, p.entry_fee * qty / old_qty
+        self.cash += proceeds - fee
+        self.realized_pnl += proceeds - fee - basis - entry_fee
+        self.turnover += proceeds
+        p.quantity -= qty
+        p.entry_fee -= entry_fee
+        p.mark_price = price
+        if p.quantity <= 1e-12:
+            del self.positions[p.market_id]
+        fill = Fill(snapshot.market_id, p.side, qty, price, fee, snapshot.timestamp, False)
+        self.fills.append(fill)
+        self._track_drawdown()
+        return fill
+
+    def settle(self, market_id: str, yes_won: bool, timestamp: datetime) -> float:
+        self._advance(timestamp)
+        p = self.positions.pop(market_id, None)
+        if not p:
+            return 0.0
+        proceeds = p.quantity if ((p.side is Side.YES) == yes_won) else 0.0
+        pnl = proceeds - p.notional - p.entry_fee
+        self.cash += proceeds
+        self.realized_pnl += pnl
+        self._track_drawdown()
+        return pnl
+
+    def _equity(self) -> float:
+        return self.cash + sum(p.quantity * p.mark_price for p in self.positions.values())
+
+    def _track_drawdown(self) -> None:
+        equity = self._equity()
+        self._peak = max(self._peak, equity)
+        self._drawdown = max(self._drawdown, self._peak - equity)
+
+    def metrics(self) -> PortfolioMetrics:
+        equity = self._equity()
+        unrealized = sum(p.quantity * p.mark_price - p.notional - p.entry_fee
+                         for p in self.positions.values())
+        pnl = equity - self.policy.initial_cash
+        return PortfolioMetrics(self.cash, self.locked_capital, equity, self.realized_pnl,
+                                unrealized, pnl, self._drawdown, self.turnover,
+                                self.requested_orders, len(self.fills),
+                                len(self.fills) / self.requested_orders if self.requested_orders else 0.0,
+                                self.capital_hours,
+                                pnl / (self.capital_hours / 24) if self.capital_hours else 0.0)

--- a/auramaur/evaluation/runner.py
+++ b/auramaur/evaluation/runner.py
@@ -1,0 +1,291 @@
+"""Deterministic, provider-agnostic shadow forecast orchestration.
+
+This module deliberately has no imports from brokers, exchanges, or persistence.
+An adapter only receives frozen episode data and returns model output plus telemetry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Awaitable, Callable, Mapping, Protocol, Sequence
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(k): _freeze(v) for k, v in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    raise TypeError(f"episode payload contains unsupported value {type(value).__name__}")
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {k: _plain(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_plain(v) for v in value]
+    return value
+
+
+@dataclass(frozen=True)
+class Episode:
+    episode_id: str
+    payload: Mapping[str, Any]
+    payload_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.episode_id.strip():
+            raise ValueError("episode_id is required")
+        frozen = _freeze(self.payload)
+        canonical = json.dumps(_plain(frozen), sort_keys=True, separators=(",", ":"))
+        object.__setattr__(self, "payload", frozen)
+        object.__setattr__(self, "payload_hash", hashlib.sha256(canonical.encode()).hexdigest())
+
+
+@dataclass(frozen=True)
+class ArmSpec:
+    arm_id: str
+    model: str
+    adapter: "ModelAdapter | AdapterCallable"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.arm_id or not self.model:
+            raise ValueError("arm_id and model are required")
+        object.__setattr__(self, "metadata", _freeze(self.metadata))
+
+
+class ExplorationPolicy(str, Enum):
+    SINGLE = "single"
+    SAMPLES = "samples"
+    SAMPLES_CRITIC = "samples_critic"
+
+
+@dataclass(frozen=True)
+class TreatmentSpec:
+    treatment_id: str
+    arm: ArmSpec
+    policy: ExplorationPolicy = ExplorationPolicy.SINGLE
+    sample_count: int = 1
+    base_seed: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.treatment_id:
+            raise ValueError("treatment_id is required")
+        if self.sample_count < 1:
+            raise ValueError("sample_count must be positive")
+        if self.policy is ExplorationPolicy.SINGLE and self.sample_count != 1:
+            raise ValueError("single policy requires sample_count=1")
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    episode_id: str
+    episode_hash: str
+    episode_payload: Mapping[str, Any]
+    treatment_id: str
+    arm_id: str
+    model: str
+    stage: str
+    sample_index: int | None
+    seed: int
+    candidate_forecasts: tuple["Forecast", ...] = ()
+
+
+@dataclass(frozen=True)
+class AdapterResponse:
+    output: Mapping[str, Any] | str
+    telemetry: Mapping[str, Any] = field(default_factory=dict)
+
+
+class ModelAdapter(Protocol):
+    def generate(self, request: GenerationRequest) -> Awaitable[AdapterResponse] | AdapterResponse: ...
+
+
+AdapterCallable = Callable[[GenerationRequest], Awaitable[AdapterResponse] | AdapterResponse]
+
+
+@dataclass(frozen=True)
+class Forecast:
+    prob_yes: float
+    action: str
+    confidence: float | None = None
+    thesis: str | None = None
+
+
+@dataclass(frozen=True)
+class ForecastAttempt:
+    stage: str
+    sample_index: int | None
+    seed: int
+    forecast: Forecast | None
+    telemetry: Mapping[str, Any]
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.forecast is not None
+
+
+@dataclass(frozen=True)
+class TreatmentResult:
+    episode_id: str
+    episode_hash: str
+    treatment_id: str
+    arm_id: str
+    attempts: tuple[ForecastAttempt, ...]
+    aggregate_forecast: Forecast | None
+    final_forecast: Forecast | None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.final_forecast is not None
+
+
+def _seed(spec: TreatmentSpec, episode: Episode, stage: str, index: int | None) -> int:
+    material = f"{spec.base_seed}|{episode.episode_id}|{episode.payload_hash}|{spec.treatment_id}|{stage}|{index}"
+    return int.from_bytes(hashlib.sha256(material.encode()).digest()[:4], "big")
+
+
+def _parse(output: Mapping[str, Any] | str) -> Forecast:
+    if isinstance(output, str):
+        try:
+            value = json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON: {exc.msg}") from exc
+    else:
+        value = output
+    if not isinstance(value, Mapping):
+        raise ValueError("output must be a JSON object")
+    allowed = {"prob_yes", "action", "confidence", "thesis"}
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(f"unknown fields: {sorted(unknown)}")
+    if "prob_yes" not in value or "action" not in value:
+        raise ValueError("prob_yes and action are required")
+    probability = value["prob_yes"]
+    if isinstance(probability, bool) or not isinstance(probability, (int, float)):
+        raise ValueError("prob_yes must be numeric")
+    probability = float(probability)
+    if not math.isfinite(probability) or not 0 <= probability <= 1:
+        raise ValueError("prob_yes must be finite and in [0, 1]")
+    action = value["action"]
+    if not isinstance(action, str) or action.upper() not in {"YES", "NO", "ABSTAIN"}:
+        raise ValueError("action must be YES, NO, or ABSTAIN")
+    confidence = value.get("confidence")
+    if confidence is not None:
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+            raise ValueError("confidence must be numeric")
+        confidence = float(confidence)
+        if not math.isfinite(confidence) or not 0 <= confidence <= 1:
+            raise ValueError("confidence must be finite and in [0, 1]")
+    thesis = value.get("thesis")
+    if thesis is not None and not isinstance(thesis, str):
+        raise ValueError("thesis must be a string")
+    return Forecast(probability, action.upper(), confidence, thesis)
+
+
+def _aggregate(forecasts: Sequence[Forecast]) -> Forecast | None:
+    if not forecasts:
+        return None
+    probability = math.fsum(item.prob_yes for item in forecasts) / len(forecasts)
+    action = "YES" if probability > 0.5 else "NO" if probability < 0.5 else "ABSTAIN"
+    return Forecast(probability, action)
+
+
+class IntelligenceEvalRunner:
+    """Run paired shadow treatments with globally bounded model concurrency."""
+
+    def __init__(self, max_concurrency: int = 4):
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be positive")
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def run(
+        self, episode: Episode, treatments: Sequence[TreatmentSpec]
+    ) -> tuple[TreatmentResult, ...]:
+        ids = [item.treatment_id for item in treatments]
+        if len(ids) != len(set(ids)):
+            raise ValueError("treatment_id values must be unique")
+        # gather preserves input order, making persistence and replays deterministic.
+        return tuple(await asyncio.gather(*(self._run_treatment(episode, t) for t in treatments)))
+
+    async def _invoke(self, spec: TreatmentSpec, request: GenerationRequest) -> ForecastAttempt:
+        try:
+            async with self._semaphore:
+                adapter = spec.arm.adapter
+                call = adapter.generate if hasattr(adapter, "generate") else adapter
+                response = call(request)
+                if inspect.isawaitable(response):
+                    response = await response
+            if not isinstance(response, AdapterResponse):
+                raise TypeError("adapter must return AdapterResponse")
+            telemetry = _freeze(response.telemetry)
+            forecast = _parse(response.output)
+            return ForecastAttempt(request.stage, request.sample_index, request.seed, forecast, telemetry)
+        except Exception as exc:  # Model, transport, and parse failures are observations.
+            return ForecastAttempt(
+                request.stage,
+                request.sample_index,
+                request.seed,
+                None,
+                MappingProxyType({}),
+                f"{type(exc).__name__}: {exc}",
+            )
+
+    async def _run_treatment(self, episode: Episode, spec: TreatmentSpec) -> TreatmentResult:
+        count = 1 if spec.policy is ExplorationPolicy.SINGLE else spec.sample_count
+        requests = [
+            GenerationRequest(
+                episode.episode_id,
+                episode.payload_hash,
+                episode.payload,
+                spec.treatment_id,
+                spec.arm.arm_id,
+                spec.arm.model,
+                "sample",
+                index,
+                _seed(spec, episode, "sample", index),
+            )
+            for index in range(count)
+        ]
+        attempts = list(await asyncio.gather(*(self._invoke(spec, item) for item in requests)))
+        successes = tuple(item.forecast for item in attempts if item.forecast is not None)
+        aggregate = _aggregate(successes)
+        final = aggregate
+
+        if spec.policy is ExplorationPolicy.SAMPLES_CRITIC and successes:
+            critic_request = GenerationRequest(
+                episode.episode_id,
+                episode.payload_hash,
+                episode.payload,
+                spec.treatment_id,
+                spec.arm.arm_id,
+                spec.arm.model,
+                "critic",
+                None,
+                _seed(spec, episode, "critic", None),
+                successes,
+            )
+            critic = await self._invoke(spec, critic_request)
+            attempts.append(critic)
+            if critic.forecast is not None:
+                final = critic.forecast
+
+        return TreatmentResult(
+            episode.episode_id,
+            episode.payload_hash,
+            spec.treatment_id,
+            spec.arm.arm_id,
+            tuple(attempts),
+            aggregate,
+            final,
+        )

--- a/auramaur/evaluation/scoring.py
+++ b/auramaur/evaluation/scoring.py
@@ -1,0 +1,36 @@
+"""Proper and market-relative scoring for binary forecasts."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ForecastScore:
+    brier: float
+    log_loss: float
+    market_brier: float
+    brier_delta: float
+    brier_skill: float | None
+
+
+def score_forecast(prob_yes: float, market_prob_yes: float, outcome: int,
+                   epsilon: float = 1e-6) -> ForecastScore:
+    if not 0 <= prob_yes <= 1 or not 0 <= market_prob_yes <= 1:
+        raise ValueError("probabilities must be in [0, 1]")
+    if outcome not in (0, 1):
+        raise ValueError("outcome must be 0 or 1")
+    if not 0 < epsilon < 0.5:
+        raise ValueError("epsilon must be in (0, 0.5)")
+    brier = (prob_yes - outcome) ** 2
+    market_brier = (market_prob_yes - outcome) ** 2
+    clipped = min(1 - epsilon, max(epsilon, prob_yes))
+    log_loss = -(outcome * math.log(clipped) + (1 - outcome) * math.log(1 - clipped))
+    return ForecastScore(
+        brier=brier,
+        log_loss=log_loss,
+        market_brier=market_brier,
+        brier_delta=market_brier - brier,
+        brier_skill=None if market_brier == 0 else 1 - brier / market_brier,
+    )

--- a/auramaur/evaluation/service.py
+++ b/auramaur/evaluation/service.py
@@ -1,0 +1,196 @@
+"""Operational shadow collector for intelligence x exploration evaluation.
+
+This module reads discovery data and calls a local model. It has deliberately
+no broker, risk, exchange execution, or production portfolio dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+import structlog
+
+from auramaur.evaluation.domain import (
+    EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun, RunStatus,
+)
+from auramaur.evaluation.runner import (
+    AdapterResponse, ArmSpec, Episode, ExplorationPolicy, GenerationRequest,
+    IntelligenceEvalRunner, TreatmentSpec,
+)
+from auramaur.evaluation.store import EvaluationStore
+
+log = structlog.get_logger()
+
+
+def _plain(value):
+    if isinstance(value, Mapping):
+        return {key: _plain(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_plain(item) for item in value]
+    return value
+
+_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "prob_yes": {"type": "number", "minimum": 0, "maximum": 1},
+        "action": {"type": "string", "enum": ["YES", "NO", "ABSTAIN"]},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "thesis": {"type": "string"},
+    },
+    "required": ["prob_yes", "action", "thesis"],
+    "additionalProperties": False,
+}
+
+
+class LocalForecastAdapter:
+    def __init__(self, client, prompt_version: str) -> None:
+        self._client = client
+        self._prompt_version = prompt_version
+
+    async def generate(self, request: GenerationRequest) -> AdapterResponse:
+        candidates = ""
+        if request.candidate_forecasts:
+            candidates = "\nINDEPENDENT FORECASTS TO CRITIQUE:\n" + json.dumps([
+                {"prob_yes": item.prob_yes, "action": item.action,
+                 "confidence": item.confidence, "thesis": item.thesis}
+                for item in request.candidate_forecasts
+            ], sort_keys=True)
+        prompt = (
+            f"PROMPT VERSION: {self._prompt_version}\n"
+            "You are producing a prospective binary-event forecast. Use ONLY "
+            "the frozen snapshot below. Do not use knowledge or events after "
+            "evidence_cutoff. ABSTAIN when the snapshot is insufficient. "
+            "Return strict JSON matching the supplied schema.\n"
+            f"STAGE: {request.stage}\nSNAPSHOT:\n"
+            f"{json.dumps(_plain(request.episode_payload), sort_keys=True)}"
+            f"{candidates}"
+        )
+        started = time.monotonic()
+        output = await self._client.generate_json(
+            prompt, schema=_OUTPUT_SCHEMA, purpose="intelligence_eval",
+            temperature=0.35 if request.stage == "sample" else 0.0,
+            seed=request.seed,
+        )
+        if output is None:
+            raise RuntimeError("local model returned no forecast")
+        return AdapterResponse(output, {
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "stage": request.stage,
+        })
+
+
+class IntelligenceEvalService:
+    """Collect paired, timestamp-locked forecasts without placing trades."""
+
+    def __init__(self, db, settings, discovery, local_client) -> None:
+        self._db = db
+        self._cfg = settings.intelligence_eval
+        self._local_cfg = settings.local_llm
+        self._discovery = discovery
+        self._store = EvaluationStore(db)
+        adapter = LocalForecastAdapter(local_client, self._cfg.prompt_version)
+        arm = ArmSpec("local", self._local_cfg.model, adapter, {
+            "num_ctx": self._local_cfg.num_ctx,
+        })
+        self._treatments = tuple(TreatmentSpec(
+            item.name, arm, ExplorationPolicy(item.policy), item.samples, item.base_seed,
+        ) for item in self._cfg.treatments)
+        self._runner = IntelligenceEvalRunner(self._cfg.max_concurrency)
+
+    async def run_once(self) -> int:
+        await self._settle_known_outcomes()
+        markets = await self._discovery.get_markets(
+            active=True, limit=self._cfg.scan_limit)
+        eligible = [market for market in markets if (
+            market.active and not market.closed
+            and market.liquidity >= self._cfg.min_liquidity
+            and 0 < market.outcome_yes_price < 1
+        )]
+        eligible.sort(key=lambda market: market.volume, reverse=True)
+        recorded = 0
+        for market in eligible[:self._cfg.markets_per_cycle]:
+            recorded += await self._evaluate_market(market)
+        log.info("intelligence_eval.cycle", markets=len(eligible), forecasts=recorded)
+        return recorded
+
+    async def _evaluate_market(self, market) -> int:
+        now = datetime.now(timezone.utc)
+        spread = max(0.0, float(market.spread or 0))
+        mid = float(market.outcome_yes_price)
+        snapshot = EpisodeSnapshot(
+            venue=market.exchange or "polymarket", market_id=market.id,
+            event_family=market.neg_risk_market_id or market.id,
+            observed_at=now, evidence_cutoff=now, market_prob_yes=mid,
+            question=market.question, rules=market.description or "",
+            yes_bid=max(0.0, mid - spread / 2),
+            yes_ask=min(1.0, mid + spread / 2),
+            context={
+                "category": market.category, "volume": market.volume,
+                "liquidity": market.liquidity,
+                "end_date": market.end_date.isoformat() if market.end_date else None,
+            },
+        )
+        await self._store.put_episode(snapshot)
+        payload = json.loads(snapshot.canonical_json())
+        episode = Episode(snapshot.episode_hash, payload)
+        results = await self._runner.run(episode, self._treatments)
+        written = 0
+        for treatment, result in zip(self._treatments, results, strict=True):
+            run_id = hashlib.sha256(
+                f"{snapshot.episode_hash}:{treatment.treatment_id}".encode()).hexdigest()
+            duration_ms = sum(int(attempt.telemetry.get("duration_ms", 0))
+                              for attempt in result.attempts)
+            status = RunStatus.SUCCEEDED if result.succeeded else RunStatus.FAILED
+            errors = "; ".join(attempt.error for attempt in result.attempts
+                               if attempt.error)
+            await self._store.put_run(EvaluationRun(
+                run_id=run_id, arm_name=treatment.treatment_id,
+                model=treatment.arm.model,
+                quantization=str(treatment.arm.metadata.get("quantization", "")),
+                exploration_policy=treatment.policy.value, seed=treatment.base_seed,
+                prompt_version=self._cfg.prompt_version,
+                output_schema_version=self._cfg.output_schema_version,
+                status=status, duration_ms=duration_ms,
+                compute_seconds=duration_ms / 1000, error=errors,
+                started_at=now, completed_at=datetime.now(timezone.utc),
+            ))
+            if result.final_forecast is None:
+                continue
+            forecast_id = hashlib.sha256(f"{run_id}:forecast".encode()).hexdigest()
+            forecast = result.final_forecast
+            await self._store.put_forecast(EvaluationForecast(
+                forecast_id=forecast_id, run_id=run_id,
+                episode_hash=snapshot.episode_hash, prob_yes=forecast.prob_yes,
+                action=forecast.action, thesis=forecast.thesis or "",
+                uncertainty=None if forecast.confidence is None
+                else 1 - forecast.confidence,
+            ))
+            written += 1
+        return written
+
+    async def _settle_known_outcomes(self) -> int:
+        rows = await self._db.fetchall(
+            """SELECT DISTINCT e.episode_hash, e.market_id
+               FROM evaluation_episodes e
+               LEFT JOIN evaluation_outcomes o ON o.episode_hash=e.episode_hash
+               WHERE o.episode_hash IS NULL""")
+        settled = 0
+        cache = {}
+        for row in rows:
+            market_id = row["market_id"]
+            if market_id not in cache:
+                cache[market_id] = await self._discovery.get_market(market_id)
+            market = cache[market_id]
+            result = str(getattr(market, "result", "") or "").strip().lower()
+            if result not in ("yes", "no"):
+                continue
+            await self._store.settle(EvaluationOutcome(
+                episode_hash=row["episode_hash"], outcome=1 if result == "yes" else 0,
+                resolved_at=datetime.now(timezone.utc), source="venue",
+            ))
+            settled += 1
+        return settled

--- a/auramaur/evaluation/store.py
+++ b/auramaur/evaluation/store.py
@@ -1,0 +1,127 @@
+"""SQLite persistence for paired prospective evaluation records."""
+
+from __future__ import annotations
+
+import json
+
+from auramaur.evaluation.domain import (
+    EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun,
+)
+from auramaur.evaluation.scoring import ForecastScore, score_forecast
+
+
+def _ts(value) -> str:
+    return value.isoformat()
+
+
+class EvaluationStore:
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def put_episode(self, episode: EpisodeSnapshot) -> str:
+        raw = episode.canonical_json()
+        async with self._db.transaction():
+            await self._db.execute(
+                """INSERT OR IGNORE INTO evaluation_episodes
+                   (episode_hash, venue, market_id, event_family, observed_at,
+                    market_prob_yes, snapshot_json) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (episode.episode_hash, episode.venue, episode.market_id,
+                 episode.event_family, _ts(episode.observed_at),
+                 episode.market_prob_yes, raw),
+            )
+            row = await self._db.fetchone(
+                "SELECT snapshot_json FROM evaluation_episodes WHERE episode_hash = ?",
+                (episode.episode_hash,),
+            )
+            if row is None or row["snapshot_json"] != raw:
+                raise ValueError("episode hash collision or immutable snapshot conflict")
+        return episode.episode_hash
+
+    async def get_episode(self, episode_hash: str) -> EpisodeSnapshot | None:
+        row = await self._db.fetchone(
+            "SELECT snapshot_json FROM evaluation_episodes WHERE episode_hash = ?",
+            (episode_hash,),
+        )
+        return None if row is None else EpisodeSnapshot.model_validate_json(row["snapshot_json"])
+
+    async def put_run(self, run: EvaluationRun) -> None:
+        async with self._db.transaction():
+            await self._db.execute(
+                """INSERT INTO evaluation_runs
+                   (run_id, arm_name, model, quantization, exploration_policy,
+                    seed, prompt_version, output_schema_version, status,
+                    input_tokens, output_tokens, tool_calls, duration_ms,
+                    compute_seconds, error, started_at, completed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(run_id) DO UPDATE SET status=excluded.status,
+                    input_tokens=excluded.input_tokens, output_tokens=excluded.output_tokens,
+                    tool_calls=excluded.tool_calls, duration_ms=excluded.duration_ms,
+                    compute_seconds=excluded.compute_seconds, error=excluded.error,
+                    completed_at=excluded.completed_at""",
+                (run.run_id, run.arm_name, run.model, run.quantization,
+                 run.exploration_policy, run.seed, run.prompt_version,
+                 run.output_schema_version, run.status.value, run.input_tokens,
+                 run.output_tokens, run.tool_calls, run.duration_ms,
+                 run.compute_seconds, run.error, _ts(run.started_at),
+                 None if run.completed_at is None else _ts(run.completed_at)),
+            )
+
+    async def put_forecast(self, forecast: EvaluationForecast) -> None:
+        if await self.get_episode(forecast.episode_hash) is None:
+            raise ValueError("unknown episode")
+        async with self._db.transaction():
+            await self._db.execute(
+                """INSERT INTO evaluation_forecasts
+                   (forecast_id, run_id, episode_hash, prob_yes, action,
+                    min_acceptable_price, max_acceptable_price, thesis,
+                    uncertainty, evidence_ids_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (forecast.forecast_id, forecast.run_id, forecast.episode_hash,
+                 forecast.prob_yes, forecast.action, forecast.min_acceptable_price,
+                 forecast.max_acceptable_price, forecast.thesis,
+                 forecast.uncertainty, json.dumps(forecast.evidence_ids)),
+            )
+
+    async def settle(self, outcome: EvaluationOutcome) -> None:
+        if await self.get_episode(outcome.episode_hash) is None:
+            raise ValueError("unknown episode")
+        async with self._db.transaction():
+            existing = await self._db.fetchone(
+                "SELECT outcome, resolved_at, source FROM evaluation_outcomes WHERE episode_hash = ?",
+                (outcome.episode_hash,),
+            )
+            values = (outcome.outcome, _ts(outcome.resolved_at), outcome.source)
+            if existing is not None:
+                if (existing["outcome"], existing["resolved_at"], existing["source"]) != values:
+                    raise ValueError("conflicting outcome settlement")
+                return
+            await self._db.execute(
+                "INSERT INTO evaluation_outcomes (episode_hash, outcome, resolved_at, source) VALUES (?, ?, ?, ?)",
+                (outcome.episode_hash, *values),
+            )
+
+    async def score(self, forecast_id: str) -> ForecastScore | None:
+        row = await self._db.fetchone(
+            """SELECT f.prob_yes, e.market_prob_yes, o.outcome
+               FROM evaluation_forecasts f
+               JOIN evaluation_episodes e ON e.episode_hash=f.episode_hash
+               LEFT JOIN evaluation_outcomes o ON o.episode_hash=f.episode_hash
+               WHERE f.forecast_id=?""", (forecast_id,))
+        if row is None or row["outcome"] is None:
+            return None
+        return score_forecast(row["prob_yes"], row["market_prob_yes"], row["outcome"])
+
+    async def summary(self) -> list[dict]:
+        """Read-only per-arm resolved scorecard for CLI/reporting consumers."""
+        rows = await self._db.fetchall(
+            """SELECT r.arm_name, r.model, COUNT(*) AS forecasts,
+                      AVG((f.prob_yes-o.outcome)*(f.prob_yes-o.outcome)) AS brier,
+                      AVG((e.market_prob_yes-o.outcome)*
+                          (e.market_prob_yes-o.outcome)) AS market_brier,
+                      SUM(CASE WHEN f.action='ABSTAIN' THEN 1 ELSE 0 END) AS abstains
+               FROM evaluation_forecasts f
+               JOIN evaluation_runs r ON r.run_id=f.run_id
+               JOIN evaluation_episodes e ON e.episode_hash=f.episode_hash
+               JOIN evaluation_outcomes o ON o.episode_hash=f.episode_hash
+               GROUP BY r.arm_name, r.model ORDER BY brier ASC""")
+        return [dict(row) for row in rows]

--- a/auramaur/nlp/local_llm.py
+++ b/auramaur/nlp/local_llm.py
@@ -87,6 +87,7 @@ class LocalLLMClient:
         purpose: str = "generic",
         max_tokens: int = 800,
         temperature: float = 0.0,
+        seed: int | None = None,
         timeout: float | None = None,
     ) -> dict | None:
         """One JSON-constrained completion. None on any failure (fail-open)."""
@@ -113,6 +114,8 @@ class LocalLLMClient:
                 "num_predict": max_tokens,
             },
         }
+        if seed is not None:
+            payload["options"]["seed"] = int(seed)
         effective_timeout = timeout or float(self._cfg.timeout_seconds)
         started = time.monotonic()
         status = "request_error"

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -516,6 +516,22 @@ local_llm:
     enabled: false
     measure_only: true     # record Brier history without entering the blend
 
+# Prospective intelligence x exploration evaluation. Shadow-only: this task
+# records paired forecasts and can never submit orders or write portfolio rows.
+intelligence_eval:
+  enabled: false
+  interval_seconds: 3600
+  scan_limit: 100
+  markets_per_cycle: 8
+  min_liquidity: 1000.0
+  max_concurrency: 1
+  prompt_version: "forecast-v1"
+  output_schema_version: "binary-v1"
+  treatments:
+    - {name: "local_single", policy: "single", samples: 1, base_seed: 11}
+    - {name: "local_samples_4", policy: "samples", samples: 4, base_seed: 23}
+    - {name: "local_samples_4_critic", policy: "samples_critic", samples: 4, base_seed: 37}
+
 market_maker:
   enabled: true
   min_spread_bps: 40        # minimum 0.4% spread (BBO-join kicks in when 1-tick improvement would go below this)

--- a/config/settings.py
+++ b/config/settings.py
@@ -1609,6 +1609,44 @@ class LocalLLMConfig(BaseModel):
     ensemble_arm: LocalEnsembleArmConfig = Field(default_factory=LocalEnsembleArmConfig)
 
 
+class IntelligenceEvalTreatment(BaseModel):
+    """One paired local inference-time exploration treatment."""
+
+    name: str
+    policy: Literal["single", "samples", "samples_critic"] = "single"
+    samples: int = Field(default=1, ge=1, le=32)
+    base_seed: int = 0
+
+    @model_validator(mode="after")
+    def single_has_one_sample(self):
+        if self.policy == "single" and self.samples != 1:
+            raise ValueError("single intelligence-eval treatment requires samples=1")
+        return self
+
+
+class IntelligenceEvalConfig(BaseModel):
+    """Shadow-only prospective model/exploration evaluation."""
+
+    enabled: bool = False
+    interval_seconds: int = Field(default=3600, ge=300)
+    scan_limit: int = Field(default=100, ge=1, le=1000)
+    markets_per_cycle: int = Field(default=8, ge=1, le=100)
+    min_liquidity: float = Field(default=1000.0, ge=0)
+    max_concurrency: int = Field(default=1, ge=1, le=16)
+    prompt_version: str = "forecast-v1"
+    output_schema_version: str = "binary-v1"
+    treatments: list[IntelligenceEvalTreatment] = Field(default_factory=lambda: [
+        IntelligenceEvalTreatment(name="local_single"),
+    ])
+
+    @model_validator(mode="after")
+    def unique_treatments(self):
+        names = [item.name for item in self.treatments]
+        if len(names) != len(set(names)):
+            raise ValueError("intelligence-eval treatment names must be unique")
+        return self
+
+
 class ArbitrageConfig(BaseModel):
     enabled: bool = True
     min_profit_after_fees_pct: float = 1.5
@@ -1748,6 +1786,9 @@ class Settings(BaseSettings):
     llm_ensemble: LLMEnsembleConfig = Field(default_factory=lambda: LLMEnsembleConfig(**_DEFAULTS.get("llm_ensemble", {})))
     gemini: GeminiConfig = Field(default_factory=lambda: GeminiConfig(**_DEFAULTS.get("gemini", {})))
     local_llm: LocalLLMConfig = Field(default_factory=lambda: LocalLLMConfig(**_DEFAULTS.get("local_llm", {})))
+    intelligence_eval: IntelligenceEvalConfig = Field(
+        default_factory=lambda: IntelligenceEvalConfig(
+            **_DEFAULTS.get("intelligence_eval", {})))
     momentum_coupling: MomentumCouplingConfig = Field(default_factory=lambda: MomentumCouplingConfig(**_DEFAULTS.get("momentum_coupling", {})))
     market_maker: MarketMakerConfig = Field(default_factory=lambda: MarketMakerConfig(**_DEFAULTS.get("market_maker", {})))
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))

--- a/tests/test_intelligence_eval_portfolio.py
+++ b/tests/test_intelligence_eval_portfolio.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import pytest
+from auramaur.evaluation.portfolio import MarketSnapshot, SimulationPolicy, VirtualPortfolio
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+@dataclass(frozen=True)
+class Forecast:
+    action: str
+
+def snap(**kw):
+    data = dict(market_id="m1", category="politics", timestamp=NOW,
+                yes_bid=.39, yes_ask=.40, no_bid=.59, no_ask=.60,
+                yes_bid_depth=1000, yes_ask_depth=1000,
+                no_bid_depth=1000, no_ask_depth=1000)
+    data.update(kw)
+    return MarketSnapshot(**data)
+
+def test_independent_arms_identical_fills_and_same_market_allowed():
+    a, b = VirtualPortfolio("a", SimulationPolicy()), VirtualPortfolio("b", SimulationPolicy())
+    assert a.enter(snap(), Forecast("yes")) == b.enter(snap(), Forecast("yes"))
+    a.settle("m1", True, NOW + timedelta(days=1))
+    assert "m1" in b.positions
+
+def test_abstain_invalid_price_and_friction_depth():
+    p = SimulationPolicy(fee_rate=.01, slippage_bps=100)
+    book = VirtualPortfolio("a", p)
+    assert book.enter(snap(), Forecast("abstain")) is None
+    assert book.enter(snap(yes_ask=0), Forecast("yes")) is None
+    fill = book.enter(snap(yes_ask_depth=10), Forecast("yes"))
+    assert fill and fill.price == pytest.approx(.404) and fill.quantity == 10
+    assert fill.fee == pytest.approx(.0404)
+
+def test_settlement_capital_time_and_limits():
+    p = SimulationPolicy(initial_cash=50, order_notional=40, max_position_notional=30,
+                         max_total_exposure=35, max_category_exposure=30, max_positions=2)
+    book = VirtualPortfolio("a", p)
+    first = book.enter(snap(), Forecast("yes"))
+    assert first and first.quantity * first.price == pytest.approx(30)
+    assert book.enter(snap(market_id="m2", timestamp=NOW+timedelta(seconds=1)), Forecast("yes")) is None
+    third = book.enter(snap(market_id="m3", category="sports", timestamp=NOW+timedelta(seconds=2)), Forecast("yes"))
+    assert third and third.quantity * third.price == pytest.approx(5)
+    pnl = book.settle("m1", True, NOW + timedelta(hours=24))
+    assert pnl == pytest.approx(45)
+    assert book.metrics().capital_hours > 0
+
+def test_partial_exit_uses_executable_bid_and_metrics():
+    book = VirtualPortfolio("a", SimulationPolicy(order_notional=40, fee_rate=.01))
+    book.enter(snap(), Forecast("yes"))
+    fill = book.exit(snap(timestamp=NOW+timedelta(hours=1), yes_bid=.5, yes_bid_depth=25))
+    assert fill and fill.quantity == 25 and fill.price == pytest.approx(.5)
+    assert book.positions["m1"].quantity == pytest.approx(75)
+    assert book.metrics().turnover == pytest.approx(52.5)

--- a/tests/test_intelligence_eval_runner.py
+++ b/tests/test_intelligence_eval_runner.py
@@ -1,0 +1,106 @@
+import asyncio
+
+import pytest
+
+from auramaur.evaluation.runner import (
+    AdapterResponse, ArmSpec, Episode, ExplorationPolicy,
+    IntelligenceEvalRunner, TreatmentSpec,
+)
+
+
+class Adapter:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.requests = []
+        self.active = self.peak = 0
+
+    async def generate(self, request):
+        self.requests.append(request)
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        await asyncio.sleep(0)
+        self.active -= 1
+        output = self.outputs(request) if callable(self.outputs) else self.outputs[request.sample_index]
+        return AdapterResponse(output, {"tokens": 7, "stage": request.stage})
+
+
+def spec(adapter, policy=ExplorationPolicy.SINGLE, count=1, name="t"):
+    return TreatmentSpec(name, ArmSpec(name + "-arm", "fake", adapter), policy, count, 42)
+
+
+@pytest.mark.asyncio
+async def test_pairing_uses_identical_frozen_payload():
+    episode = Episode("e", {"question": "q", "items": [1]})
+    a = Adapter([{"prob_yes": .4, "action": "NO"}])
+    b = Adapter([{"prob_yes": .6, "action": "YES"}])
+    results = await IntelligenceEvalRunner().run(episode, [spec(a, name="a"), spec(b, name="b")])
+    assert len(results) == 2
+    assert a.requests[0].episode_payload is episode.payload is b.requests[0].episode_payload
+    assert a.requests[0].episode_hash == b.requests[0].episode_hash
+    with pytest.raises(TypeError):
+        episode.payload["question"] = "changed"
+
+
+@pytest.mark.asyncio
+async def test_stable_seeds_aggregation_and_concurrency():
+    outputs = [
+        {"prob_yes": .2, "action": "NO"},
+        {"prob_yes": .5, "action": "ABSTAIN"},
+        {"prob_yes": .8, "action": "YES"},
+    ]
+    runner = IntelligenceEvalRunner(max_concurrency=2)
+    a = Adapter(outputs)
+    first = (await runner.run(Episode("e", {"x": 1}), [spec(a, ExplorationPolicy.SAMPLES, 3)]))[0]
+    b = Adapter(outputs)
+    replay = (await runner.run(Episode("e", {"x": 1}), [spec(b, ExplorationPolicy.SAMPLES, 3)]))[0]
+    seeds = [x.seed for x in first.attempts]
+    assert len(set(seeds)) == 3
+    assert seeds == [x.seed for x in replay.attempts]
+    assert first.final_forecast.prob_yes == pytest.approx(.5)
+    assert first.final_forecast.action == "ABSTAIN"
+    assert a.peak <= 2
+
+
+@pytest.mark.asyncio
+async def test_critic_receives_candidates_and_supplies_final():
+    def output(request):
+        if request.stage == "critic":
+            assert [x.prob_yes for x in request.candidate_forecasts] == [.3, .7]
+            return {"prob_yes": .62, "action": "YES"}
+        return {"prob_yes": (.3, .7)[request.sample_index], "action": "NO"}
+
+    result = (await IntelligenceEvalRunner().run(
+        Episode("e", {}), [spec(Adapter(output), ExplorationPolicy.SAMPLES_CRITIC, 2)]
+    ))[0]
+    assert [x.stage for x in result.attempts] == ["sample", "sample", "critic"]
+    assert result.aggregate_forecast.prob_yes == pytest.approx(.5)
+    assert result.final_forecast.prob_yes == pytest.approx(.62)
+    assert result.attempts[-1].telemetry["stage"] == "critic"
+
+
+@pytest.mark.asyncio
+async def test_partial_and_parse_failures_are_recorded():
+    class Partial:
+        async def generate(self, request):
+            if request.sample_index == 0:
+                return AdapterResponse("not json", {"tokens": 2})
+            if request.sample_index == 1:
+                raise RuntimeError("provider down")
+            return AdapterResponse({"prob_yes": .75, "action": "YES"})
+
+    result = (await IntelligenceEvalRunner().run(
+        Episode("e", {}), [spec(Partial(), ExplorationPolicy.SAMPLES, 3)]
+    ))[0]
+    assert [x.succeeded for x in result.attempts] == [False, False, True]
+    assert "invalid JSON" in result.attempts[0].error
+    assert "provider down" in result.attempts[1].error
+    assert result.final_forecast.prob_yes == .75
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_all_failures_yield_no_forecast():
+    adapter = Adapter([{"prob_yes": 1.2, "action": "YES", "extra": True}])
+    result = (await IntelligenceEvalRunner().run(Episode("e", {}), [spec(adapter)]))[0]
+    assert not result.succeeded
+    assert result.final_forecast is None
+    assert "unknown fields" in result.attempts[0].error

--- a/tests/test_intelligence_eval_service.py
+++ b/tests/test_intelligence_eval_service.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timezone
+
+from auramaur.db.database import Database
+from auramaur.evaluation.service import IntelligenceEvalService
+from auramaur.exchange.models import Market
+from config.settings import Settings
+
+
+class Discovery:
+    def __init__(self):
+        self.market = Market(
+            id="m1", question="Will the test pass?", description="Resolves YES if it passes.",
+            category="technology", outcome_yes_price=0.55, outcome_no_price=0.45,
+            spread=0.02, liquidity=5000, volume=10000,
+            end_date=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        )
+
+    async def get_markets(self, active=True, limit=100):
+        return [self.market]
+
+    async def get_market(self, market_id):
+        return self.market
+
+
+class LocalClient:
+    def __init__(self):
+        self.calls = []
+
+    async def generate_json(self, prompt, **kwargs):
+        self.calls.append((prompt, kwargs))
+        assert "evidence_cutoff" in prompt
+        assert kwargs["schema"]["additionalProperties"] is False
+        return {
+            "prob_yes": 0.65, "action": "YES", "confidence": 0.7,
+            "thesis": "The frozen rules and snapshot support YES.",
+        }
+
+
+async def test_service_records_paired_treatments_without_trading(tmp_path):
+    db = Database(str(tmp_path / "eval-service.db"))
+    await db.connect()
+    try:
+        settings = Settings()
+        settings.intelligence_eval.enabled = True
+        settings.intelligence_eval.markets_per_cycle = 1
+        settings.local_llm.enabled = True
+        client = LocalClient()
+        service = IntelligenceEvalService(db, settings, Discovery(), client)
+
+        assert await service.run_once() == 3
+        episodes = await db.fetchall("SELECT * FROM evaluation_episodes")
+        forecasts = await db.fetchall(
+            "SELECT f.*, r.arm_name FROM evaluation_forecasts f "
+            "JOIN evaluation_runs r ON r.run_id=f.run_id ORDER BY r.arm_name")
+        assert len(episodes) == 1
+        assert len(forecasts) == 3
+        assert {row["episode_hash"] for row in forecasts} == {episodes[0]["episode_hash"]}
+        assert {row["arm_name"] for row in forecasts} == {
+            "local_single", "local_samples_4", "local_samples_4_critic",
+        }
+        assert len(client.calls) == 10
+        assert len({call[1]["seed"] for call in client.calls}) == 10
+        assert await db.fetchone("SELECT 1 FROM trades") is None
+        assert await db.fetchone("SELECT 1 FROM portfolio") is None
+    finally:
+        await db.close()
+
+
+async def test_service_settles_every_snapshot_from_venue_result(tmp_path):
+    db = Database(str(tmp_path / "eval-settle.db"))
+    await db.connect()
+    try:
+        settings = Settings()
+        settings.intelligence_eval.markets_per_cycle = 1
+        discovery, client = Discovery(), LocalClient()
+        service = IntelligenceEvalService(db, settings, discovery, client)
+        await service.run_once()
+        discovery.market.result = "yes"
+        discovery.market.active = False
+        discovery.market.closed = True
+        await service.run_once()
+        row = await db.fetchone("SELECT outcome, source FROM evaluation_outcomes")
+        assert row["outcome"] == 1 and row["source"] == "venue"
+    finally:
+        await db.close()
+
+
+def test_intelligence_eval_defaults_off():
+    settings = Settings()
+    assert settings.intelligence_eval.enabled is False

--- a/tests/test_intelligence_eval_store.py
+++ b/tests/test_intelligence_eval_store.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.evaluation.domain import (
+    EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun, RunStatus,
+)
+from auramaur.evaluation.store import EvaluationStore
+
+
+def episode(**updates):
+    values = dict(
+        venue="polymarket", market_id="m1", event_family="event-1",
+        observed_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        market_prob_yes=0.6, question="Will it happen?", rules="Venue rules",
+        yes_bid=0.59, yes_ask=0.61, bid_depth=10, ask_depth=12,
+        evidence_cutoff=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        evidence_ids=("news-1",), context={"b": 2, "a": 1},
+    )
+    values.update(updates)
+    return EpisodeSnapshot(**values)
+
+
+def test_episode_hash_is_canonical_and_requires_aware_time():
+    first = episode()
+    offset = timezone(timedelta(hours=-6))
+    second = episode(
+        observed_at=first.observed_at.astimezone(offset),
+        evidence_cutoff=first.evidence_cutoff.astimezone(offset),
+        context={"a": 1, "b": 2},
+    )
+    assert first.episode_hash == second.episode_hash
+    with pytest.raises(ValueError):
+        episode(observed_at=datetime(2026, 7, 21))
+
+
+async def test_store_round_trip_idempotence_settlement_and_score(tmp_path):
+    db = Database(str(tmp_path / "eval.db"))
+    await db.connect()
+    try:
+        store = EvaluationStore(db)
+        item = episode()
+        assert await store.put_episode(item) == item.episode_hash
+        await store.put_episode(item)
+        row = await db.fetchone("SELECT COUNT(*) AS n FROM evaluation_episodes")
+        assert row["n"] == 1
+        restored = await store.get_episode(item.episode_hash)
+        assert restored is not None and restored.event_family == "event-1"
+
+        run = EvaluationRun(
+            run_id="r1", arm_name="local-single", model="qwen3:8b",
+            exploration_policy="single", prompt_version="v1",
+            output_schema_version="v1", status=RunStatus.SUCCEEDED,
+            started_at=item.observed_at, completed_at=item.observed_at,
+        )
+        await store.put_run(run)
+        forecast = EvaluationForecast(
+            forecast_id="f1", run_id="r1", episode_hash=item.episode_hash,
+            prob_yes=0.8, action="YES", thesis="Concrete mechanism",
+            evidence_ids=("news-1",),
+        )
+        await store.put_forecast(forecast)
+        resolved = EvaluationOutcome(
+            episode_hash=item.episode_hash, outcome=1,
+            resolved_at=item.observed_at + timedelta(days=1), source="venue",
+        )
+        await store.settle(resolved)
+        await store.settle(resolved)
+        score = await store.score("f1")
+        assert score is not None
+        assert score.brier == pytest.approx(0.04)
+        assert score.brier_delta > 0
+        with pytest.raises(ValueError, match="conflicting"):
+            await store.settle(resolved.model_copy(update={"outcome": 0}))
+    finally:
+        await db.close()
+
+
+def test_perfect_market_has_undefined_skill():
+    from auramaur.evaluation.scoring import score_forecast
+    assert score_forecast(0.8, 1.0, 1).brier_skill is None

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -130,11 +130,12 @@ async def test_schema_passed_as_format():
     client = LocalLLMClient(_settings(), None)
     client._request = AsyncMock(return_value=_ok_response({"x": 1}))
     schema = {"type": "object", "properties": {"x": {"type": "number"}}}
-    await client.generate_json("prompt", schema=schema)
+    await client.generate_json("prompt", schema=schema, seed=12345)
     payload = client._request.await_args.args[0]
     assert payload["format"] == schema
     assert payload["think"] is False
     assert payload["stream"] is False
+    assert payload["options"]["seed"] == 12345
 
 
 def test_get_client_is_singleton():


### PR DESCRIPTION
## Summary
- add immutable timestamp-locked evaluation episodes, paired model/exploration runs, forecasts, outcomes, and proper scoring
- add deterministic single, multi-sample, and sample-plus-critic local Ollama treatments with independent seeds
- add execution-free virtual portfolios with bid/ask fills, fees, slippage, depth, limits, settlement, and risk metrics
- add a default-off shadow collector, venue-outcome settlement, schema v36 persistence, and read-only CLI scorecard

## Safety
- disabled by default
- no ExecutionGateway, RiskManager, exchange order, trades, or production portfolio path
- every treatment receives the same immutable episode payload
- historical/prospective cutoff is embedded in the frozen snapshot and prompt

## Verification
- Ruff: passed
- focused evaluation/local-LLM/settings suite: 56 passed
- full suite: 1395 passed, 3 skipped, 1 pre-existing failure
- the lone failure is tests/test_data_lineage.py::test_paper_cycle_lineage_through_resolution_and_report (cannot start a transaction within a transaction); reproduced unchanged on origin/main in a separate worktree
- git diff --check: passed

## Operation
Enable both local_llm.enabled and intelligence_eval.enabled. View resolved results with uramaur intelligence-eval.