### PR TITLE
feat(web): add actionable operator workspaces

### DIFF
--- a/auramaur/monitoring/cockpit.py
+++ b/auramaur/monitoring/cockpit.py
@@ -127,7 +127,7 @@ async def _portfolio_pnl(db, settings, is_paper_flag: int) -> dict:
     # side when a market holds both YES and NO, duplicating positions and
     # double-counting P&L (found via the web UI's duplicate-key warning).
     rows = await db.fetchall(
-        """SELECT p.*, m.question, cb.avg_cost AS cb_avg_cost FROM portfolio p
+        """SELECT p.*, m.question, m.end_date, cb.avg_cost AS cb_avg_cost FROM portfolio p
            LEFT JOIN markets m ON p.market_id = m.id
            LEFT JOIN cost_basis cb ON cb.market_id = p.market_id
                                   AND cb.is_paper = p.is_paper
@@ -143,6 +143,8 @@ async def _portfolio_pnl(db, settings, is_paper_flag: int) -> dict:
             # alone does not identify a row.
             "token": r["token"],
             "exchange": r["exchange"] or "polymarket",
+            "category": r["category"] or "uncategorized",
+            "end_date": r["end_date"],
             "side": r["side"], "size": r["size"], "avg_price": r["avg_price"],
             "current_price": r["current_price"] or r["avg_price"],
             "updated_at": r["updated_at"],
@@ -167,9 +169,12 @@ async def _portfolio_pnl(db, settings, is_paper_flag: int) -> dict:
     signals = [
         {
             "market_id": r["market_id"], "question": r["question"] or r["market_id"],
+            "timestamp": r["timestamp"], "exchange": r["exchange"] or "polymarket",
             "claude_prob": r["claude_prob"], "market_prob": r["market_prob"],
             "edge": r["edge"], "action": r["action"] or "",
             "strategy_source": r["strategy_source"] or "llm",
+            "confidence": r["claude_confidence"] or "",
+            "evidence_summary": r["evidence_summary"] or "",
         }
         for r in sig_rows
     ]

--- a/auramaur/web/broker.py
+++ b/auramaur/web/broker.py
@@ -120,12 +120,14 @@ class StateBroker:
                 ibkr_books = await queries.ibkr_paper_books(self.db)
                 local_llm = await queries.local_llm_stats(self.db)
                 intel_eval = await queries.intelligence_eval_summary(self.db)
+                performance = await queries.performance_history(self.db)
                 for state in books.values():
                     state["venues"] = venues
                     state["reconciliation"] = reconciliation
                     state["ibkr_books"] = ibkr_books
                     state["local_llm"] = local_llm
                     state["intelligence_eval"] = intel_eval
+                    state["performance_history"] = performance
                 initial_empty = all(
                     state["position_count"] == 0 and state["trade_count"] == 0
                     for state in books.values())

--- a/auramaur/web/queries.py
+++ b/auramaur/web/queries.py
@@ -149,6 +149,19 @@ async def category_exposure(db: ReadOnlyDatabase, is_paper_flag: int) -> list[di
     ]
 
 
+async def performance_history(db: ReadOnlyDatabase, days: int = 14) -> list[dict]:
+    """Recent daily account marks for compact, honest trend context."""
+    try:
+        rows = await db.fetchall(
+            """SELECT date,total_pnl,trades_count,wins,losses,max_drawdown,peak_balance
+                 FROM daily_stats ORDER BY date DESC LIMIT ?""",
+            (days,),
+        )
+    except Exception:
+        return []
+    return [dict(r) for r in reversed(rows)]
+
+
 async def kraken_paper_positions(db: ReadOnlyDatabase) -> list[dict]:
     """The Kraken directional paper book — its own table, invisible to the
     portfolio query, so it must be surfaced explicitly (paper view only)."""

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -109,6 +109,11 @@ async def test_state_endpoint_serves_seeded_paper_book(tmp_path):
         assert s["balance"] == pytest.approx(
             settings.execution.paper_initial_balance + 3.0)
         assert s["signals"][0]["edge"] == pytest.approx(22.0)
+        assert s["signals"][0]["timestamp"]
+        assert s["signals"][0]["exchange"] == "polymarket"
+        assert s["positions"][0]["category"] == "weather"
+        assert "end_date" in s["positions"][0]
+        assert s["performance_history"] == []
         # Pillars are present but silent (no log lines seeded).
         assert all(p["age_seconds"] is None for p in s["pillars"])
 
@@ -417,6 +422,29 @@ async def test_ibkr_paper_books_degrades_without_schema(tmp_path):
     await ro.connect()
     assert await queries.ibkr_paper_books(ro) == []
     await ro.close()
+
+
+@pytest.mark.asyncio
+async def test_performance_history_is_chronological_and_bounded(tmp_path):
+    from auramaur.db.database import Database
+    from auramaur.web.db import ReadOnlyDatabase
+    from auramaur.web import queries
+    src = tmp_path / "history.db"
+    db = Database(str(src))
+    await db.connect()
+    for day, pnl in (("2026-07-19", 1.0), ("2026-07-20", 3.0), ("2026-07-21", 2.0)):
+        await db.execute(
+            "INSERT INTO daily_stats (date,total_pnl,trades_count) VALUES (?,?,1)",
+            (day, pnl),
+        )
+    await db.commit()
+    await db.close()
+    ro = ReadOnlyDatabase(str(src))
+    await ro.connect()
+    rows = await queries.performance_history(ro, days=2)
+    await ro.close()
+    assert [row["date"] for row in rows] == ["2026-07-20", "2026-07-21"]
+    assert [row["total_pnl"] for row in rows] == [3.0, 2.0]
 
 
 @pytest.mark.asyncio

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,22 +1,12 @@
 import { useEffect, useState } from "react";
 import {
-  ActivityPanel,
-  CategoriesPanel,
   ConnectionBanner,
-  HealthPanel,
-  IntelligencePanel,
   KillSwitchBanner,
-  KrakenPaperPanel,
-  PillarsPanel,
-  PositionsPanel,
-  SignalsPanel,
-  StatTiles,
-  StrategiesPanel,
   TopBar,
-  VenuesPanel,
 } from "./components";
 import type { Book } from "./types";
 import { useDashboardState } from "./useDashboardState";
+import { OperatorWorkspace, type View } from "./workspace";
 
 const TROUBLESHOOT_AFTER_S = 4;
 
@@ -79,25 +69,12 @@ export default function App() {
       />
       <ConnectionBanner phase={phase} error={envelope?.error ?? null} receivedAgo={receivedAgo} />
       {state.kill_switch && <KillSwitchBanner />}
-      <StatTiles s={state} />
-      <div className="grid">
-        <div className="col">
-          <VenuesPanel s={state} />
-          <PillarsPanel pillars={state.pillars} />
-          <CategoriesPanel categories={state.categories} />
-          <HealthPanel health={state.health} />
-          <IntelligencePanel s={state} />
-        </div>
-        <div className="col">
-          <PositionsPanel positions={state.positions} />
-          <StrategiesPanel strategies={state.strategies} />
-          <SignalsPanel signals={state.signals} />
-        </div>
-        <div className="col col-side">
-          <ActivityPanel s={state} />
-          {book === "paper" && <KrakenPaperPanel rows={state.kraken_paper ?? []} />}
-        </div>
-      </div>
+      <OperatorWorkspace
+        s={state}
+        scope={book}
+        historyIsCurrent={book === envelope!.bot_mode}
+        initialView={(location.hash.slice(1) || "overview") as View}
+      />
     </div>
   );
 }

