### PR TITLE
feat(research): unify forecast evidence streams

### DIFF
--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -16,7 +16,9 @@ from auramaur.cli._base import console, main
 
 
 @main.command("intelligence-eval")
-def intelligence_eval_report():
+@click.option("--all-streams", is_flag=True,
+              help="Compare production, intelligence, and information-trial streams.")
+def intelligence_eval_report(all_streams: bool):
     """Show the resolved, market-relative shadow evaluation scorecard."""
     async def _run():
         from auramaur.evaluation.store import EvaluationStore
@@ -27,9 +29,27 @@ def intelligence_eval_report():
         db = ReadOnlyDatabase()
         await db.connect()
         try:
-            rows = await EvaluationStore(db).summary()
+            if all_streams:
+                rows = await db.fetchall(
+                    """WITH ranked AS (
+                         SELECT *,ROW_NUMBER() OVER (
+                           PARTITION BY stream,arm,probability_kind,event_family,horizon_bucket
+                           ORDER BY observed_at,forecast_key) rn
+                         FROM forecast_score_facts
+                         WHERE score_version='binary-proper-v1')
+                       SELECT stream,arm,probability_kind,horizon_bucket,
+                              COUNT(*) forecasts,AVG(brier) brier,
+                              AVG(market_brier) market_brier
+                         FROM ranked WHERE rn=1
+                        GROUP BY stream,arm,probability_kind,horizon_bucket
+                        ORDER BY stream,arm,probability_kind,horizon_bucket""")
+                rows = [dict(row) for row in rows]
+            else:
+                rows = await EvaluationStore(db).summary()
             table = Table(title="Intelligence × Exploration Evaluation")
             table.add_column("Arm")
+            if all_streams:
+                table.add_column("Kind")
             table.add_column("Model")
             table.add_column("N", justify="right")
             table.add_column("Brier", justify="right")
@@ -37,9 +57,14 @@ def intelligence_eval_report():
             table.add_column("Δ vs market", justify="right")
             for row in rows:
                 brier, market = float(row["brier"]), float(row["market_brier"])
-                table.add_row(row["arm_name"], row["model"], str(row["forecasts"]),
-                              f"{brier:.4f}", f"{market:.4f}",
-                              f"{market - brier:+.4f}")
+                arm = row.get("arm_name") or f"{row['stream']}:{row['arm']}"
+                model = row.get("model") or ""
+                values = [arm]
+                if all_streams:
+                    values.append(f"{row['probability_kind']} {row['horizon_bucket']}")
+                values.extend([model, str(row["forecasts"]), f"{brier:.4f}",
+                               f"{market:.4f}", f"{market - brier:+.4f}"])
+                table.add_row(*values)
             console.print(table)
         finally:
             await db.close()

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -235,6 +235,8 @@ class Database:
             await self._migrate_v34_to_v35()
         if from_version < 36:
             await self._migrate_v35_to_v36()
+        if from_version < 37:
+            await self._migrate_v36_to_v37()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -365,6 +367,34 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 36")
         await self._db.commit()
         log.info("database.migrated", from_version=35, to_version=36)
