### PR TITLE
fix(risk): surface positions frozen out of the discovery universe

### DIFF
--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -287,6 +287,41 @@ class PortfolioTracker:
     # Exit checks
     # ------------------------------------------------------------------
 
+    # Throttle for the unmarkable-positions warning: once per exchange per hour,
+    # not once per 60s monitor tick.
+    _UNMARKABLE_WARN_SECONDS = 3600.0
+
+    async def _warn_unmarkable(self, exchange: str | None, market_ids: list[str]) -> None:
+        """Warn (throttled) about positions whose market discovery no longer
+        returns — their marks and exit checks are frozen until the market
+        reappears or an operator intervenes."""
+        if not hasattr(self, "_unmarkable_last_warn"):
+            self._unmarkable_last_warn: dict[str, float] = {}
+        key = exchange or "*"
+        now = datetime.now(timezone.utc).timestamp()
+        last = self._unmarkable_last_warn.get(key, 0.0)
+        if now - last < self._UNMARKABLE_WARN_SECONDS:
+            return
+        self._unmarkable_last_warn[key] = now
+        oldest = None
+        try:
+            placeholders = ",".join("?" for _ in market_ids)
+            row = await self.db.fetchone(
+                f"SELECT MIN(updated_at) AS oldest FROM portfolio "
+                f"WHERE market_id IN ({placeholders})",
+                tuple(market_ids),
+            )
+            oldest = row["oldest"] if row else None
+        except Exception:
+            pass
+        log.warning(
+            "check_exits.unmarkable_positions",
+            exchange=key,
+            count=len(market_ids),
+            oldest_mark=oldest,
+            sample=market_ids[:5],
+        )
+
     @staticmethod
     def _resolve_mark_price(pos: Position, market) -> float | None:
         """Price of the token the position actually holds, or None to keep
@@ -357,11 +392,17 @@ class PortfolioTracker:
         peak_prices = await self._get_peak_prices()
         prices_updated = False
 
+        unmarkable: list[str] = []
         for pos in positions:
             # Refresh current price from discovery client
             try:
                 market = await discovery_client.get_market(pos.market_id)
                 if market is None:
+                    # The position freezes here: no re-mark, no exit
+                    # evaluation, and nothing ever closes it (149 paper
+                    # positions rotted this way for 3 days carrying -$553
+                    # of stale marks, 2026-07-22). Surface it below.
+                    unmarkable.append(pos.market_id)
                     continue
                 # IBKR holds options priced in premium dollars, not 0-1 resolution
                 # probabilities, and its discovery returns the *reframed* binary
@@ -554,6 +595,9 @@ class PortfolioTracker:
                     )
                     exits.append((pos, ExitReason.DUST_CLEANUP))
                     continue
+
+        if unmarkable:
+            await self._warn_unmarkable(exchange, unmarkable)
 
         if prices_updated:
             await self.db.commit()

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -63,6 +63,36 @@ def _make_market(market_id: str, yes_price: float, end_date: datetime | None = N
 
 
 @pytest.mark.asyncio
+async def test_unmarkable_position_warns_and_throttles(mock_db, settings, monkeypatch):
+    """A position whose market discovery no longer returns must be surfaced
+    (it freezes marks and exit checks — the 2026-07-22 stale-paper-marks rot),
+    but only once per throttle window, not every monitor tick."""
+    from unittest.mock import patch
+
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("gone1", avg_price=0.50),
+    ])
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=None)  # dropped from discovery
+
+    tracker = PortfolioTracker(db=mock_db)
+    with patch("auramaur.risk.portfolio.log") as mock_log:
+        exits = await tracker.check_exits(settings, gamma)
+        assert exits == []
+        warns = [c for c in mock_log.warning.call_args_list
+                 if c.args and c.args[0] == "check_exits.unmarkable_positions"]
+        assert len(warns) == 1
+        assert warns[0].kwargs["count"] == 1
+        assert warns[0].kwargs["sample"] == ["gone1"]
+
+        # Second run inside the throttle window: no new warning.
+        await tracker.check_exits(settings, gamma)
+        warns = [c for c in mock_log.warning.call_args_list
+                 if c.args and c.args[0] == "check_exits.unmarkable_positions"]
+        assert len(warns) == 1
+
+
+@pytest.mark.asyncio
 async def test_stop_loss_triggered(mock_db, settings):
     """Position at -35% → STOP_LOSS."""
     mock_db.fetchall = AsyncMock(return_value=[


### PR DESCRIPTION
## Summary
`check_exits` silently skipped any position whose market discovery no longer returns (`market is None` -> `continue`) — no re-mark, no exit evaluation, and nothing ever closes it. 149 paper positions rotted that way since 2026-07-19, carrying -$553 of stale marks (found while diagnosing the phantom live-gate drawdown block).

This adds a throttled (once per exchange per hour) structured warning `check_exits.unmarkable_positions` with count, oldest mark timestamp, and a sample of market ids, so frozen positions are visible instead of silent. No behavior change to marking or exits themselves.

## Testing
- New test: unmarkable position triggers exactly one warning and throttles the second cycle
- `tests/test_exits.py`: 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)