### PR TITLE
fix(web): harden dashboard UX and accessibility

### DIFF
--- a/web/src/components.tsx
+++ b/web/src/components.tsx
@@ -48,6 +48,7 @@ export function TopBar({
           <button
             key={b}
             className={`seg${book === b ? " active" : ""}`}
+            aria-pressed={book === b}
             onClick={() => onBook(b)}
           >
             {b}

--- a/web/src/format.test.ts
+++ b/web/src/format.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { ago, deltaClass, liveness, money, price, utcClock } from "./format";
+import { ago, deltaClass, exactTime, liveness, money, price, utcClock } from "./format";
 
 describe("dashboard formatting", () => {
+  it("formats exact timestamp tooltips without invalid Intl options", () => {
+    expect(exactTime("2026-07-21T12:00:00Z")).toContain("2026");
+    expect(exactTime("not-a-date")).toBe("not-a-date");
+  });
+
   it("formats missing and signed financial values", () => {
     expect(money(null)).toBe("n/a");
     expect(money(12.5, true)).toBe("+$12.50");

--- a/web/src/format.ts
+++ b/web/src/format.ts
@@ -39,3 +39,33 @@ export function liveness(
 export function utcClock(iso: string): string {
   return `${iso.slice(11, 19)} UTC`;
 }
+
+export function compactNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function exactTime(value?: string | null): string {
+  if (!value) return "Unknown time";
+  const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)
+    ? `${value.replace(" ", "T")}Z`
+    : value;
+  const date = new Date(normalized);
+  return Number.isFinite(date.getTime())
+    ? new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+        timeZoneName: "short",
+      }).format(date)
+    : value;
+}
+
+export function humanize(value: string): string {
+  return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -385,17 +385,18 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
   display: flex; gap: 4px; overflow-x: auto; margin: 0 0 18px;
   border-bottom: 1px solid var(--border); scrollbar-width: thin;
 }
-.workspace-nav button {
+.workspace-nav a {
   flex: none; border: 0; border-bottom: 2px solid transparent; background: none;
-  color: var(--ink-muted); padding: 10px 13px; cursor: pointer;
+  color: var(--ink-muted); padding: 10px 13px; cursor: pointer; text-decoration: none;
 }
-.workspace-nav button:hover { color: var(--ink); }
-.workspace-nav button.active { color: var(--ink); border-bottom-color: var(--ink); font-weight: 600; }
+.workspace-nav a:hover { color: var(--ink); }
+.workspace-nav a.active { color: var(--ink); border-bottom-color: var(--ink); font-weight: 600; }
 
 .workspace-heading, .section-heading, .summary-card header, .venue-card header, .inspector header {
   display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
 }
 .workspace-heading { margin: 2px 0 18px; }
+.overview-heading { margin-bottom: 10px; }
 .workspace-heading h1 { margin: 0; font-size: 25px; letter-spacing: -.02em; }
 .workspace-heading p { color: var(--ink-muted); margin: 3px 0 0; }
 .workspace-heading > button, .toolbar button, .inspector-actions button, .workspace-heading select {
@@ -446,6 +447,7 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .hero-metrics small { color: var(--ink-muted); margin-top: auto; }
 .spark { width: 100%; height: 40px; margin: 4px 0; overflow: visible; }
 .spark polyline { stroke: var(--good); stroke-width: 2; }
+.spark.down polyline { stroke: var(--delta-down); }
 .spark-empty { color: var(--ink-muted) !important; margin: auto 0; font-size: 12px; }
 
 .summary-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
@@ -466,17 +468,30 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
   min-height: 36px; color: var(--ink); background: var(--surface);
   border: 1px solid var(--border); border-radius: 7px; padding: 7px 9px;
 }
+.toolbar .secondary-button {
+  min-height: 36px; color: var(--ink-2); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 7px; padding: 7px 11px; cursor: pointer;
+}
+.toolbar .secondary-button:disabled { opacity: .4; cursor: default; }
 .toolbar input { flex: 1 1 290px; }
 .toolbar select { flex: 0 1 190px; }
 .result-count { margin: 0 0 9px; color: var(--ink-muted); font-size: 12px; }
+.result-line { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.pagination { display: flex; align-items: center; gap: 8px; color: var(--ink-muted); font-size: 12px; margin-bottom: 8px; }
+.pagination button {
+  color: var(--ink-2); background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 4px 8px; cursor: pointer;
+}
+.pagination button:disabled { opacity: .4; cursor: default; }
 .data-table-wrap { overflow: auto; max-height: calc(100vh - 245px); border: 1px solid var(--border); border-radius: 9px; }
 .data-table { background: var(--surface); }
 .data-table thead { position: sticky; top: 0; z-index: 1; background: var(--surface); }
 .data-table th { padding: 8px 10px; }
 .data-table td { padding: 7px 10px; }
-.data-table tbody tr { cursor: pointer; }
-.data-table tbody tr:hover, .data-table tbody tr:focus { background: color-mix(in srgb, var(--ink) 5%, transparent); }
+.data-table tbody tr[role="button"] { cursor: pointer; }
+.data-table tbody tr[role="button"]:hover, .data-table tbody tr[role="button"]:focus { background: color-mix(in srgb, var(--ink) 5%, transparent); }
 .data-table td.market { max-width: 430px; }
+.empty-row td { padding: 24px 14px; text-align: center; color: var(--ink-muted); white-space: normal; }
 .action-chip { border: 1px solid var(--border); border-radius: 999px; padding: 2px 7px; font-size: 11px; }
 
 .venue-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px; }
@@ -490,6 +505,17 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .status.dead { color: var(--critical); }.status.dead > span { background: var(--critical); }
 .section-block { margin-top: 12px; padding: 14px; }
 .section-block > h2 { margin: 0 0 10px; font-size: 15px; }
+.section-help { color: var(--ink-muted); font-size: 12px; margin: 0 0 10px; }
+.section-block > .section-help { margin-top: -4px; }
+.unavailable {
+  color: var(--warning); background: color-mix(in srgb, var(--warning) 8%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  border-radius: 8px; padding: 12px 14px; margin-top: 12px;
+}
+.severity { display: inline-flex; border-radius: 999px; padding: 2px 7px; font-size: 11px; border: 1px solid currentColor; }
+.severity.critical { color: var(--critical); }
+.severity.warning { color: var(--warning); }
+.empty-state { color: var(--ink-muted); padding: 8px 0; }
 .section-block .data-table-wrap { max-height: 480px; margin-top: 12px; }
 .workspace-breakdowns { margin-top: 12px; }
 .workspace-breakdowns .section-block { margin-top: 0; }
@@ -500,6 +526,9 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .timeline { display: grid; gap: 7px; }
 .timeline > div { display: grid; grid-template-columns: 72px 1fr; gap: 10px; font-size: 13px; }
 .timeline time { color: var(--ink-muted); font-variant-numeric: tabular-nums; }
+.decision-timeline { display: grid; gap: 7px; }
+.decision-timeline > div { display: grid; grid-template-columns: 90px 1fr; gap: 10px; }
+.decision-timeline time { color: var(--ink-muted); }
 
 .inspector-backdrop { position: fixed; inset: 0; z-index: 50; background: rgba(0,0,0,.5); display: flex; justify-content: flex-end; }
 .inspector {
@@ -517,6 +546,7 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .inspector li { margin: 7px 0; color: var(--ink-2); }
 .inspector-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 22px; }
 .inspector-actions button { background: var(--page); }
+.copy-status { min-height: 20px; color: var(--good); font-size: 12px; }
 
 @media (max-width: 900px) {
   .attention { grid-template-columns: 1fr; }
@@ -531,7 +561,21 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
   .attention-items { grid-template-columns: 1fr; }
   .toolbar { display: grid; }
   .toolbar input, .toolbar select { width: 100%; }
-  .data-table td.market { position: sticky; left: 0; z-index: 0; max-width: 230px; background: var(--surface); }
+  .result-line { align-items: stretch; flex-direction: column; gap: 2px; }
+  .pagination { justify-content: space-between; }
+  .data-table tr[role="button"]:has(td[data-label]) {
+    display: grid; grid-template-columns: 1fr 1fr; padding: 10px 12px;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .data-table tr[role="button"]:has(td[data-label]) td {
+    display: grid; gap: 2px; padding: 5px 4px; border: 0; white-space: normal; text-align: left;
+  }
+  .data-table tr[role="button"]:has(td[data-label]) td::before {
+    content: attr(data-label); color: var(--ink-muted); font-size: 10px;
+    font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+  }
+  .data-table tr[role="button"]:has(td[data-label]) td.market { grid-column: 1 / -1; max-width: none; }
+  .data-table:has(td[data-label]) thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
   .inspector dl > div { grid-template-columns: 1fr; gap: 2px; }
 }
 

--- a/web/src/workspace.test.tsx
+++ b/web/src/workspace.test.tsx
@@ -16,6 +16,7 @@ describe("operator workspace", () => {
     const html = renderToStaticMarkup(<WorkspaceNav view="execution" onView={() => undefined} />);
     expect(html).toContain("Dashboard sections");
     expect(html).toContain('aria-current="page"');
+    expect(html).toContain('href="#execution"');
     expect(html).toContain("Opportunities");
   });
 
@@ -26,5 +27,21 @@ describe("operator workspace", () => {
     expect(html).toContain("All monitored systems are operational");
     expect(html).toContain("Baseline saved");
     expect(html).toContain("Portfolio");
+  });
+
+  it("does not report unavailable reconciliation as healthy", () => {
+    const html = renderToStaticMarkup(
+      <OperatorWorkspace s={{ ...state, reconciliation: undefined }} initialView="execution" />
+    );
+    expect(html).toContain("Reconciliation unavailable");
+    expect(html).not.toContain("No venue/database discrepancies");
+  });
+
+  it("shows explicit empty states and no dead intelligence actions", () => {
+    const html = renderToStaticMarkup(
+      <OperatorWorkspace s={state} initialView="intelligence" />
+    );
+    expect(html).toContain("No resolved forecasts are available yet");
+    expect(html).not.toContain("Open workspace");
   });
 });

--- a/web/src/workspace.tsx
+++ b/web/src/workspace.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DashboardState, HealthTop, Position, Signal } from "./types";
-import { ago, deltaClass, money, price } from "./format";
+import { ago, compactNumber, deltaClass, exactTime, humanize, money, price } from "./format";
 
 export type View = "overview" | "portfolio" | "opportunities" | "execution" | "intelligence" | "system";
 type Inspectable =
   | { kind: "position"; value: Position }
-  | { kind: "signal"; value: Signal }
+  | { kind: "signal"; value: Signal; related?: Signal[] }
   | { kind: "health"; value: HealthTop }
   | { kind: "reconciliation"; value: Record<string, unknown> };
 
@@ -35,8 +35,8 @@ function SinceLastVisit({ s, scope }: { s: DashboardState; scope: string }) {
       at: new Date().toISOString(), pnl: s.total_pnl, positions: s.position_count, fills: s.trade_count,
     }));
   }, [key, s.total_pnl, s.position_count, s.trade_count]);
