### PR TITLE
feat(long_horizon): ramp the open-book cap so the book keeps adding

### DIFF
--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -96,6 +96,9 @@ class LongHorizonPillar:
             router=None, exchange=exchange, exchange_name=venue,
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
+        # First-trade anchor for the ramped book cap; resolved lazily from the
+        # trades ledger (None = not looked up yet, "" = no trades exist).
+        self._first_trade_ts: str | None = None
 
     # ------------------------------------------------------------------
     # Scan cycle
@@ -110,9 +113,10 @@ class LongHorizonPillar:
         except Exception as e:
             log.error("long_horizon.harvest_error", error=str(e))
         open_count = await self._open_position_count()
-        if open_count >= cfg.max_open:
+        cap = await self._effective_max_open(cfg)
+        if open_count >= cap:
             log.info("long_horizon.cycle", venue=self._venue, scanned=0, in_band=0,
-                     open=open_count, entered=0, book_full=True)
+                     open=open_count, cap=cap, entered=0, book_full=True)
             return 0
         markets = await self._scan_long_dated(cfg)
         entered = 0
@@ -122,7 +126,7 @@ class LongHorizonPillar:
                 band += 1
             if entered >= cfg.max_entries_per_cycle:
                 break
-            if open_count + entered >= cfg.max_open:
+            if open_count + entered >= cap:
                 break
             try:
                 if await self._try_enter(market):
@@ -133,8 +137,41 @@ class LongHorizonPillar:
         # be distinguishable from a dead task, and the funnel numbers are the
         # diagnosis when a venue instance silently finds nothing.
         log.info("long_horizon.cycle", venue=self._venue, scanned=len(markets),
-                 in_band=band, open=open_count, entered=entered)
+                 in_band=band, open=open_count, cap=cap, entered=entered)
         return entered
