### PR TITLE
feat(web): add live market and strategy comparison tools

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -451,6 +451,29 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .spark-empty { color: var(--ink-muted) !important; margin: auto 0; font-size: 12px; }
 
 .summary-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.loop-feed {
+  margin-bottom: 12px; padding: 14px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 10px;
+}
+.loop-feed h2 { font-size: 17px; margin: 2px 0 0; }
+.loop-feed ol { list-style: none; margin: 12px 0 0; padding: 0; border-top: 1px solid var(--hairline); }
+.loop-feed li { border-bottom: 1px solid var(--hairline); }
+.loop-feed li button { display: grid; grid-template-columns: 170px minmax(220px, 1fr) auto 65px; align-items: center; gap: 12px; width: 100%; padding: 9px 4px; border: 0; background: none; text-align: left; cursor: pointer; }
+.loop-feed li button:hover { background: color-mix(in srgb, var(--ink) 4%, transparent); }
+.loop-feed time { color: var(--ink-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+.loop-market { min-width: 0; }
+.loop-market > strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-market > small { display: flex; align-items: center; gap: 4px; color: var(--ink-muted); margin-top: 2px; }
+.live-indicator { display: inline-flex; gap: 6px; align-items: center; color: var(--good); font-size: 11px; }
+.live-indicator > span { width: 7px; height: 7px; background: var(--good); border-radius: 50%; }
+.loop-warning { color: var(--warning); margin: 10px 0 0; font-size: 12px; }
+.strategy-name { display: inline-flex; flex-direction: column; vertical-align: middle; }
+.strategy-name > strong { font-weight: 600; }
+.strategy-name > small { color: var(--ink-muted); font-size: 10px; }
+.segmented { display: inline-flex; padding: 3px; margin-bottom: 12px; background: var(--page); border: 1px solid var(--border); border-radius: 8px; }
+.segmented button { padding: 6px 12px; border: 0; border-radius: 5px; background: none; cursor: pointer; }
+.segmented button.active { background: var(--surface); box-shadow: 0 1px 3px rgba(0,0,0,.12); font-weight: 600; }
+.comparison-link { color: var(--ink-muted); font-size: 12px; text-align: right; }
 .summary-card { padding: 14px; min-width: 0; }
 .summary-card p { margin: 8px 0 0; color: var(--ink-muted); font-size: 13px; }
 .text-button { color: var(--ink-2); background: none; border: 0; cursor: pointer; font-size: 12px; }
@@ -475,6 +498,27 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
 .toolbar .secondary-button:disabled { opacity: .4; cursor: default; }
 .toolbar input { flex: 1 1 290px; }
 .toolbar select { flex: 0 1 190px; }
+.opportunity-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 9px; margin-bottom: 12px; }
+.opportunity-metrics > * { display: flex; flex-direction: column; align-items: flex-start; min-height: 88px; padding: 11px 12px; color: inherit; background: var(--surface); border: 1px solid var(--border); border-radius: 9px; text-align: left; }
+.opportunity-metrics button { cursor: pointer; }
+.opportunity-metrics button:hover { border-color: var(--ink-muted); }
+.opportunity-metrics span { color: var(--ink-2); font-size: 12px; }
+.opportunity-metrics strong { margin-top: 3px; font-size: 21px; }
+.opportunity-metrics small { margin-top: auto; color: var(--ink-muted); }
+.compare-tray { margin-bottom: 12px; padding: 13px; background: color-mix(in srgb, var(--warning) 4%, var(--surface)); border: 1px solid color-mix(in srgb, var(--warning) 30%, var(--border)); border-radius: 10px; }
+.compare-tray > header { display: flex; justify-content: space-between; align-items: flex-start; }
+.compare-tray h2 { margin: 2px 0 0; font-size: 16px; }
+.compare-tray > div { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; margin-top: 10px; }
+.compare-tray article { position: relative; min-width: 0; padding: 11px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+.compare-tray article > strong { display: block; padding-right: 20px; line-height: 1.3; }
+.compare-tray article > small { display: block; margin-top: 5px; color: var(--ink-muted); }
+.compare-tray dl { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; margin: 12px 0; }
+.compare-tray dl div { padding: 6px; background: var(--page); border-radius: 5px; }
+.compare-tray dt { color: var(--ink-muted); font-size: 10px; text-transform: uppercase; }
+.compare-tray dd { margin: 2px 0 0; font-weight: 600; }
+.compare-tray p { display: -webkit-box; overflow: hidden; margin: 0; color: var(--ink-2); font-size: 12px; -webkit-box-orient: vertical; -webkit-line-clamp: 3; }
+.remove-compare { position: absolute; top: 5px; right: 6px; border: 0; background: none; cursor: pointer; font-size: 18px; }
+.evidence-preview { display: block; overflow: hidden; max-width: 430px; margin-top: 3px; color: var(--ink-muted); font-weight: 400; text-overflow: ellipsis; white-space: nowrap; }
 .result-count { margin: 0 0 9px; color: var(--ink-muted); font-size: 12px; }
 .result-line { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
 .pagination { display: flex; align-items: center; gap: 8px; color: var(--ink-muted); font-size: 12px; margin-bottom: 8px; }
@@ -552,13 +596,18 @@ button:focus-visible, input:focus-visible, select:focus-visible, [tabindex="0"]:
   .attention { grid-template-columns: 1fr; }
   .attention-items { grid-template-columns: repeat(2, 1fr); }
   .hero-metrics { grid-template-columns: repeat(2, 1fr); }
+  .opportunity-metrics { grid-template-columns: repeat(2, 1fr); }
+  .compare-tray > div { grid-template-columns: 1fr; }
 }
 @media (max-width: 620px) {
   .shell { padding: 10px 12px 30px; }
   .link-status { margin-left: 0; width: 100%; }
   .workspace-heading { align-items: stretch; flex-direction: column; }
   .summary-grid, .hero-metrics { grid-template-columns: 1fr; }
+  .opportunity-metrics { grid-template-columns: 1fr 1fr; }
   .attention-items { grid-template-columns: 1fr; }
+  .loop-feed li button { grid-template-columns: 1fr auto; }
+  .loop-feed time { grid-column: 1 / -1; }
   .toolbar { display: grid; }
   .toolbar input, .toolbar select { width: 100%; }
   .result-line { align-items: stretch; flex-direction: column; gap: 2px; }

--- a/web/src/workspace.tsx
+++ b/web/src/workspace.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { DashboardState, HealthTop, Position, Signal } from "./types";
 import { ago, compactNumber, deltaClass, exactTime, humanize, money, price } from "./format";
 
-export type View = "overview" | "portfolio" | "opportunities" | "execution" | "intelligence" | "system";
+export type View = "overview" | "portfolio" | "opportunities" | "compare" | "execution" | "intelligence" | "system";
 type Inspectable =
   | { kind: "position"; value: Position }
   | { kind: "signal"; value: Signal; related?: Signal[] }
@@ -13,10 +13,39 @@ const VIEWS: { id: View; label: string }[] = [
   { id: "overview", label: "Overview" },
   { id: "portfolio", label: "Portfolio" },
   { id: "opportunities", label: "Opportunities" },
+  { id: "compare", label: "Compare" },
   { id: "execution", label: "Execution" },
   { id: "intelligence", label: "Intelligence" },
   { id: "system", label: "System" },
 ];
+
+const STRATEGY_HELP: Record<string, { family: string; description: string }> = {
+  llm: { family: "Forecast", description: "General model-assisted probability estimate." },
+  bias_harvest: { family: "Relative value", description: "Looks for repeatable market-pricing bias." },
+  long_horizon: { family: "Forecast", description: "Targets slower-moving, longer-dated mispricing." },
+  market_maker: { family: "Liquidity", description: "Two-sided quoting intended to capture spread." },
+  cross_exchange_arb: { family: "Arbitrage", description: "Compares equivalent outcomes across venues." },
+  entailment_arb: { family: "Arbitrage", description: "Checks logically related markets for inconsistent prices." },
+  resolution_lens: { family: "Event-driven", description: "Focuses on resolution mechanics and near-expiry evidence." },
+};
+
+function strategyHelp(name: string) {
+  const base = name.replace(/_(kalshi|polymarket|haiku|opus|gpro|wide)$/, "");
+  return STRATEGY_HELP[name] ?? STRATEGY_HELP[base] ?? {
+    family: humanize(base), description: `Signals emitted by the ${humanize(name)} strategy.`,
+  };
+}
+
+function StrategyName({ name }: { name: string }) {
+  const help = strategyHelp(name);
+  return <span className="strategy-name" title={help.description}><strong>{humanize(name)}</strong><small>{help.family}</small></span>;
+}
+
+function utcTime(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? `${date.toISOString().slice(0, 19).replace("T", " ")} UTC` : value;
+}
 
 function useStored(key: string, fallback: string) {
   const [value, setValue] = useState(() => typeof localStorage === "undefined" ? fallback : localStorage.getItem(key) ?? fallback);
@@ -159,6 +188,25 @@ function Sparkline({ values }: { values: number[] }) {
   );
 }
 
+function BotLoopFeed({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
+  const signals = s.signals.slice(0, 7);
+  const repeated = signals.length >= 3 && new Set(signals.slice(0, 3).map((item) => item.market_id)).size === 1;
+  return <section className="loop-feed" aria-labelledby="loop-title">
+    <header className="section-heading"><div><span className="eyebrow">Live market loop</span>
+      <h2 id="loop-title">{signals.length ? "Latest market evaluations" : "Waiting for an evaluation"}</h2></div>
+      <span className="live-indicator"><span /> Streaming</span></header>
+    {repeated && <p className="loop-warning">The latest evaluations repeat one market. Review the decision timeline for possible lack of progress.</p>}
+    {signals.length ? <ol>{signals.map((signal, index) => <li key={`${signal.market_id}-${signal.timestamp}-${index}`}>
+      <button onClick={() => onInspect({ kind: "signal", value: signal,
+        related: s.signals.filter((item) => item.market_id === signal.market_id) })}>
+        <time title={isoAge(signal.timestamp)}>{utcTime(signal.timestamp)}</time>
+        <span className="loop-market"><strong>{signal.question}</strong><small>{signal.exchange ?? "Unknown venue"} · <StrategyName name={signal.strategy_source} /></small></span>
+        <span className="action-chip">{signal.action}</span><span className={deltaClass(signal.edge)}>{signal.edge == null ? "—" : `${signal.edge.toFixed(1)}%`}</span>
+      </button>
+    </li>)}</ol> : <div className="empty-state">No market evaluations are present in the current snapshot.</div>}
+  </section>;
+}
+
 function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
   s: DashboardState; scope: string; historyIsCurrent: boolean;
   onView: (v: View) => void; onInspect: (i: Inspectable) => void;
@@ -175,6 +223,7 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
         <p>Current posture, changes since your last browser visit, and work requiring attention.</p></div></header>
       <SinceLastVisit s={s} scope={scope} />
       <AttentionCenter s={s} onView={onView} onInspect={onInspect} />
+      <BotLoopFeed s={s} onInspect={onInspect} />
       <section className="hero-metrics" aria-label="Account summary">
         <article><span>Capital</span><strong>{money(s.balance)}</strong><small>{money(s.position_value)} deployed</small></article>
         <article><span>Total P&amp;L</span><strong className={deltaClass(s.total_pnl)}>{money(s.total_pnl, true)}</strong>
@@ -195,7 +244,7 @@ function Overview({ s, scope, historyIsCurrent, onView, onInspect }: {
           {newest && <button className="summary-row" onClick={() => onInspect({ kind: "signal", value: newest })}>
             <span>{newest.question}</span><strong>{newest.edge == null ? "—" : `${newest.edge.toFixed(1)}% edge`}</strong>
           </button>}
-          <p>{newest ? `${newest.strategy_source} · ${isoAge(newest.timestamp)}` : "No recent signals"}</p>
+          <p>{newest ? <><StrategyName name={newest.strategy_source} /> · {utcTime(newest.timestamp)}</> : "No recent signals"}</p>
         </SummaryCard>
         <SummaryCard title="Execution" status={s.reconciliation?.in_sync ? "In sync" : "Review required"} onOpen={() => onView("execution")}>
           <p>{s.trade_count} fills · {Object.keys(s.venues).length} venues</p>
@@ -297,7 +346,7 @@ function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
         </section>
         <section className="section-block"><h2>Strategy realized performance</h2>
           <DataTable headers={["Strategy", "Entries", "Fees", "Realized"]}>
-            {s.strategies.map((row) => <tr key={row.strategy}><td>{row.strategy}</td>
+            {s.strategies.map((row) => <tr key={row.strategy}><td><StrategyName name={row.strategy} /></td>
               <td className="num">{row.entries}</td><td className="num">{money(row.fees)}</td>
               <td className={`num ${deltaClass(row.pnl)}`}>{money(row.pnl, true)}</td></tr>)}
           </DataTable>
@@ -311,50 +360,129 @@ function Opportunities({ s, onInspect }: { s: DashboardState; onInspect: (i: Ins
   const [query, setQuery] = useStored("auramaur.signals.query", "");
   const [strategy, setStrategy] = useStored("auramaur.signals.strategy", "all");
   const [action, setAction] = useStored("auramaur.signals.action", "all");
+  const [venue, setVenue] = useStored("auramaur.signals.venue", "all");
+  const [sort, setSort] = useStored("auramaur.signals.sort", "edge");
+  const [edgeFloor, setEdgeFloor] = useStored("auramaur.signals.edge", "0");
+  const [selected, setSelected] = useState<string[]>([]);
   const strategies = [...new Set(s.signals.map((signal) => signal.strategy_source))].sort();
   const actions = [...new Set(s.signals.map((signal) => signal.action))].sort();
+  const venues = [...new Set(s.signals.map((signal) => signal.exchange).filter(Boolean))].sort() as string[];
   const grouped = useMemo(() => {
     const map = new Map<string, Signal[]>();
     s.signals.filter((signal) => {
       if (strategy !== "all" && signal.strategy_source !== strategy) return false;
-      if (action !== "all" && signal.action !== action) return false;
+      if (action === "__actionable" && ["hold", "skip", "abstain", "none"].includes(signal.action.toLowerCase())) return false;
+      if (action !== "all" && action !== "__actionable" && signal.action !== action) return false;
+      if (venue !== "all" && signal.exchange !== venue) return false;
+      if (Math.abs(signal.edge ?? 0) < Number(edgeFloor)) return false;
       return !query || [signal.question, signal.market_id, signal.exchange, signal.strategy_source]
         .some((value) => value?.toLowerCase().includes(query.toLowerCase()));
     }).forEach((signal) => map.set(signal.market_id, [...(map.get(signal.market_id) ?? []), signal]));
-    return [...map.values()].sort((a, b) => Math.abs(b[0].edge ?? 0) - Math.abs(a[0].edge ?? 0));
-  }, [s.signals, query, strategy, action]);
+    return [...map.values()].sort((a, b) => sort === "recent"
+      ? new Date(b[0].timestamp ?? 0).getTime() - new Date(a[0].timestamp ?? 0).getTime()
+      : sort === "agreement" ? b.length - a.length
+      : Math.abs(b[0].edge ?? 0) - Math.abs(a[0].edge ?? 0));
+  }, [s.signals, query, strategy, action, venue, edgeFloor, sort]);
+  const latestById = new Map(grouped.map((signals) => [signals[0].market_id, signals[0]]));
+  const compared = selected.map((id) => latestById.get(id) ?? s.signals.find((signal) => signal.market_id === id)).filter(Boolean) as Signal[];
+  const actionable = grouped.filter((signals) => !["hold", "skip", "abstain", "none"].includes(signals[0].action.toLowerCase())).length;
+  const averageEdge = grouped.length ? grouped.reduce((sum, signals) => sum + Math.abs(signals[0].edge ?? 0), 0) / grouped.length : 0;
+  const toggleCompare = (id: string) => setSelected((current) => current.includes(id)
+    ? current.filter((item) => item !== id) : current.length < 3 ? [...current, id] : current);
   return (
     <Workspace title="Opportunities" subtitle="Signals grouped by market so repeated evaluations read as one decision timeline."
       action={<button onClick={() => download("auramaur-signals.json", s.signals)}>Export JSON</button>}>
+      <div className="opportunity-metrics" aria-label="Opportunity summary">
+        <button onClick={() => { setAction("all"); setEdgeFloor("0"); }}><span>Markets</span><strong>{grouped.length}</strong><small>{s.signals.length} evaluations</small></button>
+        <button onClick={() => setEdgeFloor("5")}><span>Meaningful edge</span><strong>{grouped.filter((rows) => Math.abs(rows[0].edge ?? 0) >= 5).length}</strong><small>At least 5 percentage points</small></button>
+        <button onClick={() => setAction("__actionable")}><span>Actionable</span><strong>{actionable}</strong><small>Excludes hold and abstain</small></button>
+        <div><span>Average absolute edge</span><strong>{averageEdge.toFixed(1)}%</strong><small>Current filtered set</small></div>
+      </div>
       <div className="toolbar">
         <input aria-label="Search opportunities" placeholder="Search market, ID, venue, strategy…" value={query} onChange={(e) => setQuery(e.target.value)} />
         <select aria-label="Filter signal strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)}>
           <option value="all">All strategies</option>{strategies.map((value) => <option key={value}>{value}</option>)}
         </select>
         <select aria-label="Filter signal action" value={action} onChange={(e) => setAction(e.target.value)}>
-          <option value="all">All actions</option>{actions.map((value) => <option key={value}>{value}</option>)}
+          <option value="all">All actions</option><option value="__actionable">Actionable only</option>{actions.map((value) => <option key={value}>{value}</option>)}
         </select>
-        <button className="secondary-button" disabled={!query && strategy === "all" && action === "all"}
-          onClick={() => { setQuery(""); setStrategy("all"); setAction("all"); }}>Clear filters</button>
+        <select aria-label="Filter signal venue" value={venue} onChange={(e) => setVenue(e.target.value)}>
+          <option value="all">All venues</option>{venues.map((value) => <option key={value}>{value}</option>)}
+        </select>
+        <select aria-label="Minimum absolute edge" value={edgeFloor} onChange={(e) => setEdgeFloor(e.target.value)}>
+          <option value="0">Any edge</option><option value="2">Edge ≥ 2%</option><option value="5">Edge ≥ 5%</option><option value="10">Edge ≥ 10%</option>
+        </select>
+        <select aria-label="Sort opportunities" value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="edge">Sort: strongest edge</option><option value="recent">Sort: most recent</option><option value="agreement">Sort: most evaluated</option>
+        </select>
+        <button className="secondary-button" disabled={!query && strategy === "all" && action === "all" && venue === "all" && edgeFloor === "0" && sort === "edge"}
+          onClick={() => { setQuery(""); setStrategy("all"); setAction("all"); setVenue("all"); setEdgeFloor("0"); setSort("edge"); }}>Clear filters</button>
       </div>
-      <p className="result-count">{grouped.length} markets from {s.signals.length} evaluations</p>
-      <DataTable headers={["Market", "Evaluations", "Strategy", "Model probability", "Market probability", "Edge", "Action", "Observed"]}
+      <p className="result-count">{grouped.length} markets · select up to three to compare · click a row for its timeline and evidence</p>
+      {compared.length > 0 && <section className="compare-tray" aria-label="Selected opportunity comparison"><header><div><span className="eyebrow">Side-by-side</span><h2>{compared.length} selected</h2></div><button className="text-button" onClick={() => setSelected([])}>Clear comparison</button></header>
+        <div>{compared.map((sig) => <article key={sig.market_id}><button className="remove-compare" aria-label={`Remove ${sig.question} from comparison`} onClick={() => toggleCompare(sig.market_id)}>×</button>
+          <strong>{sig.question}</strong><small>{sig.exchange ?? "Unknown venue"} · {utcTime(sig.timestamp)}</small>
+          <dl><div><dt>Model</dt><dd>{price(sig.claude_prob)}</dd></div><div><dt>Market</dt><dd>{price(sig.market_prob)}</dd></div>
+            <div><dt>Edge</dt><dd className={deltaClass(sig.edge)}>{sig.edge == null ? "—" : `${sig.edge.toFixed(1)}%`}</dd></div><div><dt>Action</dt><dd>{sig.action}</dd></div></dl>
+          <p>{sig.evidence_summary || "No evidence summary was recorded."}</p></article>)}</div>
+      </section>}
+      <DataTable headers={["Compare", "Market", "Venue", "Evaluations", "Strategy", "Confidence", "Model probability", "Market probability", "Edge", "Action", "Observed"]}
         empty={grouped.length === 0 ? "No opportunities match these filters." : undefined}>
         {grouped.map((signals) => {
           const sig = signals[0];
           const open = () => onInspect({ kind: "signal", value: sig, related: signals });
           return <tr key={sig.market_id} tabIndex={0} role="button" aria-label={`Inspect signal timeline for ${sig.question}`}
             onClick={open} onKeyDown={(event) => activateRow(event, open)}>
-            <td data-label="Market" className="market">{sig.question}</td><td data-label="Evaluations" className="num">{signals.length}</td><td data-label="Strategy">{sig.strategy_source}</td>
+            <td data-label="Compare"><input type="checkbox" aria-label={`Compare ${sig.question}`} checked={selected.includes(sig.market_id)} disabled={!selected.includes(sig.market_id) && selected.length >= 3}
+              onClick={(event) => event.stopPropagation()} onChange={() => toggleCompare(sig.market_id)} /></td>
+            <td data-label="Market" className="market"><strong>{sig.question}</strong>{sig.evidence_summary && <small className="evidence-preview">{sig.evidence_summary}</small>}</td>
+            <td data-label="Venue">{sig.exchange ?? "—"}</td><td data-label="Evaluations" className="num">{signals.length}</td><td data-label="Strategy"><StrategyName name={sig.strategy_source} /></td>
+            <td data-label="Confidence">{sig.confidence ? humanize(sig.confidence) : "—"}</td>
             <td data-label="Model probability" className="num">{price(sig.claude_prob)}</td><td data-label="Market probability" className="num">{price(sig.market_prob)}</td>
             <td data-label="Edge" className={`num ${deltaClass(sig.edge)}`}>{sig.edge == null ? "—" : `${sig.edge.toFixed(1)}%`}</td>
             <td data-label="Action"><span className="action-chip">{sig.action}</span></td>
-            <td data-label="Observed" title={exactTime(sig.timestamp)}>{isoAge(sig.timestamp)}</td>
+            <td data-label="Observed" title={isoAge(sig.timestamp)}>{utcTime(sig.timestamp)}</td>
           </tr>;
         })}
       </DataTable>
     </Workspace>
   );
+}
+
+function Compare({ s, onView }: { s: DashboardState; onView: (v: View) => void }) {
+  const [mode, setMode] = useStored("auramaur.compare.mode", "strategies");
+  const strategyRows = useMemo(() => {
+    const names = new Set([...s.strategies.map((row) => row.strategy), ...s.signals.map((row) => row.strategy_source)]);
+    return [...names].map((name) => {
+      const realized = s.strategies.find((row) => row.strategy === name);
+      const signals = s.signals.filter((row) => row.strategy_source === name);
+      const latest = signals.map((row) => row.timestamp).filter(Boolean).sort().at(-1);
+      const venues = [...new Set(signals.map((row) => row.exchange).filter(Boolean))];
+      return { name, realized, signals, latest, venues };
+    }).sort((a, b) => (b.realized?.pnl ?? 0) - (a.realized?.pnl ?? 0));
+  }, [s.strategies, s.signals]);
+  const venueRows = Object.entries(s.venues).sort(([a], [b]) => a.localeCompare(b));
+  return <Workspace title="Compare" subtitle="Put strategies or venues side by side using the same current snapshot.">
+    <div className="segmented" role="group" aria-label="Comparison type">
+      <button className={mode === "strategies" ? "active" : ""} onClick={() => setMode("strategies")}>Strategies</button>
+      <button className={mode === "venues" ? "active" : ""} onClick={() => setMode("venues")}>Venues</button>
+    </div>
+    {mode === "strategies" ? <DataTable headers={["Strategy", "Health", "Evaluations", "Venues", "Entries", "Fees", "Realized", "Latest observed"]}
+      empty={!strategyRows.length ? "No strategy data is available to compare." : undefined}>
+      {strategyRows.map((row) => {
+        const age = row.latest ? (new Date(s.now).getTime() - new Date(row.latest).getTime()) / 1000 : null;
+        return <tr key={row.name}><td><StrategyName name={row.name} /></td><td><Status age={age} /></td>
+          <td className="num">{row.signals.length}</td><td>{row.venues.join(", ") || "—"}</td>
+          <td className="num">{row.realized?.entries ?? 0}</td><td className="num">{money(row.realized?.fees ?? 0)}</td>
+          <td className={`num ${deltaClass(row.realized?.pnl ?? null)}`}>{money(row.realized?.pnl ?? 0, true)}</td>
+          <td title={row.latest ? isoAge(row.latest) : undefined}>{utcTime(row.latest)}</td></tr>;
+      })}</DataTable> : <DataTable headers={["Venue", "Health", "Balance detail", "Available", "Equity", "Snapshot UTC"]}
+        empty={!venueRows.length ? "No venue snapshots are available to compare." : undefined}>
+        {venueRows.map(([name, venue]) => <tr key={name}><td><strong>{humanize(name)}</strong></td><td><Status age={venue.age_seconds} /></td>
+          <td>{venue.detail}</td><td className="num">{venue.available == null ? "—" : money(venue.available)}</td>
+          <td className="num">{venue.equity == null ? "—" : money(venue.equity)}</td><td title={ago(venue.age_seconds)}>{utcTime(venue.fetched_at)}</td></tr>)}</DataTable>}
+    <p className="comparison-link">Need detail? <button className="text-button" onClick={() => onView(mode === "strategies" ? "opportunities" : "execution")}>Open the {mode === "strategies" ? "signal explorer" : "execution workspace"} →</button></p>
+  </Workspace>;
 }
 
 function Execution({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspectable) => void }) {
@@ -370,7 +498,7 @@ function Execution({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
       action={<button disabled={!recon} onClick={() => recon && download("auramaur-reconciliation.json", recon)}>Export reconciliation</button>}>
       <div className="venue-grid">{venues.map(([name, venue]) =>
         <article className="venue-card" key={name}><header><strong>{name}</strong><Status age={venue.age_seconds} /></header>
-          <p>{venue.detail}</p><small title={exactTime(venue.fetched_at)}>Recorded {ago(venue.age_seconds)}</small></article>)}</div>
+          <p>{venue.detail}</p><small title={ago(venue.age_seconds)}>Recorded {utcTime(venue.fetched_at)}</small></article>)}</div>
       <section className="section-block"><header className="section-heading"><div><span className="eyebrow">Reconciliation</span>
         <h2>{!recon?.available ? "Reconciliation unavailable" : recon.in_sync ? "Venue and ledger agree" : `${discrepancies.length} discrepancies`}</h2></div>
         {recon && <small title={exactTime(recon.fetched_at)}>Snapshot {isoAge(recon.fetched_at)}</small>}</header>
@@ -579,6 +707,7 @@ export function OperatorWorkspace({ s, scope = "default", historyIsCurrent = tru
     {view === "overview" && <main id="main-content" tabIndex={-1}><Overview s={s} scope={scope} historyIsCurrent={historyIsCurrent} onView={changeView} onInspect={setInspect} /></main>}
     {view === "portfolio" && <Portfolio s={s} onInspect={setInspect} />}
     {view === "opportunities" && <Opportunities s={s} onInspect={setInspect} />}
+    {view === "compare" && <Compare s={s} onView={changeView} />}
     {view === "execution" && <Execution s={s} onInspect={setInspect} />}
     {view === "intelligence" && <Intelligence s={s} />}
     {view === "system" && <System s={s} onInspect={setInspect} />}


### PR DESCRIPTION
## Summary
- add an SSE-backed overview feed for recent market evaluations with explicit UTC timestamps and repeated-market warnings
- add strategy disambiguation and a comparison workspace for strategies and venue health
- make Opportunities interactive with summary presets, venue/action/edge filters, sorting, evidence previews, and three-market side-by-side comparison
- improve cross-linking between overview, opportunities, comparison, execution, and system workspaces

## Runtime context
- distinguish the recurring Kraken XBT/ETH/SOL directional gate sweep from generic exchange order activity in the operator presentation
- retain the dashboard's read-only architecture; no execution or credential paths were added

## Verification
- npm run lint
- npm test -- --run (13 passed)
- npm run build
- git diff --check