### PR TITLE
Restore Kraken paper signals with OpenAI

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -739,6 +739,7 @@ class AuramaurBot(
         spot trading runs only when kraken.directional_enabled (off by default).
         """
         from auramaur.exchange.kraken import KrakenSpotClient
+        from auramaur.nlp.openai_etf import OpenAIETFAnalyzer
         from auramaur.treasury.kraken_pillar import KrakenPillar
         from auramaur.monitoring.display import console
 
@@ -751,9 +752,27 @@ class AuramaurBot(
             coinbase_client = CoinbasePublicClient()
             comparator = CoinbasePaperBook(
                 self.settings, coinbase_client, self._components.get("db"))
+        directional_analyzer = None
+        if self.settings.kraken.directional_llm_enabled:
+            spec = self.settings.ibkr.etf_models[1]
+            directional_analyzer = OpenAIETFAnalyzer(
+                self.settings.openai_api_key, spec.model, spec.effort,
+                self.settings.ibkr.etf_openai_timeout_seconds,
+                db=self._components.get("db"), model_alias="kraken_directional",
+                input_cost_per_million=spec.input_cost_per_million,
+                output_cost_per_million=spec.output_cost_per_million,
+                instructions=(
+                    "You are a calibrated short-horizon crypto spot forecaster "
+                    "in a strict paper-trading experiment. Estimate whether the "
+                    "named asset will trade higher at the stated horizon using "
+                    "only supplied evidence. Return calibrated probability and "
+                    "confidence, not a trade recommendation. Weak or conflicting "
+                    "evidence should remain near 0.50 with LOW confidence."
+                ))
         pillar = KrakenPillar(
             self.settings, client, bot=self, console=console,
-            paper_comparator=comparator)
+            paper_comparator=comparator,
+            directional_analyzer=directional_analyzer)
         interval = self.settings.kraken.treasury_interval_seconds
         try:
             while self._running:
@@ -763,6 +782,8 @@ class AuramaurBot(
                 await asyncio.sleep(interval)
         finally:
             await client.close()
+            if directional_analyzer is not None:
+                await directional_analyzer.close()
             if coinbase_client is not None:
                 await coinbase_client.close()
 

--- a/auramaur/nlp/openai_etf.py
+++ b/auramaur/nlp/openai_etf.py
@@ -54,7 +54,8 @@ class OpenAIETFAnalyzer:
     def __init__(self, api_key: str, model: str, effort: str,
                  timeout_seconds: int = 120, db=None,
                  model_alias: str = "", input_cost_per_million: float = 0.0,
-                 output_cost_per_million: float = 0.0) -> None:
+                 output_cost_per_million: float = 0.0,
+                 instructions: str = _INSTRUCTIONS) -> None:
         self.model = model
         self.effort = effort
         self._api_key = api_key
@@ -65,6 +66,7 @@ class OpenAIETFAnalyzer:
         self._model_alias = model_alias
         self._input_cost_per_million = input_cost_per_million
         self._output_cost_per_million = output_cost_per_million
+        self._instructions = instructions
 
     async def _start_attempt(self) -> int | None:
         if self._db is None:
@@ -141,7 +143,7 @@ class OpenAIETFAnalyzer:
         )
         payload = {
             "model": self.model,
-            "instructions": _INSTRUCTIONS,
+            "instructions": self._instructions,
             "input": prompt,
             "reasoning": {"effort": self.effort},
             "text": {"format": {"type": "json_schema", "name": "etf_forecast",

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -31,12 +31,13 @@ log = structlog.get_logger()
 
 class KrakenPillar:
     def __init__(self, settings, kraken_client, bot=None, console=None,
-                 paper_comparator=None):
+                 paper_comparator=None, directional_analyzer=None):
         self._s = settings
         self._k = kraken_client
         self._bot = bot          # for _last_known_cash
         self._console = console
         self._paper_comparator = paper_comparator
+        self._directional_analyzer = directional_analyzer
         # Open directional longs: pair -> entry-price proxy. Reconciled from
         # actual Kraken balances each cycle (see _reconcile_positions), so it
         # survives restarts instead of silently over-allocating.
@@ -1014,7 +1015,7 @@ class KrakenPillar:
 
         comp = self._bot._components
         aggregator = comp.get("aggregator")
-        analyzer = comp.get("analyzer")
+        analyzer = self._directional_analyzer or comp.get("analyzer")
         cache = comp.get("cache")
         if aggregator is None or analyzer is None:
             return None
@@ -1047,8 +1048,11 @@ class KrakenPillar:
             # evaluations in [0.50, 0.51] while the non-reserved budget was
             # exhausted and everything routed to Gemini). Same treatment as the
             # resolution lens: never let bulk consumers starve it.
-            analysis = await analyzer.analyze(market, evidence, cache,
-                                              pin_claude=True)
+            if self._directional_analyzer is not None:
+                analysis = await analyzer.analyze(market, evidence, cache)
+            else:
+                analysis = await analyzer.analyze(market, evidence, cache,
+                                                  pin_claude=True)
         except Exception as e:
             log.warning("kraken.llm_view_error", pair=pair, error=str(e))
             return None

--- a/tests/test_kraken_llm_signal.py
+++ b/tests/test_kraken_llm_signal.py
@@ -108,6 +108,27 @@ def test_llm_view_pins_primary_to_claude():
     asyncio.run(run())
 
 
+def test_llm_view_uses_dedicated_analyzer_without_claude_kwarg():
+    agg = MagicMock()
+    agg.gather = AsyncMock(return_value=[])
+    analysis = SimpleNamespace(probability=0.64, confidence="HIGH",
+                               skipped_reason=None)
+    dedicated = MagicMock()
+    dedicated.analyze = AsyncMock(return_value=analysis)
+    bot = SimpleNamespace(_components=Components({
+        "aggregator": agg, "analyzer": MagicMock(), "cache": None,
+        "calibration": None,
+    }))
+    p = KrakenPillar(_settings(), MagicMock(), bot=bot,
+                     directional_analyzer=dedicated)
+
+    async def run():
+        assert await p._llm_view("XBTUSDC") == (0.64, "HIGH")
+        assert dedicated.analyze.await_args.kwargs == {}
+
+    asyncio.run(run())
+
+
 def test_llm_view_unknown_pair_returns_none():
     bot = SimpleNamespace(_components=Components({}))
     p = _pillar(bot=bot)


### PR DESCRIPTION
## Summary
- give Kraken directional paper research a dedicated OpenAI analyzer while Claude authentication is unavailable
- keep the existing Claude-pinned path as the fallback when no dedicated analyzer is supplied
- make OpenAI forecast instructions configurable so Kraken receives a crypto-specific calibrated prompt
- retain validate-only paper fills and all existing live/funding gates

## Safety
- no global live gates changed
- directional_llm_paper remains true
- auto-convert remains false; no CAD or crypto moves
- real Kraken order submission remains impossible in this deployment

## Verification
- full suite: 1460 passed, 3 skipped
- focused Kraken/OpenAI suite: 52 passed
- ruff and diff checks clean