### PR TITLE
fix(strategy): zero-entry cycles must log — two more silent pillars

### DIFF
--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -337,6 +337,10 @@ class CrossVenueArbPillar:
         await self._ensure_schema()
         pairs = await self._candidate_pairs()
         if not pairs:
+            # Log EVERY cycle (the settlement_arb #246 lesson): this early
+            # return was silent, so a pillar whose pair discovery never fires
+            # is indistinguishable from a dead task.
+            log.info("cross_venue.cycle", pairs=0, entered=0)
             return 0
         entered = 0
         for a, b in pairs:

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -108,8 +108,12 @@ class PlatformConsensusPillar:
             # Sleep between queries to be nice to public APIs
             await asyncio.sleep(1.0)
 
-        if entered > 0:
-            log.info("platform_consensus.cycle_done", entered=entered)
+        # Log EVERY cycle (the settlement_arb #246 lesson): the previous
+        # entered>0 guard made zero-entry cycles silent, so weeks of "running
+        # fine, entering nothing" were indistinguishable from a dead task.
+        log.info("platform_consensus.cycle_done", scanned=len(markets),
+                 eligible=len(eligible_markets), evaluated=eval_limit,
+                 entered=entered, open=open_count)
         return entered
 
     def _eligible(self, market: Market, cfg) -> bool:

--- a/tests/test_cross_venue_arb.py
+++ b/tests/test_cross_venue_arb.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from auramaur.broker.pnl import PnLTracker
 from auramaur.db.database import Database
@@ -249,6 +249,26 @@ def test_second_leg_rejection_marks_partial_not_traded_and_does_not_retry():
             assert await pillar.run_once() == 0
             assert poly_ex.place_order.await_count == 1
             assert kalshi_ex.place_order.await_count == 1
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_zero_pair_cycle_still_logs():
+    """A cycle with no candidate pairs must still log (the silent early return
+    made a never-matching pair scan indistinguishable from a dead task)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            pillar = _pillar(db, _settings(), [], [])
+            with patch("auramaur.strategy.cross_venue_arb.log") as mock_log:
+                entered = await pillar.run_once()
+            assert entered == 0
+            calls = [c for c in mock_log.info.call_args_list
+                     if c.args and c.args[0] == "cross_venue.cycle"]
+            assert len(calls) == 1
+            assert calls[0].kwargs == {"pairs": 0, "entered": 0}
         finally:
             await db.close()
     asyncio.run(run())

--- a/tests/test_platform_consensus.py
+++ b/tests/test_platform_consensus.py
@@ -400,3 +400,32 @@ def test_platform_consensus_quality_thresholds_fail_closed():
 
     assert not PlatformConsensusPillar._quality_ok(thin, "Manifold", cfg)
     assert not PlatformConsensusPillar._quality_ok(missing, "Metaculus", cfg)
+
+
+def test_zero_entry_cycle_still_logs():
+    """A zero-entry cycle must still log cycle_done (the entered>0 guard made
+    zero-entry cycles silent — weeks of 'running fine, entering nothing' were
+    indistinguishable from a dead task)."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            disc = MagicMock()
+            disc.get_markets = AsyncMock(return_value=[])
+            pillar = PlatformConsensusPillar(
+                db=db, settings=_settings(), discovery=disc,
+                exchange=_exchange(), risk_manager=_risk(),
+                pnl_tracker=PnLTracker(db, _settings()),
+                calibration=MagicMock(),
+            )
+            with patch("auramaur.strategy.platform_consensus.log") as mock_log:
+                entered = await pillar.run_once()
+            assert entered == 0
+            calls = [c for c in mock_log.info.call_args_list
+                     if c.args and c.args[0] == "platform_consensus.cycle_done"]
+            assert len(calls) == 1
+            assert calls[0].kwargs["entered"] == 0
+            assert calls[0].kwargs["scanned"] == 0
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
A sweep for enabled-but-silent strategies (prompted by the settlement_arb 222-predicated/0-entered diagnosis) found two pillars with zero log lines across days of retained logs despite running fine:

- **platform_consensus** (`platform_consensus.py`): `if entered > 0: log(...)` — zero-entry cycles were completely silent, and it has never entered since #326 merged. Now logs every cycle with scanned/eligible/evaluated/entered/open.
- **cross_venue_arb** (`cross_venue_arb.py`): `if not pairs: return 0` before the cycle log — pair discovery finding nothing (every cycle so far) was indistinguishable from a dead task. Now logs `pairs=0, entered=0`.

Same class of fix as #339 (settlement_arb funnel stages): a quiet log must not be indistinguishable from a dead task — the codebase already documents this as the settlement_arb #246 lesson.

## Testing
- Two new tests assert the zero-path cycle log fires exactly once with the expected fields
- `tests/test_platform_consensus.py` + `tests/test_cross_venue_arb.py`: 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)