### PR TITLE
fix(ibkr): warn when a disabled multiasset book holds open paper positions

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -818,6 +818,9 @@ class AuramaurBot(
             rates_provider=rates_provider)
             for book in IBKRBook
             if self.settings.ibkr.multiasset_books[book.value].enabled]
+        from auramaur.strategy.ibkr_multiasset_paper import warn_stranded_positions
+        await warn_stranded_positions(
+            self._components.get("db"), {b.book.value for b in books})
         try:
             while self._running:
                 if await self._check_kill_switch():

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -23,6 +23,34 @@ from auramaur.risk.ibkr_math import (
 log = structlog.get_logger()
 
 
+async def warn_stranded_positions(db, enabled_books: set[str]) -> list[str]:
+    """Warn for paper positions stranded in books that are NOT running.
+
+    A disabled book never cycles, so its open positions are never re-marked
+    and never exit-managed (2026-07-22: a SHEL.L row sat frozen in the held
+    international_equity book from the day of the hold). Visibility only —
+    flattening stays an operator decision, because a temporary hold must not
+    destroy positions. Returns the stranded book names (for tests)."""
+    stranded: list[str] = []
+    try:
+        rows = await db.fetchall(
+            "SELECT book, COUNT(*) AS n FROM ibkr_paper_positions GROUP BY book")
+    except Exception as e:
+        log.debug("ibkr_multiasset.stranded_check_error", error=str(e))
+        return stranded
+    for row in rows or []:
+        book = str(row["book"] or "")
+        if book and book not in enabled_books and int(row["n"] or 0) > 0:
+            stranded.append(book)
+            log.warning(
+                "ibkr_multiasset.stranded_positions",
+                book=book, count=int(row["n"]),
+                detail="book disabled — positions stay unmarked and "
+                       "unmanaged until the book is re-enabled or the "
+                       "operator closes them")
+    return stranded
+
+
 class IBKRMultiAssetPaperBook:
     """One asset-specific ledger; this class has no broker order capability."""
 

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -429,3 +429,54 @@ async def test_fx_research_recorder_records_trend_and_carry_once_daily():
     gbpjpy = next(r for r in carry if r["instrument_key"] == "GBPJPY")
     assert gbpjpy["direction"] == 1  # positive carry + uptrend agree
     await db.close()
+
+
+def test_stranded_positions_in_disabled_book_warn():
+    """Positions in a book that is not running must be surfaced — a disabled
+    book never cycles, so its positions are never re-marked or exit-managed."""
+    import asyncio
+    from unittest.mock import patch
+    from auramaur.db.database import Database
+    from auramaur.strategy.ibkr_multiasset_paper import warn_stranded_positions
+
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await db.execute(
+                """INSERT INTO ibkr_paper_positions
+                   (book, instrument_key, con_id, currency, quantity, multiplier,
+                    fx_to_usd, avg_cost, current_price, price_source,
+                    instrument_spec_json, stop_price, initial_risk_usd,
+                    entry_commission_usd, entry_fill_ref)
+                   VALUES ('international_equity', 'SHEL.L', 1, 'GBP', 0.1, 1.0,
+                           1.35, 3200.0, 3200.0, 'ibkr_live', '{}', 3100.0,
+                           12.0, 1.0, 'ref-1')""")
+            await db.execute(
+                """INSERT INTO ibkr_paper_positions
+                   (book, instrument_key, con_id, currency, quantity, multiplier,
+                    fx_to_usd, avg_cost, current_price, price_source,
+                    instrument_spec_json, stop_price, initial_risk_usd,
+                    entry_commission_usd, entry_fill_ref)
+                   VALUES ('fx', 'USDCAD', 2, 'CAD', 1.0, 1000.0, 0.71,
+                           1.40, 1.40, 'ibkr_live', '{}', 1.39, 5.0, 0.2,
+                           'ref-2')""")
+            await db.commit()
+            with patch("auramaur.strategy.ibkr_multiasset_paper.log") as mock_log:
+                stranded = await warn_stranded_positions(db, {"fx"})
+            assert stranded == ["international_equity"]
+            warns = [c for c in mock_log.warning.call_args_list
+                     if c.args and c.args[0] == "ibkr_multiasset.stranded_positions"]
+            assert len(warns) == 1
+            assert warns[0].kwargs["book"] == "international_equity"
+            assert warns[0].kwargs["count"] == 1
+
+            # All books enabled -> nothing stranded, no warning.
+            with patch("auramaur.strategy.ibkr_multiasset_paper.log") as mock_log:
+                stranded = await warn_stranded_positions(
+                    db, {"fx", "international_equity"})
+            assert stranded == []
+            assert not mock_log.warning.called
+        finally:
+            await db.close()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
A disabled multiasset book never cycles, so any open paper positions in it are never re-marked and never exit-managed. A SHEL.L position sat frozen in the held `international_equity` book from the moment of the 2026-07-18 hold — at entry cost, invisible to every management path — until found in today''s paper-book audit (closed administratively with a proper round-trip record, net -$2.00 in commissions).

The multiasset task now sweeps `ibkr_paper_positions` at startup and emits `ibkr_multiasset.stranded_positions` per book that holds positions but is not running. Visibility only — auto-flattening is deliberately NOT done, since a temporary operator hold must not destroy positions.

## Testing
- New test: stranded book warns with book/count; fully-enabled set warns nothing
- `tests/test_ibkr_multiasset_paper.py`: 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)