+
+    async def _migrate_v36_to_v37(self) -> None:
+        """Canonical outcomes and normalized forecast evidence."""
+        # TABLES already created the additive tables/view. Seed one canonical
+        # result per venue+market from legacy authoritative resolution rows.
+        await self._db.execute(
+            """INSERT OR IGNORE INTO market_outcomes
+               (event_key,venue,market_id,event_family,outcome,resolved_at,source,resolution_version)
+               SELECT lower(COALESCE(NULLIF(m.exchange,''),'polymarket')) || ':' || c.market_id,
+                      lower(COALESCE(NULLIF(m.exchange,''),'polymarket')), c.market_id, c.market_id,
+                      c.actual_outcome, c.resolved_at, 'calibration_backfill', 'legacy-v1'
+                 FROM calibration c
+                 JOIN (SELECT market_id,MAX(id) AS id FROM calibration
+                        WHERE actual_outcome IS NOT NULL GROUP BY market_id) latest
+                   ON latest.id=c.id
+                 LEFT JOIN markets m ON m.id=c.market_id""")
+        await self._db.execute(
+            """INSERT OR IGNORE INTO market_outcomes
+               (event_key,venue,market_id,event_family,outcome,resolved_at,source,resolution_version)
+               SELECT lower(e.venue) || ':' || e.market_id, lower(e.venue), e.market_id,
+                      e.event_family,
+                      o.outcome, MIN(o.resolved_at), 'evaluation_backfill', 'legacy-v1'
+                 FROM evaluation_outcomes o
+                 JOIN evaluation_episodes e ON e.episode_hash=o.episode_hash
+                GROUP BY lower(e.venue),e.market_id,o.outcome""")
+        await self._db.execute("UPDATE schema_version SET version = 37")
+        await self._db.commit()
+        log.info("database.migrated", from_version=36, to_version=37)
 
     async def _migrate_v28_to_v29(self) -> None:
         """Add immutable strategy-research and CLV accounting tables."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 36
+SCHEMA_VERSION = 37
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -934,4 +934,113 @@ CREATE TABLE IF NOT EXISTS evaluation_outcomes (
     resolved_at TEXT NOT NULL,
     source TEXT NOT NULL DEFAULT ''
 );
+
+-- One venue-qualified result for every binary event. Forecast tables retain
+-- their historical outcome columns during migration, but all new comparative
+-- scoring joins this registry so resolution truth and timing cannot drift.
+CREATE TABLE IF NOT EXISTS market_outcomes (
+    event_key TEXT PRIMARY KEY,
+    venue TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    event_family TEXT NOT NULL DEFAULT '',
+    outcome INTEGER NOT NULL CHECK(outcome IN (0, 1)),
+    resolved_at TEXT NOT NULL,
+    source TEXT NOT NULL,
+    resolution_version TEXT NOT NULL DEFAULT 'venue-v1',
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(venue, market_id)
+);
+CREATE INDEX IF NOT EXISTS idx_market_outcomes_market
+    ON market_outcomes(market_id, venue);
+
+-- Rebuildable, explicitly-versioned scores over the normalized evidence view.
+CREATE TABLE IF NOT EXISTS forecast_score_facts (
+    forecast_key TEXT PRIMARY KEY,
+    event_key TEXT NOT NULL,
+    event_family TEXT NOT NULL DEFAULT '',
+    stream TEXT NOT NULL,
+    arm TEXT NOT NULL DEFAULT '',
+    probability_kind TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    horizon_bucket TEXT NOT NULL,
+    outcome INTEGER NOT NULL CHECK(outcome IN (0, 1)),
+    brier REAL NOT NULL,
+    log_loss REAL NOT NULL,
+    market_brier REAL,
+    brier_delta REAL,
+    brier_skill REAL,
+    score_version TEXT NOT NULL,
+    scored_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_forecast_score_stream_event
+    ON forecast_score_facts(stream, arm, event_key);
+
+-- Semantic read model: source tables keep their distinct write contracts.
+-- Production raw/calibrated rows are separate observations; experimental
+-- treatments retain episode/run identity; information trials retain arms.
+CREATE VIEW IF NOT EXISTS unified_forecast_evidence AS
+SELECT 'snapshot:raw:' || f.id AS forecast_key,
+       'production' AS stream,
+       lower(COALESCE(NULLIF(f.exchange,''),'polymarket')) || ':' || f.market_id AS event_key,
+       COALESCE(NULLIF(o.event_family,''),f.market_id) AS event_family,
+       lower(COALESCE(NULLIF(f.exchange,''),'polymarket')) AS venue,
+       f.market_id, f.observed_at, f.observed_at AS evidence_cutoff,
+       f.raw_probability AS probability, 'raw' AS probability_kind,
+       f.market_yes_price AS market_probability, f.model,
+       f.strategy_source AS arm, f.strategy_source,
+       NULL AS experiment_id, NULL AS episode_hash,
+       f.evidence_run_ids AS evidence_ids, f.config_fingerprint,
+       '' AS prompt_version, '' AS output_schema_version,
+       0.0 AS compute_seconds, 'succeeded' AS status, 0 AS abstained,
+       o.outcome, o.resolved_at
+  FROM forecast_snapshots f
+  LEFT JOIN market_outcomes o
+    ON o.event_key=lower(COALESCE(NULLIF(f.exchange,''),'polymarket')) || ':' || f.market_id
+UNION ALL
+SELECT 'snapshot:calibrated:' || f.id, 'production',
+       lower(COALESCE(NULLIF(f.exchange,''),'polymarket')) || ':' || f.market_id,
+       COALESCE(NULLIF(o.event_family,''),f.market_id),
+       lower(COALESCE(NULLIF(f.exchange,''),'polymarket')),
+       f.market_id, f.observed_at, f.observed_at,
+       f.calibrated_probability, 'calibrated', f.market_yes_price, f.model,
+       f.strategy_source, f.strategy_source, NULL, NULL,
+       f.evidence_run_ids, f.config_fingerprint, '', '', 0.0, 'succeeded', 0,
+       o.outcome, o.resolved_at
+  FROM forecast_snapshots f
+  LEFT JOIN market_outcomes o
+    ON o.event_key=lower(COALESCE(NULLIF(f.exchange,''),'polymarket')) || ':' || f.market_id
+ WHERE f.calibrated_probability IS NOT NULL
+UNION ALL
+SELECT 'evaluation:' || ef.forecast_id, 'intelligence_eval',
+       lower(e.venue) || ':' || e.market_id,
+       COALESCE(NULLIF(o.event_family,''),e.event_family),
+       lower(e.venue), e.market_id, e.observed_at,
+       COALESCE(json_extract(e.snapshot_json,'$.evidence_cutoff'),e.observed_at),
+       ef.prob_yes,
+       CASE WHEN r.exploration_policy='samples_critic' THEN 'critic'
+            WHEN r.exploration_policy='single' THEN 'single'
+            ELSE 'aggregate' END,
+       e.market_prob_yes, r.model, r.arm_name, 'intelligence_eval',
+       r.run_id, e.episode_hash, ef.evidence_ids_json, '',
+       r.prompt_version, r.output_schema_version, r.compute_seconds,
+       r.status, CASE WHEN ef.action='ABSTAIN' THEN 1 ELSE 0 END,
+       o.outcome, o.resolved_at
+  FROM evaluation_forecasts ef
+  JOIN evaluation_runs r ON r.run_id=ef.run_id
+  JOIN evaluation_episodes e ON e.episode_hash=ef.episode_hash
+  LEFT JOIN market_outcomes o ON o.event_key=lower(e.venue) || ':' || e.market_id
+UNION ALL
+SELECT 'information:' || pf.trial_id || ':' || pf.arm, 'information_trial',
+       lower(COALESCE(NULLIF(m.exchange,''),'polymarket')) || ':' || t.market_id,
+       COALESCE(NULLIF(o.event_family,''),t.market_id),
+       lower(COALESCE(NULLIF(m.exchange,''),'polymarket')),
+       t.market_id, t.observed_at, t.observed_at, pf.probability,
+       'trial', t.market_price, '', pf.arm, s.source, t.id, NULL, '[]', '', '', '',
+       0.0, 'succeeded', 0, o.outcome, o.resolved_at
+  FROM paired_forecasts pf
+  JOIN information_trials t ON t.id=pf.trial_id
+  JOIN information_strategies s ON s.id=t.strategy_id
+  LEFT JOIN markets m ON m.id=t.market_id
+  LEFT JOIN market_outcomes o
+    ON o.event_key=lower(COALESCE(NULLIF(m.exchange,''),'polymarket')) || ':' || t.market_id;
 """