--- a/web/src/components.tsx
+++ b/web/src/components.tsx
@@ -319,7 +319,7 @@ export function HealthPanel({ health }: { health: Health }) {
         {health.top.map((t) => (
           <div className="row" key={t.event}>
             <span className="count">{t.count}</span>
-            <span className="event" title={t.message}>{t.event}</span>
+            <span className="event" title={t.last_msg}>{t.event}</span>
           </div>
         ))}
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -364,3 +364,177 @@ code {
   border-radius: 4px;
   padding: 1px 5px;
 }
+
+/* ---- operator workspace ---- */
+
+button, input, select { font: inherit; }
+button { color: inherit; }
+button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:focus-visible {
+  outline: 2px solid var(--warning);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: fixed; top: 8px; left: 8px; z-index: 100;
+  padding: 8px 12px; background: var(--ink); color: var(--page);
+  transform: translateY(-150%); border-radius: 6px;
+}
+.skip-link:focus { transform: none; }
+
+.workspace-nav {
+  display: flex; gap: 4px; overflow-x: auto; margin: 0 0 18px;
+  border-bottom: 1px solid var(--border); scrollbar-width: thin;
+}
+.workspace-nav button {
+  flex: none; border: 0; border-bottom: 2px solid transparent; background: none;
+  color: var(--ink-muted); padding: 10px 13px; cursor: pointer;
+}
+.workspace-nav button:hover { color: var(--ink); }
+.workspace-nav button.active { color: var(--ink); border-bottom-color: var(--ink); font-weight: 600; }
+
+.workspace-heading, .section-heading, .summary-card header, .venue-card header, .inspector header {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+}
+.workspace-heading { margin: 2px 0 18px; }
+.workspace-heading h1 { margin: 0; font-size: 25px; letter-spacing: -.02em; }
+.workspace-heading p { color: var(--ink-muted); margin: 3px 0 0; }
+.workspace-heading > button, .toolbar button, .inspector-actions button, .workspace-heading select {
+  border: 1px solid var(--border); border-radius: 7px; background: var(--surface);
+  padding: 7px 11px; cursor: pointer;
+}
+.workspace-heading button:disabled { opacity: .45; cursor: default; }
+
+.eyebrow {
+  display: block; color: var(--ink-muted); font-size: 11px; font-weight: 700;
+  letter-spacing: .09em; text-transform: uppercase;
+}
+.attention {
+  display: grid; grid-template-columns: minmax(190px, .7fr) 2fr; gap: 18px;
+  align-items: center; padding: 16px 18px; margin-bottom: 14px;
+  background: var(--surface); border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  border-radius: 12px;
+}
+.attention h2, .summary-card h2, .section-heading h2 { font-size: 17px; margin: 2px 0 0; }
+.attention-items { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 8px; }
+.attention-item {
+  display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 7px;
+  text-align: left; background: var(--page); border: 1px solid var(--border);
+  border-radius: 8px; padding: 9px 10px; cursor: pointer;
+}
+.attention-item strong { font-size: 18px; }
+.attention-item span { color: var(--ink-2); font-size: 12px; }
+.attention-item.critical strong { color: var(--critical); }
+.attention-item.warning strong { color: var(--warning); }
+.attention-item.serious strong { color: var(--serious); }
+.all-clear {
+  color: var(--good); border: 1px solid color-mix(in srgb, var(--good) 35%, var(--border));
+  background: color-mix(in srgb, var(--good) 7%, var(--surface));
+  border-radius: 9px; padding: 11px 14px; margin-bottom: 14px;
+}
+.visit-summary {
+  margin: -5px 0 10px; color: var(--ink-muted); font-size: 12px; text-align: right;
+}
+.visit-summary strong { font-weight: 600; }
+
+.hero-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 12px; }
+.hero-metrics article, .summary-card, .venue-card, .pillar-card, .section-block {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+}
+.hero-metrics article { padding: 13px 14px; min-height: 100px; display: flex; flex-direction: column; }
+.hero-metrics article > span { color: var(--ink-2); font-size: 12px; }
+.hero-metrics strong { font-size: 22px; margin-top: 5px; }
+.hero-metrics small { color: var(--ink-muted); margin-top: auto; }
+.spark { width: 100%; height: 40px; margin: 4px 0; overflow: visible; }
+.spark polyline { stroke: var(--good); stroke-width: 2; }
+.spark-empty { color: var(--ink-muted) !important; margin: auto 0; font-size: 12px; }
+
+.summary-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.summary-card { padding: 14px; min-width: 0; }
+.summary-card p { margin: 8px 0 0; color: var(--ink-muted); font-size: 13px; }
+.text-button { color: var(--ink-2); background: none; border: 0; cursor: pointer; font-size: 12px; }
+.text-button:hover { color: var(--ink); }
+.summary-row {
+  display: flex; width: 100%; gap: 14px; justify-content: space-between;
+  color: var(--ink-2); background: var(--page); border: 0; border-radius: 7px;
+  margin-top: 12px; padding: 9px; cursor: pointer; text-align: left;
+}
+.summary-row span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.summary-row strong { flex: none; }
+
+.toolbar { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 7px; }
+.toolbar input, .toolbar select {
+  min-height: 36px; color: var(--ink); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 7px; padding: 7px 9px;
+}
+.toolbar input { flex: 1 1 290px; }
+.toolbar select { flex: 0 1 190px; }
+.result-count { margin: 0 0 9px; color: var(--ink-muted); font-size: 12px; }
+.data-table-wrap { overflow: auto; max-height: calc(100vh - 245px); border: 1px solid var(--border); border-radius: 9px; }
+.data-table { background: var(--surface); }
+.data-table thead { position: sticky; top: 0; z-index: 1; background: var(--surface); }
+.data-table th { padding: 8px 10px; }
+.data-table td { padding: 7px 10px; }
+.data-table tbody tr { cursor: pointer; }
+.data-table tbody tr:hover, .data-table tbody tr:focus { background: color-mix(in srgb, var(--ink) 5%, transparent); }
+.data-table td.market { max-width: 430px; }
+.action-chip { border: 1px solid var(--border); border-radius: 999px; padding: 2px 7px; font-size: 11px; }
+
+.venue-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px; }
+.venue-card { padding: 12px; }
+.venue-card p { margin: 10px 0 3px; }
+.venue-card small, .pillar-card small { color: var(--ink-muted); }
+.status { display: inline-flex; align-items: center; gap: 5px; color: var(--ink-muted); font-size: 11px; text-transform: capitalize; }
+.status > span { width: 7px; height: 7px; border-radius: 50%; background: var(--ink-muted); }
+.status.fresh { color: var(--good); }.status.fresh > span { background: var(--good); }
+.status.stale { color: var(--warning); }.status.stale > span { background: var(--warning); }
+.status.dead { color: var(--critical); }.status.dead > span { background: var(--critical); }
+.section-block { margin-top: 12px; padding: 14px; }
+.section-block > h2 { margin: 0 0 10px; font-size: 15px; }
+.section-block .data-table-wrap { max-height: 480px; margin-top: 12px; }
+.workspace-breakdowns { margin-top: 12px; }
+.workspace-breakdowns .section-block { margin-top: 0; }
+.workspace-breakdowns .data-table-wrap { max-height: 330px; }
+.pillar-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(155px, 1fr)); gap: 9px; }
+.pillar-card { display: flex; align-items: center; gap: 9px; padding: 11px; }
+.pillar-card small { display: block; }
+.timeline { display: grid; gap: 7px; }
+.timeline > div { display: grid; grid-template-columns: 72px 1fr; gap: 10px; font-size: 13px; }
+.timeline time { color: var(--ink-muted); font-variant-numeric: tabular-nums; }
+
+.inspector-backdrop { position: fixed; inset: 0; z-index: 50; background: rgba(0,0,0,.5); display: flex; justify-content: flex-end; }
+.inspector {
+  width: min(520px, 100%); height: 100%; overflow-y: auto; padding: 20px;
+  background: var(--surface); border-left: 1px solid var(--border);
+  box-shadow: -20px 0 60px rgba(0,0,0,.25);
+}
+.inspector h2 { font-size: 19px; margin: 4px 0 0; line-height: 1.3; }
+.icon-button { border: 0; background: none; font-size: 27px; cursor: pointer; }
+.inspector dl { margin: 20px 0; }
+.inspector dl > div { display: grid; grid-template-columns: 125px 1fr; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--hairline); }
+.inspector dt { color: var(--ink-muted); text-transform: capitalize; }
+.inspector dd { margin: 0; overflow-wrap: anywhere; }
+.inspector h3 { font-size: 14px; }
+.inspector li { margin: 7px 0; color: var(--ink-2); }
+.inspector-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 22px; }
+.inspector-actions button { background: var(--page); }
+
+@media (max-width: 900px) {
+  .attention { grid-template-columns: 1fr; }
+  .attention-items { grid-template-columns: repeat(2, 1fr); }
+  .hero-metrics { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 620px) {
+  .shell { padding: 10px 12px 30px; }
+  .link-status { margin-left: 0; width: 100%; }
+  .workspace-heading { align-items: stretch; flex-direction: column; }
+  .summary-grid, .hero-metrics { grid-template-columns: 1fr; }
+  .attention-items { grid-template-columns: 1fr; }
+  .toolbar { display: grid; }
+  .toolbar input, .toolbar select { width: 100%; }
+  .data-table td.market { position: sticky; left: 0; z-index: 0; max-width: 230px; background: var(--surface); }
+  .inspector dl > div { grid-template-columns: 1fr; gap: 2px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; }
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -16,7 +16,8 @@ export interface HealthTop {
   event: string;
   count: number;
   level?: string;
-  message?: string;
+  last_msg?: string;
+  last_ts?: string;
 }
 
 export interface Health {
@@ -37,6 +38,8 @@ export interface Position {
   current_price: number;
   pnl: number;
   updated_at?: string;
+  category?: string;
+  end_date?: string | null;
   initial_value?: number;
   current_value?: number;
   to_win?: number;
@@ -67,11 +70,15 @@ export interface KrakenPaperPosition {
 export interface Signal {
   market_id: string;
   question: string;
+  timestamp?: string;
+  exchange?: string;
   claude_prob: number | null;
   market_prob: number | null;
   edge: number | null;
   action: string;
   strategy_source: string;
+  confidence?: string;
+  evidence_summary?: string;
 }
 
 /** Venue cash as recorded bot-side into the DB; age is how old the row is —
@@ -129,6 +136,10 @@ export interface DashboardState {
   intelligence_eval?: {
     arm: string; model: string; forecasts: number;
     brier: number | null; market_brier: number | null; abstains: number;
+  }[];
+  performance_history?: {
+    date: string; total_pnl: number; trades_count: number; wins: number;
+    losses: number; max_drawdown: number; peak_balance: number;
   }[];
 }
 

--- a/web/src/workspace.test.tsx
+++ b/web/src/workspace.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { DashboardState } from "./types";
+import { OperatorWorkspace, WorkspaceNav } from "./workspace";
+
+const state: DashboardState = {
+  now: "2026-07-21T12:00:00Z", is_live: false, transfers_armed: false,
+  kill_switch: false, venues: {}, ibkr_books: [], pillars: [], activity: [],
+  health: { errors: 0, warnings: 0, top: [] }, positions: [], position_count: 0,
+  position_value: 0, signals: [], trade_count: 0, total_pnl: 0, drawdown: 0,
+  balance: 100, strategies: [], categories: [], performance_history: [],
+};
+
+describe("operator workspace", () => {
+  it("renders task-based navigation with an active destination", () => {
+    const html = renderToStaticMarkup(<WorkspaceNav view="execution" onView={() => undefined} />);
+    expect(html).toContain("Dashboard sections");
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain("Opportunities");
+  });
+
+  it("falls back to the overview and presents an all-clear posture", () => {
+    const html = renderToStaticMarkup(
+      <OperatorWorkspace s={state} initialView={"not-a-view" as never} />
+    );
+    expect(html).toContain("All monitored systems are operational");
+    expect(html).toContain("Baseline saved");
+    expect(html).toContain("Portfolio");
+  });
+});

--- a/web/src/workspace.tsx
+++ b/web/src/workspace.tsx
@@ -1,0 +1,469 @@
+import { useEffect, useMemo, useState } from "react";
+import type { DashboardState, HealthTop, Position, Signal } from "./types";
+import { ago, deltaClass, money, price } from "./format";
+
+export type View = "overview" | "portfolio" | "opportunities" | "execution" | "intelligence" | "system";
+type Inspectable =
+  | { kind: "position"; value: Position }
+  | { kind: "signal"; value: Signal }
+  | { kind: "health"; value: HealthTop }
+  | { kind: "reconciliation"; value: Record<string, unknown> };
+
+const VIEWS: { id: View; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "portfolio", label: "Portfolio" },
+  { id: "opportunities", label: "Opportunities" },
+  { id: "execution", label: "Execution" },
+  { id: "intelligence", label: "Intelligence" },
+  { id: "system", label: "System" },
+];
+
+function useStored(key: string, fallback: string) {
+  const [value, setValue] = useState(() => typeof localStorage === "undefined" ? fallback : localStorage.getItem(key) ?? fallback);
+  useEffect(() => { if (typeof localStorage !== "undefined") localStorage.setItem(key, value); }, [key, value]);
+  return [value, setValue] as const;
+}
+
+function SinceLastVisit({ s, scope }: { s: DashboardState; scope: string }) {
+  const key = `auramaur.last-visit.${scope}`;
+  const [previous] = useState<{ at: string; pnl: number; positions: number; fills: number } | null>(() => {
+    if (typeof localStorage === "undefined") return null;
+    try { return JSON.parse(localStorage.getItem(key) ?? "null"); } catch { return null; }
+  });
+  useEffect(() => {
+    if (typeof localStorage !== "undefined") localStorage.setItem(key, JSON.stringify({
+      at: new Date().toISOString(), pnl: s.total_pnl, positions: s.position_count, fills: s.trade_count,
+    }));
+  }, [key, s.total_pnl, s.position_count, s.trade_count]);
+  if (!previous) return <p className="visit-summary">Baseline saved. Changes will appear on your next visit.</p>;
+  return <p className="visit-summary">
+    Since {isoAge(previous.at)}: <strong className={deltaClass(s.total_pnl - previous.pnl)}>{money(s.total_pnl - previous.pnl, true)} P&amp;L</strong>
+    {" · "}{s.position_count - previous.positions >= 0 ? "+" : ""}{s.position_count - previous.positions} positions
+    {" · "}{s.trade_count - previous.fills >= 0 ? "+" : ""}{s.trade_count - previous.fills} fills
+  </p>;
+}
+
+function isoAge(value?: string | null) {
+  if (!value) return "unknown";
+  const stamp = new Date(value).getTime();
+  return Number.isFinite(stamp) ? ago((Date.now() - stamp) / 1000) : value;
+}
+
+function safeJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+async function copyText(value: string) {
+  await navigator.clipboard.writeText(value);
+}
+
+function activateRow(event: React.KeyboardEvent, action: () => void) {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    action();
+  }
+}
+
+function download(name: string, value: unknown) {
+  const blob = new Blob([safeJson(value)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function WorkspaceNav({ view, onView }: { view: View; onView: (view: View) => void }) {
+  return (
+    <nav className="workspace-nav" aria-label="Dashboard sections">
+      {VIEWS.map((item) => (
+        <button
+          className={view === item.id ? "active" : ""}
+          key={item.id}
+          aria-current={view === item.id ? "page" : undefined}
+          onClick={() => onView(item.id)}
+        >
+          {item.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+function AttentionCenter({
+  s,
+  onView,
+  onInspect,
+}: {
+  s: DashboardState;
+  onView: (view: View) => void;
+  onInspect: (item: Inspectable) => void;
+}) {
+  const stale = Object.values(s.venues).filter((venue) => (venue.age_seconds ?? Infinity) > 900).length;
+  const dead = s.pillars.filter((pillar) => (pillar.age_seconds ?? Infinity) >= 600).length;
+  const recon = s.reconciliation;
+  const mismatches = recon?.available && !recon.in_sync
+    ? recon.missing.length + recon.extra.length + recon.size_mismatches.length
+    : 0;
+  const cards = [
+    { count: s.health.errors, label: "errors", tone: "critical", view: "system" as View },
+    { count: s.health.warnings, label: "warnings", tone: "warning", view: "system" as View },
+    { count: stale + dead, label: "stale sources", tone: "warning", view: "system" as View },
+    { count: mismatches, label: "sync mismatches", tone: "serious", view: "execution" as View },
+  ].filter((card) => card.count > 0);
+  if (!cards.length) {
+    return <div className="all-clear" role="status">✓ All monitored systems are operational</div>;
+  }
+  return (
+    <section className="attention" aria-labelledby="attention-title">
+      <div>
+        <span className="eyebrow">Needs attention</span>
+        <h2 id="attention-title">{cards.reduce((sum, card) => sum + card.count, 0)} items to review</h2>
+      </div>
+      <div className="attention-items">
+        {cards.map((card) => (
+          <button
+            className={"attention-item " + card.tone}
+            key={card.label}
+            onClick={() => {
+              onView(card.view);
+              if (card.label === "sync mismatches" && recon) {
+                onInspect({ kind: "reconciliation", value: recon as unknown as Record<string, unknown> });
+              }
+            }}
+          >
+            <strong>{card.count}</strong><span>{card.label}</span><span aria-hidden="true">→</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return <span className="spark-empty">Trend builds as daily marks arrive</span>;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const spread = max - min || 1;
+  const points = values.map((value, index) =>
+    `${(index / (values.length - 1)) * 100},${28 - ((value - min) / spread) * 24}`
+  ).join(" ");
+  return (
+    <svg className="spark" viewBox="0 0 100 32" role="img" aria-label="Recent P and L trend">
+      <polyline points={points} fill="none" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
+  s: DashboardState; scope: string; historyIsCurrent: boolean;
+  onView: (v: View) => void; onInspect: (i: Inspectable) => void;
+}) {
+  const history = historyIsCurrent ? s.performance_history ?? [] : [];
+  const today = history.at(-1);
+  const prior = history.at(-2);
+  const dailyDelta = today && prior ? today.total_pnl - prior.total_pnl : null;
+  const largest = [...s.positions].sort((a, b) => Math.abs(b.pnl) - Math.abs(a.pnl))[0];
+  const newest = s.signals[0];
+  return (
+    <>
+      <SinceLastVisit s={s} scope={scope} />
+      <AttentionCenter s={s} onView={onView} onInspect={onInspect} />
+      <section className="hero-metrics" aria-label="Account summary">
+        <article><span>Capital</span><strong>{money(s.balance)}</strong><small>{money(s.position_value)} deployed</small></article>
+        <article><span>Total P&amp;L</span><strong className={deltaClass(s.total_pnl)}>{money(s.total_pnl, true)}</strong>
+          <small className={deltaClass(dailyDelta)}>{dailyDelta == null ? "Daily delta unavailable" : `${money(dailyDelta, true)} today`}</small>
+        </article>
+        <article className="metric-trend"><span>14-day performance</span><Sparkline values={history.map((row) => row.total_pnl)} />
+          <small>{history.length} daily marks</small></article>
+        <article><span>Open risk</span><strong>{s.position_count} positions</strong><small>Max drawdown {s.drawdown.toFixed(1)}%</small></article>
+      </section>
+      <div className="summary-grid">
+        <SummaryCard title="Portfolio" status={largest ? "Review largest mover" : "No open exposure"} onOpen={() => onView("portfolio")}>
+          {largest && <button className="summary-row" onClick={() => onInspect({ kind: "position", value: largest })}>
+            <span>{largest.question}</span><strong className={deltaClass(largest.pnl)}>{money(largest.pnl, true)}</strong>
+          </button>}
+          <p>{s.categories.slice(0, 3).map((c) => `${c.category} ${money(c.value)}`).join(" · ") || "No category exposure"}</p>
+        </SummaryCard>
+        <SummaryCard title="Opportunities" status={`${s.signals.length} recent signals`} onOpen={() => onView("opportunities")}>
+          {newest && <button className="summary-row" onClick={() => onInspect({ kind: "signal", value: newest })}>
+            <span>{newest.question}</span><strong>{newest.edge == null ? "—" : `${newest.edge.toFixed(1)}% edge`}</strong>
+          </button>}
+          <p>{newest ? `${newest.strategy_source} · ${isoAge(newest.timestamp)}` : "No recent signals"}</p>
+        </SummaryCard>
+        <SummaryCard title="Execution" status={s.reconciliation?.in_sync ? "In sync" : "Review required"} onOpen={() => onView("execution")}>
+          <p>{s.trade_count} fills · {Object.keys(s.venues).length} venues</p>
+          <p>Last venue snapshot {isoAge(s.reconciliation?.fetched_at)}</p>
+        </SummaryCard>
+        <SummaryCard title="System" status={s.health.errors ? `${s.health.errors} errors` : "Healthy"} onOpen={() => onView("system")}>
+          <p>{s.pillars.filter((p) => (p.age_seconds ?? Infinity) < 90).length}/{s.pillars.length} pillars fresh</p>
+          <p>{s.health.warnings} warnings in current log window</p>
+        </SummaryCard>
+      </div>
+    </>
+  );
+}
+
+function SummaryCard({ title, status, onOpen, children }: {
+  title: string; status: string; onOpen: () => void; children: React.ReactNode;
+}) {
+  return (
+    <article className="summary-card">
+      <header><div><span className="eyebrow">{title}</span><h2>{status}</h2></div>
+        <button className="text-button" onClick={onOpen}>Open workspace →</button></header>
+      {children}
+    </article>
+  );
+}
+
+function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const [query, setQuery] = useStored("auramaur.positions.query", "");
+  const [venue, setVenue] = useStored("auramaur.positions.venue", "all");
+  const [preset, setPreset] = useStored("auramaur.positions.preset", "all");
+  const [sort, setSort] = useStored("auramaur.positions.sort", "pnl");
+  const venues = [...new Set(s.positions.map((p) => p.exchange))].sort();
+  const rows = useMemo(() => {
+    const q = query.toLowerCase();
+    const now = new Date(s.now).getTime();
+    return s.positions.filter((p) => {
+      if (venue !== "all" && p.exchange !== venue) return false;
+      if (q && ![p.question, p.market_id, p.token, p.category, p.exchange].some((v) => v?.toLowerCase().includes(q))) return false;
+      if (preset === "review" && Math.abs(p.pnl) < 1) return false;
+      if (preset === "movers" && Math.abs(p.pnl) < 0.5) return false;
+      if (preset === "stale" && (!p.updated_at || now - new Date(p.updated_at).getTime() < 15 * 60_000)) return false;
+      if (preset === "resolution" && (!p.end_date || new Date(p.end_date).getTime() - now > 7 * 86400_000)) return false;
+      return true;
+    }).sort((a, b) => sort === "value"
+      ? (b.current_value ?? 0) - (a.current_value ?? 0)
+      : sort === "age" ? new Date(a.updated_at ?? 0).getTime() - new Date(b.updated_at ?? 0).getTime()
+      : Math.abs(b.pnl) - Math.abs(a.pnl));
+  }, [s.positions, s.now, query, venue, preset, sort]);
+  return (
+    <Workspace title="Portfolio" subtitle="Find exposure, stale marks, concentration, and positions requiring review."
+      action={<button onClick={() => download("auramaur-positions.json", rows)}>Export JSON</button>}>
+      <div className="toolbar">
+        <input aria-label="Search positions" placeholder="Search market, ID, token, category…" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <select aria-label="Filter venue" value={venue} onChange={(e) => setVenue(e.target.value)}>
+          <option value="all">All venues</option>{venues.map((v) => <option key={v}>{v}</option>)}
+        </select>
+        <select aria-label="Position preset" value={preset} onChange={(e) => setPreset(e.target.value)}>
+          <option value="all">All positions</option><option value="review">Needs review</option>
+          <option value="movers">Largest movers</option><option value="stale">Stale marks</option>
+          <option value="resolution">Resolving soon</option>
+        </select>
+        <select aria-label="Sort positions" value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="pnl">Sort: absolute P&amp;L</option><option value="value">Sort: exposure</option><option value="age">Sort: stalest</option>
+        </select>
+      </div>
+      <p className="result-count">{rows.length} of {s.positions.length} positions · filters save automatically</p>
+      <DataTable headers={["Market", "Venue", "Category", "Outcome", "Exposure", "Mark", "P&L", "Updated"]}>
+        {rows.map((p) => {
+          const open = () => onInspect({ kind: "position", value: p } as Inspectable);
+          return <tr key={`${p.market_id}-${p.token}`} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+          <td className="market">{p.question}</td><td>{p.exchange}</td><td>{p.category ?? "—"}</td>
+          <td>{p.token}</td><td className="num">{money(p.current_value)}</td><td className="num">{price(p.current_price)}</td>
+          <td className={`num ${deltaClass(p.pnl)}`}>{money(p.pnl, true)}</td><td>{isoAge(p.updated_at)}</td>
+        </tr>;
+        })}
+      </DataTable>
+      <div className="summary-grid workspace-breakdowns">
+        <section className="section-block"><h2>Category concentration</h2>
+          <DataTable headers={["Category", "Positions", "Exposure"]}>
+            {s.categories.map((row) => <tr key={row.category}><td>{row.category}</td>
+              <td className="num">{row.positions}</td><td className="num">{money(row.value)}</td></tr>)}
+          </DataTable>
+        </section>
+        <section className="section-block"><h2>Strategy realized performance</h2>
+          <DataTable headers={["Strategy", "Entries", "Fees", "Realized"]}>
+            {s.strategies.map((row) => <tr key={row.strategy}><td>{row.strategy}</td>
+              <td className="num">{row.entries}</td><td className="num">{money(row.fees)}</td>
+              <td className={`num ${deltaClass(row.pnl)}`}>{money(row.pnl, true)}</td></tr>)}
+          </DataTable>
+        </section>
+      </div>
+    </Workspace>
+  );
+}
+
+function Opportunities({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const grouped = useMemo(() => {
+    const map = new Map<string, Signal[]>();
+    s.signals.forEach((signal) => map.set(signal.market_id, [...(map.get(signal.market_id) ?? []), signal]));
+    return [...map.values()].sort((a, b) => Math.abs(b[0].edge ?? 0) - Math.abs(a[0].edge ?? 0));
+  }, [s.signals]);
+  return (
+    <Workspace title="Opportunities" subtitle="Signals grouped by market so repeated evaluations read as one decision timeline."
+      action={<button onClick={() => download("auramaur-signals.json", s.signals)}>Export JSON</button>}>
+      <DataTable headers={["Market", "Evaluations", "Strategy", "Model", "Market", "Edge", "Action", "Observed"]}>
+        {grouped.map((signals) => {
+          const sig = signals[0];
+          const open = () => onInspect({ kind: "signal", value: sig });
+          return <tr key={sig.market_id} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+            <td className="market">{sig.question}</td><td className="num">{signals.length}</td><td>{sig.strategy_source}</td>
+            <td className="num">{price(sig.claude_prob)}</td><td className="num">{price(sig.market_prob)}</td>
+            <td className={`num ${deltaClass(sig.edge)}`}>{sig.edge == null ? "—" : `${sig.edge.toFixed(1)}%`}</td>
+            <td><span className="action-chip">{sig.action}</span></td><td>{isoAge(sig.timestamp)}</td>
+          </tr>;
+        })}
+      </DataTable>
+    </Workspace>
+  );
+}
+
+function Execution({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const recon = s.reconciliation;
+  const discrepancies = recon ? [
+    ...recon.missing.map((v) => ({ type: "Missing locally", ...v as object })),
+    ...recon.extra.map((v) => ({ type: "Extra locally", ...v as object })),
+    ...recon.size_mismatches.map((v) => ({ type: "Quantity mismatch", ...v as object })),
+  ] as Record<string, unknown>[] : [];
+  return (
+    <Workspace title="Execution" subtitle="Venue posture, fills, and exact reconciliation differences."
+      action={<button disabled={!recon} onClick={() => recon && download("auramaur-reconciliation.json", recon)}>Export reconciliation</button>}>
+      <div className="venue-grid">{Object.entries(s.venues).map(([name, venue]) =>
+        <article className="venue-card" key={name}><header><strong>{name}</strong><Status age={venue.age_seconds} /></header>
+          <p>{venue.detail}</p><small>Recorded {ago(venue.age_seconds)}</small></article>)}</div>
+      <section className="section-block"><header className="section-heading"><div><span className="eyebrow">Reconciliation</span>
+        <h2>{recon?.in_sync ? "Venue and ledger agree" : `${discrepancies.length} discrepancies`}</h2></div>
+        {recon && <small>Snapshot {isoAge(recon.fetched_at)}</small>}</header>
+        {discrepancies.length ? <DataTable headers={["Type", "Market / asset", "Outcome", "Venue qty", "Ledger qty"]}>
+          {discrepancies.map((row, index) => {
+            const open = () => onInspect({ kind: "reconciliation", value: row });
+            return <tr key={index} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+            <td>{String(row.type)}</td><td className="market">{String(row.title ?? row.market_id ?? row.asset_id ?? "—")}</td>
+            <td>{String(row.outcome ?? row.token ?? "—")}</td><td className="num">{String(row.venue_size ?? row.size ?? "—")}</td>
+            <td className="num">{String(row.db_size ?? "—")}</td>
+          </tr>;
+          })}</DataTable> : <div className="all-clear">✓ No venue/database discrepancies</div>}
+      </section>
+      {(s.kraken_paper ?? []).length > 0 && <section className="section-block"><h2>Kraken paper positions</h2>
+        <DataTable headers={["Pair", "Strategy", "Quantity", "Entry", "Peak gain", "Opened"]}>
+          {(s.kraken_paper ?? []).map((row) => <tr key={`${row.strategy}-${row.pair}`}><td>{row.pair}</td>
+            <td>{row.strategy}</td><td className="num">{row.quantity.toFixed(4)}</td>
+            <td className="num">{row.entry_price.toFixed(2)}</td><td className="num">{row.peak_gain_pct.toFixed(1)}%</td>
+            <td>{isoAge(row.opened_at)}</td></tr>)}
+        </DataTable>
+      </section>}
+    </Workspace>
+  );
+}
+
+function Intelligence({ s }: { s: DashboardState }) {
+  const llm = s.local_llm;
+  return <Workspace title="Intelligence" subtitle="Model throughput, reliability, calibration, and evidence output.">
+    <div className="summary-grid">
+      <SummaryCard title="Evidence distiller" status={`${llm?.claims_24h ?? 0} claims in 24h`} onOpen={() => undefined}>
+        <p>Last claim {isoAge(llm?.last_claim_at)}</p>
+      </SummaryCard>
+      {llm && Object.entries(llm.purposes).map(([purpose, stat]) =>
+        <SummaryCard key={purpose} title={purpose} status={`${stat.ok}/${stat.calls} successful`} onOpen={() => undefined}>
+          <p>{stat.errors} errors · {stat.avg_ms ?? "—"}ms average</p><p>{stat.prompt_tokens + stat.output_tokens} tokens</p>
+        </SummaryCard>)}
+    </div>
+    <section className="section-block"><h2>Resolved forecast scorecard</h2>
+      <DataTable headers={["Arm", "Model", "Forecasts", "Brier", "Market Brier", "Abstains"]}>
+        {(s.intelligence_eval ?? []).map((row) => <tr key={row.arm}><td>{row.arm}</td><td>{row.model}</td>
+          <td className="num">{row.forecasts}</td><td className="num">{row.brier ?? "—"}</td>
+          <td className="num">{row.market_brier ?? "—"}</td><td className="num">{row.abstains}</td></tr>)}
+      </DataTable>
+    </section>
+  </Workspace>;
+}
+
+function System({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  return <Workspace title="System" subtitle="Source liveness and diagnostics ordered for investigation."
+    action={<button onClick={() => download("auramaur-diagnostics.json", { pillars: s.pillars, health: s.health, activity: s.activity })}>Export diagnostics</button>}>
+    <div className="pillar-grid">{s.pillars.map((pillar) =>
+      <article className="pillar-card" key={pillar.name}><Status age={pillar.age_seconds} /><div><strong>{pillar.name}</strong>
+        <small>Last event {ago(pillar.age_seconds)}</small></div></article>)}</div>
+    <section className="section-block"><header className="section-heading"><div><span className="eyebrow">Diagnostics</span>
+      <h2>{s.health.errors} errors · {s.health.warnings} warnings</h2></div></header>
+      <DataTable headers={["Occurrences", "Event", "Latest detail", "Last seen"]}>
+        {s.health.top.map((event) => {
+          const open = () => onInspect({ kind: "health", value: event });
+          return <tr key={event.event} tabIndex={0} onClick={open} onKeyDown={(keyEvent) => activateRow(keyEvent, open)}>
+          <td className="num">{event.count}</td><td>{event.event}</td><td className="market">{event.last_msg || "No message recorded"}</td>
+          <td>{isoAge(event.last_ts)}</td></tr>;
+        })}
+      </DataTable>
+    </section>
+    <section className="section-block"><h2>Recent operational activity</h2>
+      <div className="timeline">{[...s.activity].reverse().map((item, index) =>
+        <div key={index}><time>{item.time}</time><span>{item.text}</span></div>)}</div>
+    </section>
+  </Workspace>;
+}
+
+function Status({ age }: { age: number | null }) {
+  const state = age == null ? "unknown" : age < 90 ? "fresh" : age < 600 ? "stale" : "dead";
+  return <span className={`status ${state}`}><span aria-hidden="true" />{state}</span>;
+}
+
+function Workspace({ title, subtitle, action, children }: {
+  title: string; subtitle: string; action?: React.ReactNode; children: React.ReactNode;
+}) {
+  return <main id="main-content" className="workspace"><header className="workspace-heading"><div><h1>{title}</h1><p>{subtitle}</p></div>{action}</header>{children}</main>;
+}
+
+function DataTable({ headers, children }: { headers: string[]; children: React.ReactNode }) {
+  return <div className="data-table-wrap"><table className="data-table"><thead><tr>{headers.map((header) =>
+    <th key={header} className={["Exposure", "Mark", "P&L", "Edge", "Model", "Market", "Occurrences", "Forecasts", "Brier", "Market Brier", "Abstains", "Venue qty", "Ledger qty", "Evaluations", "Positions", "Entries", "Fees", "Realized", "Quantity", "Entry", "Peak gain"].includes(header) ? "num" : ""}>{header}</th>)}
+  </tr></thead><tbody>{children}</tbody></table></div>;
+}
+
+function Inspector({ item, onClose }: { item: Inspectable | null; onClose: () => void }) {
+  useEffect(() => {
+    const close = (event: KeyboardEvent) => event.key === "Escape" && onClose();
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [onClose]);
+  if (!item) return null;
+  const value = item.value as unknown as Record<string, unknown>;
+  const title = item.kind === "position" || item.kind === "signal"
+    ? String(value.question) : item.kind === "health" ? String(value.event) : "Reconciliation detail";
+  const checklist = item.kind === "health"
+    ? ["Confirm the latest occurrence time", "Review the event message and related activity", "Check the affected pillar or venue", "Copy diagnostics before remediation"]
+    : item.kind === "reconciliation"
+      ? ["Confirm snapshot freshness", "Compare venue and ledger quantities", "Copy the asset or market ID", "Run the position sync/reconciliation workflow"]
+      : ["Confirm source freshness", "Review exposure and related signal", "Copy the market ID for deeper investigation"];
+  return <div className="inspector-backdrop" onMouseDown={onClose}>
+    <aside className="inspector" role="dialog" aria-modal="true" aria-labelledby="inspector-title" onMouseDown={(e) => e.stopPropagation()}>
+      <header><div><span className="eyebrow">{item.kind}</span><h2 id="inspector-title">{title}</h2></div>
+        <button className="icon-button" aria-label="Close details" onClick={onClose}>×</button></header>
+      <dl>{Object.entries(value).filter(([, v]) => v !== "" && v != null && typeof v !== "object").map(([key, val]) =>
+        <div key={key}><dt>{key.replaceAll("_", " ")}</dt><dd>{String(val)}</dd></div>)}</dl>
+      <section><h3>Investigation checklist</h3><ol>{checklist.map((step) => <li key={step}>{step}</li>)}</ol></section>
+      <div className="inspector-actions">
+        {"market_id" in value && <button onClick={() => copyText(String(value.market_id))}>Copy market ID</button>}
+        {"asset_id" in value && <button onClick={() => copyText(String(value.asset_id))}>Copy asset ID</button>}
+        <button onClick={() => copyText(safeJson(value))}>Copy details</button>
+        <button onClick={() => download(`auramaur-${item.kind}.json`, value)}>Export JSON</button>
+      </div>
+    </aside>
+  </div>;
+}
+
+export function OperatorWorkspace({ s, scope = "default", historyIsCurrent = true, initialView = "overview" }: {
+  s: DashboardState; scope?: string; historyIsCurrent?: boolean; initialView?: View;
+}) {
+  const safeInitial = VIEWS.some((candidate) => candidate.id === initialView) ? initialView : "overview";
+  const [view, setView] = useState<View>(safeInitial);
+  const [inspect, setInspect] = useState<Inspectable | null>(null);
+  const changeView = (next: View) => {
+    setView(next);
+    history.replaceState(null, "", `#${next}`);
+    document.getElementById("main-content")?.focus();
+  };
+  return <>
+    <a className="skip-link" href="#main-content">Skip to dashboard content</a>
+    <WorkspaceNav view={view} onView={changeView} />
+    {view === "overview" && <main id="main-content" tabIndex={-1}><Overview s={s} scope={scope} historyIsCurrent={historyIsCurrent} onView={changeView} onInspect={setInspect} /></main>}
+    {view === "portfolio" && <Portfolio s={s} onInspect={setInspect} />}
+    {view === "opportunities" && <Opportunities s={s} onInspect={setInspect} />}
+    {view === "execution" && <Execution s={s} onInspect={setInspect} />}
+    {view === "intelligence" && <Intelligence s={s} />}
+    {view === "system" && <System s={s} onInspect={setInspect} />}
+    <Inspector item={inspect} onClose={() => setInspect(null)} />
+  </>;
+}


### PR DESCRIPTION
## Summary
- reorganize the dashboard into six task-based operator workspaces with URL-backed navigation
- add an attention center, saved portfolio filters, grouped signal timelines, reconciliation details, and contextual inspectors
- add daily performance context and richer position/signal metadata while preserving the read-only web boundary
- add keyboard activation, focus treatment, responsive layouts, reduced-motion support, copy/export actions, and investigation checklists

## Safety
- no writable API or trading control was added
- existing read-only SQLite and network isolation boundaries remain intact
- paper/live history and saved baselines remain isolated

## Verification
- `npm test -- --run` — 10 passed
- `npm run build` — passed
- `npm run lint` — passed
- `python -m pytest -q -p no:cacheprovider tests/test_web_api.py tests/test_cockpit_unified.py` — 17 passed
- `git diff --check` — passed

## Review notes
An initial backend run encountered a non-deterministic double-close teardown race in the database recovery test. The isolated test passed immediately afterward and the complete 17-test suite then passed cleanly; no lifecycle code was changed by this PR.