-  if (!previous) return <p className="visit-summary">Baseline saved. Changes will appear on your next visit.</p>;
-  return <p className="visit-summary">
+  if (!previous) return <p className="visit-summary" title="Stored only in this browser">Baseline saved in this browser. Changes will appear on your next visit.</p>;
+  return <p className="visit-summary" title="Compared with a baseline stored only in this browser">
     Since {isoAge(previous.at)}: <strong className={deltaClass(s.total_pnl - previous.pnl)}>{money(s.total_pnl - previous.pnl, true)} P&amp;L</strong>
     {" · "}{s.position_count - previous.positions >= 0 ? "+" : ""}{s.position_count - previous.positions} positions
     {" · "}{s.trade_count - previous.fills >= 0 ? "+" : ""}{s.trade_count - previous.fills} fills
@@ -78,14 +78,15 @@ export function WorkspaceNav({ view, onView }: { view: View; onView: (view: View
   return (
     <nav className="workspace-nav" aria-label="Dashboard sections">
       {VIEWS.map((item) => (
-        <button
+        <a
           className={view === item.id ? "active" : ""}
           key={item.id}
+          href={`#${item.id}`}
           aria-current={view === item.id ? "page" : undefined}
-          onClick={() => onView(item.id)}
+          onClick={(event) => { event.preventDefault(); onView(item.id); }}
         >
           {item.label}
-        </button>
+        </a>
       ))}
     </nav>
   );
@@ -149,8 +150,10 @@ function Sparkline({ values }: { values: number[] }) {
   const points = values.map((value, index) =>
     `${(index / (values.length - 1)) * 100},${28 - ((value - min) / spread) * 24}`
   ).join(" ");
+  const trend = values.at(-1)! - values[0];
   return (
-    <svg className="spark" viewBox="0 0 100 32" role="img" aria-label="Recent P and L trend">
+    <svg className={`spark ${deltaClass(trend)}`} viewBox="0 0 100 32" role="img"
+      aria-label={`Recent P and L trend, ${trend >= 0 ? "up" : "down"} ${money(Math.abs(trend))}`}>
       <polyline points={points} fill="none" vectorEffect="non-scaling-stroke" />
     </svg>
   );
@@ -160,7 +163,7 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
   s: DashboardState; scope: string; historyIsCurrent: boolean;
   onView: (v: View) => void; onInspect: (i: Inspectable) => void;
 }) {
-  const history = historyIsCurrent ? s.performance_history ?? [] : [];
+  const history = historyIsCurrent ? (s.performance_history ?? []).slice(-14) : [];
   const today = history.at(-1);
   const prior = history.at(-2);
   const dailyDelta = today && prior ? today.total_pnl - prior.total_pnl : null;
@@ -168,6 +171,8 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
   const newest = s.signals[0];
   return (
     <>
+      <header className="workspace-heading overview-heading"><div><h1>Overview</h1>
+        <p>Current posture, changes since your last browser visit, and work requiring attention.</p></div></header>
       <SinceLastVisit s={s} scope={scope} />
       <AttentionCenter s={s} onView={onView} onInspect={onInspect} />
       <section className="hero-metrics" aria-label="Account summary">
@@ -196,7 +201,7 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
           <p>{s.trade_count} fills · {Object.keys(s.venues).length} venues</p>
           <p>Last venue snapshot {isoAge(s.reconciliation?.fetched_at)}</p>
         </SummaryCard>
-        <SummaryCard title="System" status={s.health.errors ? `${s.health.errors} errors` : "Healthy"} onOpen={() => onView("system")}>
+        <SummaryCard title="System" status={s.health.errors ? `${s.health.errors} errors` : s.health.warnings ? `${s.health.warnings} warnings` : "Healthy"} onOpen={() => onView("system")}>
           <p>{s.pillars.filter((p) => (p.age_seconds ?? Infinity) < 90).length}/{s.pillars.length} pillars fresh</p>
           <p>{s.health.warnings} warnings in current log window</p>
         </SummaryCard>
@@ -206,12 +211,12 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
 }
 
 function SummaryCard({ title, status, onOpen, children }: {
-  title: string; status: string; onOpen: () => void; children: React.ReactNode;
+  title: string; status: string; onOpen?: () => void; children: React.ReactNode;
 }) {
   return (
     <article className="summary-card">
       <header><div><span className="eyebrow">{title}</span><h2>{status}</h2></div>
-        <button className="text-button" onClick={onOpen}>Open workspace →</button></header>
+        {onOpen && <button className="text-button" onClick={onOpen}>Open workspace →</button>}</header>
       {children}
     </article>
   );
@@ -222,6 +227,7 @@ function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
   const [venue, setVenue] = useStored("auramaur.positions.venue", "all");
   const [preset, setPreset] = useStored("auramaur.positions.preset", "all");
   const [sort, setSort] = useStored("auramaur.positions.sort", "pnl");
+  const [page, setPage] = useState(1);
   const venues = [...new Set(s.positions.map((p) => p.exchange))].sort();
   const rows = useMemo(() => {
     const q = query.toLowerCase();
@@ -239,31 +245,46 @@ function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
       : sort === "age" ? new Date(a.updated_at ?? 0).getTime() - new Date(b.updated_at ?? 0).getTime()
       : Math.abs(b.pnl) - Math.abs(a.pnl));
   }, [s.positions, s.now, query, venue, preset, sort]);
+  const pageSize = 50;
+  const pageCount = Math.max(1, Math.ceil(rows.length / pageSize));
+  const currentPage = Math.min(page, pageCount);
+  const visibleRows = rows.slice((currentPage - 1) * pageSize, currentPage * pageSize);
   return (
     <Workspace title="Portfolio" subtitle="Find exposure, stale marks, concentration, and positions requiring review."
       action={<button onClick={() => download("auramaur-positions.json", rows)}>Export JSON</button>}>
       <div className="toolbar">
-        <input aria-label="Search positions" placeholder="Search market, ID, token, category…" value={query} onChange={(e) => setQuery(e.target.value)} />
-        <select aria-label="Filter venue" value={venue} onChange={(e) => setVenue(e.target.value)}>
+        <input aria-label="Search positions" placeholder="Search market, ID, token, category…" value={query}
+          onChange={(e) => { setQuery(e.target.value); setPage(1); }} />
+        <select aria-label="Filter venue" value={venue} onChange={(e) => { setVenue(e.target.value); setPage(1); }}>
           <option value="all">All venues</option>{venues.map((v) => <option key={v}>{v}</option>)}
         </select>
-        <select aria-label="Position preset" value={preset} onChange={(e) => setPreset(e.target.value)}>
+        <select aria-label="Position preset" value={preset} onChange={(e) => { setPreset(e.target.value); setPage(1); }}>
           <option value="all">All positions</option><option value="review">Needs review</option>
           <option value="movers">Largest movers</option><option value="stale">Stale marks</option>
           <option value="resolution">Resolving soon</option>
         </select>
-        <select aria-label="Sort positions" value={sort} onChange={(e) => setSort(e.target.value)}>
+        <select aria-label="Sort positions" value={sort} onChange={(e) => { setSort(e.target.value); setPage(1); }}>
           <option value="pnl">Sort: absolute P&amp;L</option><option value="value">Sort: exposure</option><option value="age">Sort: stalest</option>
         </select>
+        <button className="secondary-button" disabled={!query && venue === "all" && preset === "all" && sort === "pnl"}
+          onClick={() => { setQuery(""); setVenue("all"); setPreset("all"); setSort("pnl"); }}>Clear filters</button>
       </div>
-      <p className="result-count">{rows.length} of {s.positions.length} positions · filters save automatically</p>
-      <DataTable headers={["Market", "Venue", "Category", "Outcome", "Exposure", "Mark", "P&L", "Updated"]}>
-        {rows.map((p) => {
+      <div className="result-line"><p className="result-count">{rows.length} of {s.positions.length} positions · filters save automatically</p>
+        {rows.length > pageSize && <nav className="pagination" aria-label="Position pages">
+          <button disabled={currentPage === 1} onClick={() => setPage((value) => value - 1)}>Previous</button>
+          <span>Page {currentPage} of {pageCount}</span>
+          <button disabled={currentPage === pageCount} onClick={() => setPage((value) => value + 1)}>Next</button>
+        </nav>}</div>
+      <DataTable headers={["Market", "Venue", "Category", "Outcome", "Exposure", "Mark", "P&L", "Updated"]}
+        empty={rows.length === 0 ? "No positions match these filters." : undefined}>
+        {visibleRows.map((p) => {
           const open = () => onInspect({ kind: "position", value: p } as Inspectable);
-          return <tr key={`${p.market_id}-${p.token}`} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
-          <td className="market">{p.question}</td><td>{p.exchange}</td><td>{p.category ?? "—"}</td>
-          <td>{p.token}</td><td className="num">{money(p.current_value)}</td><td className="num">{price(p.current_price)}</td>
-          <td className={`num ${deltaClass(p.pnl)}`}>{money(p.pnl, true)}</td><td>{isoAge(p.updated_at)}</td>
+          return <tr key={`${p.market_id}-${p.token}`} tabIndex={0} role="button" aria-label={`Inspect ${p.question}`}
+            onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+          <td data-label="Market" className="market">{p.question}</td><td data-label="Venue">{p.exchange}</td><td data-label="Category">{p.category ?? "—"}</td>
+          <td data-label="Outcome">{p.token}</td><td data-label="Exposure" className="num">{money(p.current_value)}</td><td data-label="Mark" className="num">{price(p.current_price)}</td>
+          <td data-label="P&L" className={`num ${deltaClass(p.pnl)}`}>{money(p.pnl, true)}</td>
+          <td data-label="Updated" title={exactTime(p.updated_at)}>{isoAge(p.updated_at)}</td>
         </tr>;
         })}
       </DataTable>
@@ -287,23 +308,48 @@ function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
 }
 
 function Opportunities({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const [query, setQuery] = useStored("auramaur.signals.query", "");
+  const [strategy, setStrategy] = useStored("auramaur.signals.strategy", "all");
+  const [action, setAction] = useStored("auramaur.signals.action", "all");
+  const strategies = [...new Set(s.signals.map((signal) => signal.strategy_source))].sort();
+  const actions = [...new Set(s.signals.map((signal) => signal.action))].sort();
   const grouped = useMemo(() => {
     const map = new Map<string, Signal[]>();
-    s.signals.forEach((signal) => map.set(signal.market_id, [...(map.get(signal.market_id) ?? []), signal]));
+    s.signals.filter((signal) => {
+      if (strategy !== "all" && signal.strategy_source !== strategy) return false;
+      if (action !== "all" && signal.action !== action) return false;
+      return !query || [signal.question, signal.market_id, signal.exchange, signal.strategy_source]
+        .some((value) => value?.toLowerCase().includes(query.toLowerCase()));
+    }).forEach((signal) => map.set(signal.market_id, [...(map.get(signal.market_id) ?? []), signal]));
     return [...map.values()].sort((a, b) => Math.abs(b[0].edge ?? 0) - Math.abs(a[0].edge ?? 0));
-  }, [s.signals]);
+  }, [s.signals, query, strategy, action]);
   return (
     <Workspace title="Opportunities" subtitle="Signals grouped by market so repeated evaluations read as one decision timeline."
       action={<button onClick={() => download("auramaur-signals.json", s.signals)}>Export JSON</button>}>
-      <DataTable headers={["Market", "Evaluations", "Strategy", "Model", "Market", "Edge", "Action", "Observed"]}>
+      <div className="toolbar">
+        <input aria-label="Search opportunities" placeholder="Search market, ID, venue, strategy…" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <select aria-label="Filter signal strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)}>
+          <option value="all">All strategies</option>{strategies.map((value) => <option key={value}>{value}</option>)}
+        </select>
+        <select aria-label="Filter signal action" value={action} onChange={(e) => setAction(e.target.value)}>
+          <option value="all">All actions</option>{actions.map((value) => <option key={value}>{value}</option>)}
+        </select>
+        <button className="secondary-button" disabled={!query && strategy === "all" && action === "all"}
+          onClick={() => { setQuery(""); setStrategy("all"); setAction("all"); }}>Clear filters</button>
+      </div>
+      <p className="result-count">{grouped.length} markets from {s.signals.length} evaluations</p>
+      <DataTable headers={["Market", "Evaluations", "Strategy", "Model probability", "Market probability", "Edge", "Action", "Observed"]}
+        empty={grouped.length === 0 ? "No opportunities match these filters." : undefined}>
         {grouped.map((signals) => {
           const sig = signals[0];
-          const open = () => onInspect({ kind: "signal", value: sig });
-          return <tr key={sig.market_id} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
-            <td className="market">{sig.question}</td><td className="num">{signals.length}</td><td>{sig.strategy_source}</td>
-            <td className="num">{price(sig.claude_prob)}</td><td className="num">{price(sig.market_prob)}</td>
-            <td className={`num ${deltaClass(sig.edge)}`}>{sig.edge == null ? "—" : `${sig.edge.toFixed(1)}%`}</td>
-            <td><span className="action-chip">{sig.action}</span></td><td>{isoAge(sig.timestamp)}</td>
+          const open = () => onInspect({ kind: "signal", value: sig, related: signals });
+          return <tr key={sig.market_id} tabIndex={0} role="button" aria-label={`Inspect signal timeline for ${sig.question}`}
+            onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+            <td data-label="Market" className="market">{sig.question}</td><td data-label="Evaluations" className="num">{signals.length}</td><td data-label="Strategy">{sig.strategy_source}</td>
+            <td data-label="Model probability" className="num">{price(sig.claude_prob)}</td><td data-label="Market probability" className="num">{price(sig.market_prob)}</td>
+            <td data-label="Edge" className={`num ${deltaClass(sig.edge)}`}>{sig.edge == null ? "—" : `${sig.edge.toFixed(1)}%`}</td>
+            <td data-label="Action"><span className="action-chip">{sig.action}</span></td>
+            <td data-label="Observed" title={exactTime(sig.timestamp)}>{isoAge(sig.timestamp)}</td>
           </tr>;
         })}
       </DataTable>
@@ -313,6 +359,7 @@ function Opportunities({ s, onInspect }: { s: DashboardState; onInspect: (i: Ins
 
 function Execution({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
   const recon = s.reconciliation;
+  const venues = Object.entries(s.venues).sort(([, a], [, b]) => (b.age_seconds ?? Infinity) - (a.age_seconds ?? Infinity));
   const discrepancies = recon ? [
     ...recon.missing.map((v) => ({ type: "Missing locally", ...v as object })),
     ...recon.extra.map((v) => ({ type: "Extra locally", ...v as object })),
@@ -321,16 +368,20 @@ function Execution({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
   return (
     <Workspace title="Execution" subtitle="Venue posture, fills, and exact reconciliation differences."
       action={<button disabled={!recon} onClick={() => recon && download("auramaur-reconciliation.json", recon)}>Export reconciliation</button>}>
-      <div className="venue-grid">{Object.entries(s.venues).map(([name, venue]) =>
+      <div className="venue-grid">{venues.map(([name, venue]) =>
         <article className="venue-card" key={name}><header><strong>{name}</strong><Status age={venue.age_seconds} /></header>
-          <p>{venue.detail}</p><small>Recorded {ago(venue.age_seconds)}</small></article>)}</div>
+          <p>{venue.detail}</p><small title={exactTime(venue.fetched_at)}>Recorded {ago(venue.age_seconds)}</small></article>)}</div>
       <section className="section-block"><header className="section-heading"><div><span className="eyebrow">Reconciliation</span>
-        <h2>{recon?.in_sync ? "Venue and ledger agree" : `${discrepancies.length} discrepancies`}</h2></div>
-        {recon && <small>Snapshot {isoAge(recon.fetched_at)}</small>}</header>
-        {discrepancies.length ? <DataTable headers={["Type", "Market / asset", "Outcome", "Venue qty", "Ledger qty"]}>
+        <h2>{!recon?.available ? "Reconciliation unavailable" : recon.in_sync ? "Venue and ledger agree" : `${discrepancies.length} discrepancies`}</h2></div>
+        {recon && <small title={exactTime(recon.fetched_at)}>Snapshot {isoAge(recon.fetched_at)}</small>}</header>
+        {!recon?.available ? <div className="unavailable">No venue snapshot is available, so sync has not been verified.</div>
+          : discrepancies.length ? <DataTable headers={["Severity", "Type", "Market / asset", "Outcome", "Venue qty", "Ledger qty"]}>
           {discrepancies.map((row, index) => {
             const open = () => onInspect({ kind: "reconciliation", value: row });
-            return <tr key={index} tabIndex={0} onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+            return <tr key={index} tabIndex={0} role="button" aria-label={`Inspect ${String(row.type)} discrepancy`}
+              onClick={open} onKeyDown={(event) => activateRow(event, open)}>
+            <td><span className={`severity ${row.type === "Missing locally" ? "critical" : "warning"}`}>
+              {row.type === "Missing locally" ? "Critical" : "Review"}</span></td>
             <td>{String(row.type)}</td><td className="market">{String(row.title ?? row.market_id ?? row.asset_id ?? "—")}</td>
             <td>{String(row.outcome ?? row.token ?? "—")}</td><td className="num">{String(row.venue_size ?? row.size ?? "—")}</td>
             <td className="num">{String(row.db_size ?? "—")}</td>
@@ -353,16 +404,18 @@ function Intelligence({ s }: { s: DashboardState }) {
   const llm = s.local_llm;
   return <Workspace title="Intelligence" subtitle="Model throughput, reliability, calibration, and evidence output.">
     <div className="summary-grid">
-      <SummaryCard title="Evidence distiller" status={`${llm?.claims_24h ?? 0} claims in 24h`} onOpen={() => undefined}>
+      <SummaryCard title="Evidence distiller" status={`${llm?.claims_24h ?? 0} claims in 24h`}>
         <p>Last claim {isoAge(llm?.last_claim_at)}</p>
       </SummaryCard>
       {llm && Object.entries(llm.purposes).map(([purpose, stat]) =>
-        <SummaryCard key={purpose} title={purpose} status={`${stat.ok}/${stat.calls} successful`} onOpen={() => undefined}>
-          <p>{stat.errors} errors · {stat.avg_ms ?? "—"}ms average</p><p>{stat.prompt_tokens + stat.output_tokens} tokens</p>
+        <SummaryCard key={purpose} title={humanize(purpose)} status={`${stat.ok}/${stat.calls} successful`}>
+          <p>{stat.errors} errors · {stat.avg_ms ?? "—"}ms average</p><p>{compactNumber(stat.prompt_tokens + stat.output_tokens)} tokens</p>
         </SummaryCard>)}
     </div>
     <section className="section-block"><h2>Resolved forecast scorecard</h2>
-      <DataTable headers={["Arm", "Model", "Forecasts", "Brier", "Market Brier", "Abstains"]}>
+      <p className="section-help">Lower Brier scores indicate better calibrated forecasts.</p>
+      <DataTable headers={["Arm", "Model", "Forecasts", "Brier", "Market Brier", "Abstains"]}
+        empty={(s.intelligence_eval ?? []).length === 0 ? "No resolved forecasts are available yet. Calibration appears after outcomes resolve." : undefined}>
         {(s.intelligence_eval ?? []).map((row) => <tr key={row.arm}><td>{row.arm}</td><td>{row.model}</td>
           <td className="num">{row.forecasts}</td><td className="num">{row.brier ?? "—"}</td>
           <td className="num">{row.market_brier ?? "—"}</td><td className="num">{row.abstains}</td></tr>)}
@@ -372,25 +425,34 @@ function Intelligence({ s }: { s: DashboardState }) {
 }
 
 function System({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const pillars = [...s.pillars].sort((a, b) => (b.age_seconds ?? Infinity) - (a.age_seconds ?? Infinity));
+  const diagnostics = [...s.health.top].sort((a, b) => {
+    const rank = (level?: string) => level === "error" || level === "critical" ? 2 : level === "warning" ? 1 : 0;
+    return rank(b.level) - rank(a.level) || b.count - a.count;
+  });
   return <Workspace title="System" subtitle="Source liveness and diagnostics ordered for investigation."
     action={<button onClick={() => download("auramaur-diagnostics.json", { pillars: s.pillars, health: s.health, activity: s.activity })}>Export diagnostics</button>}>
-    <div className="pillar-grid">{s.pillars.map((pillar) =>
+    <p className="section-help">Fresh &lt; 90 seconds · stale 90 seconds–10 minutes · dead after 10 minutes.</p>
+    <div className="pillar-grid">{pillars.map((pillar) =>
       <article className="pillar-card" key={pillar.name}><Status age={pillar.age_seconds} /><div><strong>{pillar.name}</strong>
         <small>Last event {ago(pillar.age_seconds)}</small></div></article>)}</div>
     <section className="section-block"><header className="section-heading"><div><span className="eyebrow">Diagnostics</span>
       <h2>{s.health.errors} errors · {s.health.warnings} warnings</h2></div></header>
-      <DataTable headers={["Occurrences", "Event", "Latest detail", "Last seen"]}>
-        {s.health.top.map((event) => {
+      <DataTable headers={["Occurrences", "Event", "Latest detail", "Last seen"]}
+        empty={diagnostics.length === 0 ? "No diagnostics in the current log window." : undefined}>
+        {diagnostics.map((event) => {
           const open = () => onInspect({ kind: "health", value: event });
-          return <tr key={event.event} tabIndex={0} onClick={open} onKeyDown={(keyEvent) => activateRow(keyEvent, open)}>
+          return <tr key={event.event} tabIndex={0} role="button" aria-label={`Inspect diagnostic ${event.event}`}
+            onClick={open} onKeyDown={(keyEvent) => activateRow(keyEvent, open)}>
           <td className="num">{event.count}</td><td>{event.event}</td><td className="market">{event.last_msg || "No message recorded"}</td>
-          <td>{isoAge(event.last_ts)}</td></tr>;
+          <td title={exactTime(event.last_ts)}>{isoAge(event.last_ts)}</td></tr>;
         })}
       </DataTable>
     </section>
     <section className="section-block"><h2>Recent operational activity</h2>
-      <div className="timeline">{[...s.activity].reverse().map((item, index) =>
-        <div key={index}><time>{item.time}</time><span>{item.text}</span></div>)}</div>
+      {s.activity.length ? <div className="timeline">{[...s.activity].reverse().map((item, index) =>
+        <div key={index}><time>{item.time}</time><span>{humanize(item.text)}</span></div>)}</div>
+        : <div className="empty-state">No recent operational activity.</div>}
     </section>
   </Workspace>;
 }
@@ -403,22 +465,55 @@ function Status({ age }: { age: number | null }) {
 function Workspace({ title, subtitle, action, children }: {
   title: string; subtitle: string; action?: React.ReactNode; children: React.ReactNode;
 }) {
-  return <main id="main-content" className="workspace"><header className="workspace-heading"><div><h1>{title}</h1><p>{subtitle}</p></div>{action}</header>{children}</main>;
+  return <main id="main-content" className="workspace" tabIndex={-1}><header className="workspace-heading"><div><h1>{title}</h1><p>{subtitle}</p></div>{action}</header>{children}</main>;
 }
 
-function DataTable({ headers, children }: { headers: string[]; children: React.ReactNode }) {
+function DataTable({ headers, children, empty }: { headers: string[]; children: React.ReactNode; empty?: string }) {
   return <div className="data-table-wrap"><table className="data-table"><thead><tr>{headers.map((header) =>
-    <th key={header} className={["Exposure", "Mark", "P&L", "Edge", "Model", "Market", "Occurrences", "Forecasts", "Brier", "Market Brier", "Abstains", "Venue qty", "Ledger qty", "Evaluations", "Positions", "Entries", "Fees", "Realized", "Quantity", "Entry", "Peak gain"].includes(header) ? "num" : ""}>{header}</th>)}
-  </tr></thead><tbody>{children}</tbody></table></div>;
+    <th key={header} className={["Exposure", "Mark", "P&L", "Edge", "Model probability", "Market probability", "Occurrences", "Forecasts", "Brier", "Market Brier", "Abstains", "Venue qty", "Ledger qty", "Evaluations", "Positions", "Entries", "Fees", "Realized", "Quantity", "Entry", "Peak gain"].includes(header) ? "num" : ""}>{header}</th>)}
+  </tr></thead><tbody>{empty ? <tr className="empty-row"><td colSpan={headers.length}>{empty}</td></tr> : children}</tbody></table></div>;
 }
 
 function Inspector({ item, onClose }: { item: Inspectable | null; onClose: () => void }) {
+  const dialogRef = useRef<HTMLElement>(null);
+  const returnFocus = useRef<HTMLElement | null>(null);
+  const [notice, setNotice] = useState("");
   useEffect(() => {
-    const close = (event: KeyboardEvent) => event.key === "Escape" && onClose();
-    window.addEventListener("keydown", close);
-    return () => window.removeEventListener("keydown", close);
-  }, [onClose]);
+    if (!item) return;
+    returnFocus.current = document.activeElement as HTMLElement;
+    const dialog = dialogRef.current;
+    const focusable = () => [...(dialog?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    ) ?? [])];
+    focusable()[0]?.focus();
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+      if (event.key === "Tab") {
+        const nodes = focusable();
+        if (!nodes.length) return;
+        const first = nodes[0], last = nodes[nodes.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault(); last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault(); first.focus();
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      returnFocus.current?.focus();
+    };
+  }, [item, onClose]);
   if (!item) return null;
+  const copy = async (label: string, text: string) => {
+    try {
+      await copyText(text);
+      setNotice(`${label} copied`);
+    } catch {
+      setNotice(`Could not copy ${label.toLowerCase()}`);
+    }
+  };
   const value = item.value as unknown as Record<string, unknown>;
   const title = item.kind === "position" || item.kind === "signal"
     ? String(value.question) : item.kind === "health" ? String(value.event) : "Reconciliation detail";
@@ -428,18 +523,25 @@ function Inspector({ item, onClose }: { item: Inspectable | null; onClose: () =>
       ? ["Confirm snapshot freshness", "Compare venue and ledger quantities", "Copy the asset or market ID", "Run the position sync/reconciliation workflow"]
       : ["Confirm source freshness", "Review exposure and related signal", "Copy the market ID for deeper investigation"];
   return <div className="inspector-backdrop" onMouseDown={onClose}>
-    <aside className="inspector" role="dialog" aria-modal="true" aria-labelledby="inspector-title" onMouseDown={(e) => e.stopPropagation()}>
+    <aside ref={dialogRef} className="inspector" role="dialog" aria-modal="true" aria-labelledby="inspector-title" onMouseDown={(e) => e.stopPropagation()}>
       <header><div><span className="eyebrow">{item.kind}</span><h2 id="inspector-title">{title}</h2></div>
         <button className="icon-button" aria-label="Close details" onClick={onClose}>×</button></header>
       <dl>{Object.entries(value).filter(([, v]) => v !== "" && v != null && typeof v !== "object").map(([key, val]) =>
         <div key={key}><dt>{key.replaceAll("_", " ")}</dt><dd>{String(val)}</dd></div>)}</dl>
+      {item.kind === "signal" && item.related && item.related.length > 1 && <section>
+        <h3>Decision timeline</h3>
+        <div className="decision-timeline">{item.related.map((signal, index) =>
+          <div key={`${signal.timestamp}-${index}`}><time title={exactTime(signal.timestamp)}>{isoAge(signal.timestamp)}</time>
+            <span>{signal.action} · {signal.edge == null ? "no edge" : `${signal.edge.toFixed(1)}% edge`}</span></div>)}</div>
+      </section>}
       <section><h3>Investigation checklist</h3><ol>{checklist.map((step) => <li key={step}>{step}</li>)}</ol></section>
       <div className="inspector-actions">
-        {"market_id" in value && <button onClick={() => copyText(String(value.market_id))}>Copy market ID</button>}
-        {"asset_id" in value && <button onClick={() => copyText(String(value.asset_id))}>Copy asset ID</button>}
-        <button onClick={() => copyText(safeJson(value))}>Copy details</button>
+        {"market_id" in value && <button onClick={() => void copy("Market ID", String(value.market_id))}>Copy market ID</button>}
+        {"asset_id" in value && <button onClick={() => void copy("Asset ID", String(value.asset_id))}>Copy asset ID</button>}
+        <button onClick={() => void copy("Details", safeJson(value))}>Copy details</button>
         <button onClick={() => download(`auramaur-${item.kind}.json`, value)}>Export JSON</button>
       </div>
+      <p className="copy-status" role="status" aria-live="polite">{notice}</p>
     </aside>
   </div>;
 }
@@ -450,11 +552,27 @@ export function OperatorWorkspace({ s, scope = "default", historyIsCurrent = tru
   const safeInitial = VIEWS.some((candidate) => candidate.id === initialView) ? initialView : "overview";
   const [view, setView] = useState<View>(safeInitial);
   const [inspect, setInspect] = useState<Inspectable | null>(null);
-  const changeView = (next: View) => {
+  const changeView = (next: View, replace = false) => {
     setView(next);
-    history.replaceState(null, "", `#${next}`);
-    document.getElementById("main-content")?.focus();
+    history[replace ? "replaceState" : "pushState"](null, "", `#${next}`);
+    document.title = `${VIEWS.find((candidate) => candidate.id === next)?.label ?? "Overview"} · Auramaur`;
+    requestAnimationFrame(() => document.getElementById("main-content")?.focus());
   };
+  useEffect(() => {
+    const sync = () => {
+      const hash = location.hash.slice(1) as View;
+      const next = VIEWS.some((candidate) => candidate.id === hash) ? hash : "overview";
+      setView(next);
+      document.title = `${VIEWS.find((candidate) => candidate.id === next)?.label ?? "Overview"} · Auramaur`;
+    };
+    window.addEventListener("hashchange", sync);
+    window.addEventListener("popstate", sync);
+    sync();
+    return () => {
+      window.removeEventListener("hashchange", sync);
+      window.removeEventListener("popstate", sync);
+    };
+  }, []);
   return <>
     <a className="skip-link" href="#main-content">Skip to dashboard content</a>
     <WorkspaceNav view={view} onView={changeView} />


### PR DESCRIPTION
## Summary
- make all six dashboard views browser-history aware and give each a distinct document title
- harden the inspector modal with focus trapping/restoration, accessible interactive rows, selected-state semantics, and copy feedback
- add truthful unavailable and empty states, severity ordering, exact timestamps, human-readable formatting, and improved performance/status hierarchy
- add Portfolio pagination and filter reset, Opportunities filtering and decision timelines, and mobile card layouts for dense operator data

## Validation
- `npm test -- --run` (13 tests passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

## Context
Follow-up remediation to the operator dashboard introduced in #333, based on a page-by-page live frontend audit.