+
+    async def _effective_max_open(self, cfg) -> int:
+        """Ramped open-book cap: max_open + ramp*weeks-since-first-trade,
+        clamped to max_open_plateau.
+
+        A long-horizon book holds positions for months, so a flat cap freezes
+        the book at day-one size — no new entries, near-zero ledger accrual,
+        and a graduation bar it can never reach. Anchoring to the pillar's own
+        first trade makes the ramp deterministic from the ledger (no new
+        state), and each venue instance ramps off its own tag's history.
+        """
+        rate = float(cfg.max_open_ramp_per_week)
+        plateau = max(int(cfg.max_open), int(cfg.max_open_plateau))
+        if rate <= 0 or plateau <= cfg.max_open:
+            return cfg.max_open
+        if self._first_trade_ts is None:
+            row = await self._db.fetchone(
+                "SELECT MIN(timestamp) AS t FROM trades WHERE strategy_source = ?",
+                (self._tag,))
+            self._first_trade_ts = str(row["t"]) if row and row["t"] else ""
+        if not self._first_trade_ts:
+            return cfg.max_open
+        try:
+            first = datetime.fromisoformat(
+                self._first_trade_ts.replace("Z", "+00:00"))
+            if first.tzinfo is None:
+                first = first.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return cfg.max_open
+        weeks = max(
+            0.0,
+            (datetime.now(timezone.utc) - first).total_seconds() / 604800.0)
+        return min(plateau, cfg.max_open + int(weeks * rate))
 
     async def _scan_long_dated(self, cfg) -> list[Market]:
         """Fetch the LONG-DATED slice directly via Gamma's resolution-date window,

--- a/config/settings.py
+++ b/config/settings.py
@@ -574,7 +574,18 @@ class LongHorizonConfig(BaseModel):
     band_hi: float = 0.92
     min_edge: float = 0.03
     stake_usd: float = 10.0
+    # Open-book cap RAMPS from max_open toward max_open_plateau at
+    # max_open_ramp_per_week slots/week (anchored to the pillar's first trade).
+    # A truly long-horizon book holds positions for months — a flat cap freezes
+    # the book at day-one size and starves the graduation ledger (3 resolved
+    # events/90d against a bar of 30); ramping keeps NEW entries flowing while
+    # early holdings age toward resolution, and the plateau bounds capital
+    # lock-up. Set ramp to 0 for the old flat-cap behavior. Per-venue: the
+    # Polymarket and Kalshi instances each run their own ramp off their own
+    # first trade.
     max_open: int = 30
+    max_open_plateau: int = 60
+    max_open_ramp_per_week: float = 3.0
     max_entries_per_cycle: int = 5
     # Raised 300->500 (2026-06-29): the binding constraint on data collection was
     # Pagination depth for the DATED scan (see _scan_long_dated). The 06-29

--- a/tests/test_long_horizon.py
+++ b/tests/test_long_horizon.py
@@ -398,3 +398,88 @@ async def test_decay_harvest_skips_below_floor_and_stale_marks():
         assert await db.fetchone("SELECT 1 FROM pnl_ledger") is None
     finally:
         await db.close()
+
+
+# ----------------------------------------------------------------------
+# Ramped book cap — max_open grows toward the plateau as the book ages
+# ----------------------------------------------------------------------
+
+def test_ramp_cap_is_flat_before_first_trade():
+    """With no trade history the cap stays at max_open."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            pillar, _ = _pillar(db, _settings(max_open=30, max_open_plateau=60,
+                                              max_open_ramp_per_week=3.0), [])
+            cap = await pillar._effective_max_open(pillar._settings.long_horizon)
+            assert cap == 30
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_ramp_cap_grows_with_book_age_and_plateaus():
+    """Cap = max_open + ramp*weeks since the pillar's first trade, clamped."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            five_weeks_ago = (datetime.now(timezone.utc)
+                              - timedelta(weeks=5)).isoformat()
+            await db.execute(
+                """INSERT INTO trades (market_id, side, size, price, is_paper,
+                       status, exchange, strategy_source, timestamp)
+                   VALUES ('m-old', 'BUY', 10, 0.7, 1, 'paper', 'polymarket',
+                       'long_horizon', ?)""", (five_weeks_ago,))
+            await db.commit()
+            cfg_kw = dict(max_open=30, max_open_plateau=60,
+                          max_open_ramp_per_week=3.0)
+            pillar, _ = _pillar(db, _settings(**cfg_kw), [])
+            cap = await pillar._effective_max_open(pillar._settings.long_horizon)
+            assert cap == 45  # 30 + 3*5
+
+            # A much older anchor clamps at the plateau.
+            pillar2, _ = _pillar(db, _settings(**cfg_kw), [])
+            pillar2._first_trade_ts = (datetime.now(timezone.utc)
+                                       - timedelta(weeks=52)).isoformat()
+            cap2 = await pillar2._effective_max_open(pillar2._settings.long_horizon)
+            assert cap2 == 60
+
+            # Ramp disabled -> old flat behavior regardless of history.
+            pillar3, _ = _pillar(db, _settings(max_open=30, max_open_plateau=60,
+                                               max_open_ramp_per_week=0.0), [])
+            cap3 = await pillar3._effective_max_open(pillar3._settings.long_horizon)
+            assert cap3 == 30
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_ramp_anchor_is_per_venue_tag():
+    """The Kalshi instance ramps off long_horizon_kalshi trades only — a
+    Polymarket trade history must not age the Kalshi book's cap."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await db.execute(
+                """INSERT INTO trades (market_id, side, size, price, is_paper,
+                       status, exchange, strategy_source, timestamp)
+                   VALUES ('m-poly', 'BUY', 10, 0.7, 1, 'paper', 'polymarket',
+                       'long_horizon', ?)""",
+                ((datetime.now(timezone.utc) - timedelta(weeks=8)).isoformat(),))
+            await db.commit()
+            s = _settings(max_open=30, max_open_plateau=60,
+                          max_open_ramp_per_week=3.0)
+            disc = MagicMock(); disc.get_markets = AsyncMock(return_value=[])
+            cal = MagicMock(); cal.record_prediction = AsyncMock()
+            kalshi = LongHorizonPillar(
+                db=db, settings=s, discovery=disc, exchange=_exchange(),
+                risk_manager=_risk(), pnl_tracker=PnLTracker(db, s),
+                calibration=cal, venue="kalshi")
+            cap = await kalshi._effective_max_open(s.long_horizon)
+            assert cap == 30  # no long_horizon_kalshi trades -> unramped
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
long_horizon''s flat `max_open=30` froze the book at day-one size: `book_full: true` every cycle, ~3 resolved ledger events per 90 days against a graduation bar of 30 — structurally unreachable, because the strategy''s holding period rivals the evaluation window.

The open-book cap now **ramps** from `max_open` toward `max_open_plateau` (default 60) at `max_open_ramp_per_week` (default 3) slots per week, anchored to the pillar''s own first trade — deterministic from the trades ledger, no new state. New entries keep flowing while early holdings age toward resolution; the plateau bounds capital lock-up; `ramp=0` restores the old flat behavior.

- Per-venue: the Polymarket and Kalshi instances each ramp off their own tag''s history (`long_horizon` vs `long_horizon_kalshi`)
- The effective `cap` is logged on every cycle line, so the ramp is observable
- At today''s anchor (~5+ weeks of history) the Poly book unfreezes immediately with a cap in the mid-40s, reaching the plateau of 60 over the next ~5 weeks; steady-state resolutions then feed the graduation ledger continuously

## Testing
- New tests: flat before first trade, ramp arithmetic + plateau clamp, ramp-disabled fallback, per-venue anchor isolation
- `tests/test_long_horizon.py`: 16 passed; `tests/test_settings.py` + `tests/test_strategy_protocol.py`: 45 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)