### PR TITLE
Expand term-structure paper exploration

### DIFF
--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -36,6 +36,7 @@ stacks; see agent_trader for the same rule and rationale).
 from __future__ import annotations
 
 import asyncio
+import calendar
 import json
 import re
 import tempfile
@@ -54,8 +55,20 @@ _MONTHS = {m.lower(): i + 1 for i, m in enumerate(
      "August", "September", "October", "November", "December"])}
 
 # "... by July 10, 2026?" / "... by July 10?" / "... by end of 2026?"
-_BY_DATE_RE = re.compile(
+_BY_DAY_RE = re.compile(
     r"\bby\s+([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s*(\d{4}))?\s*\??\s*$",
+    re.IGNORECASE,
+)
+_BY_END_YEAR_RE = re.compile(
+    r"\bby\s+(?:the\s+)?end\s+of\s+(\d{4})\s*\??\s*$", re.IGNORECASE)
+_BY_QUARTER_RE = re.compile(
+    r"\bby\s+(?:the\s+end\s+of\s+)?q([1-4])\s+(\d{4})\s*\??\s*$",
+    re.IGNORECASE,
+)
+_BEFORE_MONTH_RE = re.compile(
+    r"\bbefore\s+([A-Za-z]+)\s+(\d{4})\s*\??\s*$", re.IGNORECASE)
+_BY_MONTH_RE = re.compile(
+    r"\bby\s+(?:the\s+end\s+of\s+)?([A-Za-z]+)\s+(\d{4})\s*\??\s*$",
     re.IGNORECASE,
 )
 
@@ -92,7 +105,37 @@ CREATE TABLE IF NOT EXISTS term_structure_curves (
     model_prob REAL,
     market_prob REAL,
     thesis TEXT DEFAULT '',
+    provider TEXT NOT NULL DEFAULT 'claude',
+    model TEXT NOT NULL DEFAULT '',
     created_at TEXT DEFAULT (datetime('now'))
+)
+"""
+
+_OBSERVATIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS term_structure_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    family TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    deadline TEXT DEFAULT '',
+    model_prob REAL NOT NULL,
+    market_prob REAL NOT NULL,
+    gap_pts REAL NOT NULL,
+    provider TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    claimed INTEGER NOT NULL DEFAULT 0,
+    execution_liquid INTEGER NOT NULL DEFAULT 0,
+    disposition TEXT NOT NULL DEFAULT '',
+    observed_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+_COSTS_TABLE = """
+CREATE TABLE IF NOT EXISTS agent_trader_costs (
+    day TEXT NOT NULL,
+    model_alias TEXT NOT NULL,
+    calls INTEGER NOT NULL DEFAULT 0,
+    usd REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (day, model_alias)
 )
 """
 
@@ -101,14 +144,33 @@ def parse_deadline(question: str) -> datetime | None:
     """Deadline from the question tail ('… by July 10, 2026?'). The stored
     end_date is unreliable for ladder strikes (NULL/wrong), so the question
     text is the source of truth."""
-    m = _BY_DATE_RE.search(question or "")
-    if not m:
+    text = question or ""
+    m = _BY_DAY_RE.search(text)
+    if m:
+        month = _MONTHS.get(m.group(1).lower())
+        if month is None:
+            return None
+        day = int(m.group(2))
+        year = int(m.group(3)) if m.group(3) else datetime.now(timezone.utc).year
+    elif m := _BY_END_YEAR_RE.search(text):
+        year, month, day = int(m.group(1)), 12, 31
+    elif m := _BY_QUARTER_RE.search(text):
+        quarter, year = int(m.group(1)), int(m.group(2))
+        month = quarter * 3
+        day = calendar.monthrange(year, month)[1]
+    elif m := _BEFORE_MONTH_RE.search(text):
+        month = _MONTHS.get(m.group(1).lower())
+        if month is None:
+            return None
+        year, day = int(m.group(2)), 1
+    elif m := _BY_MONTH_RE.search(text):
+        month = _MONTHS.get(m.group(1).lower())
+        if month is None:
+            return None
+        year = int(m.group(2))
+        day = calendar.monthrange(year, month)[1]
+    else:
         return None
-    month = _MONTHS.get(m.group(1).lower())
-    if month is None:
-        return None
-    day = int(m.group(2))
-    year = int(m.group(3)) if m.group(3) else datetime.now(timezone.utc).year
     try:
         return datetime(year, month, day, tzinfo=timezone.utc)
     except ValueError:
@@ -117,10 +179,13 @@ def parse_deadline(question: str) -> datetime | None:
 
 def family_key(question: str) -> str | None:
     """Normalized family identity: the question up to its ' by <date>' tail."""
-    m = _BY_DATE_RE.search(question or "")
-    if not m:
-        return None
-    return question[: m.start()].strip().lower()
+    for pattern in (
+        _BY_DAY_RE, _BY_END_YEAR_RE, _BY_QUARTER_RE,
+        _BEFORE_MONTH_RE, _BY_MONTH_RE,
+    ):
+        if m := pattern.search(question or ""):
+            return question[: m.start()].strip().lower()
+    return None
 
 
 def parse_curve(raw: str, strikes: list[Market]) -> tuple[str, dict[str, float]]:
@@ -179,11 +244,28 @@ class TermStructurePillar:
             settings=settings, db=db, pnl_tracker=pnl_tracker,
         )
         self._schema_ready = False
+        self._claude_blocked_until: datetime | None = None
+        self._last_reader = ("claude", str(settings.term_structure.model))
 
     async def _ensure_schema(self) -> None:
         if self._schema_ready:
             return
         await self._db.execute(_CURVES_TABLE)
+        for column in (
+            "provider TEXT NOT NULL DEFAULT 'claude'",
+            "model TEXT NOT NULL DEFAULT ''",
+        ):
+            try:
+                await self._db.execute(
+                    f"ALTER TABLE term_structure_curves ADD COLUMN {column}")
+            except Exception as exc:  # noqa: BLE001 - additive compatibility
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        await self._db.execute(_OBSERVATIONS_TABLE)
+        await self._db.execute(_COSTS_TABLE)
+        await self._db.execute(
+            """CREATE INDEX IF NOT EXISTS idx_term_observations_market
+               ON term_structure_observations(market_id, observed_at)""")
         await self._db.commit()
         self._schema_ready = True
 
@@ -204,7 +286,7 @@ class TermStructurePillar:
         calls = 0
         for fam, strikes in families:
             try:
-                curve = await self._cached_curve(fam, cfg)
+                curve = await self._cached_curve(fam, strikes, cfg)
                 if curve is None:
                     if calls >= cfg.families_per_cycle:
                         continue  # fresh reads capped; cached fams still trade
@@ -303,7 +385,7 @@ class TermStructurePillar:
             return False
         if (market.exchange or "polymarket") != "polymarket":
             return False
-        if market.liquidity < cfg.min_liquidity:
+        if market.liquidity < cfg.context_min_liquidity:
             return False
         if not (0.02 <= market.outcome_yes_price <= 0.98):
             return False
@@ -329,15 +411,28 @@ class TermStructurePillar:
     # Curve read — one LLM call per family, cached
     # ------------------------------------------------------------------
 
-    async def _cached_curve(self, fam: str, cfg) -> tuple[str, dict[str, float]] | None:
+    async def _cached_curve(
+        self, fam: str, strikes: list[Market], cfg,
+    ) -> tuple[str, dict[str, float]] | None:
         rows = await self._db.fetchall(
-            """SELECT market_id, model_prob, thesis FROM term_structure_curves
-               WHERE family = ? AND created_at > datetime('now', ?)""",
-            (fam, f"-{float(cfg.curve_ttl_hours)} hours"),
+            """SELECT market_id, model_prob, thesis, provider, model
+                 FROM term_structure_curves
+                WHERE family = ? AND created_at = (
+                    SELECT MAX(created_at) FROM term_structure_curves
+                     WHERE family = ? AND created_at > datetime('now', ?)
+                )""",
+            (fam, fam, f"-{float(cfg.curve_ttl_hours)} hours"),
         )
         if not rows:
             return None
         probs = {r["market_id"]: float(r["model_prob"]) for r in rows}
+        if not {m.id for m in strikes} <= set(probs):
+            log.info("term_structure.cache_strike_set_changed", family=fam)
+            return None
+        self._last_reader = (
+            rows[0]["provider"] or "claude",
+            rows[0]["model"] or str(cfg.model),
+        )
         return (rows[0]["thesis"] or "", probs)
 
     async def _read_family(self, fam: str, strikes: list[Market],
@@ -355,19 +450,21 @@ class TermStructurePillar:
         if not probs:
             log.info("term_structure.unparseable_curve", family=fam)
             return None
+        provider, model = self._last_reader
         for m in strikes:
             if m.id in probs:
                 d = parse_deadline(m.question)
                 await self._db.execute(
                     """INSERT INTO term_structure_curves
-                       (family, market_id, deadline, model_prob, market_prob, thesis)
-                       VALUES (?, ?, ?, ?, ?, ?)""",
+                       (family, market_id, deadline, model_prob, market_prob,
+                        thesis, provider, model)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                     (fam, m.id, d.strftime("%Y-%m-%d"), probs[m.id],
-                     m.outcome_yes_price, thesis[:400]),
+                     m.outcome_yes_price, thesis[:400], provider, model),
                 )
         await self._db.commit()
-        log.info("term_structure.curve_read", family=fam,
-                 strikes=len(probs))
+        log.info("term_structure.curve_read", family=fam, strikes=len(probs),
+                 provider=provider, model=model)
         return thesis, probs
 
     async def _call_model(self, prompt: str, cfg) -> str:
@@ -375,10 +472,16 @@ class TermStructurePillar:
         from auramaur.nlp.errors import BudgetExhausted
         from auramaur.subprocess_security import analysis_subprocess_env
 
+        now = datetime.now(timezone.utc)
+        if self._claude_blocked_until and now < self._claude_blocked_until:
+            return await self._call_gemini(prompt, cfg, "claude_quota_circuit")
         budget = self._settings.nlp.daily_claude_call_budget
         if budget > 0:
             limit = call_budget.non_reserved_limit(self._settings)
             if call_budget.calls_today() >= limit:
+                if cfg.gemini_fallback:
+                    return await self._call_gemini(
+                        prompt, cfg, "claude_daily_budget")
                 raise BudgetExhausted(
                     f"non-reserved Claude budget ({limit}/{budget}, paced) exhausted")
         # Neutral cwd: `claude -p` loads CLAUDE.md + project memory from its
@@ -402,8 +505,80 @@ class TermStructurePillar:
             raise RuntimeError("curve read timed out")
         call_budget.record_call()
         if proc.returncode != 0:
-            raise RuntimeError(f"curve read failed: {stderr.decode()[:200]}")
+            detail = (stderr.decode().strip() or stdout.decode().strip())[:300]
+            if "weekly limit" in detail.lower() or "usage limit" in detail.lower():
+                self._claude_blocked_until = now + timedelta(hours=12)
+            if cfg.gemini_fallback:
+                log.warning(
+                    "term_structure.claude_fallback", error=detail,
+                    blocked_until=(self._claude_blocked_until.isoformat()
+                                   if self._claude_blocked_until else ""),
+                )
+                return await self._call_gemini(prompt, cfg, "claude_call_failed")
+            raise RuntimeError(f"curve read failed: {detail}")
+        self._last_reader = ("claude", str(cfg.model))
         return stdout.decode()
+
+    async def _call_gemini(self, prompt: str, cfg, reason: str) -> str:
+        """Grounded Gemini fallback with the agent-trader's shared cost cap."""
+        await self._ensure_schema()
+        key = self._settings.gemini_api_key
+        if not key or not self._settings.gemini.enabled:
+            raise RuntimeError("term-structure Gemini fallback is unavailable")
+        row = await self._db.fetchone(
+            """SELECT COALESCE(SUM(calls), 0) AS n FROM agent_trader_costs
+                WHERE day = date('now')""")
+        calls = int(row["n"]) if row else 0
+        if (cfg.gemini_daily_call_limit > 0
+                and calls >= cfg.gemini_daily_call_limit):
+            raise RuntimeError("shared Gemini daily call limit exhausted")
+        model = str(self._settings.gemini.model)
+        url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
+               f"{model}:generateContent?key={key}")
+        body = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "tools": [{"google_search": {}}],
+            "generationConfig": {"temperature": 0.3, "maxOutputTokens": 2048},
+        }
+        data = await self._gemini_request(
+            url, body, int(cfg.llm_timeout_seconds))
+        try:
+            parts = data["candidates"][0]["content"]["parts"]
+            text = "".join(part.get("text", "") for part in parts).strip()
+        except (KeyError, IndexError, TypeError):
+            raise RuntimeError(
+                f"term-structure Gemini reply: {str(data)[:200]}")
+        usage = data.get("usageMetadata", {}) or {}
+        prices = cfg.gemini_price_per_mtok
+        usd = (
+            float(usage.get("promptTokenCount", 0)) * float(prices[0])
+            + float(usage.get("candidatesTokenCount", 0)) * float(prices[1])
+        ) / 1e6
+        await self._db.execute(
+            """INSERT INTO agent_trader_costs (day, model_alias, calls, usd)
+               VALUES (date('now'), 'term_structure_gemini', 1, ?)
+               ON CONFLICT(day, model_alias) DO UPDATE SET
+                   calls=calls+1, usd=usd+excluded.usd""",
+            (usd,),
+        )
+        await self._db.commit()
+        self._last_reader = ("gemini", model)
+        log.info("term_structure.gemini_call", model=model, reason=reason,
+                 usd=round(usd, 5))
+        return text
+
+    async def _gemini_request(
+        self, url: str, body: dict, timeout_seconds: int,
+    ) -> dict:
+        """One grounded Gemini request, split out for deterministic tests."""
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, json=body,
+                timeout=aiohttp.ClientTimeout(total=timeout_seconds),
+            ) as response:
+                return await response.json()
 
     # ------------------------------------------------------------------
     # Trading the curve — standard rails per strike
