### PR TITLE
feat(evaluation): accelerate paper strategy exploration

### DIFF
--- a/auramaur/bot_strategy_tasks.py
+++ b/auramaur/bot_strategy_tasks.py
@@ -124,11 +124,15 @@ class StrategyTaskMixin:
         while self._running:
             if await self._check_kill_switch():
                 return
+            started = asyncio.get_running_loop().time()
             try:
                 await service.run_once()
             except Exception as exc:  # noqa: BLE001 — shadow task fails isolated
                 log.error("intelligence_eval.cycle_error", error=str(exc))
-            await asyncio.sleep(interval)
+            # Fixed-start cadence: cycle runtime consumes its interval instead of
+            # being added to it. Overruns restart immediately without overlap.
+            elapsed = asyncio.get_running_loop().time() - started
+            await asyncio.sleep(max(0, interval - elapsed))
 
     async def _task_term_structure(self) -> None:
         """Periodic deadline-ladder curve reader (paper-forced; one LLM read

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -944,6 +944,23 @@ CREATE TABLE IF NOT EXISTS evaluation_forecasts (
 CREATE INDEX IF NOT EXISTS idx_evaluation_forecasts_episode
     ON evaluation_forecasts(episode_hash);
 
+CREATE TABLE IF NOT EXISTS evaluation_attempts (
+    attempt_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, episode_hash TEXT NOT NULL,
+    stage TEXT NOT NULL, sample_index INTEGER, seed INTEGER NOT NULL,
+    prob_yes REAL, action TEXT, confidence REAL, thesis TEXT NOT NULL DEFAULT '',
+    telemetry_json TEXT NOT NULL DEFAULT '{}', error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(run_id, stage, sample_index)
+);
+CREATE INDEX IF NOT EXISTS idx_evaluation_attempts_run ON evaluation_attempts(run_id);
+CREATE TABLE IF NOT EXISTS evaluation_cycles (
+    cycle_id TEXT PRIMARY KEY, started_at TEXT NOT NULL, completed_at TEXT NOT NULL,
+    eligible_markets INTEGER NOT NULL, selected_markets INTEGER NOT NULL,
+    unique_families INTEGER NOT NULL, forecasts INTEGER NOT NULL,
+    attempts INTEGER NOT NULL, failed_attempts INTEGER NOT NULL,
+    duration_ms INTEGER NOT NULL, compute_seconds REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS evaluation_outcomes (
     episode_hash TEXT PRIMARY KEY,
     outcome INTEGER NOT NULL CHECK(outcome IN (0, 1)),

--- a/auramaur/evaluation/runner.py
+++ b/auramaur/evaluation/runner.py
@@ -11,6 +11,7 @@ import hashlib
 import inspect
 import json
 import math
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from types import MappingProxyType
@@ -219,8 +220,11 @@ class IntelligenceEvalRunner:
         return tuple(await asyncio.gather(*(self._run_treatment(episode, t) for t in treatments)))
 
     async def _invoke(self, spec: TreatmentSpec, request: GenerationRequest) -> ForecastAttempt:
+        queued_at = time.monotonic()
+        queue_ms = 0
         try:
             async with self._semaphore:
+                queue_ms = int((time.monotonic() - queued_at) * 1000)
                 adapter = spec.arm.adapter
                 call = adapter.generate if hasattr(adapter, "generate") else adapter
                 response = call(request)
@@ -228,7 +232,9 @@ class IntelligenceEvalRunner:
                     response = await response
             if not isinstance(response, AdapterResponse):
                 raise TypeError("adapter must return AdapterResponse")
-            telemetry = _freeze(response.telemetry)
+            telemetry_values = dict(response.telemetry)
+            telemetry_values["queue_ms"] = queue_ms
+            telemetry = _freeze(telemetry_values)
             forecast = _parse(response.output)
             return ForecastAttempt(request.stage, request.sample_index, request.seed, forecast, telemetry)
         except Exception as exc:  # Model, transport, and parse failures are observations.
@@ -237,7 +243,7 @@ class IntelligenceEvalRunner:
                 request.sample_index,
                 request.seed,
                 None,
-                MappingProxyType({}),
+                MappingProxyType({"queue_ms": queue_ms}),
                 f"{type(exc).__name__}: {exc}",
             )
 

--- a/auramaur/evaluation/service.py
+++ b/auramaur/evaluation/service.py
@@ -6,8 +6,10 @@ no broker, risk, exchange execution, or production portfolio dependencies.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+import math
 import time
 from collections.abc import Mapping
 from datetime import datetime, timezone
@@ -104,6 +106,8 @@ class IntelligenceEvalService:
         self._runner = IntelligenceEvalRunner(self._cfg.max_concurrency)
 
     async def run_once(self) -> int:
+        cycle_started = datetime.now(timezone.utc)
+        wall_started = time.monotonic()
         # ResolutionTracker owns venue truth. Refreshing here makes newly
         # canonicalized results visible even during quiet/no-resolution cycles.
         await self._score_materializer.refresh()
@@ -114,14 +118,88 @@ class IntelligenceEvalService:
             and market.liquidity >= self._cfg.min_liquidity
             and 0 < market.outcome_yes_price < 1
         )]
-        eligible.sort(key=lambda market: market.volume, reverse=True)
-        recorded = 0
-        for market in eligible[:self._cfg.markets_per_cycle]:
-            recorded += await self._evaluate_market(market)
-        log.info("intelligence_eval.cycle", markets=len(eligible), forecasts=recorded)
+        selected = await self._select_markets(eligible, cycle_started)
+        expensive_n = math.ceil(len(selected) * self._cfg.expensive_fraction)
+        informative = sorted(selected, key=self._information_priority)[:expensive_n]
+        expensive_ids = {market.id for market in informative}
+        semaphore = asyncio.Semaphore(self._cfg.market_concurrency)
+
+        async def evaluate(market):
+            async with semaphore:
+                treatments = (self._treatments if market.id in expensive_ids
+                              else self._treatments[:1])
+                return await self._evaluate_market(market, treatments)
+
+        results = await asyncio.gather(*(evaluate(market) for market in selected))
+        recorded = sum(item[0] for item in results)
+        attempts = sum(item[1] for item in results)
+        failed = sum(item[2] for item in results)
+        compute = sum(item[3] for item in results)
+        completed = datetime.now(timezone.utc)
+        metrics = dict(
+            cycle_id=hashlib.sha256(cycle_started.isoformat().encode()).hexdigest(),
+            started_at=cycle_started.isoformat(), completed_at=completed.isoformat(),
+            eligible_markets=len(eligible), selected_markets=len(selected),
+            unique_families=len({self._family(m) for m in selected}),
+            forecasts=recorded, attempts=attempts, failed_attempts=failed,
+            duration_ms=int((time.monotonic() - wall_started) * 1000),
+            compute_seconds=compute,
+        )
+        await self._store.put_cycle(metrics)
+        log.info("intelligence_eval.cycle", **metrics)
         return recorded
 
-    async def _evaluate_market(self, market) -> int:
+    @staticmethod
+    def _family(market) -> str:
+        return market.neg_risk_market_id or market.id
+
+    def _information_priority(self, market):
+        end = market.end_date or datetime.max.replace(tzinfo=timezone.utc)
+        days = (end - datetime.now(timezone.utc)).total_seconds() / 86400
+        horizon_bucket = 0 if 0 <= days <= self._cfg.near_resolution_days else 1
+        ambiguity = abs(float(market.outcome_yes_price) - 0.5)
+        return (horizon_bucket, end, ambiguity, -float(market.volume or 0))
+
+    async def _select_markets(self, eligible, now):
+        """Select changed/novel markets, one per family, with category rotation."""
+        latest = await self._store.latest_market_observations()
+        candidates = []
+        for market in eligible:
+            venue = (market.exchange or "polymarket").lower()
+            previous = latest.get((venue, market.id))
+            if previous:
+                observed = datetime.fromisoformat(previous["observed_at"])
+                age_hours = (now - observed.astimezone(timezone.utc)).total_seconds() / 3600
+                moved = abs(float(market.outcome_yes_price)
+                            - float(previous["market_prob_yes"]))
+                if (age_hours < self._cfg.reevaluate_after_hours
+                        and moved < self._cfg.reprice_threshold):
+                    continue
+            candidates.append(market)
+
+        candidates.sort(key=self._information_priority)
+        families, categories, selected = set(), {}, []
+        for market in candidates:
+            family = self._family(market)
+            if family in families:
+                continue
+            categories.setdefault(market.category or "unknown", []).append(market)
+        queues = list(categories.values())
+        while queues and len(selected) < self._cfg.markets_per_cycle:
+            next_queues = []
+            for queue in queues:
+                if queue and len(selected) < self._cfg.markets_per_cycle:
+                    market = queue.pop(0)
+                    family = self._family(market)
+                    if family not in families:
+                        selected.append(market)
+                        families.add(family)
+                if queue:
+                    next_queues.append(queue)
+            queues = next_queues
+        return selected
+
+    async def _evaluate_market(self, market, treatments=None) -> tuple[int, int, int, float]:
         now = datetime.now(timezone.utc)
         spread = max(0.0, float(market.spread or 0))
         mid = float(market.outcome_yes_price)
@@ -141,13 +219,19 @@ class IntelligenceEvalService:
         await self._store.put_episode(snapshot)
         payload = json.loads(snapshot.canonical_json())
         episode = Episode(snapshot.episode_hash, payload)
-        results = await self._runner.run(episode, self._treatments)
+        treatments = treatments or self._treatments
+        results = await self._runner.run(episode, treatments)
         written = 0
-        for treatment, result in zip(self._treatments, results, strict=True):
+        attempt_count = failed_count = 0
+        compute_seconds = 0.0
+        for treatment, result in zip(treatments, results, strict=True):
             run_id = hashlib.sha256(
                 f"{snapshot.episode_hash}:{treatment.treatment_id}".encode()).hexdigest()
             duration_ms = sum(int(attempt.telemetry.get("duration_ms", 0))
                               for attempt in result.attempts)
+            compute_seconds += duration_ms / 1000
+            attempt_count += len(result.attempts)
+            failed_count += sum(not attempt.succeeded for attempt in result.attempts)
             status = RunStatus.SUCCEEDED if result.succeeded else RunStatus.FAILED
             errors = "; ".join(attempt.error for attempt in result.attempts
                                if attempt.error)
@@ -162,6 +246,8 @@ class IntelligenceEvalService:
                 compute_seconds=duration_ms / 1000, error=errors,
                 started_at=now, completed_at=datetime.now(timezone.utc),
             ))
+            for attempt in result.attempts:
+                await self._store.put_attempt(run_id, snapshot.episode_hash, attempt)
             if result.final_forecast is None:
                 continue
             forecast_id = hashlib.sha256(f"{run_id}:forecast".encode()).hexdigest()
@@ -174,4 +260,4 @@ class IntelligenceEvalService:
                 else 1 - forecast.confidence,
             ))
             written += 1
-        return written
+        return written, attempt_count, failed_count, compute_seconds

--- a/auramaur/evaluation/store.py
+++ b/auramaur/evaluation/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 from auramaur.evaluation.domain import (
@@ -82,6 +83,43 @@ class EvaluationStore:
                  forecast.max_acceptable_price, forecast.thesis,
                  forecast.uncertainty, json.dumps(forecast.evidence_ids)),
             )
+
+    async def put_attempt(self, run_id, episode_hash, attempt) -> None:
+        """Retain raw samples, critics, telemetry, and failures."""
+        attempt_id = hashlib.sha256(
+            f"{run_id}:{attempt.stage}:{attempt.sample_index}".encode()).hexdigest()
+        forecast = attempt.forecast
+        async with self._db.transaction():
+            await self._db.execute(
+                """INSERT OR REPLACE INTO evaluation_attempts
+                   (attempt_id,run_id,episode_hash,stage,sample_index,seed,prob_yes,
+                    action,confidence,thesis,telemetry_json,error)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (attempt_id, run_id, episode_hash, attempt.stage, attempt.sample_index,
+                 attempt.seed, None if forecast is None else forecast.prob_yes,
+                 None if forecast is None else forecast.action,
+                 None if forecast is None else forecast.confidence,
+                 "" if forecast is None else (forecast.thesis or ""),
+                 json.dumps(dict(attempt.telemetry), sort_keys=True), attempt.error or ""))
+
+    async def latest_market_observations(self) -> dict[tuple[str, str], dict]:
+        rows = await self._db.fetchall(
+            """SELECT e.venue,e.market_id,e.observed_at,e.market_prob_yes,e.event_family
+                 FROM evaluation_episodes e JOIN
+                 (SELECT venue,market_id,MAX(observed_at) observed_at
+                    FROM evaluation_episodes GROUP BY venue,market_id) latest
+                 ON latest.venue=e.venue AND latest.market_id=e.market_id
+                 AND latest.observed_at=e.observed_at""")
+        return {(r["venue"].lower(), r["market_id"]): dict(r) for r in rows}
+
+    async def put_cycle(self, values: dict) -> None:
+        keys = ("cycle_id","started_at","completed_at","eligible_markets",
+                "selected_markets","unique_families","forecasts","attempts",
+                "failed_attempts","duration_ms","compute_seconds")
+        async with self._db.transaction():
+            await self._db.execute(
+                "INSERT INTO evaluation_cycles VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                tuple(values[key] for key in keys))
 
     async def settle(self, outcome: EvaluationOutcome) -> None:
         if await self.get_episode(outcome.episode_hash) is None:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -525,6 +525,11 @@ intelligence_eval:
   markets_per_cycle: 8
   min_liquidity: 1000.0
   max_concurrency: 1
+  market_concurrency: 2
+  reprice_threshold: 0.03
+  reevaluate_after_hours: 24
+  near_resolution_days: 14
+  expensive_fraction: 0.25
   prompt_version: "forecast-v1"
   output_schema_version: "binary-v1"
   treatments:

--- a/config/settings.py
+++ b/config/settings.py
@@ -1653,6 +1653,11 @@ class IntelligenceEvalConfig(BaseModel):
     markets_per_cycle: int = Field(default=8, ge=1, le=100)
     min_liquidity: float = Field(default=1000.0, ge=0)
     max_concurrency: int = Field(default=1, ge=1, le=16)
+    market_concurrency: int = Field(default=2, ge=1, le=16)
+    reprice_threshold: float = Field(default=0.03, ge=0, le=1)
+    reevaluate_after_hours: float = Field(default=24.0, ge=0)
+    near_resolution_days: float = Field(default=14.0, ge=0)
+    expensive_fraction: float = Field(default=0.25, ge=0, le=1)
     prompt_version: str = "forecast-v1"
     output_schema_version: str = "binary-v1"
     treatments: list[IntelligenceEvalTreatment] = Field(default_factory=lambda: [

--- a/tests/test_intelligence_eval_runner.py
+++ b/tests/test_intelligence_eval_runner.py
@@ -59,6 +59,7 @@ async def test_stable_seeds_aggregation_and_concurrency():
     assert first.final_forecast.prob_yes == pytest.approx(.5)
     assert first.final_forecast.action == "ABSTAIN"
     assert a.peak <= 2
+    assert all(item.telemetry["queue_ms"] >= 0 for item in first.attempts)
 
 
 @pytest.mark.asyncio
@@ -94,6 +95,7 @@ async def test_partial_and_parse_failures_are_recorded():
     assert [x.succeeded for x in result.attempts] == [False, False, True]
     assert "invalid JSON" in result.attempts[0].error
     assert "provider down" in result.attempts[1].error
+    assert result.attempts[1].telemetry["queue_ms"] >= 0
     assert result.final_forecast.prob_yes == .75
 
 

--- a/tests/test_intelligence_eval_service.py
+++ b/tests/test_intelligence_eval_service.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+import asyncio
+from datetime import datetime, timedelta, timezone
 
 from auramaur.db.database import Database
 from auramaur.evaluation.service import IntelligenceEvalService
@@ -60,6 +61,13 @@ async def test_service_records_paired_treatments_without_trading(tmp_path):
         }
         assert len(client.calls) == 10
         assert len({call[1]["seed"] for call in client.calls}) == 10
+        attempts = await db.fetchall("SELECT * FROM evaluation_attempts")
+        assert len(attempts) == 10
+        assert {row["stage"] for row in attempts} == {"sample", "critic"}
+        cycle = await db.fetchone("SELECT * FROM evaluation_cycles")
+        assert cycle["selected_markets"] == 1
+        assert cycle["attempts"] == 10
+        assert cycle["failed_attempts"] == 0
         assert await db.fetchone("SELECT 1 FROM trades") is None
         assert await db.fetchone("SELECT 1 FROM portfolio") is None
     finally:
@@ -88,3 +96,87 @@ async def test_service_does_not_duplicate_resolution_detection(tmp_path):
 def test_intelligence_eval_defaults_off():
     settings = Settings()
     assert settings.intelligence_eval.enabled is False
+
+
+async def test_unchanged_market_is_skipped_until_reprice(tmp_path):
+    db = Database(str(tmp_path / "eval-change.db"))
+    await db.connect()
+    try:
+        settings = Settings()
+        settings.intelligence_eval.markets_per_cycle = 1
+        settings.intelligence_eval.reevaluate_after_hours = 24
+        discovery, client = Discovery(), LocalClient()
+        service = IntelligenceEvalService(db, settings, discovery, client)
+        assert await service.run_once() == 3
+        assert await service.run_once() == 0
+        assert len(client.calls) == 10
+        discovery.market.outcome_yes_price += settings.intelligence_eval.reprice_threshold
+        assert await service.run_once() == 3
+        assert len(client.calls) == 20
+    finally:
+        await db.close()
+
+
+async def test_multi_market_rotation_family_dedup_and_successive_halving(tmp_path):
+    class ManyMarkets:
+        def __init__(self):
+            now = datetime.now(timezone.utc)
+            specs = [
+                ("m1", "family-a", "politics", 0.49, 2),
+                ("m2", "family-b", "sports", 0.30, 3),
+                ("m3", "family-c", "economics", 0.70, 4),
+                ("m4", "family-d", "technology", 0.20, 5),
+                # Higher-volume duplicate must not consume a second family slot.
+                ("m1-duplicate", "family-a", "weather", 0.51, 1),
+            ]
+            self.markets = []
+            for index, (market_id, family, category, price, days) in enumerate(specs):
+                self.markets.append(Market(
+                    id=market_id, question=f"Question {market_id}?", description="Rules",
+                    category=category, outcome_yes_price=price,
+                    outcome_no_price=1 - price, spread=0.02, liquidity=5000,
+                    volume=10000 - index, end_date=now + timedelta(days=days),
+                    neg_risk_market_id=family,
+                ))
+
+        async def get_markets(self, active=True, limit=100):
+            return self.markets
+
+    class ConcurrentClient(LocalClient):
+        def __init__(self):
+            super().__init__()
+            self.active = self.peak = 0
+
+        async def generate_json(self, prompt, **kwargs):
+            self.active += 1
+            self.peak = max(self.peak, self.active)
+            await asyncio.sleep(0.001)
+            try:
+                return await super().generate_json(prompt, **kwargs)
+            finally:
+                self.active -= 1
+
+    db = Database(str(tmp_path / "eval-many.db"))
+    await db.connect()
+    try:
+        settings = Settings()
+        settings.intelligence_eval.markets_per_cycle = 4
+        settings.intelligence_eval.expensive_fraction = 0.25
+        settings.intelligence_eval.max_concurrency = 2
+        settings.intelligence_eval.market_concurrency = 4
+        discovery, client = ManyMarkets(), ConcurrentClient()
+        service = IntelligenceEvalService(db, settings, discovery, client)
+
+        # One informative market gets all three arms (10 calls); the other
+        # three get one cheap call each.
+        assert await service.run_once() == 6
+        assert len(client.calls) == 13
+        assert client.peak == 2
+        episodes = await db.fetchall(
+            "SELECT DISTINCT event_family FROM evaluation_episodes")
+        assert len(episodes) == 4
+        cycle = await db.fetchone("SELECT * FROM evaluation_cycles")
+        assert cycle["unique_families"] == 4
+        assert cycle["selected_markets"] == 4
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary
- diversify shadow evaluation across categories and distinct event families, prioritizing near-resolution and ambiguous markets
- skip unchanged markets until a configured age or meaningful reprice, and use successive halving for expensive sample/critic arms
- overlap market evaluation under bounded inference concurrency and keep cycle starts on a fixed cadence
- persist every inference attempt plus queue telemetry, failures, and cycle-level throughput metrics
- add focused multi-market coverage for rotation, deduplication, concurrency, and treatment allocation

## Safety
- remains shadow-only and execution-free
- evaluator and local-model semaphores continue to bound inference concurrency
- defaults remain disabled

## Validation
- `27 passed` across intelligence evaluation, unified evidence, portfolio, and database transaction tests
- `ruff check` passed
- `git diff --check` passed