### PR TITLE
fix(risk,ibkr): drawdown equity noise, live-gate paper leak + self-clearing latch, IB preflight timeouts

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -351,6 +351,7 @@ class AuramaurBot(
             try:
                 all_positions = []
                 per_exchange_cash: dict[str, float] = {}
+                sync_failures: list[str] = []
 
                 for syncer in syncers:
                     name = getattr(syncer, "exchange_name", "polymarket")
@@ -359,6 +360,7 @@ class AuramaurBot(
                         cash = await syncer.get_cash_balance()
                     except Exception as e:
                         log.debug("portfolio_monitor.sync_error", exchange=name, error=str(e))
+                        sync_failures.append(name)
                         continue
 
                     per_exchange_cash[name] = cash
@@ -401,12 +403,19 @@ class AuramaurBot(
                 # daily_stats.peak_balance, so get_drawdown() returned 0.0
                 # forever and check_max_drawdown / check_drawdown_heat could
                 # never trip (2026-07-20 audit, confirmed critical).
-                try:
-                    equity = total_cash + sum(
-                        p.size * p.current_price for p in all_positions)
-                    await portfolio_tracker.note_equity(equity)
-                except Exception as e:
-                    log.debug("drawdown.note_equity_error", error=str(e))
+                # Complete ticks only: with any venue missing, "equity" is just
+                # the venues that answered, and those partial sums recorded
+                # phantom 75-92% drawdowns in daily_stats on 2026-07-21/22.
+                if sync_failures:
+                    log.debug("drawdown.equity_tick_skipped",
+                              failed_venues=sync_failures)
+                else:
+                    try:
+                        equity = total_cash + sum(
+                            p.size * p.current_price for p in all_positions)
+                        await portfolio_tracker.note_equity(equity)
+                    except Exception as e:
+                        log.debug("drawdown.note_equity_error", error=str(e))
 
                 if first_tick:
                     first_tick = False

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -676,6 +676,57 @@ class AuramaurBot(
                 return
             await asyncio.sleep(1)
 
+    async def _run_live_gate(self, *, startup: bool = False) -> None:
+        """Evaluate the live-readiness preflight and move the risk manager's
+        ``live_entries_blocked`` latch in BOTH directions.
+
+        The latch was previously set once at startup and never cleared, so a
+        cold-start BLOCK (equity feed not yet warm, IB Gateway awaiting its
+        manual re-login) paper-forced live entries until the next restart —
+        and every restart re-blocked.
+        """
+        from auramaur.monitoring.live_gate import preflight
+
+        rm = self._components.risk_manager
+        report = await preflight(
+            self.settings, self._components.db,
+            tracker=rm.portfolio if rm is not None else None)
+        blocked_now = not report.live_allowed
+        was_blocked = bool(rm.live_entries_blocked) if rm is not None else False
+        if rm is not None:
+            rm.live_entries_blocked = blocked_now
+        alerts = self._components.alerts
+
+        if blocked_now and (startup or not was_blocked):
+            blocked = ", ".join(b.name for b in report.blocks)
+            log.error("live_gate.entries_blocked",
+                      blocks=[f"{b.name}: {b.detail}" for b in report.blocks])
+            console.print(f"  [bold red]LIVE ENTRIES BLOCKED by preflight:[/] "
+                          f"{blocked} — exits stay live")
+            if alerts is not None:
+                await alerts.send(
+                    f"LIVE ENTRIES BLOCKED by preflight: {blocked}", level="critical")
+        elif not blocked_now and was_blocked:
+            log.info("live_gate.entries_unblocked", warnings=len(report.warnings))
+            console.print("  [green]live entries unblocked — preflight passes[/]")
+            if alerts is not None:
+                await alerts.send(
+                    "Live entries unblocked — preflight passes", level="warning")
+        elif startup:
+            log.info("live_gate.passed", warnings=len(report.warnings))
+            if report.warnings:
+                console.print(f"  [yellow]preflight OK, {len(report.warnings)} warning(s)[/]")
+
+    async def _task_live_gate_monitor(self) -> None:
+        """Periodic live-readiness re-check (armed-live runs only)."""
+        interval = max(60, int(self.settings.intervals.live_gate_recheck_seconds))
+        while self._running:
+            await asyncio.sleep(interval)
+            try:
+                await self._run_live_gate()
+            except Exception as e:
+                log.error("live_gate.error", error=str(e))
+
     async def _task_kraken_pillar(self) -> None:
         """Dual-purpose Kraken pillar: treasury (always) + directional (gated).
 
@@ -1519,28 +1570,12 @@ class AuramaurBot(
         # Operational live-readiness preflight. If any BLOCK condition is present
         # while armed live, force new ENTRIES to paper (exits bypass the risk
         # manager, so held positions can still get out). Same checks as
-        # `auramaur health`; a "refuse to fool itself" gate.
+        # `auramaur health`; a "refuse to fool itself" gate. Re-evaluated
+        # periodically by _task_live_gate_monitor so the latch moves in BOTH
+        # directions without a restart.
         if self.settings.is_live:
             try:
-                from auramaur.monitoring.live_gate import preflight
-                report = await preflight(self.settings, self._components.db)
-                if not report.live_allowed:
-                    rm = self._components.risk_manager
-                    if rm is not None:
-                        rm.live_entries_blocked = True
-                    blocked = ", ".join(b.name for b in report.blocks)
-                    log.error("live_gate.entries_blocked",
-                              blocks=[f"{b.name}: {b.detail}" for b in report.blocks])
-                    console.print(f"  [bold red]LIVE ENTRIES BLOCKED by preflight:[/] "
-                                  f"{blocked} — exits stay live")
-                    alerts = self._components.alerts
-                    if alerts is not None:
-                        await alerts.send(
-                            f"LIVE ENTRIES BLOCKED by preflight: {blocked}", level="critical")
-                else:
-                    log.info("live_gate.passed", warnings=len(report.warnings))
-                    if report.warnings:
-                        console.print(f"  [yellow]preflight OK, {len(report.warnings)} warning(s)[/]")
+                await self._run_live_gate(startup=True)
             except Exception as e:
                 log.error("live_gate.error", error=str(e))
 
@@ -1549,6 +1584,9 @@ class AuramaurBot(
             asyncio.create_task(self._task_cache_cleanup(), name="cache_cleanup"),
             asyncio.create_task(self._task_recalibrate(), name="recalibrate"),
         ]
+        if self.settings.is_live:
+            tasks.append(asyncio.create_task(
+                self._task_live_gate_monitor(), name="live_gate"))
 
         # Portfolio monitor runs whenever any exchange syncer is present so
         # Kalshi-only runs still populate `_last_known_cash` and exits fire.

--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -34,9 +34,11 @@ class MultiAssetPreflightReport:
         return not any(result.severity == "BLOCK" for result in self.results)
 
 
-async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
+async def preflight(settings, db, *, client=None, timeout_seconds: float | None = None,
                     books: tuple[IBKRBook, ...] | None = None):
     cfg = settings.ibkr
+    if timeout_seconds is None:
+        timeout_seconds = cfg.multiasset_preflight_timeout_seconds
     results: list[MultiAssetPreflightResult] = []
 
     def add(book, severity, detail):
@@ -96,20 +98,30 @@ async def preflight(settings, db, *, client=None, timeout_seconds: int = 30,
                                         has_history=True)
                 return None, source, None
             except Exception as exc:  # noqa: BLE001
-                if pacing_error(exc) and attempt + 1 < attempts:
+                # A wait_for deadline cancels the pending IB request, which the
+                # gateway logs as "Error 162 ... query cancelled" — same
+                # transient class as pacing, so it gets the same backoff.
+                timed_out = isinstance(exc, TimeoutError)
+                if (pacing_error(exc) or timed_out) and attempt + 1 < attempts:
                     delay = cfg.multiasset_preflight_retry_seconds * (2 ** attempt)
-                    log.warning("ibkr_multiasset.preflight_pacing_retry", key=spec.key,
+                    log.warning("ibkr_multiasset.preflight_transient_retry", key=spec.key,
                                 attempt=attempt + 1, delay_seconds=delay,
-                                error=str(exc)[:160])
+                                timed_out=timed_out, error=str(exc)[:160])
                     await asyncio.sleep(delay)
                     continue
-                prefix = "pacing exhausted" if pacing_error(exc) else "probe failed"
+                if timed_out:
+                    prefix = f"no gateway response within {timeout_seconds:.0f}s"
+                elif pacing_error(exc):
+                    prefix = "pacing exhausted"
+                else:
+                    prefix = "probe failed"
+                detail = str(exc)[:140] or exc.__class__.__name__
                 await record_validation(
                     db, spec, SimpleNamespace(conId=0, exchange=spec.exchange,
                                               currency=spec.currency,
                                               multiplier=spec.multiplier),
-                    quote_source="none", has_history=False, error=str(exc))
-                return f"{spec.key}: {prefix}: {str(exc)[:140]}", None, None
+                    quote_source="none", has_history=False, error=f"{prefix}: {detail}")
+                return f"{spec.key}: {prefix}: {detail}", None, None
         return f"{spec.key}: pacing retry exhausted", None, None  # pragma: no cover
     if not getattr(client, "readonly", False) or hasattr(client, "place_order"):
         add("isolation", "BLOCK", "market-data client is not structurally read-only")

--- a/auramaur/monitoring/live_gate.py
+++ b/auramaur/monitoring/live_gate.py
@@ -46,9 +46,14 @@ class PreflightReport:
         return [r for r in self.results if r.severity == "WARN"]
 
 
-async def preflight(settings, db: Database) -> PreflightReport:
+async def preflight(settings, db: Database, tracker=None) -> PreflightReport:
     """Run the operational live-readiness checks. Never raises — a check that
-    can't evaluate degrades to WARN rather than crashing the gate."""
+    can't evaluate degrades to WARN rather than crashing the gate.
+
+    ``tracker`` is the risk manager's own PortfolioTracker when available: its
+    equity-fed drawdown (note_equity) is what the in-cycle gates read, so the
+    preflight should judge the same number instead of re-deriving a cold one.
+    """
     report = PreflightReport()
 
     def add(name: str, severity: Severity, detail: str) -> None:
@@ -83,9 +88,15 @@ async def preflight(settings, db: Database) -> PreflightReport:
         add("fee_model", "BLOCK", f"unavailable: {str(e)[:80]}")
 
     # 4. Drawdown — never arm fresh entries through a breached drawdown limit.
+    # The cold-start fallback must be scoped to the armed book (settings ->
+    # _mode_flag): the unscoped estimate summed PAPER unrealised marks into the
+    # LIVE gate — the same leak get_daily_pnl fixed for the daily-loss gate —
+    # and latched a phantom block at every startup.
     try:
         from auramaur.risk.portfolio import PortfolioTracker
-        dd = await PortfolioTracker(db).get_drawdown()
+        if tracker is None:
+            tracker = PortfolioTracker(db, settings=settings)
+        dd = await tracker.get_drawdown()
         maxdd = float(settings.risk.max_drawdown_pct)
         if dd >= maxdd:
             add("drawdown", "BLOCK", f"{dd:.1f}% >= limit {maxdd:.1f}%")

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from datetime import datetime, timezone
 
 import structlog
@@ -19,6 +20,7 @@ class PortfolioTracker:
     def __init__(self, db: Database, settings=None):
         self.db = db
         self.settings = settings
+        self._equity_window: deque[float] = deque(maxlen=self._PEAK_CONFIRM_TICKS)
 
     def _mode_flag(self, is_paper: bool | None = None) -> int | None:
         """Return the paper/live DB flag, or None for legacy unscoped reads."""
@@ -215,6 +217,15 @@ class PortfolioTracker:
     # ------------------------------------------------------------------
 
     _current_drawdown_pct: float | None = None
+    # A single optimistic tick (thin-book mark spike, venue glitch) must not
+    # ratchet the peak the gate measures drawdown against, so the ratchet uses
+    # the minimum of the last N samples: a spike only counts once it has
+    # persisted a full window of monitor ticks.
+    _PEAK_CONFIRM_TICKS = 3
+    # Drawdown is measured against the peak over this window, not all time —
+    # an all-time ratchet never forgives a one-off inflated sample and turns
+    # any capital withdrawal into permanent phantom drawdown.
+    _PEAK_WINDOW_DAYS = 30
 
     async def note_equity(self, equity: float) -> None:
         """Record current equity: maintain the daily peak and the live
@@ -226,19 +237,30 @@ class PortfolioTracker:
         this once per tick with venue cash + position marks; the peak
         persists across restarts via daily_stats, the current drawdown is
         held in memory (staleness bounded by the monitor interval).
+
+        Asymmetric by design: the latest equity is compared against the peak
+        immediately (a real crash trips the gate within one tick), but the
+        peak only rises to a level sustained for ``_PEAK_CONFIRM_TICKS``
+        consecutive ticks, and only the last ``_PEAK_WINDOW_DAYS`` days of
+        peaks bind.
         """
         if equity is None or equity <= 0:
             return
-        async with self.db.transaction():
-            await self.db.execute(
-                """INSERT INTO daily_stats (date, total_pnl, trades_count, wins, losses, peak_balance)
-                   VALUES (date('now'), 0, 0, 0, 0, ?)
-                   ON CONFLICT(date) DO UPDATE SET
-                       peak_balance = MAX(COALESCE(peak_balance, 0), excluded.peak_balance)""",
-                (equity,),
-            )
+        self._equity_window.append(equity)
+        if len(self._equity_window) == self._PEAK_CONFIRM_TICKS:
+            sustained = min(self._equity_window)
+            async with self.db.transaction():
+                await self.db.execute(
+                    """INSERT INTO daily_stats (date, total_pnl, trades_count, wins, losses, peak_balance)
+                       VALUES (date('now'), 0, 0, 0, 0, ?)
+                       ON CONFLICT(date) DO UPDATE SET
+                           peak_balance = MAX(COALESCE(peak_balance, 0), excluded.peak_balance)""",
+                    (sustained,),
+                )
         row = await self.db.fetchone(
-            "SELECT MAX(peak_balance) AS peak FROM daily_stats")
+            "SELECT MAX(peak_balance) AS peak FROM daily_stats "
+            "WHERE date >= date('now', ?)",
+            (f"-{self._PEAK_WINDOW_DAYS} days",))
         peak = float(row["peak"] or 0.0) if row else 0.0
         self._current_drawdown_pct = (
             max(0.0, (peak - equity) / peak * 100.0) if peak > 0 else 0.0)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -280,6 +280,9 @@ ibkr:
   multiasset_preflight_concurrency: 2
   multiasset_preflight_pacing_retries: 2
   multiasset_preflight_retry_seconds: 2.0
+  # Probe deadline; the gateway's history farm exceeds 30s around IB's
+  # nightly reset, and shorter deadlines self-cancel (IB "Error 162").
+  multiasset_preflight_timeout_seconds: 60.0
   # Runtime universe = deterministic manifest intersected with this machine's
   # qualified, approved broker registry. Run preflight before enabling books.
   multiasset_registry_required: true

--- a/config/settings.py
+++ b/config/settings.py
@@ -227,6 +227,10 @@ class IntervalsConfig(BaseModel):
     analysis_seconds: int = 180
     portfolio_check_seconds: int = 60
     dashboard_refresh_seconds: int = 5
+    # Live-readiness preflight re-check (monitoring/live_gate): clears a
+    # startup BLOCK once conditions recover (equity feed warm, IB Gateway
+    # re-authenticated) and latches a new BLOCK without waiting for a restart.
+    live_gate_recheck_seconds: int = 600
     # Adaptive scheduling — scale intensity by market activity
     adaptive_enabled: bool = True
     peak_hours_utc: list[int] = Field(

--- a/config/settings.py
+++ b/config/settings.py
@@ -1258,6 +1258,11 @@ class IBKRConfig(BaseModel):
     multiasset_preflight_concurrency: int = 2
     multiasset_preflight_pacing_retries: int = 2
     multiasset_preflight_retry_seconds: float = 2.0
+    # Per-request deadline for preflight quote/history probes. The gateway's
+    # historical farm routinely takes >30s around IB's nightly reset
+    # (~03:45-05:00 UTC); a too-short deadline cancels the request client-side,
+    # which IB reports as "Error 162 ... query cancelled".
+    multiasset_preflight_timeout_seconds: float = 60.0
     # Require a current broker-qualified identity before opening new risk.
     # Kept false in model defaults so isolated test/library users can opt in;
     # tracked deployment defaults enable it.
@@ -1324,7 +1329,8 @@ class IBKRConfig(BaseModel):
             raise ValueError("IBKR multi-asset quote/cache limits must be positive")
         if (self.multiasset_preflight_concurrency <= 0
                 or self.multiasset_preflight_pacing_retries < 0
-                or self.multiasset_preflight_retry_seconds < 0):
+                or self.multiasset_preflight_retry_seconds < 0
+                or self.multiasset_preflight_timeout_seconds <= 0):
             raise ValueError("IBKR multi-asset preflight pacing limits are invalid")
         if len(self.multiasset_disabled_instruments) != len(
                 set(self.multiasset_disabled_instruments)):

--- a/tests/test_ibkr_multiasset_preflight.py
+++ b/tests/test_ibkr_multiasset_preflight.py
@@ -136,6 +136,46 @@ async def test_preflight_retries_transient_pacing_errors():
 
 
 @pytest.mark.asyncio
+async def test_preflight_retries_gateway_timeouts():
+    class SlowOnceClient(ReadyClient):
+        def __init__(self):
+            self.attempts = set()
+
+        async def get_daily_bars(self, spec):
+            if spec.key not in self.attempts:
+                self.attempts.add(spec.key)
+                raise TimeoutError
+            return await super().get_daily_bars(spec)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    settings.ibkr.multiasset_preflight_retry_seconds = 0
+    report = await preflight(settings, db, client=SlowOnceClient())
+    assert report.ready
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_reports_exhausted_timeouts_as_gateway_unresponsive():
+    class DeadGatewayClient(ReadyClient):
+        async def get_daily_bars(self, spec):
+            raise TimeoutError
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.enabled = True
+    settings.ibkr.multiasset_preflight_pacing_retries = 0
+    report = await preflight(settings, db, client=DeadGatewayClient())
+    assert not report.ready
+    blocked = [r for r in report.results if r.severity == "BLOCK"]
+    assert any("no gateway response within" in r.detail for r in blocked)
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_entitlement_quarantine_skips_instrument_but_reports_coverage():
     class EntitledClient(ReadyClient):
         async def get_quote(self, spec):

--- a/tests/test_live_gate.py
+++ b/tests/test_live_gate.py
@@ -91,6 +91,64 @@ async def test_zero_marked_live_positions_block(tmp_path, monkeypatch):
         await db.close()
 
 
+@pytest.mark.asyncio
+async def test_paper_book_losses_do_not_block_live_drawdown(tmp_path, monkeypatch):
+    """Regression (2026-07-22): the cold-start drawdown fallback summed PAPER
+    unrealised marks into the LIVE gate and latched a phantom block at every
+    startup. Deep paper losses + a healthy live book must read OK."""
+    monkeypatch.chdir(tmp_path)
+    db = await _db()
+    try:
+        s = Settings()
+        s.auramaur_live = True
+        s.execution.live = True
+        assert s.is_live
+        await db.execute(
+            "INSERT INTO daily_stats (date, peak_balance) VALUES (date('now'), 2000.0)")
+        # Paper book down 600 (30% of peak — would BLOCK if it leaked in)
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                token, is_paper, updated_at)
+               VALUES ('paper1', 'polymarket', 'BUY', 2000, 0.5, 0.2, 'YES', 1,
+                       datetime('now'))""")
+        # Live book slightly up
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                token, is_paper, updated_at)
+               VALUES ('live1', 'polymarket', 'BUY', 100, 0.5, 0.6, 'YES', 0,
+                       datetime('now'))""")
+        await db.commit()
+        rep = await preflight(s, db)
+        sev = {r.name: r.severity for r in rep.results}
+        assert sev["drawdown"] == "OK", [r for r in rep.results if r.name == "drawdown"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_prefers_warm_tracker(tmp_path, monkeypatch):
+    """A provided (risk-manager) tracker's equity-fed drawdown is authoritative:
+    the preflight must judge the number the in-cycle gates read."""
+    from auramaur.risk.portfolio import PortfolioTracker
+
+    monkeypatch.chdir(tmp_path)
+    db = await _db()
+    try:
+        s = Settings()
+        tracker = PortfolioTracker(db, settings=s)
+        tracker._current_drawdown_pct = 20.0  # breached (limit 15%)
+        rep = await preflight(s, db, tracker=tracker)
+        assert any(b.name == "drawdown" for b in rep.blocks)
+        tracker._current_drawdown_pct = 1.0
+        rep = await preflight(s, db, tracker=tracker)
+        sev = {r.name: r.severity for r in rep.results}
+        assert sev["drawdown"] == "OK"
+    finally:
+        await db.close()
+
+
 def test_committed_defaults_yaml_is_not_live():
     """The TRACKED config/defaults.yaml must ship with execution.live: false.
 

--- a/tests/test_portfolio_drawdown.py
+++ b/tests/test_portfolio_drawdown.py
@@ -1,0 +1,98 @@
+"""Drawdown gate equity feed: peak ratchet and windowing in note_equity."""
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.risk.portfolio import PortfolioTracker
+
+
+async def _tracker():
+    db = Database(":memory:")
+    await db.connect()
+    return db, PortfolioTracker(db)
+
+
+@pytest.mark.asyncio
+async def test_sustained_equity_sets_peak_and_dip_reads_as_drawdown():
+    db, tracker = await _tracker()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    assert await tracker.get_drawdown() == pytest.approx(0.0)
+    await tracker.note_equity(800.0)
+    assert await tracker.get_drawdown() == pytest.approx(20.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_dip_is_detected_on_the_very_next_tick():
+    db, tracker = await _tracker()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    await tracker.note_equity(700.0)
+    assert await tracker.get_drawdown() == pytest.approx(30.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_single_tick_spike_does_not_ratchet_peak():
+    db, tracker = await _tracker()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    # One optimistic mark tick, then equity returns to its sustained level:
+    # the peak must stay at 1000, not 5000, so no phantom 80% drawdown.
+    await tracker.note_equity(5000.0)
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    assert await tracker.get_drawdown() == pytest.approx(0.0)
+    row = await db.fetchone("SELECT MAX(peak_balance) AS peak FROM daily_stats")
+    assert float(row["peak"]) == pytest.approx(1000.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sustained_new_high_does_ratchet_peak():
+    db, tracker = await _tracker()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    for _ in range(3):
+        await tracker.note_equity(1200.0)
+    await tracker.note_equity(900.0)
+    assert await tracker.get_drawdown() == pytest.approx(25.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_peak_older_than_window_no_longer_binds():
+    db, tracker = await _tracker()
+    await db.execute(
+        "INSERT INTO daily_stats (date, peak_balance) "
+        "VALUES (date('now', '-40 days'), 5000.0)")
+    await db.commit()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    assert await tracker.get_drawdown() == pytest.approx(0.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_recent_persisted_peak_still_binds_across_restart():
+    db, tracker = await _tracker()
+    await db.execute(
+        "INSERT INTO daily_stats (date, peak_balance) "
+        "VALUES (date('now', '-5 days'), 2000.0)")
+    await db.commit()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    assert await tracker.get_drawdown() == pytest.approx(50.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_zero_or_negative_equity_is_ignored():
+    db, tracker = await _tracker()
+    for _ in range(3):
+        await tracker.note_equity(1000.0)
+    await tracker.note_equity(0.0)
+    await tracker.note_equity(-5.0)
+    assert await tracker.get_drawdown() == pytest.approx(0.0)
+    await db.close()

--- a/tests/test_portfolio_drawdown.py
+++ b/tests/test_portfolio_drawdown.py
@@ -88,6 +88,30 @@ async def test_recent_persisted_peak_still_binds_across_restart():
 
 
 @pytest.mark.asyncio
+async def test_cold_fallback_scopes_to_the_armed_book():
+    """With settings attached, the legacy peak+unrealised fallback only sums
+    the armed book's positions — paper marks must not read as live drawdown."""
+
+    class _Live:
+        is_live = True
+
+    db = Database(":memory:")
+    await db.connect()
+    tracker = PortfolioTracker(db, settings=_Live())
+    await db.execute(
+        "INSERT INTO daily_stats (date, peak_balance) VALUES (date('now'), 2000.0)")
+    await db.execute(
+        """INSERT INTO portfolio
+           (market_id, exchange, side, size, avg_price, current_price,
+            token, is_paper, updated_at)
+           VALUES ('paper1', 'polymarket', 'BUY', 2000, 0.5, 0.2, 'YES', 1,
+                   datetime('now'))""")
+    await db.commit()
+    assert await tracker.get_drawdown() == pytest.approx(0.0)
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_zero_or_negative_equity_is_ignored():
     db, tracker = await _tracker()
     for _ in range(3):


### PR DESCRIPTION
## Summary
Three related fixes to the drawdown gate and IBKR preflight:

**Equity-feed hardening (6fb1261, already validated in the WSL deployment as 7a0704e):**
- Complete-tick-only equity feed: partial-venue sync ticks no longer ratchet phantom peaks
- Peak ratchet requires the level be sustained 3 consecutive ticks; drawdown measured against a 30-day rolling peak window
- IBKR preflight history timeouts (Error 162 bursts during the IB nightly reset) now retry with a configurable `multiasset_preflight_timeout_seconds` (default 60s)

**Live-gate drawdown paper leak + stuck latch (44a4d93):**
- The startup preflight built a bare `PortfolioTracker`, so its cold-start fallback summed unrealized marks across the entire portfolio table — paper and live. ~-$550 of paper-book marks against a $2,000 equity peak read as ~23% >= 15% and latched "LIVE ENTRIES BLOCKED by preflight: drawdown" at every startup, while the real live drawdown was 1.6%. The fallback is now scoped to the armed book (the same leak `get_daily_pnl` fixed for the daily-loss gate), and the bot passes the risk manager's warm tracker so re-checks judge the equity-fed figure the in-cycle gates actually read.
- `rm.live_entries_blocked` was set once at startup and never cleared — a cold-start block (equity feed not yet warm, IB Gateway awaiting its manual re-login) paper-forced live entries until the next restart, and every restart re-blocked. The preflight now re-runs every `intervals.live_gate_recheck_seconds` (default 600) and moves the latch in both directions, alerting on transitions.

## Testing
- New regression tests: paper-book losses must not block the live gate; preflight prefers the warm tracker; cold fallback scopes to the armed book
- `tests/test_live_gate.py`, `tests/test_portfolio_drawdown.py`, `tests/test_risk_manager.py`, `tests/test_ibkr_multiasset_preflight.py`: 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)