@@ -417,16 +592,35 @@ class TermStructurePillar:
             if m.id not in probs:
                 continue
             gap = abs(probs[m.id] - m.outcome_yes_price) * 100.0
-            if gap >= cfg.min_edge_pts:
+            claimed = await self._market_claimed(m.id)
+            liquid = m.liquidity >= cfg.min_liquidity
+            if claimed:
+                disposition = "claimed"
+            elif not liquid:
+                disposition = "context_only"
+            elif gap < cfg.min_edge_pts:
+                disposition = "below_edge"
+            else:
+                disposition = "candidate"
+            deadline = parse_deadline(m.question)
+            provider, model = self._last_reader
+            await self._db.execute(
+                """INSERT INTO term_structure_observations
+                   (family, market_id, deadline, model_prob, market_prob,
+                    gap_pts, provider, model, claimed, execution_liquid,
+                    disposition)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (fam, m.id, deadline.strftime("%Y-%m-%d") if deadline else "",
+                 probs[m.id], m.outcome_yes_price, gap, provider, model,
+                 int(claimed), int(liquid), disposition),
+            )
+            if disposition == "candidate":
                 gaps.append((gap, m))
+        await self._db.commit()
         gaps.sort(reverse=True, key=lambda g: g[0])
         for gap, market in gaps:
             if entered >= cfg.max_entries_per_family:
                 break
-            # Claimed markets don't consume an entry slot — the cap applies
-            # to entries actually made, largest gaps first.
-            if await self._market_claimed(market.id):
-                continue
             if await self._try_enter(market, probs[market.id], thesis, cfg):
                 entered += 1
         return entered

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -784,7 +784,7 @@ term_structure:
   interval_seconds: 7200
   model: claude-opus-4-8
   effort: medium
-  scan_limit: 300
+  scan_limit: 750
   min_strikes: 3
   # Throughput raised 2026-07-15 (12->16 families, 3->5 fresh reads/cycle):
   # the pillar's early ledger is the strongest of the new cells and its
@@ -795,11 +795,19 @@ term_structure:
   curve_ttl_hours: 24.0
   max_entries_per_family: 2
   stake_usd: 10.0
+  # Thin siblings may inform the curve, but cannot be traded. This avoids
+  # discarding an otherwise valid ladder because a deep strike is illiquid.
+  context_min_liquidity: 100.0
   min_liquidity: 1000.0
   min_days: 0.25
-  max_days: 90.0
+  max_days: 180.0
   min_edge_pts: 8.0
   llm_timeout_seconds: 420
+  # Claude weekly/daily exhaustion must not starve exploration. The grounded
+  # Gemini fallback shares the agent-trader's paid-call ceiling.
+  gemini_fallback: true
+  gemini_daily_call_limit: 30
+  gemini_price_per_mtok: [2.0, 12.0]
   exclude_categories: []
 
 vol_anchor:

--- a/config/settings.py
+++ b/config/settings.py
@@ -718,7 +718,7 @@ class TermStructureConfig(BaseModel):
     interval_seconds: int = 7200
     model: str = "claude-opus-4-8"
     effort: str = "medium"
-    scan_limit: int = 300
+    scan_limit: int = 750
     min_strikes: int = 3
     max_families: int = 16
     families_per_cycle: int = 5   # fresh LLM reads per cycle (cached fams free)
@@ -727,9 +727,13 @@ class TermStructureConfig(BaseModel):
     stake_usd: float = 10.0
     min_liquidity: float = 1000.0
     min_days: float = 0.25
-    max_days: float = 90.0
+    max_days: float = 180.0
+    context_min_liquidity: float = 100.0
     min_edge_pts: float = 8.0
     llm_timeout_seconds: int = 420
+    gemini_fallback: bool = True
+    gemini_daily_call_limit: int = 30
+    gemini_price_per_mtok: list[float] = [2.0, 12.0]
     exclude_categories: list[str] = []
 
 

--- a/tests/test_term_structure.py
+++ b/tests/test_term_structure.py
@@ -33,6 +33,19 @@ def test_parse_deadline_variants():
     assert parse_deadline("") is None
 
 
+def test_parse_deadline_extended_ladder_variants():
+    assert parse_deadline("Event by end of 2026?") == datetime(
+        2026, 12, 31, tzinfo=timezone.utc)
+    assert parse_deadline("Event by Q3 2026?") == datetime(
+        2026, 9, 30, tzinfo=timezone.utc)
+    assert parse_deadline("Event before September 2026?") == datetime(
+        2026, 9, 1, tzinfo=timezone.utc)
+    assert parse_deadline("Event by February 2028?") == datetime(
+        2028, 2, 29, tzinfo=timezone.utc)
+    assert family_key("Event by Q3 2026?") == "event"
+    assert family_key("Event before September 2026?") == "event"
+
+
 def test_family_key_strips_deadline_and_normalizes():
     a = family_key("US x Iran diplomatic meeting by July 10, 2026?")
     b = family_key("US x Iran diplomatic meeting by July 17, 2026?")
@@ -85,13 +98,20 @@ def _settings():
     cfg.max_entries_per_family = 2
     cfg.stake_usd = 10.0
     cfg.min_liquidity = 1000.0
+    cfg.context_min_liquidity = 100.0
     cfg.min_days = 0.25
     cfg.max_days = 90.0
     cfg.min_edge_pts = 8.0
     cfg.llm_timeout_seconds = 420
+    cfg.gemini_fallback = True
+    cfg.gemini_daily_call_limit = 30
+    cfg.gemini_price_per_mtok = [2.0, 12.0]
     cfg.exclude_categories = []
     s.risk.blocked_categories = []
     s.nlp.daily_claude_call_budget = 0
+    s.gemini.enabled = True
+    s.gemini.model = "gemini-test"
+    s.gemini_api_key = "test-key"
     return s
 
 
@@ -250,5 +270,66 @@ async def test_seed_and_search_completes_a_family(tmp_path):
         sigs = {r["market_id"] for r in await db.fetchall(
             "SELECT market_id FROM signals")}
         assert sigs == {"a", "b"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_thin_strike_informs_curve_but_is_not_traded(tmp_path):
+    strikes = _ladder()
+    strikes[1].liquidity = 200.0  # context floor passes; execution floor fails
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.90}, '
+             '{"market_id": "c", "prob": 0.72}]}')
+    pillar, db, _ = await _pillar(tmp_path, strikes, reply)
+    try:
+        assert await pillar.run_once() == 2
+        traded = {r["market_id"] for r in await db.fetchall(
+            "SELECT market_id FROM signals")}
+        assert traded == {"a", "c"}
+        row = await db.fetchone(
+            """SELECT disposition FROM term_structure_observations
+                WHERE market_id='b' ORDER BY id DESC LIMIT 1""")
+        assert row["disposition"] == "context_only"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_changed_strike_set_invalidates_cached_curve(tmp_path):
+    reply = ('{"thesis": "t", "curve": [{"market_id": "a", "prob": 0.40},'
+             '{"market_id": "b", "prob": 0.70}, '
+             '{"market_id": "c", "prob": 0.72}]}')
+    pillar, db, _ = await _pillar(tmp_path, _ladder(), reply)
+    try:
+        await pillar._ensure_schema()
+        await pillar._read_family("event", _ladder(), pillar._settings.term_structure)
+        expanded = _ladder() + [_strike("d", 28, 0.60)]
+        cached = await pillar._cached_curve(
+            "event", expanded, pillar._settings.term_structure)
+        assert cached is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_grounded_gemini_fallback_records_cost(tmp_path):
+    pillar, db, _ = await _pillar(tmp_path, _ladder(), "")
+    pillar._gemini_request = AsyncMock(return_value={
+        "candidates": [{"content": {"parts": [{"text": '{"curve": []}'}]}}],
+        "usageMetadata": {"promptTokenCount": 1000, "candidatesTokenCount": 500},
+    })
+    try:
+        text = await pillar._call_gemini(
+            "prompt", pillar._settings.term_structure, "test")
+        assert text == '{"curve": []}'
+        assert pillar._last_reader == ("gemini", "gemini-test")
+        row = await db.fetchone(
+            """SELECT calls, usd FROM agent_trader_costs
+                WHERE model_alias='term_structure_gemini'""")
+        assert row["calls"] == 1
+        assert row["usd"] == pytest.approx(0.008)
+        body = pillar._gemini_request.await_args.args[1]
+        assert body["tools"] == [{"google_search": {}}]
     finally:
         await db.close()


### PR DESCRIPTION
## Summary
- expand deadline-ladder discovery from 300 to 750 markets and 90 to 180 days
- admit $100-liquidity sibling strikes as curve context while retaining the $1,000 execution floor
- support end-of-year, quarter, before-month, and month-only deadline forms
- add strike-set-aware curve caching and per-strike shadow observations
- fall back from exhausted Claude quota to grounded Gemini with a shared paid-call ceiling and cost attribution

## Safety
- remains paper-forced
- retains the 8-point minimum edge, $10 stake, two-entry family cap, and standard risk/execution gates
- low-liquidity context strikes cannot be traded
- provider and model are persisted for evaluation

## Validation
- `python -m ruff check auramaur/strategy/term_structure.py config/settings.py tests/test_term_structure.py`
- `python -m pytest -q -p no:cacheprovider` — 1,464 passed, 3 skipped
- `git diff --check`
- Docker image built and deployed successfully
- live shakedown detected Claude weekly quota, used grounded Gemini 3.1 Pro, stored a three-strike curve, and recorded two below-edge plus one context-only observation with no trade