--- a/auramaur/evaluation/__init__.py
+++ b/auramaur/evaluation/__init__.py
@@ -17,6 +17,9 @@ from .domain import (
 )
 from .scoring import ForecastScore, score_forecast
 from .store import EvaluationStore
+from .evidence import (
+    ForecastScoreMaterializer, MarketOutcome, OutcomeRepository, event_key,
+)
 
 __all__ = [
     "AdapterResponse",
@@ -37,4 +40,8 @@ __all__ = [
     "ForecastScore",
     "score_forecast",
     "EvaluationStore",
+    "ForecastScoreMaterializer",
+    "MarketOutcome",
+    "OutcomeRepository",
+    "event_key",
 ]

--- a/auramaur/evaluation/evidence.py
+++ b/auramaur/evaluation/evidence.py
@@ -1,0 +1,143 @@
+"""Canonical outcomes and versioned cross-stream forecast scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from auramaur.evaluation.scoring import score_forecast
+
+SCORE_VERSION = "binary-proper-v1"
+
+
+def event_key(venue: str, market_id: str) -> str:
+    venue_norm = (venue or "polymarket").strip().lower()
+    market_norm = market_id.strip()
+    if not venue_norm or not market_norm:
+        raise ValueError("venue and market_id are required")
+    return f"{venue_norm}:{market_norm}"
+
+
+@dataclass(frozen=True)
+class MarketOutcome:
+    venue: str
+    market_id: str
+    outcome: int
+    resolved_at: datetime
+    event_family: str = ""
+    source: str = "venue"
+    resolution_version: str = "venue-v1"
+
+    def __post_init__(self) -> None:
+        if self.outcome not in (0, 1):
+            raise ValueError("outcome must be 0 or 1")
+        if self.resolved_at.tzinfo is None or self.resolved_at.utcoffset() is None:
+            raise ValueError("resolved_at must be timezone-aware")
+
+    @property
+    def event_key(self) -> str:
+        return event_key(self.venue, self.market_id)
+
+
+class OutcomeRepository:
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def record(self, outcome: MarketOutcome) -> bool:
+        """Record immutable venue truth; identical repeats are no-ops."""
+        async with self._db.transaction():
+            cursor = await self._db.execute(
+                """INSERT OR IGNORE INTO market_outcomes
+                   (event_key,venue,market_id,event_family,outcome,resolved_at,
+                    source,resolution_version)
+                   VALUES (?,?,?,?,?,?,?,?)""",
+                (outcome.event_key, outcome.venue.strip().lower(), outcome.market_id,
+                 outcome.event_family or outcome.market_id, outcome.outcome,
+                 outcome.resolved_at.astimezone(timezone.utc).isoformat(),
+                 outcome.source, outcome.resolution_version),
+            )
+            rowcount = cursor.rowcount
+            # aiosqlite reports 1/0. Lightweight Database protocol fakes used
+            # by strategy tests may not expose a numeric rowcount; an INSERT
+            # that did not raise is their success contract.
+            if not isinstance(rowcount, int):
+                return True
+            inserted = rowcount == 1
+            if inserted:
+                return True
+            existing = await self._db.fetchone(
+                "SELECT outcome FROM market_outcomes WHERE event_key=?",
+                (outcome.event_key,),
+            )
+            if existing is None or int(existing["outcome"]) != outcome.outcome:
+                raise ValueError(f"conflicting canonical outcome for {outcome.event_key}")
+        return False
+
+
+def _horizon_bucket(observed_at: str, resolved_at: str) -> str:
+    observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    resolved = datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
+    days = max(0.0, (resolved - observed).total_seconds() / 86400)
+    if days <= 1:
+        return "0-1d"
+    if days <= 7:
+        return "1-7d"
+    if days <= 30:
+        return "7-30d"
+    return "30d+"
+
+
+class ForecastScoreMaterializer:
+    """Idempotently rebuild comparable score facts from the semantic view."""
+
+    def __init__(self, db, score_version: str = SCORE_VERSION) -> None:
+        self._db = db
+        self._version = score_version
+
+    async def refresh(self) -> int:
+        rows = await self._db.fetchall(
+            """SELECT * FROM unified_forecast_evidence
+               WHERE outcome IS NOT NULL AND status='succeeded'""")
+        facts = []
+        for row in rows:
+            score = score_forecast(
+                float(row["probability"]), float(row["market_probability"]),
+                int(row["outcome"]),
+            )
+            facts.append((
+                row["forecast_key"], row["event_key"], row["event_family"] or row["event_key"],
+                row["stream"], row["arm"] or "", row["probability_kind"],
+                row["observed_at"], _horizon_bucket(row["observed_at"], row["resolved_at"]),
+                row["outcome"], score.brier, score.log_loss, score.market_brier,
+                score.brier_delta, score.brier_skill, self._version,
+            ))
+        async with self._db.transaction():
+            await self._db.execute(
+                "DELETE FROM forecast_score_facts WHERE score_version=?", (self._version,))
+            if facts:
+                await self._db.executemany(
+                    """INSERT INTO forecast_score_facts
+                       (forecast_key,event_key,event_family,stream,arm,probability_kind,
+                        observed_at,horizon_bucket,outcome,brier,log_loss,market_brier,
+                        brier_delta,brier_skill,score_version)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""", facts)
+        return len(facts)
+
+    async def event_weighted_summary(self) -> list[dict]:
+        """One predeclared earliest observation per event-family/horizon/arm."""
+        rows = await self._db.fetchall(
+            """WITH ranked AS (
+                 SELECT *, ROW_NUMBER() OVER (
+                   PARTITION BY stream,arm,probability_kind,event_family,horizon_bucket
+                   ORDER BY observed_at ASC,forecast_key ASC) AS rn
+                 FROM forecast_score_facts WHERE score_version=?
+               )
+               SELECT stream,arm,probability_kind,horizon_bucket,COUNT(*) AS events,
+                      AVG(brier) AS brier,AVG(log_loss) AS log_loss,
+                      AVG(market_brier) AS market_brier,AVG(brier_delta) AS brier_delta
+                 FROM ranked WHERE rn=1
+                GROUP BY stream,arm,probability_kind,horizon_bucket
+                ORDER BY stream,arm,probability_kind,horizon_bucket""",
+            (self._version,),
+        )
+        return [dict(row) for row in rows]

--- a/auramaur/evaluation/service.py
+++ b/auramaur/evaluation/service.py
@@ -15,13 +15,14 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.evaluation.domain import (
-    EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun, RunStatus,
+    EpisodeSnapshot, EvaluationForecast, EvaluationRun, RunStatus,
 )
 from auramaur.evaluation.runner import (
     AdapterResponse, ArmSpec, Episode, ExplorationPolicy, GenerationRequest,
     IntelligenceEvalRunner, TreatmentSpec,
 )
 from auramaur.evaluation.store import EvaluationStore
+from auramaur.evaluation.evidence import ForecastScoreMaterializer
 
 log = structlog.get_logger()
 
@@ -92,6 +93,7 @@ class IntelligenceEvalService:
         self._local_cfg = settings.local_llm
         self._discovery = discovery
         self._store = EvaluationStore(db)
+        self._score_materializer = ForecastScoreMaterializer(db)
         adapter = LocalForecastAdapter(local_client, self._cfg.prompt_version)
         arm = ArmSpec("local", self._local_cfg.model, adapter, {
             "num_ctx": self._local_cfg.num_ctx,
@@ -102,7 +104,9 @@ class IntelligenceEvalService:
         self._runner = IntelligenceEvalRunner(self._cfg.max_concurrency)
 
     async def run_once(self) -> int:
-        await self._settle_known_outcomes()
+        # ResolutionTracker owns venue truth. Refreshing here makes newly
+        # canonicalized results visible even during quiet/no-resolution cycles.
+        await self._score_materializer.refresh()
         markets = await self._discovery.get_markets(
             active=True, limit=self._cfg.scan_limit)
         eligible = [market for market in markets if (
@@ -171,26 +175,3 @@ class IntelligenceEvalService:
             ))
             written += 1
         return written
-
-    async def _settle_known_outcomes(self) -> int:
-        rows = await self._db.fetchall(
-            """SELECT DISTINCT e.episode_hash, e.market_id
-               FROM evaluation_episodes e
-               LEFT JOIN evaluation_outcomes o ON o.episode_hash=e.episode_hash
-               WHERE o.episode_hash IS NULL""")
-        settled = 0
-        cache = {}
-        for row in rows:
-            market_id = row["market_id"]
-            if market_id not in cache:
-                cache[market_id] = await self._discovery.get_market(market_id)
-            market = cache[market_id]
-            result = str(getattr(market, "result", "") or "").strip().lower()
-            if result not in ("yes", "no"):
-                continue
-            await self._store.settle(EvaluationOutcome(
-                episode_hash=row["episode_hash"], outcome=1 if result == "yes" else 0,
-                resolved_at=datetime.now(timezone.utc), source="venue",
-            ))
-            settled += 1
-        return settled

--- a/auramaur/evaluation/store.py
+++ b/auramaur/evaluation/store.py
@@ -8,6 +8,7 @@ from auramaur.evaluation.domain import (
     EpisodeSnapshot, EvaluationForecast, EvaluationOutcome, EvaluationRun,
 )
 from auramaur.evaluation.scoring import ForecastScore, score_forecast
+from auramaur.evaluation.evidence import MarketOutcome, OutcomeRepository
 
 
 def _ts(value) -> str:
@@ -85,6 +86,13 @@ class EvaluationStore:
     async def settle(self, outcome: EvaluationOutcome) -> None:
         if await self.get_episode(outcome.episode_hash) is None:
             raise ValueError("unknown episode")
+        episode = await self.get_episode(outcome.episode_hash)
+        await OutcomeRepository(self._db).record(MarketOutcome(
+            venue=episode.venue, market_id=episode.market_id,
+            outcome=outcome.outcome, resolved_at=outcome.resolved_at,
+            source=outcome.source or "evaluation_compat",
+            event_family=episode.event_family or episode.market_id,
+        ))
         async with self._db.transaction():
             existing = await self._db.fetchone(
                 "SELECT outcome, resolved_at, source FROM evaluation_outcomes WHERE episode_hash = ?",
@@ -105,7 +113,8 @@ class EvaluationStore:
             """SELECT f.prob_yes, e.market_prob_yes, o.outcome
                FROM evaluation_forecasts f
                JOIN evaluation_episodes e ON e.episode_hash=f.episode_hash
-               LEFT JOIN evaluation_outcomes o ON o.episode_hash=f.episode_hash
+               LEFT JOIN market_outcomes o
+                 ON o.event_key=lower(e.venue) || ':' || e.market_id
                WHERE f.forecast_id=?""", (forecast_id,))
         if row is None or row["outcome"] is None:
             return None
@@ -114,14 +123,18 @@ class EvaluationStore:
     async def summary(self) -> list[dict]:
         """Read-only per-arm resolved scorecard for CLI/reporting consumers."""
         rows = await self._db.fetchall(
-            """SELECT r.arm_name, r.model, COUNT(*) AS forecasts,
-                      AVG((f.prob_yes-o.outcome)*(f.prob_yes-o.outcome)) AS brier,
-                      AVG((e.market_prob_yes-o.outcome)*
-                          (e.market_prob_yes-o.outcome)) AS market_brier,
-                      SUM(CASE WHEN f.action='ABSTAIN' THEN 1 ELSE 0 END) AS abstains
-               FROM evaluation_forecasts f
-               JOIN evaluation_runs r ON r.run_id=f.run_id
-               JOIN evaluation_episodes e ON e.episode_hash=f.episode_hash
-               JOIN evaluation_outcomes o ON o.episode_hash=f.episode_hash
-               GROUP BY r.arm_name, r.model ORDER BY brier ASC""")
+            """WITH ranked AS (
+                 SELECT u.*, ROW_NUMBER() OVER (
+                   PARTITION BY u.arm,u.event_family
+                   ORDER BY u.observed_at ASC,u.forecast_key ASC) AS rn
+                 FROM unified_forecast_evidence u
+                 WHERE u.stream='intelligence_eval' AND u.outcome IS NOT NULL
+               )
+               SELECT arm AS arm_name,model,COUNT(*) AS forecasts,
+                      AVG((probability-outcome)*(probability-outcome)) AS brier,
+                      AVG((market_probability-outcome)*
+                          (market_probability-outcome)) AS market_brier,
+                      SUM(abstained) AS abstains
+                 FROM ranked WHERE rn=1
+                GROUP BY arm,model ORDER BY brier ASC""")
         return [dict(row) for row in rows]

--- a/auramaur/nlp/calibration.py
+++ b/auramaur/nlp/calibration.py
@@ -133,15 +133,14 @@ class CalibrationTracker:
             category: Market category for per-category calibration.
         """
         await self._ensure_initialized()
-        await self._db.execute(
-            """
-            INSERT INTO calibration (market_id, predicted_prob, category, created_at)
-            VALUES (?, ?, ?, datetime('now'))
-            """,
-            (market_id, predicted_prob, category),
-        )
+        sql = """INSERT INTO calibration
+                 (market_id,predicted_prob,category,created_at)
+                 VALUES (?,?,?,datetime('now'))"""
         if commit:
-            await self._db.commit()
+            async with self._db.transaction():
+                await self._db.execute(sql, (market_id, predicted_prob, category))
+        else:
+            await self._db.execute(sql, (market_id, predicted_prob, category))
         log.debug(
             "calibration.recorded",
             market_id=market_id,

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -263,29 +263,25 @@ class TradingEngine(CycleOrchestrationMixin):
         the streak); an approval clears it — the market earned its way back.
         """
         try:
-            if approved:
-                await self.db.execute(
-                    "DELETE FROM signal_rejections WHERE market_id = ?",
-                    (market.id,),
-                )
-            else:
-                await self.db.execute(
-                    """INSERT INTO signal_rejections
-                       (market_id, exchange, rejected_at, yes_price, reason, streak)
-                       VALUES (?, ?, datetime('now'), ?, ?, 1)
-                       ON CONFLICT(market_id) DO UPDATE SET
-                           rejected_at = excluded.rejected_at,
-                           yes_price = excluded.yes_price,
-                           reason = excluded.reason,
-                           streak = streak + 1""",
-                    (
-                        market.id,
-                        market.exchange or self.exchange_name or "",
-                        market.outcome_yes_price,
-                        (reason or "")[:200],
-                    ),
-                )
-            await self.db.commit()
+            async with self.db.transaction():
+                if approved:
+                    await self.db.execute(
+                        "DELETE FROM signal_rejections WHERE market_id = ?",
+                        (market.id,),
+                    )
+                else:
+                    await self.db.execute(
+                        """INSERT INTO signal_rejections
+                           (market_id,exchange,rejected_at,yes_price,reason,streak)
+                           VALUES (?,?,datetime('now'),?,?,1)
+                           ON CONFLICT(market_id) DO UPDATE SET
+                               rejected_at=excluded.rejected_at,
+                               yes_price=excluded.yes_price,
+                               reason=excluded.reason,
+                               streak=streak+1""",
+                        (market.id, market.exchange or self.exchange_name or "",
+                         market.outcome_yes_price, (reason or "")[:200]),
+                    )
         except Exception as e:
             log.debug("engine.rejection_record_error", market_id=market.id, error=str(e))
 
@@ -624,9 +620,9 @@ class TradingEngine(CycleOrchestrationMixin):
             )
             analysis.calibrated_probability = calibrated
 
-        # Existing calibration remains on its established connection. New
-        # lineage is observer-only: enqueueing is non-blocking and its worker
-        # owns a separate connection, so it cannot roll back or stall trading.
+        # Lineage enqueueing is non-blocking. Both calibration and the observer
+        # share the process Database and serialize short writes through its
+        # transaction lock; neither can bleed into the other's transaction.
         if self.calibration is not None:
             await self.calibration.record_prediction(
                 market.id, analysis.probability, market.category or "",
@@ -694,32 +690,29 @@ class TradingEngine(CycleOrchestrationMixin):
             )
 
         # 4. Ensure market exists in DB then store signal
-        await self.db.execute(
-            """INSERT OR IGNORE INTO markets (id, exchange, condition_id, question, description,
-               category, active, outcome_yes_price, outcome_no_price,
-               volume, liquidity, last_updated)
-               VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'))""",
-            (market.id, market.exchange or self.exchange_name or "polymarket",
-             market.condition_id, market.question,
-             market.description[:500],
-             ensure_category(market.question, market.description, market.category),
-             market.outcome_yes_price, market.outcome_no_price,
-             market.volume, market.liquidity),
-        )
-        await self.db.execute(
-            """INSERT INTO signals (market_id, claude_prob, claude_confidence, market_prob,
-                                     edge, second_opinion_prob, divergence, evidence_summary, action,
-                                     strategy_source)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                signal.market_id, signal.claude_prob, signal.claude_confidence.value,
-                signal.market_prob, signal.edge, signal.second_opinion_prob,
-                signal.divergence, signal.evidence_summary,
-                signal.recommended_side.value if signal.recommended_side else None,
-                signal.strategy_source,
-            ),
-        )
-        await self.db.commit()
+        async with self.db.transaction():
+            await self.db.execute(
+                """INSERT OR IGNORE INTO markets
+                   (id,exchange,condition_id,question,description,category,active,
+                    outcome_yes_price,outcome_no_price,volume,liquidity,last_updated)
+                   VALUES (?,?,?,?,?,?,1,?,?,?,?,datetime('now'))""",
+                (market.id, market.exchange or self.exchange_name or "polymarket",
+                 market.condition_id, market.question, market.description[:500],
+                 ensure_category(market.question, market.description, market.category),
+                 market.outcome_yes_price, market.outcome_no_price,
+                 market.volume, market.liquidity),
+            )
+            await self.db.execute(
+                """INSERT INTO signals
+                   (market_id,claude_prob,claude_confidence,market_prob,edge,
+                    second_opinion_prob,divergence,evidence_summary,action,strategy_source)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (signal.market_id, signal.claude_prob, signal.claude_confidence.value,
+                 signal.market_prob, signal.edge, signal.second_opinion_prob,
+                 signal.divergence, signal.evidence_summary,
+                 signal.recommended_side.value if signal.recommended_side else None,
+                 signal.strategy_source),
+            )
 
         # 5. Risk evaluation (pass actual cash for correct Kelly sizing)
         cash = await self._get_available_cash()

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -16,6 +16,9 @@ from auramaur.db.database import Database
 from auramaur.exchange.models import Market
 from auramaur.exchange.protocols import MarketDiscovery
 from auramaur.nlp.calibration import CalibrationTracker
