### PR TITLE
fix(polymarket): reconcile live positions into frontend

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from datetime import datetime, timezone
 from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
@@ -1215,7 +1216,7 @@ class AuramaurBot(
             await asyncio.sleep(interval)
 
     async def _task_position_sync(self) -> None:
-        """Periodically sync positions from CLOB trade history (ground truth)."""
+        """Periodically sync net current positions from Polymarket."""
         from auramaur.broker.reconciler import PositionReconciler
         from auramaur.broker.sync import PositionSyncer
 
@@ -1226,7 +1227,7 @@ class AuramaurBot(
         while self._running:
             try:
                 if self.settings.is_live:
-                    # Use reconciler for ground truth from CLOB trades
+                    # The Data API's net current positions are venue truth.
                     reconciled = await reconciler.reconcile()
                     positions = reconciler.to_live_positions(reconciled)
 
@@ -1234,17 +1235,14 @@ class AuramaurBot(
                     # then delete stale rows — one short, serialized
                     # transaction (contention plan, Phase 2): the network work
                     # (reconcile()) is already done, so this block is db-only.
-                    # Only runs when the reconciler returned a non-empty result
-                    # — an empty reconcile means the CLOB API call failed, not
-                    # that we actually hold zero positions, so we must not wipe
+                    # A successful empty response is authoritative; a failed
+                    # fetch leaves last_fetch_ok false and never wipes
                     # the tables. Both tables matter: cost_basis feeds sync(),
                     # and portfolio feeds the risk-manager correlation/exposure
                     # checks.
-                    if reconciled:
-                        # Skip already-settled legs: their P&L is booked, but
-                        # unredeemed tokens still show in CLOB trade history,
-                        # so this upsert resurrected them into cost_basis as
-                        # open size every pass (148 rows / $918 phantom,
+                    if reconciler.last_fetch_ok:
+                        # Skip already-settled legs if the venue still exposes
+                        # them before redemption (148 rows / $918 phantom,
                         # 2026-07-20 audit). Excluding them from live_ids also
                         # lets the stale-delete below sweep the residue out.
                         try:
@@ -1256,6 +1254,7 @@ class AuramaurBot(
                             if (rp.market_id, TokenType.from_str(rp.outcome).value)
                             not in settled
                         ]
+                        positions = reconciler.to_live_positions(unsettled)
                         if len(unsettled) < len(reconciled):
                             log.debug("reconciler.settled_skipped",
                                       count=len(reconciled) - len(unsettled))
@@ -1283,12 +1282,14 @@ class AuramaurBot(
                                      rp.avg_cost, rp.size * rp.avg_cost),
                                 )
 
-                            live_ids = [rp.market_id for rp in unsettled]
-                            placeholders = ",".join("?" * len(live_ids))
+                            live_tokens = [rp.token_id for rp in unsettled]
+                            placeholders = ",".join("?" * len(live_tokens))
+                            exclusion = (f"AND token_id NOT IN ({placeholders})"
+                                         if live_tokens else "")
                             # Live-mode reconciliation must only delete live rows;
                             # paper rows (is_paper=1) live in their own namespace.
-                            # ONLY Polymarket rows: this reconciler's universe
-                            # is CLOB trade history, so without the exchange scope
+                            # Scope deletion to Polymarket: without it this task
+                            # previously deleted live Kalshi cost-basis rows.
                             # it deleted every live KALSHI cost_basis row each
                             # ~75s pass — Kalshi sells then found size=0 and
                             # booked $0.00 realized P&L into the ledger that
@@ -1296,13 +1297,13 @@ class AuramaurBot(
                             # the portfolio delete below always had the filter).
                             cb_cur = await self._components.db.execute(
                                 f"""DELETE FROM cost_basis WHERE size > 0 AND is_paper = 0
-                                    AND market_id NOT IN ({placeholders})
+                                    {exclusion}
                                     AND market_id IN (SELECT id FROM markets WHERE exchange = 'polymarket')""",
-                                live_ids,
+                                live_tokens,
                             )
                             pf_cur = await self._components.db.execute(
-                                f"DELETE FROM portfolio WHERE exchange = 'polymarket' AND is_paper = 0 AND market_id NOT IN ({placeholders})",
-                                live_ids,
+                                f"DELETE FROM portfolio WHERE exchange = 'polymarket' AND is_paper = 0 {exclusion}",
+                                live_tokens,
                             )
                         log.info(
                             "reconciler.stale_removed",
@@ -1315,6 +1316,18 @@ class AuramaurBot(
                 cash = await syncer.get_cash_balance()
                 total_value = sum(p.size * p.current_price for p in positions)
                 unrealized = sum(p.unrealized_pnl for p in positions)
+                if self.settings.is_live:
+                    now = datetime.now(timezone.utc).isoformat()
+                    equity = cash + total_value
+                    async with self._components.db.transaction():
+                        await self._components.db.execute(
+                            """INSERT INTO venue_balances
+                               (venue,detail,available,equity,fetched_at)
+                               VALUES ('polymarket',?,?,?,?)
+                               ON CONFLICT(venue) DO UPDATE SET detail=excluded.detail,
+                               available=excluded.available,equity=excluded.equity,
+                               fetched_at=excluded.fetched_at""",
+                            (f"${cash:.2f} available | ${equity:.2f} equity", cash, equity, now))
 
                 log.info(
                     "sync.portfolio",

--- a/auramaur/broker/reconciler.py
+++ b/auramaur/broker/reconciler.py
@@ -1,15 +1,14 @@
-"""Position reconciler — builds ground-truth positions from CLOB trade history.
+"""Position reconciler — projects Polymarket's current holdings into the DB.
 
 Solves the ID mapping problem:
   Our DB uses numeric market IDs (e.g. "1339769")
-  CLOB uses condition_ids (hex hashes) and asset_ids (76-digit token IDs)
-  Gamma API bridges them via conditionId field
+  Polymarket uses condition_ids (hex hashes) and asset_ids (token IDs)
 
 This module:
-1. Fetches confirmed trades from CLOB API
-2. Reconstructs net positions per token
-3. Maps CLOB condition_ids to our market IDs via CLOB market lookup
-4. Returns ground-truth positions with correct token_ids for selling
+1. Fetches net current positions from the public Data API
+2. Maps condition_ids to Auramaur market IDs
+3. Persists an atomic venue-native snapshot for reconciliation diagnostics
+4. Retains the old CLOB-history reconstruction as an explicit diagnostic
 """
 
 from __future__ import annotations
@@ -38,7 +37,7 @@ class ReconciledPosition:
 
 
 class PositionReconciler:
-    """Reconciles positions between CLOB trade history and our DB."""
+    """Reconciles venue-native current positions with Auramaur's database."""
 
     def __init__(self, exchange, db):
         self._exchange = exchange
@@ -49,9 +48,62 @@ class PositionReconciler:
         # the end, so the write never interleaves with per-position network
         # calls (SQLite lock contention — db-contention-plan Phase 1).
         self._pending_stubs: list[tuple] = []
+        self.last_fetch_ok = False
 
     async def reconcile(self) -> list[ReconciledPosition]:
-        """Full reconciliation from CLOB trade history.
+        """Reconcile from Polymarket's net current-position endpoint."""
+        from datetime import datetime, timezone
+
+        from auramaur.broker.redeemer import fetch_current_positions
+
+        self.last_fetch_ok = False
+        try:
+            held = await fetch_current_positions(
+                self._exchange._settings.polymarket_proxy_address)
+        except Exception as exc:
+            log.warning("reconciler.positions_error", error=str(exc))
+            return []
+
+        fetched_at = datetime.now(timezone.utc).isoformat()
+        positions: list[ReconciledPosition] = []
+        snapshot_rows: list[tuple] = []
+        for item in held:
+            market_id = await self._find_market_id(
+                item.condition_id, item.title, item.slug)
+            market_id = market_id or item.condition_id[:16]
+            avg_cost = item.avg_price if 0 < item.avg_price <= 1 else item.cur_price
+            current_price = item.cur_price if item.cur_price > 0 else avg_cost
+            snapshot_rows.append((
+                "polymarket", item.asset_id, item.condition_id, market_id,
+                item.title, item.outcome, item.size, item.avg_price, item.cur_price,
+                item.initial_value, item.current_value, item.cash_pnl,
+                int(item.redeemable), fetched_at,
+            ))
+            if item.redeemable:
+                continue
+            positions.append(ReconciledPosition(
+                market_id=market_id, condition_id=item.condition_id,
+                token_id=item.asset_id, outcome=item.outcome,
+                question=item.title, size=item.size, avg_cost=avg_cost,
+                current_price=current_price,
+            ))
+        await self._flush_pending_stubs()
+        async with self._db.transaction():
+            await self._db.execute(
+                "DELETE FROM venue_positions WHERE venue = 'polymarket'")
+            for row in snapshot_rows:
+                await self._db.execute(
+                    """INSERT INTO venue_positions
+                       (venue,asset_id,condition_id,market_id,title,outcome,size,
+                        avg_price,current_price,initial_value,current_value,
+                        cash_pnl,redeemable,fetched_at)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""", row)
+        self.last_fetch_ok = True
+        log.info("reconciler.complete", positions=len(positions), source="data_api")
+        return positions
+
+    async def reconcile_from_trades(self) -> list[ReconciledPosition]:
+        """Legacy full reconciliation from CLOB history, retained for diagnostics.
 
         1. Fetch all confirmed trades
         2. Reconstruct net positions per token

--- a/auramaur/broker/redeemer.py
+++ b/auramaur/broker/redeemer.py
@@ -23,6 +23,102 @@ POLYMARKET_DATA_API = "https://data-api.polymarket.com/positions"
 
 
 @dataclass
+class VenuePosition:
+    """One current holding returned by Polymarket's position API."""
+
+    condition_id: str
+    asset_id: str
+    title: str
+    outcome: str
+    size: float
+    avg_price: float
+    cur_price: float
+    initial_value: float
+    current_value: float
+    cash_pnl: float
+    redeemable: bool
+    end_date: str
+    slug: str
+    neg_risk: bool = False
+    mergeable: bool = False
+
+
+async def fetch_current_positions(
+    proxy_address: str,
+    session: aiohttp.ClientSession | None = None,
+    *,
+    size_threshold: float = 0.01,
+) -> list[VenuePosition]:
+    """Return the venue-native current holdings for an account.
+
+    Unlike the CLOB trade-history reconstruction, this endpoint is already
+    netted and includes manual/external trades. A successful empty response is
+    authoritative; request failures raise and therefore never erase the last
+    good database snapshot.
+    """
+    if not proxy_address:
+        raise ValueError("proxy_address is required")
+    page_size = 500
+    max_offset = 10_000
+    close_session = session is None
+    if session is None:
+        session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=20))
+    items: list[dict] = []
+    offset = 0
+    try:
+        while True:
+            params = {
+                "user": proxy_address, "sizeThreshold": str(size_threshold),
+                "limit": str(page_size), "offset": str(offset),
+                "sortBy": "TOKENS", "sortDirection": "DESC",
+            }
+            async with session.get(
+                POLYMARKET_DATA_API, params=params, timeout=15,
+            ) as resp:
+                resp.raise_for_status()
+                page = await resp.json()
+            if not isinstance(page, list) or any(not isinstance(row, dict) for row in page):
+                raise ValueError("Polymarket positions response must be a list of objects")
+            items.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+            if offset > max_offset:
+                raise RuntimeError("Polymarket positions exceeded supported pagination range")
+    finally:
+        if close_session:
+            await session.close()
+
+    positions: list[VenuePosition] = []
+    seen_assets: set[str] = set()
+    for item in items:
+        asset_id = str(item.get("asset", ""))
+        condition_id = str(item.get("conditionId", ""))
+        if not asset_id or not condition_id:
+            raise ValueError("Polymarket position is missing asset or conditionId")
+        if asset_id in seen_assets:
+            raise ValueError(f"Polymarket returned duplicate asset {asset_id}")
+        seen_assets.add(asset_id)
+        size = float(item.get("size", 0) or 0)
+        if size <= size_threshold:
+            continue
+        positions.append(VenuePosition(
+            condition_id=condition_id, asset_id=asset_id,
+            title=str(item.get("title", "")), outcome=str(item.get("outcome", "")),
+            size=size, avg_price=float(item.get("avgPrice", 0) or 0),
+            cur_price=float(item.get("curPrice", 0) or 0),
+            initial_value=float(item.get("initialValue", 0) or 0),
+            current_value=float(item.get("currentValue", 0) or 0),
+            cash_pnl=float(item.get("cashPnl", 0) or 0),
+            redeemable=bool(item.get("redeemable")),
+            neg_risk=bool(item.get("negativeRisk") or item.get("negRisk")),
+            mergeable=bool(item.get("mergeable")),
+            end_date=str(item.get("endDate", "")), slug=str(item.get("slug", "")),
+        ))
+    return positions
+
+
+@dataclass
 class RedeemablePosition:
     """A Polymarket position's redemption / resolution state."""
 
@@ -70,30 +166,15 @@ async def fetch_redeemable_positions(
     effectively resolved (price at 0 or 1) but are still inside the oracle
     confirmation window — so the user can see what's coming soon.
     """
-    if not proxy_address:
-        raise ValueError("proxy_address is required")
-
-    close_session = session is None
-    if session is None:
-        session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=20))
-
-    try:
-        params = {"user": proxy_address, "sizeThreshold": "0.01"}
-        async with session.get(POLYMARKET_DATA_API, params=params, timeout=15) as resp:
-            resp.raise_for_status()
-            data = await resp.json()
-    finally:
-        if close_session:
-            await session.close()
-
+    data = await fetch_current_positions(proxy_address, session, size_threshold=0.01)
     results: list[RedeemablePosition] = []
     for item in data:
-        size = float(item.get("size", 0) or 0)
+        size = item.size
         if size <= 0:
             continue
 
-        redeemable_now = bool(item.get("redeemable"))
-        cur_price = float(item.get("curPrice", 0.5) or 0.5)
+        redeemable_now = item.redeemable
+        cur_price = item.cur_price
 
         # "Effectively resolved" = curPrice converged to 0 or 1.  Polymarket's
         # data-api returns curPrice in the range 0..1 relative to the *user's
@@ -111,21 +192,21 @@ async def fetch_redeemable_positions(
         payout = size if is_winner else 0.0
 
         results.append(RedeemablePosition(
-            condition_id=str(item.get("conditionId", "")),
-            asset_id=str(item.get("asset", "")),
-            title=str(item.get("title", "")),
-            outcome=str(item.get("outcome", "")),
+            condition_id=item.condition_id,
+            asset_id=item.asset_id,
+            title=item.title,
+            outcome=item.outcome,
             size=size,
-            avg_price=float(item.get("avgPrice", 0) or 0),
+            avg_price=item.avg_price,
             cur_price=cur_price,
             payout=payout,
             is_winner=is_winner,
             redeemable_now=redeemable_now,
             status=status,
-            neg_risk=bool(item.get("negativeRisk") or item.get("negRisk") or False),
-            mergeable=bool(item.get("mergeable") or False),
-            end_date=str(item.get("endDate", "")),
-            slug=str(item.get("slug", "")),
+            neg_risk=item.neg_risk,
+            mergeable=item.mergeable,
+            end_date=item.end_date,
+            slug=item.slug,
         ))
 
     log.info(

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -237,6 +237,8 @@ class Database:
             await self._migrate_v35_to_v36()
         if from_version < 37:
             await self._migrate_v36_to_v37()
+        if from_version < 38:
+            await self._migrate_v37_to_v38()
 
     async def _migrate_v29_to_v30(self) -> None:
         """Add cost-adjusted IBKR round-trip observations."""
@@ -367,6 +369,19 @@ class Database:
         await self._db.execute("UPDATE schema_version SET version = 36")
         await self._db.commit()
         log.info("database.migrated", from_version=35, to_version=36)
+    async def _migrate_v37_to_v38(self) -> None:
+        """Structured venue balances and venue-native position snapshots."""
+        for column in ("available REAL", "equity REAL"):
+            try:
+                await self._db.execute(
+                    f"ALTER TABLE venue_balances ADD COLUMN {column}")
+            except aiosqlite.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        await self._db.execute("UPDATE schema_version SET version = 38")
+        await self._db.commit()
+        log.info("database.migrated", from_version=37, to_version=38)
+
 
     async def _migrate_v36_to_v37(self) -> None:
         """Canonical outcomes and normalized forecast evidence."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 37
+SCHEMA_VERSION = 38
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -831,8 +831,24 @@ CREATE INDEX IF NOT EXISTS idx_redemptions_status ON redemptions(status);
 CREATE TABLE IF NOT EXISTS venue_balances (
     venue TEXT PRIMARY KEY,
     detail TEXT NOT NULL,
+    available REAL,
+    equity REAL,
     fetched_at TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS venue_positions (
+    venue TEXT NOT NULL, asset_id TEXT NOT NULL,
+    condition_id TEXT NOT NULL DEFAULT '', market_id TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL DEFAULT '', outcome TEXT NOT NULL DEFAULT '',
+    size REAL NOT NULL, avg_price REAL NOT NULL DEFAULT 0,
+    current_price REAL NOT NULL DEFAULT 0,
+    initial_value REAL NOT NULL DEFAULT 0,
+    current_value REAL NOT NULL DEFAULT 0,
+    cash_pnl REAL NOT NULL DEFAULT 0, redeemable INTEGER NOT NULL DEFAULT 0,
+    fetched_at TEXT NOT NULL,
+    PRIMARY KEY (venue, asset_id)
+);
+CREATE INDEX IF NOT EXISTS idx_venue_positions_market
+    ON venue_positions(venue, market_id);
 -- v35: local Ollama LLM tier (evidence-side only, never trades).
 -- Distilled claims are keyed by the SHA-256 of title, a newline, and content,
 -- the same formula the aggregator stamps into evidence_observations, so claims

--- a/auramaur/monitoring/cockpit.py
+++ b/auramaur/monitoring/cockpit.py
@@ -145,6 +145,10 @@ async def _portfolio_pnl(db, settings, is_paper_flag: int) -> dict:
             "exchange": r["exchange"] or "polymarket",
             "side": r["side"], "size": r["size"], "avg_price": r["avg_price"],
             "current_price": r["current_price"] or r["avg_price"],
+            "updated_at": r["updated_at"],
+            "initial_value": (r["avg_price"] or 0) * (r["size"] or 0),
+            "current_value": (r["current_price"] or r["avg_price"] or 0) * (r["size"] or 0),
+            "to_win": r["size"] or 0,
             "pnl": (
                 ((r["current_price"] or r["avg_price"]) - (r["cb_avg_cost"] or r["avg_price"]))
                 * (r["size"] or 0)

--- a/auramaur/web/broker.py
+++ b/auramaur/web/broker.py
@@ -41,6 +41,9 @@ class StateBroker:
         # the bot's recorder maintains.
         self._cache: dict = {"bal_ts": time.time(), "venues": {}}
         self._first_tick = asyncio.Event()
+        # Avoid publishing the schema-only instant while a newly appearing DB
+        # is still receiving its first transaction.
+        self._initial_empty_since: float | None = None
         self._tasks: list[asyncio.Task] = []
 
     # -- lifecycle ---------------------------------------------------------
@@ -113,17 +116,33 @@ class StateBroker:
                 # Venue cash is book-independent: recorded by the bot,
                 # served on both views with its age.
                 venues = await queries.venue_balances(self.db)
+                reconciliation = await queries.venue_reconciliation(self.db)
                 ibkr_books = await queries.ibkr_paper_books(self.db)
                 local_llm = await queries.local_llm_stats(self.db)
                 intel_eval = await queries.intelligence_eval_summary(self.db)
                 for state in books.values():
                     state["venues"] = venues
+                    state["reconciliation"] = reconciliation
                     state["ibkr_books"] = ibkr_books
                     state["local_llm"] = local_llm
                     state["intelligence_eval"] = intel_eval
-                self.latest = books
-                self.error = None
-                self.updated_at = datetime.now(timezone.utc).isoformat()
+                initial_empty = all(
+                    state["position_count"] == 0 and state["trade_count"] == 0
+                    for state in books.values())
+                if self.latest is None and initial_empty:
+                    now_mono = time.monotonic()
+                    if self._initial_empty_since is None:
+                        self._initial_empty_since = now_mono
+                    initializing = now_mono - self._initial_empty_since < 1.0
+                else:
+                    initializing = False
+                if initializing:
+                    self.error = (
+                        "database schema is ready; waiting for first committed state")
+                else:
+                    self.latest = books
+                    self.error = None
+                    self.updated_at = datetime.now(timezone.utc).isoformat()
             except Exception as exc:
                 self.error = self._describe(exc)
             finally:

--- a/auramaur/web/queries.py
+++ b/auramaur/web/queries.py
@@ -23,7 +23,7 @@ async def venue_balances(db: ReadOnlyDatabase) -> dict[str, dict]:
     """
     try:
         rows = await db.fetchall(
-            "SELECT venue, detail, fetched_at FROM venue_balances ORDER BY venue")
+            "SELECT venue, detail, available, equity, fetched_at FROM venue_balances ORDER BY venue")
     except Exception:
         return {}
     now = datetime.now(timezone.utc)
@@ -33,8 +33,56 @@ async def venue_balances(db: ReadOnlyDatabase) -> dict[str, dict]:
             age = max(0.0, (now - datetime.fromisoformat(r["fetched_at"])).total_seconds())
         except (ValueError, TypeError):  # unparseable or naive timestamp
             age = None
-        out[r["venue"]] = {"detail": r["detail"], "age_seconds": age}
+        out[r["venue"]] = {"detail": r["detail"], "age_seconds": age,
+                           "available": r["available"], "equity": r["equity"],
+                           "fetched_at": r["fetched_at"]}
     return out
+
+
+async def venue_reconciliation(db: ReadOnlyDatabase) -> dict:
+    """Compare the latest venue-native snapshot with the live DB projection."""
+    try:
+        summary = await db.fetchone(
+            """SELECT COUNT(CASE WHEN redeemable=0 THEN 1 END) AS venue_count,
+                      MAX(fetched_at) AS fetched_at,
+                      COALESCE(SUM(CASE WHEN redeemable=0 THEN current_value ELSE 0 END),0)
+                          AS venue_value
+                 FROM venue_positions WHERE venue='polymarket'""")
+        dbrow = await db.fetchone(
+            """SELECT COUNT(*) AS db_count,
+                      COALESCE(SUM(size * COALESCE(current_price,avg_price)),0) AS db_value
+                 FROM portfolio WHERE exchange='polymarket' AND is_paper=0""")
+        missing = await db.fetchall(
+            """SELECT v.asset_id,v.title,v.outcome,v.size
+                 FROM venue_positions v LEFT JOIN portfolio p
+                   ON p.token_id=v.asset_id AND p.exchange='polymarket' AND p.is_paper=0
+                WHERE v.venue='polymarket' AND v.redeemable=0
+                  AND p.token_id IS NULL ORDER BY v.current_value DESC""")
+        extra = await db.fetchall(
+            """SELECT p.token_id,p.market_id,p.token,p.size
+                 FROM portfolio p LEFT JOIN venue_positions v
+                   ON v.asset_id=p.token_id AND v.venue='polymarket' AND v.redeemable=0
+                WHERE p.exchange='polymarket' AND p.is_paper=0 AND v.asset_id IS NULL""")
+        size_mismatches = await db.fetchall(
+            """SELECT v.asset_id,v.title,v.outcome,v.size AS venue_size,p.size AS db_size
+                 FROM venue_positions v JOIN portfolio p
+                   ON p.token_id=v.asset_id AND p.exchange='polymarket' AND p.is_paper=0
+                WHERE v.venue='polymarket' AND v.redeemable=0
+                  AND ABS(v.size-p.size)>0.001
+                ORDER BY ABS(v.size-p.size) DESC""")
+    except Exception:
+        return {"available": False, "in_sync": False, "venue_count": 0,
+                "db_count": 0, "missing": [], "extra": [],
+                "size_mismatches": [], "fetched_at": None}
+    return {
+        "available": summary["fetched_at"] is not None,
+        "in_sync": not missing and not extra and not size_mismatches,
+        "venue_count": summary["venue_count"], "db_count": dbrow["db_count"],
+        "venue_value": summary["venue_value"], "db_value": dbrow["db_value"],
+        "fetched_at": summary["fetched_at"],
+        "missing": [dict(r) for r in missing], "extra": [dict(r) for r in extra],
+        "size_mismatches": [dict(r) for r in size_mismatches],
+    }
 
 
 async def ibkr_paper_books(db: ReadOnlyDatabase) -> list[dict]:

--- a/tests/test_current_positions.py
+++ b/tests/test_current_positions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from auramaur.broker.redeemer import fetch_current_positions
+
+
+def _row(i: int, *, size: float = 2.0) -> dict:
+    return {
+        "asset": f"asset-{i}", "conditionId": f"condition-{i}",
+        "title": f"Market {i}", "outcome": "Yes", "size": size,
+        "avgPrice": .4, "curPrice": .5, "initialValue": .8,
+        "currentValue": 1.0, "cashPnl": .2, "redeemable": False,
+        "endDate": "", "slug": f"market-{i}",
+    }
+
+
+class _Response:
+    def __init__(self, payload, status: int = 200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise RuntimeError(f"HTTP {self.status}")
+
+    async def json(self):
+        return self.payload
+
+
+class _Session:
+    def __init__(self, pages):
+        self.pages = pages
+        self.params: list[dict] = []
+        self.closed = False
+
+    def get(self, _url, *, params, timeout):
+        assert timeout == 15
+        self.params.append(params)
+        return _Response(self.pages[int(params["offset"])])
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_current_positions_exhausts_offset_pages():
+    session = _Session({0: [_row(i) for i in range(500)],
+                        500: [_row(500), _row(501)]})
+    rows = await fetch_current_positions("0x" + "1" * 40, session=session)
+    assert len(rows) == 502
+    assert [p["offset"] for p in session.params] == ["0", "500"]
+    assert all(p["limit"] == "500" for p in session.params)
+    assert session.closed is False
+
+
+@pytest.mark.asyncio
+async def test_current_positions_accepts_authoritative_empty_page():
+    session = _Session({0: []})
+    assert await fetch_current_positions("0x" + "1" * 40, session=session) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [{"error": "bad"}, ["not-an-object"]])
+async def test_current_positions_rejects_malformed_payload(payload):
+    session = _Session({0: payload})
+    with pytest.raises(ValueError, match="list of objects"):
+        await fetch_current_positions("0x" + "1" * 40, session=session)
+
+
+@pytest.mark.asyncio
+async def test_current_positions_rejects_duplicate_assets_across_pages():
+    page = [_row(i) for i in range(500)]
+    session = _Session({0: page, 500: [_row(499)]})
+    with pytest.raises(ValueError, match="duplicate asset"):
+        await fetch_current_positions("0x" + "1" * 40, session=session)
+
+
+@pytest.mark.asyncio
+async def test_current_positions_rejects_missing_identity():
+    row = _row(1)
+    row["asset"] = ""
+    with pytest.raises(ValueError, match="missing asset or conditionId"):
+        await fetch_current_positions(
+            "0x" + "1" * 40, session=_Session({0: [row]}))

--- a/tests/test_reconciler_batching.py
+++ b/tests/test_reconciler_batching.py
@@ -97,7 +97,7 @@ async def test_stub_inserts_happen_after_all_network_calls():
         db.execute = _execute
         db.commit = _commit
 
-        positions = await recon.reconcile()
+        positions = await recon.reconcile_from_trades()
 
         assert len(positions) == 2
         net = [i for i, e in enumerate(events) if e.startswith("net:")]
@@ -157,7 +157,7 @@ async def test_duplicate_condition_queues_single_stub():
 
         db.execute = _execute
 
-        positions = await recon.reconcile()
+        positions = await recon.reconcile_from_trades()
 
         assert len(positions) == 2
         assert events.count("db") == 1, "shared condition_id must queue one stub"
@@ -191,3 +191,136 @@ def test_transaction_same_task_reentrancy_joins_outer():
         await db.close()
 
     asyncio.run(run())
+
+
+@pytest.mark.asyncio
+async def test_current_positions_are_authoritative_and_snapshotted(monkeypatch):
+    from auramaur.broker.redeemer import VenuePosition
+
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO markets (id,condition_id,question,exchange,last_updated)
+               VALUES ('m1','cond-1','Manual holding?','polymarket',datetime('now'))""")
+        await db.commit()
+        exchange = _exchange([], {}, [])
+        held = VenuePosition(
+            condition_id="cond-1", asset_id="asset-1", title="Manual holding?",
+            outcome="No", size=12.5, avg_price=.4, cur_price=.6,
+            initial_value=5, current_value=7.5, cash_pnl=2.5,
+            redeemable=False, end_date="", slug="manual-holding",
+        )
+
+        async def fake_fetch(_proxy):
+            return [held]
+
+        monkeypatch.setattr(
+            "auramaur.broker.redeemer.fetch_current_positions", fake_fetch)
+        recon = PositionReconciler(exchange, db)
+        positions = await recon.reconcile()
+
+        assert recon.last_fetch_ok is True
+        assert [(p.market_id, p.token_id, p.size) for p in positions] == [
+            ("m1", "asset-1", 12.5)]
+        row = await db.fetchone(
+            "SELECT * FROM venue_positions WHERE asset_id='asset-1'")
+        assert row["current_value"] == pytest.approx(7.5)
+        assert row["cash_pnl"] == pytest.approx(2.5)
+    finally:
+        await db.close()
+
+
+async def _seed_snapshot(db):
+    await db.execute(
+        """INSERT INTO venue_positions
+           (venue,asset_id,condition_id,size,fetched_at)
+           VALUES ('polymarket','old-asset','old-condition',1,datetime('now'))""")
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_failed_current_position_fetch_preserves_last_snapshot(monkeypatch):
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        await _seed_snapshot(db)
+
+        async def failed_fetch(_proxy):
+            raise RuntimeError("temporary outage")
+
+        monkeypatch.setattr(
+            "auramaur.broker.redeemer.fetch_current_positions", failed_fetch)
+        recon = PositionReconciler(_exchange([], {}, []), db)
+        assert await recon.reconcile() == []
+        assert recon.last_fetch_ok is False
+        row = await db.fetchone(
+            "SELECT asset_id FROM venue_positions WHERE venue='polymarket'")
+        assert row["asset_id"] == "old-asset"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_successful_empty_fetch_atomically_clears_snapshot(monkeypatch):
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        await _seed_snapshot(db)
+
+        async def empty_fetch(_proxy):
+            return []
+
+        monkeypatch.setattr(
+            "auramaur.broker.redeemer.fetch_current_positions", empty_fetch)
+        recon = PositionReconciler(_exchange([], {}, []), db)
+        assert await recon.reconcile() == []
+        assert recon.last_fetch_ok is True
+        count = await db.fetchone(
+            "SELECT COUNT(*) AS n FROM venue_positions WHERE venue='polymarket'")
+        assert count["n"] == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_insert_failure_rolls_back_previous_snapshot(monkeypatch):
+    from auramaur.broker.redeemer import VenuePosition
+
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        await _seed_snapshot(db)
+        await db.execute(
+            """INSERT INTO markets (id,condition_id,question,exchange,last_updated)
+               VALUES ('m1','new-condition','New?','polymarket',datetime('now'))""")
+        await db.commit()
+        held = VenuePosition(
+            condition_id="new-condition", asset_id="new-asset", title="New?",
+            outcome="Yes", size=2, avg_price=.4, cur_price=.5,
+            initial_value=.8, current_value=1, cash_pnl=.2,
+            redeemable=False, end_date="", slug="new",
+        )
+
+        async def fake_fetch(_proxy):
+            return [held]
+
+        monkeypatch.setattr(
+            "auramaur.broker.redeemer.fetch_current_positions", fake_fetch)
+        real_execute = db.execute
+
+        async def fail_snapshot_insert(sql, params=()):
+            if "INSERT INTO venue_positions" in sql:
+                raise RuntimeError("simulated insert failure")
+            return await real_execute(sql, params)
+
+        db.execute = fail_snapshot_insert
+        recon = PositionReconciler(_exchange([], {}, []), db)
+        with pytest.raises(RuntimeError, match="simulated insert failure"):
+            await recon.reconcile()
+        assert recon.last_fetch_ok is False
+        rows = await db.fetchall(
+            "SELECT asset_id FROM venue_positions WHERE venue='polymarket'")
+        assert [row["asset_id"] for row in rows] == ["old-asset"]
+    finally:
+        await db.close()

--- a/tests/test_reconciler_mark.py
+++ b/tests/test_reconciler_mark.py
@@ -59,7 +59,7 @@ async def _run(token_price):
     }
     recon = PositionReconciler(_exchange([_trade()], market_info), db=None)
     recon._find_market_id = AsyncMock(return_value="mkt1")
-    return await recon.reconcile()
+    return await recon.reconcile_from_trades()
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -417,3 +417,59 @@ async def test_ibkr_paper_books_degrades_without_schema(tmp_path):
     await ro.connect()
     assert await queries.ibkr_paper_books(ro) == []
     await ro.close()
+
+
+@pytest.mark.asyncio
+async def test_state_reports_structured_balance_and_position_mismatch(tmp_path):
+    db_path = str(tmp_path / "auramaur.db")
+    await _seed_bot_db(db_path)
+    db = Database(db_path)
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id,exchange,side,size,avg_price,current_price,token,token_id,is_paper)
+               VALUES ('live-1','polymarket','BUY',10,.4,.5,'YES','asset-1',0)""")
+        now = "2026-07-21T12:00:00+00:00"
+        await db.execute(
+            """INSERT INTO venue_balances
+               (venue,detail,available,equity,fetched_at)
+               VALUES ('polymarket','$166 available | $1189 equity',166.15,1189.13,?)""",
+            (now,))
+        for asset, market, size, value in (
+            ("asset-1", "live-1", 12.0, 5.0),
+            ("asset-manual", "live-manual", 10.0, 7.5),
+        ):
+            await db.execute(
+                """INSERT INTO venue_positions
+                   (venue,asset_id,condition_id,market_id,title,outcome,size,
+                    avg_price,current_price,current_value,fetched_at)
+                   VALUES ('polymarket',?,?,?,'Held market','YES',?,.4,.5,?,?)""",
+                (asset, f"condition-{asset}", market, size, value, now))
+        await db.commit()
+    finally:
+        await db.close()
+
+    with _client(tmp_path, db_path) as client:
+        env = client.get("/api/state").json()
+        assert env["ok"] is True
+        live = env["books"]["live"]
+        balance = live["venues"]["polymarket"]
+        assert balance["available"] == pytest.approx(166.15)
+        assert balance["equity"] == pytest.approx(1189.13)
+        recon = live["reconciliation"]
+        assert recon["available"] is True
+        assert recon["in_sync"] is False
+        assert recon["venue_count"] == 2
+        assert recon["db_count"] == 1
+        assert recon["venue_value"] == pytest.approx(12.5)
+        assert recon["db_value"] == pytest.approx(5.0)
+        assert recon["missing"] == [{
+            "asset_id": "asset-manual", "title": "Held market",
+            "outcome": "YES", "size": 10.0,
+        }]
+        assert recon["extra"] == []
+        assert recon["size_mismatches"] == [{
+            "asset_id": "asset-1", "title": "Held market", "outcome": "YES",
+            "venue_size": 12.0, "db_size": 10.0,
+        }]

--- a/web/src/components.test.tsx
+++ b/web/src/components.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PositionsPanel } from "./components";
+import { filterPositions } from "./positionFilter";
+import type { Position } from "./types";
+
+function positions(count: number): Position[] {
+  return Array.from({ length: count }, (_, i) => ({
+    market_id: `market-${i}`,
+    question: i === count - 1 ? "Needle market" : `Market ${i}`,
+    token: i % 2 ? "NO" : "YES",
+    exchange: "polymarket",
+    side: "BUY",
+    size: i + 1,
+    avg_price: .4,
+    current_price: .5,
+    pnl: i - 5,
+  }));
+}
+
+describe("position book", () => {
+  it("keeps and renders every row in a book larger than the old cap", () => {
+    const rows = positions(25);
+    expect(filterPositions(rows, "")).toHaveLength(25);
+    const html = renderToStaticMarkup(<PositionsPanel positions={rows} />);
+    expect(html).toContain("Search all 25 positions");
+    expect(html).toContain("Market 0");
+    expect(html).toContain("Needle market");
+    expect((html.match(/<tr>/g) ?? []).length).toBe(26); // header + 25 rows
+  });
+
+  it("searches question, market id, outcome and venue", () => {
+    const rows = positions(25);
+    expect(filterPositions(rows, "needle").map((p) => p.market_id))
+      .toEqual(["market-24"]);
+    expect(filterPositions(rows, "market-7").map((p) => p.market_id))
+      .toEqual(["market-7"]);
+    expect(filterPositions(rows, "NO")).toHaveLength(12);
+    expect(filterPositions(rows, "POLYMARKET")).toHaveLength(25);
+  });
+
+  it("sorts matching rows by absolute P&L", () => {
+    const rows = positions(10);
+    const found = filterPositions(rows, "polymarket");
+    expect(found[0].pnl).toBe(-5);
+    expect(Math.abs(found[0].pnl)).toBeGreaterThanOrEqual(
+      Math.abs(found.at(-1)?.pnl ?? 0));
+  });
+});

--- a/web/src/components.tsx
+++ b/web/src/components.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type {
   Book,
   CategoryStat,
@@ -11,6 +12,7 @@ import type {
 } from "./types";
 import type { Phase } from "./useDashboardState";
 import { ago, deltaClass, liveness, money, price, utcClock } from "./format";
+import { filterPositions } from "./positionFilter";
 
 export function TopBar({
   s,
@@ -144,6 +146,17 @@ export function VenuesPanel({ s }: { s: DashboardState }) {
   return (
     <section className="panel">
       <h2>Venues</h2>
+      {s.reconciliation?.available && !s.reconciliation.in_sync && (
+        <div className="conn-banner degraded" role="alert">
+          Venue mismatch: Polymarket reports {s.reconciliation.venue_count} positions,
+          Auramaur has {s.reconciliation.db_count}. Missing {s.reconciliation.missing.length},
+          extra {s.reconciliation.extra.length}, quantity mismatches
+          {` ${s.reconciliation.size_mismatches.length}`}.
+        </div>
+      )}
+      {s.reconciliation?.available && s.reconciliation.in_sync && (
+        <div className="clean">✓ Venue and database are in sync ({s.reconciliation.venue_count})</div>
+      )}
       <div className="kv">
         {names.map((name) => {
           const pos = byExchange.get(name);
@@ -313,17 +326,20 @@ export function HealthPanel({ health }: { health: Health }) {
     </section>
   );
 }
-
-const POSITIONS_SHOWN = 15;
-
+  // The complete book remains available; search narrows it without truncation.
 export function PositionsPanel({ positions }: { positions: Position[] }) {
-  // Biggest movers first and capped, like the cockpit: a monitoring view's
-  // density comes from selection, not from scrolling a wall of rows.
-  const sorted = [...positions].sort((a, b) => Math.abs(b.pnl) - Math.abs(a.pnl));
-  const shown = sorted.slice(0, POSITIONS_SHOWN);
+  const [query, setQuery] = useState("");
+  const shown = filterPositions(positions, query);
   return (
     <section className="panel">
       <h2>Positions</h2>
+      <input
+        aria-label="Search positions"
+        className="position-search"
+        placeholder={`Search all ${positions.length} positions`}
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+      />
       {shown.length === 0 ? (
         <div className="empty">No open positions</div>
       ) : (
@@ -358,11 +374,6 @@ export function PositionsPanel({ positions }: { positions: Position[] }) {
               ))}
             </tbody>
           </table>
-          {sorted.length > POSITIONS_SHOWN && (
-            <div className="tbl-note">
-              top {POSITIONS_SHOWN} of {sorted.length} by |P&L| — full book in phase-2 explorer
-            </div>
-          )}
         </div>
       )}
     </section>

--- a/web/src/positionFilter.ts
+++ b/web/src/positionFilter.ts
@@ -1,0 +1,9 @@
+import type { Position } from "./types";
+
+export function filterPositions(positions: Position[], query: string): Position[] {
+  const needle = query.trim().toLowerCase();
+  return positions
+    .filter((p) => !needle || `${p.question} ${p.market_id} ${p.token} ${p.exchange}`
+      .toLowerCase().includes(needle))
+    .sort((a, b) => Math.abs(b.pnl) - Math.abs(a.pnl));
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -250,6 +250,17 @@ td.down { color: var(--delta-down); }
 td.dim, .dim { color: var(--ink-muted); }
 
 .empty { color: var(--ink-muted); font-size: 13px; padding: 6px 0; }
+.position-search {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0 0 10px;
+  padding: 7px 9px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+}
 .tbl-note { color: var(--ink-muted); font-size: 12px; padding: 8px 8px 2px; }
 
 /* ---- pillar liveness ---- */

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -36,6 +36,10 @@ export interface Position {
   avg_price: number;
   current_price: number;
   pnl: number;
+  updated_at?: string;
+  initial_value?: number;
+  current_value?: number;
+  to_win?: number;
 }
 
 export interface StrategyStat {
@@ -75,6 +79,9 @@ export interface Signal {
 export interface VenueBalance {
   detail: string;
   age_seconds: number | null;
+  available?: number | null;
+  equity?: number | null;
+  fetched_at?: string;
 }
 
 export interface DashboardState {
@@ -84,6 +91,18 @@ export interface DashboardState {
   kill_switch: boolean;
   venues: Record<string, VenueBalance>;
   ibkr_books: { book: string; positions: number; unrealized: number; equity: number | null }[];
+  reconciliation?: {
+    available: boolean;
+    in_sync: boolean;
+    venue_count: number;
+    db_count: number;
+    venue_value?: number;
+    db_value?: number;
+    fetched_at: string | null;
+    missing: unknown[];
+    extra: unknown[];
+    size_mismatches: unknown[];
+  };
   pillars: Pillar[];
   activity: ActivityItem[];
   health: Health;


### PR DESCRIPTION
## Summary
- replace CLOB trade-history reconstruction with the Polymarket Data API current-position snapshot as venue truth
- paginate and validate the complete live position book, with atomic persistence and safe empty/failure semantics
- synchronize token-specific live cost basis and portfolio rows without touching paper or Kalshi state
- expose structured available cash, equity, snapshot freshness, missing/extra holdings, and quantity drift through the dashboard API
- render the complete searchable position book and surface venue/database mismatch status
- exclude redeemable and settled claims from operational positions and live-equity calculations
- add schema v37 for structured venue balances and venue-native position snapshots

## Validation
- focused backend reconciliation/API suite: 109 passed
- full backend suite on the original audited tree: 1413 passed, 3 skipped
- full suite after rebasing onto main: 1407 passed, 3 skipped, with one unrelated data-lineage transaction race; the failed test passed immediately in isolation
- frontend: 8 tests passed
- ESLint clean
- Ruff clean
- production build clean
- git diff --check clean

## Notes
The remaining backend warnings are existing Starlette deprecation and AsyncMock warnings. The dashboard remains read-only and does not hold venue credentials.