### PR TITLE
Fix paper position metadata and expose unrealized P&L

### DIFF
--- a/auramaur/broker/sync.py
+++ b/auramaur/broker/sync.py
@@ -12,6 +12,7 @@ from auramaur.db.database import Database
 from auramaur.exchange.client import PolymarketClient
 from auramaur.exchange.models import LivePosition, OrderSide, TokenType
 from auramaur.exchange.paper import PaperTrader
+from auramaur.strategy.classifier import ensure_category
 from config.settings import Settings
 
 log = structlog.get_logger()
@@ -262,16 +263,38 @@ class PositionSyncer:
     async def _sync_paper(self) -> list[LivePosition]:
         """Convert ``PaperTrader.positions`` dict to ``LivePosition`` list."""
         positions: list[LivePosition] = []
+        market_ids = list(self._paper.positions)
+        metadata: dict[str, dict] = {}
+        if market_ids:
+            placeholders = ",".join("?" for _ in market_ids)
+            rows = await self._db.fetchall(
+                f"SELECT id, exchange, question, description, category "
+                f"FROM markets WHERE id IN ({placeholders})",
+                tuple(market_ids),
+            )
+            metadata = {row["id"]: row for row in rows}
 
         for market_id, pos in self._paper.positions.items():
-            # Look up cost basis from PnLTracker for more accurate avg cost
-            # and to get the token type/ID
+            market = metadata.get(market_id)
+            exchange = (market["exchange"] if market else "") or ""
+            # PaperTrader is shared by every venue. Polymarket reconciliation
+            # must never claim Kalshi tickers or overwrite their venue/category.
+            if exchange == "kalshi" or market_id.upper().startswith("KX"):
+                continue
+
             avg_cost, cb_size = await self._pnl.get_cost_basis(market_id)
             token, token_id = await self._pnl.get_token_info(market_id)
             if cb_size <= 0:
-                # Fall back to paper trader's own tracking
                 avg_cost = pos.avg_price
 
+            question = market["question"] if market else market_id
+            description = market["description"] if market else ""
+            stored_category = market["category"] if market else ""
+            category = ensure_category(
+                question or market_id,
+                description or "",
+                stored_category or getattr(pos, "category", "") or "",
+            )
             positions.append(
                 LivePosition(
                     market_id=market_id,
@@ -280,10 +303,9 @@ class PositionSyncer:
                     size=pos.size,
                     avg_cost=avg_cost,
                     current_price=pos.current_price,
-                    category=pos.category,
+                    category=category,
                 ),
             )
-
         log.info("sync.paper.done", positions=len(positions))
         return positions
 
@@ -551,8 +573,9 @@ class KalshiPositionSyncer:
         # tracked in PaperTrader memory (2026-07-20 audit). Scope this pass
         # to markets discovery knows as Kalshi.
         kalshi_rows = await self._db.fetchall(
-            "SELECT id FROM markets WHERE exchange = 'kalshi'")
-        kalshi_ids = {r["id"] for r in kalshi_rows}
+            "SELECT id, category FROM markets WHERE exchange = 'kalshi'")
+        kalshi_categories = {r["id"]: (r["category"] or "") for r in kalshi_rows}
+        kalshi_ids = set(kalshi_categories)
 
         # PaperTrader state is in memory, so the whole upsert+cleanup pass is
         # db-only — one short, serialized transaction (contention plan,
@@ -563,7 +586,8 @@ class KalshiPositionSyncer:
                     continue
                 token = pos.token if pos.token else TokenType.YES
                 token_id = pos.token_id or market_id