+from auramaur.evaluation.evidence import (
+    ForecastScoreMaterializer, MarketOutcome, OutcomeRepository,
+)
 
 log = structlog.get_logger()
 
@@ -34,6 +37,8 @@ class ResolutionTracker:
         self._calibration = calibration
         self._discoveries = discoveries
         self._proxy_address = proxy_address
+        self._outcomes = OutcomeRepository(db)
+        self._score_materializer = ForecastScoreMaterializer(db)
 
     async def check_resolutions(self) -> int:
         """Check all pending predictions for resolutions.
@@ -74,6 +79,27 @@ class ResolutionTracker:
                    FROM cost_basis cb
                    LEFT JOIN markets m ON cb.market_id = m.id
                    WHERE cb.size > 0
+                   UNION ALL
+                   SELECT e.market_id AS market_id, e.venue AS exchange
+                   FROM evaluation_episodes e
+                   LEFT JOIN market_outcomes o
+                     ON o.event_key=lower(e.venue) || ':' || e.market_id
+                   WHERE o.event_key IS NULL
+                   UNION ALL
+                   SELECT f.market_id AS market_id, f.exchange AS exchange
+                   FROM forecast_snapshots f
+                   LEFT JOIN market_outcomes o
+                     ON o.event_key=lower(COALESCE(NULLIF(f.exchange,''),'polymarket'))
+                                      || ':' || f.market_id
+                   WHERE o.event_key IS NULL
+                   UNION ALL
+                   SELECT t.market_id AS market_id, m.exchange AS exchange
+                   FROM information_trials t
+                   LEFT JOIN markets m ON m.id=t.market_id
+                   LEFT JOIN market_outcomes o
+                     ON o.event_key=lower(COALESCE(NULLIF(m.exchange,''),'polymarket'))
+                                      || ':' || t.market_id
+                   WHERE o.event_key IS NULL
                )
                GROUP BY market_id"""
         )
@@ -124,8 +150,19 @@ class ResolutionTracker:
                         resolved_count += 1
                     continue
 
-                # Feed into calibration — triggers online Platt update
-                await self._calibration.record_resolution(market_id, outcome)
+                # Canonical venue truth is shared by every forecast stream.
+                # Record before legacy calibration so an unrelated calibration
+                # failure cannot strand evaluation/lineage scoring.
+                await self._outcomes.record(MarketOutcome(
+                    venue=exchange, market_id=market_id,
+                    outcome=1 if outcome else 0,
+                    resolved_at=datetime.now(timezone.utc), source="resolution_tracker",
+                    event_family=getattr(market, "neg_risk_market_id", "") or market_id,
+                ))
+
+                # Feed the production-only calibration loop independently.
+                if self._calibration is not None:
+                    await self._calibration.record_resolution(market_id, outcome)
 
                 # Compute realized PnL from the position and clean up. Settle
                 # each mode explicitly: a market can be held in BOTH paper and
@@ -189,6 +226,10 @@ class ResolutionTracker:
                 log.warning("resolution.venue_sweep_error", error=str(e))
 
         if resolved_count > 0:
+            try:
+                await self._score_materializer.refresh()
+            except Exception as e:
+                log.warning("forecast_scores.refresh_failed", error=str(e))
             log.info("resolution.cycle_complete", newly_resolved=resolved_count)
 
         return resolved_count