-                category = getattr(pos, "category", "") or ""
+                category = (getattr(pos, "category", "") or
+                            kalshi_categories.get(market_id, ""))
                 current_ids.add(market_id)
 
                 await self._db.execute(
@@ -578,7 +602,8 @@ class KalshiPositionSyncer:
                            avg_price = excluded.avg_price,
                            current_price = excluded.current_price,
                            unrealized_pnl = excluded.unrealized_pnl,
-                           category = excluded.category,
+                           category = COALESCE(NULLIF(excluded.category, ''),
+                                               portfolio.category),
                            token = excluded.token,
                            token_id = excluded.token_id,
                            is_paper = excluded.is_paper,

--- a/tests/test_category_lineage.py
+++ b/tests/test_category_lineage.py
@@ -7,7 +7,7 @@ import pytest
 
 from auramaur.broker.sync import PositionSyncer
 from auramaur.db.database import Database
-from auramaur.exchange.models import LivePosition
+from auramaur.exchange.models import LivePosition, OrderSide, Position, TokenType
 from auramaur.risk.portfolio import PortfolioTracker
 from auramaur.web.queries import category_exposure
 
@@ -75,5 +75,38 @@ async def test_reconciler_does_not_erase_existing_category():
         row = await db.fetchone(
             "SELECT category FROM portfolio WHERE market_id = 'm1'")
         assert row["category"] == "crypto"
+    finally:
+        await db.close()
+
+@pytest.mark.asyncio
+async def test_paper_polymarket_sync_filters_kalshi_and_enriches_category():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO markets
+               (id, exchange, question, description, category, active, last_updated)
+               VALUES ('poly1', 'polymarket', 'Will Bitcoin rise?', '', 'crypto', 1,
+                       datetime('now')),
+                      ('KXTEST', 'kalshi', 'Kalshi test?', '', 'economics', 1,
+                       datetime('now'))""")
+        await db.commit()
+        poly = Position(market_id="poly1", side=OrderSide.BUY, size=10,
+                        avg_price=.4, current_price=.5, category="")
+        kalshi = Position(market_id="KXTEST", side=OrderSide.BUY, size=5,
+                          avg_price=.3, current_price=.35, category="")
+        syncer = PositionSyncer.__new__(PositionSyncer)
+        syncer._db = db
+        syncer._paper = SimpleNamespace(
+            positions={"poly1": poly, "KXTEST": kalshi})
+        syncer._pnl = SimpleNamespace(
+            get_cost_basis=AsyncMock(return_value=(0, 0)),
+            get_token_info=AsyncMock(return_value=(TokenType.YES, "tok")),
+        )
+
+        positions = await syncer._sync_paper()
+
+        assert [p.market_id for p in positions] == ["poly1"]
+        assert positions[0].category == "crypto"
     finally:
         await db.close()

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -68,7 +68,8 @@ class TestKalshiPositionSyncerPaperSync:
         db.commit = AsyncMock()
         # _sync_paper scopes the shared PaperTrader book to markets known as
         # exchange='kalshi' (2026-07-20 audit fix).
-        db.fetchall = AsyncMock(return_value=[{"id": mid} for mid in kalshi_ids])
+        db.fetchall = AsyncMock(return_value=[
+            {"id": mid, "category": "economics"} for mid in kalshi_ids])
         return db
 
     @pytest.mark.asyncio

--- a/web/src/format.test.ts
+++ b/web/src/format.test.ts
@@ -12,6 +12,7 @@ describe("dashboard formatting", () => {
     expect(money(null)).toBe("n/a");
     expect(money(12.5, true)).toBe("+$12.50");
     expect(money(-12.5, true)).toBe("-$12.50");
+    expect(money(-1.3e-15, true)).toBe("$0.00");
     expect(price(null)).toBe("—");
     expect(price(0.625)).toBe("0.625");
   });

--- a/web/src/format.ts
+++ b/web/src/format.ts
@@ -1,7 +1,8 @@
 export function money(v: number | null | undefined, signed = false): string {
   if (v === null || v === undefined) return "n/a";
-  const sign = signed && v > 0 ? "+" : v < 0 ? "-" : "";
-  return `${sign}$${Math.abs(v).toLocaleString("en-US", {
+  const rounded = Math.round(v * 100) / 100;
+  const sign = signed && rounded > 0 ? "+" : rounded < 0 ? "-" : "";
+  return `${sign}$${Math.abs(rounded).toLocaleString("en-US", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;

--- a/web/src/workspace.tsx
+++ b/web/src/workspace.tsx
@@ -345,10 +345,12 @@ function Portfolio({ s, onInspect }: { s: DashboardState; onInspect: (i: Inspect
           </DataTable>
         </section>
         <section className="section-block"><h2>Strategy realized performance</h2>
-          <DataTable headers={["Strategy", "Entries", "Fees", "Realized"]}>
+          <DataTable headers={["Strategy", "Entries", "Open", "Fees", "Realized", "Unrealized"]}>
             {s.strategies.map((row) => <tr key={row.strategy}><td><StrategyName name={row.strategy} /></td>
-              <td className="num">{row.entries}</td><td className="num">{money(row.fees)}</td>
-              <td className={`num ${deltaClass(row.pnl)}`}>{money(row.pnl, true)}</td></tr>)}
+              <td className="num">{row.entries}</td><td className="num">{row.open_positions ?? 0}</td>
+              <td className="num">{money(row.fees)}</td>
+              <td className={`num ${deltaClass(row.pnl)}`}>{money(row.pnl, true)}</td>
+              <td className={`num ${deltaClass(row.unrealized ?? 0)}`}>{money(row.unrealized ?? 0, true)}</td></tr>)}
           </DataTable>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- scope shared PaperTrader reconciliation by venue so Polymarket cannot relabel Kalshi positions
- enrich paper positions from authoritative market categories and preserve non-empty categories
- add Open and Unrealized columns to strategy performance
- normalize floating-point negative zero in money formatting

## Verification
- 1456 passed, 3 skipped
- frontend: 14 passed
- production web build passed