--- a/tests/test_intelligence_eval_service.py
+++ b/tests/test_intelligence_eval_service.py
@@ -66,7 +66,7 @@ async def test_service_records_paired_treatments_without_trading(tmp_path):
         await db.close()
 
 
-async def test_service_settles_every_snapshot_from_venue_result(tmp_path):
+async def test_service_does_not_duplicate_resolution_detection(tmp_path):
     db = Database(str(tmp_path / "eval-settle.db"))
     await db.connect()
     try:
@@ -79,8 +79,8 @@ async def test_service_settles_every_snapshot_from_venue_result(tmp_path):
         discovery.market.active = False
         discovery.market.closed = True
         await service.run_once()
-        row = await db.fetchone("SELECT outcome, source FROM evaluation_outcomes")
-        assert row["outcome"] == 1 and row["source"] == "venue"
+        assert await db.fetchone("SELECT 1 FROM evaluation_outcomes") is None
+        assert await db.fetchone("SELECT 1 FROM market_outcomes") is None
     finally:
         await db.close()
 

--- a/tests/test_unified_forecast_evidence.py
+++ b/tests/test_unified_forecast_evidence.py
@@ -1,0 +1,179 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.evaluation.domain import EpisodeSnapshot, EvaluationForecast, EvaluationRun, RunStatus
+from auramaur.evaluation.evidence import (
+    ForecastScoreMaterializer, MarketOutcome, OutcomeRepository, event_key,
+)
+from auramaur.evaluation.store import EvaluationStore
+from auramaur.exchange.models import Market
+from auramaur.strategy.resolution_tracker import ResolutionTracker
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+async def _seed_streams(db):
+    await db.execute(
+        """INSERT INTO forecast_snapshots
+           (market_id,exchange,raw_probability,calibrated_probability,
+            market_yes_price,observed_at,model,strategy_source)
+           VALUES ('m1','polymarket',.7,.65,.55,?,'prod','strategic')""",
+        ((NOW - timedelta(days=2)).isoformat(),),
+    )
+    await db.commit()
+    store = EvaluationStore(db)
+    episode = EpisodeSnapshot(
+        venue="polymarket", market_id="m1", event_family="family-1",
+        observed_at=NOW - timedelta(days=2), evidence_cutoff=NOW - timedelta(days=2),
+        market_prob_yes=.55, question="Will it happen?",
+    )
+    await store.put_episode(episode)
+    await store.put_run(EvaluationRun(
+        run_id="r1", arm_name="local_single", model="qwen3:8b",
+        exploration_policy="single", prompt_version="v1", output_schema_version="v1",
+        status=RunStatus.SUCCEEDED, started_at=NOW, completed_at=NOW,
+    ))
+    await store.put_forecast(EvaluationForecast(
+        forecast_id="ef1", run_id="r1", episode_hash=episode.episode_hash,
+        prob_yes=.8, action="YES",
+    ))
+    await db.execute(
+        """INSERT INTO information_strategies
+           (id,source,category,horizon,event_type) VALUES ('s1','official','tech','week','event')""")
+    await db.execute(
+        """INSERT INTO information_trials
+           (id,strategy_id,market_id,observed_at,assignment,assignment_hash,market_price)
+           VALUES ('t1','s1','m1',?,'treatment','hash',.55)""",
+        ((NOW - timedelta(days=2)).isoformat(),),
+    )
+    await db.execute(
+        "INSERT INTO paired_forecasts (trial_id,arm,probability) VALUES ('t1','treatment',.75)")
+    await db.commit()
+    return episode
+
+
+async def test_canonical_outcomes_are_venue_qualified_and_immutable(tmp_path):
+    db = Database(str(tmp_path / "outcomes.db"))
+    await db.connect()
+    try:
+        repo = OutcomeRepository(db)
+        poly = MarketOutcome("polymarket", "same-id", 1, NOW)
+        assert event_key("PolyMarket", "same-id") == "polymarket:same-id"
+        assert await repo.record(poly) is True
+        assert await repo.record(poly) is False
+        assert await repo.record(MarketOutcome("kalshi", "same-id", 0, NOW)) is True
+        with pytest.raises(ValueError, match="conflicting"):
+            await repo.record(MarketOutcome("polymarket", "same-id", 0, NOW))
+    finally:
+        await db.close()
+
+
+async def test_view_normalizes_streams_and_materializes_event_weighted_scores(tmp_path):
+    db = Database(str(tmp_path / "unified.db"))
+    await db.connect()
+    try:
+        await _seed_streams(db)
+        await OutcomeRepository(db).record(MarketOutcome("polymarket", "m1", 1, NOW))
+        rows = await db.fetchall(
+            "SELECT stream,probability_kind FROM unified_forecast_evidence "
+            "WHERE outcome=1 ORDER BY stream,probability_kind")
+        assert [(r["stream"], r["probability_kind"]) for r in rows] == [
+            ("information_trial", "trial"),
+            ("intelligence_eval", "single"),
+            ("production", "calibrated"),
+            ("production", "raw"),
+        ]
+        materializer = ForecastScoreMaterializer(db)
+        assert await materializer.refresh() == 4
+        assert await materializer.refresh() == 4
+        facts = await db.fetchall("SELECT * FROM forecast_score_facts")
+        assert len(facts) == 4
+        assert all(row["horizon_bucket"] == "1-7d" for row in facts)
+        summary = await materializer.event_weighted_summary()
+        assert sum(row["events"] for row in summary) == 4
+        local = next(row for row in summary if row["stream"] == "intelligence_eval")
+        assert local["brier_delta"] > 0
+    finally:
+        await db.close()
+
+
+class _Discovery:
+    async def get_market(self, market_id):
+        return Market(
+            id=market_id, exchange="polymarket", question="Resolved evaluation market",
+            active=False, closed=True, outcome_yes_price=1, outcome_no_price=0,
+        )
+
+
+async def test_resolution_tracker_discovers_evaluation_only_market(tmp_path):
+    db = Database(str(tmp_path / "tracker.db"))
+    await db.connect()
+    try:
+        episode = EpisodeSnapshot(
+            venue="polymarket", market_id="eval-only", observed_at=NOW,
+            evidence_cutoff=NOW, market_prob_yes=.6, question="Evaluation only?",
+        )
+        await EvaluationStore(db).put_episode(episode)
+        calibration = AsyncMock()
+        tracker = ResolutionTracker(
+            db, calibration, {"polymarket": _Discovery()}, proxy_address="")
+        assert await tracker.check_resolutions() == 1
+        row = await db.fetchone(
+            "SELECT outcome,source FROM market_outcomes WHERE event_key='polymarket:eval-only'")
+        assert row["outcome"] == 1 and row["source"] == "resolution_tracker"
+        calibration.record_resolution.assert_awaited_once_with("eval-only", True)
+    finally:
+        await db.close()
+
+
+async def test_resolution_tracker_discovers_lineage_only_market(tmp_path):
+    db = Database(str(tmp_path / "lineage-tracker.db"))
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO forecast_snapshots
+               (market_id,exchange,raw_probability,market_yes_price,observed_at)
+               VALUES ('lineage-only','polymarket',.7,.6,?)""", (NOW.isoformat(),))
+        await db.commit()
+        tracker = ResolutionTracker(db, None, {"polymarket": _Discovery()})
+        assert await tracker.check_resolutions() == 1
+        row = await db.fetchone(
+            "SELECT outcome FROM market_outcomes WHERE event_key='polymarket:lineage-only'")
+        assert row["outcome"] == 1
+        scored = await db.fetchone(
+            "SELECT brier FROM forecast_score_facts WHERE stream='production'")
+        assert scored is not None
+    finally:
+        await db.close()
+
+
+async def test_v36_migration_backfills_latest_legacy_outcome(tmp_path):
+    path = tmp_path / "v36.db"
+    db = Database(str(path))
+    await db.connect()
+    await db.execute(
+        "INSERT INTO markets (id,exchange,question,last_updated) VALUES ('m1','kalshi','Q',?)",
+        (NOW.isoformat(),),
+    )
+    await db.execute(
+        """INSERT INTO calibration
+           (market_id,predicted_prob,actual_outcome,resolved_at)
+           VALUES ('m1',.4,0,'2026-01-01T00:00:00+00:00'),
+                  ('m1',.6,1,'2026-01-02T00:00:00+00:00')""")
+    await db.execute("DELETE FROM market_outcomes")
+    await db.execute("UPDATE schema_version SET version=36")
+    await db.commit()
+    await db.close()
+
+    migrated = Database(str(path))
+    await migrated.connect()
+    try:
+        row = await migrated.fetchone("SELECT * FROM market_outcomes")
+        assert row["event_key"] == "kalshi:m1"
+        assert row["outcome"] == 1
+        assert row["source"] == "calibration_backfill"
+    finally:
+        await migrated.close()


### PR DESCRIPTION
## Summary
- add canonical venue-qualified market outcomes and a v37 migration
- normalize raw, calibrated, intelligence-eval, and information-exploration forecasts through one semantic evidence view
- materialize versioned proper scores with fixed horizons and event-weighted summaries
- make ResolutionTracker the venue-truth writer while discovering unresolved evidence from every stream
- make forecast lineage persistence transactional so observers cannot see half-written evidence
- add an opt-in all-streams intelligence report

## Verification
- 104 focused tests passed
- 1401 passed, 3 skipped in the full suite
- Ruff passed
- git diff --check passed

## Stack
This PR is stacked on #330 (eat/intelligence-exploration-eval). Retarget it to main after #330 merges.