### PR TITLE
fix: unblock evidence throughput

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1163,7 +1163,9 @@ class AuramaurBot(
                 # Fetch liquid markets sorted by volume
                 try:
                     markets = await asyncio.wait_for(
-                        discovery.get_markets(limit=50, order="liquidity"),
+                        discovery.get_markets(
+                            limit=self.settings.market_maker.market_scan_limit,
+                            order="liquidity"),
                         timeout=op_timeout)
                 except asyncio.TimeoutError:
                     log.warning("market_maker.op_timeout", op="get_markets",

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -286,7 +286,12 @@ class AuramaurBot(
                        LIMIT ?""",
                     (engine.exchange_name or "polymarket", min_liquidity, max_markets),
                 )
-                recorded = 0
+                # Fetch every book over the network FIRST, then write the
+                # batch in one tight span. Interleaving the INSERTs with the
+                # per-market fetch + sleep held the shared connection's
+                # implicit write transaction open for the entire sweep,
+                # wedging every other pillar writer for its duration.
+                snapshots = []
                 for row in rows:
                     if not self._running:
                         break
@@ -305,11 +310,7 @@ class AuramaurBot(
                     # bids[0]/asks[0] (see OrderBook docstring).
                     bids = sorted(book.bids, key=lambda lv: lv.price, reverse=True)
                     asks = sorted(book.asks, key=lambda lv: lv.price)
-                    await engine.db.execute(
-                        "INSERT INTO orderbook_snapshots "
-                        "(market_id, token_id, exchange, best_bid, best_ask, bid_size, "
-                        "ask_size, mid, bid2, ask2, bid2_size, ask2_size) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    snapshots.append(
                         (
                             market_id, token_id, engine.exchange_name or "polymarket",
                             bid, ask,
@@ -320,13 +321,20 @@ class AuramaurBot(
                             asks[1].price if len(asks) > 1 else None,
                             bids[1].size if len(bids) > 1 else None,
                             asks[1].size if len(asks) > 1 else None,
-                        ),
+                        )
                     )
-                    recorded += 1
                     await asyncio.sleep(pause)
-                if recorded:
+                if snapshots:
+                    for params in snapshots:
+                        await engine.db.execute(
+                            "INSERT INTO orderbook_snapshots "
+                            "(market_id, token_id, exchange, best_bid, best_ask, bid_size, "
+                            "ask_size, mid, bid2, ask2, bid2_size, ask2_size) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            params,
+                        )
                     await engine.db.commit()
-                    log.debug("orderbook_recorder.swept", exchange=name, recorded=recorded)
+                    log.debug("orderbook_recorder.swept", exchange=name, recorded=len(snapshots))
             except Exception as e:
                 show_error(f"Order-book recorder failed ({name}): {e}")
             await asyncio.sleep(self._adaptive_interval(interval))
@@ -1887,7 +1895,9 @@ class AuramaurBot(
                 clients.setdefault(id(client), (name, client))
 
         db = self._components.db
-        cancelled = 0
+        # Cancel over the network first, then write the batch tightly — no
+        # open transaction on the shared connection across cancel_order calls.
+        cancelled_ids: list[str] = []
         for exchange_name, client in clients.values():
             for order_id in list(getattr(client, "_live_pending", {}).keys()):
                 try:
@@ -1902,17 +1912,15 @@ class AuramaurBot(
                     continue
                 if not ok:
                     continue
-                cancelled += 1
-                if db is not None:
-                    try:
-                        await db.execute(
-                            "UPDATE trades SET status = 'cancelled' WHERE order_id = ?",
-                            (order_id,),
-                        )
-                    except Exception:
-                        pass
+                cancelled_ids.append(order_id)
+        cancelled = len(cancelled_ids)
         if cancelled and db is not None:
             try:
+                for order_id in cancelled_ids:
+                    await db.execute(
+                        "UPDATE trades SET status = 'cancelled' WHERE order_id = ?",
+                        (order_id,),
+                    )
                 await db.commit()
             except Exception:
                 pass

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -339,17 +339,16 @@ class OrderMonitorMixin:
         # kalshi row did exactly that); mark them terminal instead.
         sentinel_ids = {"unknown", "ERROR", "BLOCKED", "INSUFFICIENT_BALANCE",
                         "SKIP_DUP", "POST_ONLY_REJECTED"}
-        fixed = 0
+        # Resolve every terminal status over the network FIRST, then apply
+        # the UPDATEs in one tight write span — get_order_status must never
+        # be awaited while the shared connection holds an open transaction.
+        updates: list[tuple[str, str]] = []  # (new_status, order_id)
         for row in rows:
             order_id = row["order_id"]
             if order_id in tracked or order_id.startswith("PAPER"):
                 continue
             if order_id in sentinel_ids:
-                await db.execute(
-                    "UPDATE trades SET status = 'error' WHERE order_id = ? AND status = 'pending'",
-                    (order_id,),
-                )
-                fixed += 1
+                updates.append(("error", order_id))
                 continue
             client = clients_by_name.get(row["exchange"] or "polymarket")
             if client is None or not hasattr(client, "get_order_status"):
@@ -359,16 +358,23 @@ class OrderMonitorMixin:
             except Exception:
                 continue
             if result.status in ("filled", "cancelled", "expired", "rejected"):
-                await db.execute(
-                    "UPDATE trades SET status = ? WHERE order_id = ?",
-                    (result.status, order_id),
-                )
-                fixed += 1
-            if fixed >= 5:
+                updates.append((result.status, order_id))
+            if len(updates) >= 5:
                 break
-        if fixed:
+        if updates:
+            for new_status, order_id in updates:
+                if new_status == "error":
+                    await db.execute(
+                        "UPDATE trades SET status = 'error' WHERE order_id = ? AND status = 'pending'",
+                        (order_id,),
+                    )
+                else:
+                    await db.execute(
+                        "UPDATE trades SET status = ? WHERE order_id = ?",
+                        (new_status, order_id),
+                    )
             await db.commit()
-            log.info("order_monitor.orphans_reconciled", count=fixed)
+            log.info("order_monitor.orphans_reconciled", count=len(updates))
 
     async def _task_resolution_checker(self) -> None:
         """Poll for resolved markets and record calibration outcomes.

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -22,6 +22,7 @@ per-leg ``submit`` could not.
 from __future__ import annotations
 
 import asyncio
+import uuid
 from dataclasses import dataclass
 from typing import Literal
 
@@ -476,7 +477,27 @@ class ExecutionGateway:
         returns the pair. Recording stays with the order monitor (orders carry
         ``source="market_maker"``); the gateway owns the placement so no strategy
         calls ``exchange.place_order`` directly.
+
+        PAPER quotes never reach the exchange client: the paper branch of
+        ``place_order`` fills every order INSTANTLY into the shared PaperTrader
+        book, whose in-memory positions are keyed by market_id alone — so a
+        two-sided quote's YES-bid and NO-ask legs merged into one blended
+        ~mid-priced phantom position that regrew on every refresh, was never
+        recorded to trades/fills (by design, anti-flooding), and was then
+        persisted by position_sync as an untraceable orphan (2026-07-23: 7 rows,
+        ~$700 phantom cost). A resting post-only quote must not fill at
+        placement; until the MM gets a real paper fill simulation, paper quotes
+        rest synthetically and expire without ever filling.
         """
+        if bid_order.dry_run or ask_order.dry_run:
+            def _resting(order: Order) -> OrderResult:
+                return OrderResult(
+                    order_id=f"PAPER-QUOTE-{uuid.uuid4().hex[:12]}",
+                    market_id=order.market_id,
+                    status="pending",
+                    is_paper=True,
+                )
+            return _resting(bid_order), _resting(ask_order)
         bid_result = await exchange.place_order(bid_order)
         ask_result = await exchange.place_order(ask_order)
         return bid_result, ask_result

--- a/auramaur/data_sources/rss.py
+++ b/auramaur/data_sources/rss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -13,6 +14,13 @@ import structlog
 from auramaur.data_sources.base import NewsItem
 
 logger = structlog.get_logger(__name__)
+
+# feedparser.parse is synchronous and CPU-bound; a pathological body (observed
+# 2026-07-23: ~25-minute parse) run on the event loop freezes exits and risk
+# checks for its whole duration. Bodies are size-capped and parsed in a worker
+# thread with a deadline; a feed that trips either limit is dropped, not waited on.
+_MAX_FEED_BYTES = 3_000_000
+_PARSE_TIMEOUT_SECONDS = 60.0
 
 _DEFAULT_FEEDS: list[str] = [
     # Major news
@@ -70,7 +78,17 @@ class RSSSource:
             logger.debug("rss_feed_unreachable", url=url, error=str(e)[:60])
             return []
 
-        feed = feedparser.parse(body)
+        if len(body) > _MAX_FEED_BYTES:
+            logger.warning("rss_feed_oversized", url=url, body_bytes=len(body))
+            return []
+        try:
+            feed = await asyncio.wait_for(
+                asyncio.to_thread(feedparser.parse, body),
+                timeout=_PARSE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("rss_feed_parse_timeout", url=url, body_bytes=len(body))
+            return []
         items: list[NewsItem] = []
 
         # Build keyword set from query for fuzzy matching

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -33,7 +33,14 @@ class Database:
         database still gets the full init — the flag can never leave a caller
         on a stale schema.
         """
-        self._db = await aiosqlite.connect(self.db_path)
+        # True autocommit is required on the shared connection. Hundreds of
+        # older one-statement writers still call execute()+commit(); with
+        # sqlite's default implicit-deferred mode, an exception/cancellation
+        # between those calls strands the ONE shared connection inside a
+        # transaction and blocks every transaction() adopter for 15 seconds.
+        # Atomic multi-statement paths use transaction() below, whose explicit
+        # BEGIN IMMEDIATE/COMMIT semantics are unchanged by autocommit.
+        self._db = await aiosqlite.connect(self.db_path, isolation_level=None)
         self._db.row_factory = aiosqlite.Row
         await self._db.execute("PRAGMA journal_mode=WAL")
         # foreign_keys stays OFF by design, NOT as repair debt. The markets
@@ -99,15 +106,10 @@ class Database:
             return
         requested_owner = owner or asyncio.current_task().get_name()
         async with self._txn_lock:
-            # A legacy autocommit-style writer may be mid-flight (implicit
-            # txn open, its commit() imminent). Wait it out rather than
-            # committing on its behalf — that would be the exact bleed this
-            # context manager exists to remove. Bounded so a genuinely wedged
-            # writer still fails loudly in BEGIN — but the bound must OUTLAST
-            # real write bursts: measured engine bursts run 1-3.4s, and a 2s
-            # bound turned every unlucky overlap into a position_sync error
-            # (2026-07-20). 15s clears every burst ever observed while still
-            # bounding a true wedge.
+            # Autocommit legacy writes cannot strand an implicit transaction.
+            # Keep this check as a corruption/concurrency tripwire: the only
+            # legitimate active transaction is owned by transaction(), which
+            # also owns _txn_lock and therefore cannot reach this block.
             deadline = time.monotonic() + 15.0
             while self._db._conn.in_transaction and time.monotonic() < deadline:
                 await asyncio.sleep(0.005)

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -270,6 +270,41 @@ class Database:
             await self._migrate_v37_to_v38()
         if from_version < 39:
             await self._migrate_v38_to_v39()
+        if from_version < 40:
+            await self._migrate_v39_to_v40()
+
+    async def _migrate_v39_to_v40(self) -> None:
+        """Unified LLM cost/quota ledger view (llm_costs_daily)."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS agent_trader_costs (
+                day TEXT NOT NULL,
+                model_alias TEXT NOT NULL,
+                calls INTEGER NOT NULL DEFAULT 0,
+                usd REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (day, model_alias)
+            );
+            CREATE TABLE IF NOT EXISTS llm_call_counter (
+                day TEXT PRIMARY KEY,
+                claude_calls INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE VIEW IF NOT EXISTS llm_costs_daily AS
+            SELECT day, 'gemini:' || model_alias AS source, calls, usd AS cost_usd
+              FROM agent_trader_costs
+            UNION ALL
+            SELECT date(started_at) AS day, 'openai:' || model_alias AS source,
+                   COUNT(*) AS calls, COALESCE(SUM(cost_usd), 0) AS cost_usd
+              FROM ibkr_etf_openai_attempts GROUP BY date(started_at), model_alias
+            UNION ALL
+            SELECT day, 'claude_cli(quota)' AS source, claude_calls AS calls, 0.0 AS cost_usd
+              FROM llm_call_counter
+            UNION ALL
+            SELECT date(created_at) AS day, 'local:' || model AS source,
+                   COUNT(*) AS calls, 0.0 AS cost_usd
+              FROM local_llm_calls GROUP BY date(created_at), model;
+        """)
+        await self._db.execute("UPDATE schema_version SET version = 40")
+        await self._db.commit()
+        log.info("database.migrated", from_version=39, to_version=40)
 
     async def _migrate_v38_to_v39(self) -> None:
         """Durable lifecycle for graduated IBKR broker orders."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 39
+SCHEMA_VERSION = 40
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -1097,4 +1097,41 @@ SELECT 'information:' || pf.trial_id || ':' || pf.arm, 'information_trial',
   LEFT JOIN markets m ON m.id=t.market_id
   LEFT JOIN market_outcomes o
     ON o.event_key=lower(COALESCE(NULLIF(m.exchange,''),'polymarket')) || ':' || t.market_id;
+
+-- Promoted from lazy runtime creation (agent_trader.py / call_budget.py) so
+-- the llm_costs_daily view below always has its tables on a fresh database.
+-- Shapes must stay identical to the lazy CREATE IF NOT EXISTS definitions.
+CREATE TABLE IF NOT EXISTS agent_trader_costs (
+    day TEXT NOT NULL,
+    model_alias TEXT NOT NULL,
+    calls INTEGER NOT NULL DEFAULT 0,
+    usd REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (day, model_alias)
+);
+
+CREATE TABLE IF NOT EXISTS llm_call_counter (
+    day TEXT PRIMARY KEY,
+    claude_calls INTEGER NOT NULL DEFAULT 0
+);
+
+-- Unified LLM cost/quota ledger: one row per (day, source). Marginal dollars
+-- for metered APIs (gemini/openai); call counts for the quota-bound Claude
+-- subscription and the free local tier (cost_usd 0 by definition — their
+-- scarcity is quota and hardware, not dollars). daily_stats.api_cost_estimate
+-- was never wired; this view is the authoritative answer to "what does a day
+-- of inference cost" (2026-07-24 breadth/cost audit).
+CREATE VIEW IF NOT EXISTS llm_costs_daily AS
+SELECT day, 'gemini:' || model_alias AS source, calls, usd AS cost_usd
+  FROM agent_trader_costs
+UNION ALL
+SELECT date(started_at) AS day, 'openai:' || model_alias AS source,
+       COUNT(*) AS calls, COALESCE(SUM(cost_usd), 0) AS cost_usd
+  FROM ibkr_etf_openai_attempts GROUP BY date(started_at), model_alias
+UNION ALL
+SELECT day, 'claude_cli(quota)' AS source, claude_calls AS calls, 0.0 AS cost_usd
+  FROM llm_call_counter
+UNION ALL
+SELECT date(created_at) AS day, 'local:' || model AS source,
+       COUNT(*) AS calls, 0.0 AS cost_usd
+  FROM local_llm_calls GROUP BY date(created_at), model;
 """

--- a/auramaur/evaluation/runner.py
+++ b/auramaur/evaluation/runner.py
@@ -77,6 +77,10 @@ class TreatmentSpec:
     policy: ExplorationPolicy = ExplorationPolicy.SINGLE
     sample_count: int = 1
     base_seed: int = 0
+    # Treatment-side evidence merged into the request payload (NOT the frozen
+    # episode): the episode hash and pairing stay identical across arms, so a
+    # claims-enriched arm scores against the bare arm on the same snapshot.
+    extra_payload: Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if not self.treatment_id:
@@ -249,11 +253,13 @@ class IntelligenceEvalRunner:
 
     async def _run_treatment(self, episode: Episode, spec: TreatmentSpec) -> TreatmentResult:
         count = 1 if spec.policy is ExplorationPolicy.SINGLE else spec.sample_count
+        payload = (episode.payload if spec.extra_payload is None
+                   else {**dict(episode.payload), **dict(spec.extra_payload)})
         requests = [
             GenerationRequest(
                 episode.episode_id,
                 episode.payload_hash,
-                episode.payload,
+                payload,
                 spec.treatment_id,
                 spec.arm.arm_id,
                 spec.arm.model,
@@ -272,7 +278,7 @@ class IntelligenceEvalRunner:
             critic_request = GenerationRequest(
                 episode.episode_id,
                 episode.payload_hash,
-                episode.payload,
+                payload,
                 spec.treatment_id,
                 spec.arm.arm_id,
                 spec.arm.model,

--- a/auramaur/evaluation/service.py
+++ b/auramaur/evaluation/service.py
@@ -7,6 +7,7 @@ no broker, risk, exchange execution, or production portfolio dependencies.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
 import json
 import math
@@ -103,6 +104,8 @@ class IntelligenceEvalService:
         self._treatments = tuple(TreatmentSpec(
             item.name, arm, ExplorationPolicy(item.policy), item.samples, item.base_seed,
         ) for item in self._cfg.treatments)
+        self._claims_treatments = frozenset(
+            item.name for item in self._cfg.treatments if item.claims_evidence)
         self._runner = IntelligenceEvalRunner(self._cfg.max_concurrency)
 
     async def run_once(self) -> int:
@@ -148,6 +151,34 @@ class IntelligenceEvalService:
         await self._store.put_cycle(metrics)
         log.info("intelligence_eval.cycle", **metrics)
         return recorded
+
+    async def _attach_claims(self, treatments, market_id: str):
+        """Give claims_evidence arms this market's distilled claims.
+
+        Evidence rides the REQUEST payload, never the frozen episode, so the
+        episode hash (and therefore pairing) is identical across arms. An arm
+        with no matched claims is dropped for that market — running it would
+        duplicate the bare arm and dilute the paired comparison. Claims are
+        no-lookahead by construction: only already-distilled rows exist.
+        """
+        if not self._claims_treatments or not any(
+                t.treatment_id in self._claims_treatments for t in treatments):
+            return treatments
+        rows = await self._db.fetchall(
+            """SELECT claim, source, event_date FROM distilled_claims
+               WHERE markets_affected LIKE ?
+               ORDER BY created_at DESC LIMIT 8""",
+            (f'%"{market_id}"%',))
+        claims = [{"claim": r["claim"], "source": r["source"],
+                   "event_date": r["event_date"]} for r in rows or []]
+        kept = []
+        for spec in treatments:
+            if spec.treatment_id not in self._claims_treatments:
+                kept.append(spec)
+            elif claims:
+                kept.append(dataclasses.replace(
+                    spec, extra_payload={"distilled_evidence": claims}))
+        return tuple(kept)
 
     @staticmethod
     def _family(market) -> str:
@@ -220,6 +251,7 @@ class IntelligenceEvalService:
         payload = json.loads(snapshot.canonical_json())
         episode = Episode(snapshot.episode_hash, payload)
         treatments = treatments or self._treatments
+        treatments = await self._attach_claims(treatments, market.id)
         results = await self._runner.run(episode, treatments)
         written = 0
         attempt_count = failed_count = 0

--- a/auramaur/monitoring/balances.py
+++ b/auramaur/monitoring/balances.py
@@ -96,7 +96,10 @@ async def record_venue_balances(db, settings, *, include_ibkr: bool = True) -> N
     if include_ibkr and settings.ibkr.enabled:
         fetchers["ibkr"] = ibkr_balance
 
-    wrote = False
+    # All venue fetches complete BEFORE the first write: a slow/hung venue
+    # API (the 2026-07-21 gateway outage ran 8h) must never be awaited while
+    # the shared connection holds an open write transaction.
+    fetched: list[tuple[str, str]] = []
     for venue, fetch in fetchers.items():
         try:
             detail = await fetch(settings)
@@ -107,13 +110,14 @@ async def record_venue_balances(db, settings, *, include_ibkr: bool = True) -> N
             log.warning("balance_recorder.fetch_error", venue=venue,
                         error=str(exc)[:120])
             continue
-        await db.execute(
-            """INSERT INTO venue_balances (venue, detail, fetched_at)
-               VALUES (?, ?, ?)
-               ON CONFLICT(venue) DO UPDATE SET
-                   detail = excluded.detail, fetched_at = excluded.fetched_at""",
-            (venue, detail, datetime.now(timezone.utc).isoformat()),
-        )
-        wrote = True
-    if wrote:
+        fetched.append((venue, detail))
+    if fetched:
+        for venue, detail in fetched:
+            await db.execute(
+                """INSERT INTO venue_balances (venue, detail, fetched_at)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(venue) DO UPDATE SET
+                       detail = excluded.detail, fetched_at = excluded.fetched_at""",
+                (venue, detail, datetime.now(timezone.utc).isoformat()),
+            )
         await db.commit()

--- a/auramaur/monitoring/feed.py
+++ b/auramaur/monitoring/feed.py
@@ -16,6 +16,7 @@ display layer two tools:
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 
@@ -86,10 +87,18 @@ class LoopWatchdog(threading.Thread):
         stall_seconds: float = 180.0,
         check_interval: float = 30.0,
         alert=None,
+        hard_exit_seconds: float = 900.0,
     ):
         super().__init__(name="loop-watchdog", daemon=True)
         self.stall_seconds = stall_seconds
         self.check_interval = check_interval
+        # A stall this long means exits and risk checks have been dead for
+        # its whole duration and self-recovery is no longer worth waiting
+        # for: exit nonzero so Docker's restart:on-failure revives the bot
+        # (the 2026-07-23 wedges each froze the book 25-35 min and needed
+        # manual restarts; the container healthcheck cannot see a stall).
+        # Set <= 0 to disable.
+        self.hard_exit_seconds = hard_exit_seconds
         self._alert = alert or (lambda msg: None)
         self._last_beat = time.monotonic()
         self._stalled_since: float | None = None
@@ -97,6 +106,14 @@ class LoopWatchdog(threading.Thread):
 
     def beat(self) -> None:
         self._last_beat = time.monotonic()
+
+    @staticmethod
+    def _hard_exit() -> None:  # pragma: no cover - patched in tests
+        # os._exit, not sys.exit: the event loop is dead, so graceful
+        # shutdown would hang behind the very stall being escaped. State is
+        # safe — every completed write is committed, and the WAL recovers
+        # anything mid-flight on the next open.
+        os._exit(70)
 
     def stop(self) -> None:
         self._stop.set()
@@ -107,6 +124,18 @@ class LoopWatchdog(threading.Thread):
 
     def _check(self) -> None:
         gap = time.monotonic() - self._last_beat
+        if (
+            self.hard_exit_seconds > 0
+            and gap >= self.hard_exit_seconds
+            and not self._stop.is_set()
+        ):
+            self._alert(
+                f"EVENT LOOP DEAD for {gap:.0f}s — exiting so the "
+                f"container restart policy can revive the bot."
+            )
+            log.critical("watchdog.hard_exit", gap_seconds=round(gap))
+            self._hard_exit()
+            return
         if gap >= self.stall_seconds and self._stalled_since is None:
             self._stalled_since = self._last_beat
             self._alert(

--- a/auramaur/monitoring/intraday_drift.py
+++ b/auramaur/monitoring/intraday_drift.py
@@ -115,7 +115,9 @@ class IntradayDriftTracker:
             f"""SELECT DISTINCT market_id, signal_at, estimate, p0 FROM intraday_drift_obs
                 WHERE (julianday('now') - julianday(signal_at)) * 24.0 < {cfg.time_box_hours}
                 LIMIT ?""", (cfg.max_tracks_per_cycle,))
-        observed = 0
+        # Discovery fetches complete BEFORE the first write so the shared
+        # connection never holds an open transaction across network awaits.
+        mids: list[tuple[dict, float]] = []
         for t in active or []:
             try:
                 m = await self._discovery.get_market(t["market_id"])
@@ -123,6 +125,9 @@ class IntradayDriftTracker:
                 m = None
             if m is None or not (0.0 < m.outcome_yes_price < 1.0):
                 continue
+            mids.append((t, m.outcome_yes_price))
+        observed = 0
+        for t, mid in mids:
             minutes = await self._db.fetchone(
                 "SELECT (julianday('now') - julianday(?)) * 1440.0 AS m", (t["signal_at"],))
             await self._db.execute(
@@ -130,7 +135,7 @@ class IntradayDriftTracker:
                    (market_id, signal_at, strategy, estimate, p0, obs_at, minutes, mid)
                    VALUES (?, ?, '', ?, ?, datetime('now'), ?, ?)""",
                 (t["market_id"], t["signal_at"], float(t["estimate"]), float(t["p0"]),
-                 float(minutes["m"]), m.outcome_yes_price))
+                 float(minutes["m"]), mid))
             observed += 1
         await self._db.commit()
 

--- a/auramaur/nlp/analyzer.py
+++ b/auramaur/nlp/analyzer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import re
 
@@ -20,6 +21,11 @@ from auramaur.nlp.prompts import (
 from config.settings import Settings
 
 log = structlog.get_logger()
+
+# The Claude CLI uses one account/session directory. Parallel subprocesses
+# were exiting rc=1 with empty stderr and multiplying each logical call into
+# three retries. Serialize the process lane; callers remain async while queued.
+_CLAUDE_CLI_SEMAPHORE = asyncio.Semaphore(1)
 
 
 class AnalysisResult(BaseModel):
@@ -159,16 +165,25 @@ class ClaudeAnalyzer:
         for attempt in range(1, max_attempts + 1):
             try:
                 from auramaur.subprocess_security import analysis_subprocess_env
-                proc = await asyncio.create_subprocess_exec(
-                    "claude", "-p", prompt,
-                    "--output-format", "text",
-                    "--model", self._model,
-                    "--effort", use_effort,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=analysis_subprocess_env(),
-                )
-                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=180)
+                async with _CLAUDE_CLI_SEMAPHORE:
+                    proc = await asyncio.create_subprocess_exec(
+                        "claude", "-p", prompt,
+                        "--output-format", "text",
+                        "--model", self._model,
+                        "--effort", use_effort,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=analysis_subprocess_env(),
+                    )
+                    try:
+                        stdout, stderr = await asyncio.wait_for(
+                            proc.communicate(), timeout=180)
+                    except (TimeoutError, asyncio.TimeoutError):
+                        killed = proc.kill()
+                        if inspect.isawaitable(killed):  # test doubles
+                            await killed
+                        await proc.wait()
+                        raise
 
                 if proc.returncode != 0:
                     err_msg = stderr.decode().strip()

--- a/auramaur/nlp/evidence_distiller.py
+++ b/auramaur/nlp/evidence_distiller.py
@@ -151,7 +151,7 @@ class EvidenceDistiller:
                WHERE eo.observed_at >= datetime('now', ?)
                  AND eo.title != ''
                  AND (dp.content_hash IS NULL
-                      OR (dp.status = 'error' AND dp.attempts < ?))
+                      OR (dp.status IN ('error', 'empty') AND dp.attempts < ?))
                GROUP BY eo.content_hash
                ORDER BY MAX(eo.observed_at) DESC
                LIMIT ?""",

--- a/auramaur/strategy/arbitrage.py
+++ b/auramaur/strategy/arbitrage.py
@@ -57,12 +57,13 @@ class ArbitrageExecutor:
 
         if opp["type"] == "conditional_violation":
             # A implies B, but P(A) > P(B) — buy B (underpriced), sell A (overpriced)
-            return self._make_signal_pair(
+            pair = self._make_signal_pair(
                 buy_market=market_b,
                 sell_market=market_a,
                 edge=opp["price_a"] - opp["price_b"],
                 opp=opp,
             )
+            return pair if self._pair_is_executable(market_b, market_a, opp) else None
 
         elif opp["type"] == "price_divergence":
             # Same event priced differently — buy cheap, sell expensive
@@ -70,14 +71,29 @@ class ArbitrageExecutor:
                 buy_market, sell_market = market_a, market_b
             else:
                 buy_market, sell_market = market_b, market_a
-            return self._make_signal_pair(
+            pair = self._make_signal_pair(
                 buy_market=buy_market,
                 sell_market=sell_market,
                 edge=opp.get("divergence", abs(opp["price_a"] - opp["price_b"])),
                 opp=opp,
             )
+            return pair if self._pair_is_executable(buy_market, sell_market, opp) else None
 
         return None
+
+    @staticmethod
+    def _pair_is_executable(buy: Market, sell: Market, opp: dict) -> bool:
+        """Reject structurally untradeable pairs before they reach the bot loop."""
+        missing: list[tuple[str, str]] = []
+        if (buy.exchange or "polymarket") == "polymarket" and not buy.clob_token_yes:
+            missing.append((buy.id, "YES"))
+        if (sell.exchange or "polymarket") == "polymarket" and not sell.clob_token_no:
+            missing.append((sell.id, "NO"))
+        if missing:
+            log.info("arbitrage.candidate_suppressed", type=opp.get("type"),
+                     reason="missing_execution_metadata", missing_tokens=missing)
+            return False
+        return True
 
     def _make_signal_pair(
         self,

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -131,6 +131,7 @@ class BiasHarvestPillar:
                     entered += 1
             except Exception as e:
                 log.error("bias_harvest.entry_error", market_id=market.id, error=str(e))
+        self.last_cycle_detail = {"scanned": len(markets), "entered": entered}
         log.info("bias_harvest.cycle", scanned=len(markets), entered=entered)
         return entered
 

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -340,6 +340,7 @@ class CrossVenueArbPillar:
             # Log EVERY cycle (the settlement_arb #246 lesson): this early
             # return was silent, so a pillar whose pair discovery never fires
             # is indistinguishable from a dead task.
+            self.last_cycle_detail = {"pairs": 0, "entered": 0}
             log.info("cross_venue.cycle", pairs=0, entered=0)
             return 0
         entered = 0
@@ -362,5 +363,6 @@ class CrossVenueArbPillar:
                     entered += 1
             except Exception as e:
                 log.error("cross_venue.entry_error", a=a.id, b=b.id, error=str(e))
+        self.last_cycle_detail = {"pairs": len(pairs), "entered": entered}
         log.info("cross_venue.cycle", pairs=len(pairs), entered=entered)
         return entered

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -489,6 +489,7 @@ class EntailmentArbPillar:
             except Exception as e:
                 log.error("entailment.entry_error", a=implier.id, b=implied.id,
                           error=str(e))
+        self.last_cycle_detail = {"candidates": len(candidates), "placed": placed}
         log.info("entailment.cycle", candidates=len(candidates), placed=placed)
         return placed
 

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -497,18 +497,18 @@ class IBKRMultiAssetPaperBook:
 
             from auramaur.research.ibkr_signals import PricePoint, fx_carry_trend
             now = datetime.now(timezone.utc)
+            # Gather all bars/rates over the network FIRST; the write+commit
+            # span at the end stays pure-DB so the shared connection never
+            # holds an open transaction across gateway/rates awaits.
+            signal_rows: list[tuple] = []
             for spec in BY_BOOK[self.book]:
                 try:
                     bars = await self._client.get_daily_bars(spec)
                     closes = closes_from_bars(bars)
                     momentum = normalized_momentum(closes)
                     if momentum is not None:
-                        await self._db.execute(
-                            """INSERT OR IGNORE INTO ibkr_research_signals
-                               (instrument_key, signal_date, signal_name,
-                                direction, strength, detail)
-                               VALUES (?, date('now'), 'trend_normalized', ?, ?, ?)""",
-                            (spec.key,
+                        signal_rows.append(
+                            (spec.key, "trend_normalized",
                              1 if momentum > 0 else -1 if momentum < 0 else 0,
                              abs(momentum), f"normalized_momentum={momentum:.4f}"))
                     if self._rates_provider is None or len(spec.key) < 6:
@@ -525,16 +525,19 @@ class IBKRMultiAssetPaperBook:
                         for i, c in enumerate(window)]
                     signal = fx_carry_trend(points, as_of=now, base_rate=base_rate,
                                             quote_rate=quote_rate)
-                    await self._db.execute(
-                        """INSERT OR IGNORE INTO ibkr_research_signals
-                           (instrument_key, signal_date, signal_name,
-                            direction, strength, detail)
-                           VALUES (?, date('now'), 'fx_carry_trend', ?, ?, ?)""",
-                        (spec.key, signal.direction, signal.score,
-                         signal.rationale[:200]))
+                    signal_rows.append(
+                        (spec.key, "fx_carry_trend", signal.direction,
+                         signal.score, signal.rationale[:200]))
                 except Exception as e:  # noqa: BLE001 - one pair must not stop the sweep
                     log.warning("ibkr_multiasset.research_signal_error",
                               key=spec.key, error=str(e)[:100])
+            for key, name, direction, strength, detail in signal_rows:
+                await self._db.execute(
+                    """INSERT OR IGNORE INTO ibkr_research_signals
+                       (instrument_key, signal_date, signal_name,
+                        direction, strength, detail)
+                       VALUES (?, date('now'), ?, ?, ?, ?)""",
+                    (key, name, direction, strength, detail))
             await self._db.commit()
         except Exception as e:  # noqa: BLE001 - research-only
             log.warning("ibkr_multiasset.research_error", error=str(e)[:120])

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -111,6 +111,10 @@ class PlatformConsensusPillar:
         # Log EVERY cycle (the settlement_arb #246 lesson): the previous
         # entered>0 guard made zero-entry cycles silent, so weeks of "running
         # fine, entering nothing" were indistinguishable from a dead task.
+        self.last_cycle_detail = {"scanned": len(markets),
+                                  "eligible": len(eligible_markets),
+                                  "evaluated": eval_limit,
+                                  "entered": entered, "open": open_count}
         log.info("platform_consensus.cycle_done", scanned=len(markets),
                  eligible=len(eligible_markets), evaluated=eval_limit,
                  entered=entered, open=open_count)

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -254,6 +254,10 @@ class SettlementArbPillar:
         # annual / compound-range markets) was previously SILENT, making the
         # pillar indistinguishable from dead. scanned/with_predicate/entered tell
         # the three stories apart: no candidates vs none determinable vs converged.
+        self.last_cycle_detail = {"scanned": len(markets),
+                                  "with_predicate": with_pred,
+                                  "entered": entered,
+                                  "stages": dict(self._stages)}
         log.info("settlement_arb.cycle", scanned=len(markets),
                  with_predicate=with_pred, entered=entered,
                  stages=dict(self._stages))

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -562,6 +562,7 @@ market_maker:
   quote_size: 10.0          # tokens per side
   max_inventory: 50.0       # max directional exposure per market
   max_markets: 5            # max simultaneous MM markets
+  market_scan_limit: 200    # widen discovery; downstream safety filters still apply
   # No NEW quote pairs while spendable live cash <= this floor (exits and
   # cancels never gated). MM is the only always-live cell, so without a
   # floor it auto-claims every free dollar as inventory working capital.

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -547,6 +547,13 @@ intelligence_eval:
     - {name: "local_single", policy: "single", samples: 1, base_seed: 11}
     - {name: "local_samples_4", policy: "samples", samples: 4, base_seed: 23}
     - {name: "local_samples_4_critic", policy: "samples_critic", samples: 4, base_seed: 37}
+    # Distillation-value arm (2026-07-24): same model/policy as local_single
+    # but the request payload carries the market's matched distilled_claims.
+    # Paired against local_single on identical episodes, its brier_delta is
+    # the direct measurement of whether the distiller's output adds skill —
+    # the question phase 1 was built to answer (the bare arms measured an
+    # information-free prompt: 502/502 forecasts echoed the market price).
+    - {name: "local_single_claims", policy: "single", samples: 1, base_seed: 53, claims_evidence: true}
 
 market_maker:
   enabled: true

--- a/config/settings.py
+++ b/config/settings.py
@@ -393,6 +393,9 @@ class MarketMakerConfig(BaseModel):
     quote_size: float = 10.0  # tokens per side
     max_inventory: float = 50.0  # max directional exposure per market
     max_markets: int = 5  # max simultaneous MM markets
+    # Discovery must be wider than max_markets: only a small fraction of the
+    # venue clears category, token, liquidity, spread, and expiry filters.
+    market_scan_limit: int = Field(default=200, ge=50, le=1000)
     # Live-cash floor MM must leave untouched: no NEW quote pairs while
     # spendable collateral <= this (exits/cancels never gated). Stops MM —
     # the only always-live cell — from auto-claiming every deposited dollar

--- a/config/settings.py
+++ b/config/settings.py
@@ -1675,6 +1675,11 @@ class IntelligenceEvalTreatment(BaseModel):
     policy: Literal["single", "samples", "samples_critic"] = "single"
     samples: int = Field(default=1, ge=1, le=32)
     base_seed: int = 0
+    # Inject matched distilled_claims into this arm's request payload — the
+    # direct measurement of distillation value (arm ± claims on the same
+    # episode). The arm is SKIPPED for markets with no matched claims, so its
+    # record never dilutes into a duplicate of the bare arm.
+    claims_evidence: bool = False
 
     @model_validator(mode="after")
     def single_has_one_sample(self):

--- a/scripts/evidence_audit.py
+++ b/scripts/evidence_audit.py
@@ -47,6 +47,9 @@ QUERIES = {
 def audit(path: Path) -> dict[str, list[dict]]:
     conn = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
+    # Out-of-process readers share the file with the live bot: wait for the
+    # write lock instead of failing instantly (project DB-access convention).
+    conn.execute("PRAGMA busy_timeout=5000")
     try:
         return {name: [dict(row) for row in conn.execute(sql)]
                 for name, sql in QUERIES.items()}

--- a/scripts/evidence_audit.py
+++ b/scripts/evidence_audit.py
@@ -1,0 +1,73 @@
+"""Read-only evidence-throughput and lineage audit for an Auramaur database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+QUERIES = {
+    "ingestion": """SELECT COUNT(*) runs, MIN(started_at) oldest,
+        MAX(started_at) newest, SUM(status='ok') ok, SUM(status!='ok') bad
+        FROM ingestion_runs""",
+    "evidence": """SELECT COUNT(*) items, COUNT(DISTINCT run_id) runs,
+        COUNT(DISTINCT market_id) markets, COUNT(DISTINCT source) sources,
+        MIN(observed_at) oldest, MAX(observed_at) newest
+        FROM evidence_observations""",
+    "lineage_integrity": """SELECT
+        (SELECT COUNT(*) FROM ingestion_runs
+          WHERE completed_at IS NULL OR status='running') unfinished_runs,
+        (SELECT COUNT(*) FROM evidence_observations e
+          LEFT JOIN ingestion_runs r ON r.id=e.run_id WHERE r.id IS NULL)
+          orphan_evidence,
+        (SELECT COUNT(*) FROM evidence_observations
+          WHERE datetime(published_at)>datetime(observed_at,'+1 hour'))
+          future_dated""",
+    "forecast_yield": """SELECT COUNT(*) forecasts,
+        COUNT(DISTINCT market_id) markets,
+        SUM(actual_outcome IS NOT NULL) resolved,
+        MIN(observed_at) oldest, MAX(observed_at) newest
+        FROM forecast_snapshots""",
+    "evidence_daily": """SELECT substr(observed_at,1,10) day, COUNT(*) items,
+        COUNT(DISTINCT run_id) runs, COUNT(DISTINCT market_id) markets
+        FROM evidence_observations GROUP BY 1 ORDER BY 1 DESC LIMIT 14""",
+    "source_health_24h": """SELECT source,status,COUNT(*) runs,
+        SUM(item_count) items,ROUND(AVG(latency_ms),1) avg_ms,
+        MAX(latency_ms) max_ms,MAX(observed_at) latest
+        FROM source_fetches WHERE observed_at>=datetime('now','-24 hours')
+        GROUP BY source,status ORDER BY source,status""",
+    "strategy_evidence": """SELECT strategy_source,COUNT(*) events,
+        COUNT(DISTINCT market_id) markets,ROUND(SUM(pnl),4) pnl
+        FROM pnl_ledger GROUP BY strategy_source ORDER BY events DESC""",
+}
+
+
+def audit(path: Path) -> dict[str, list[dict]]:
+    conn = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        return {name: [dict(row) for row in conn.execute(sql)]
+                for name, sql in QUERIES.items()}
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("db", type=Path, help="Path to auramaur.db")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    report = audit(args.db)
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+    for section, rows in report.items():
+        print(f"\n## {section}")
+        for row in rows:
+            print(json.dumps(row, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -51,13 +51,17 @@ class TestArbitrageExecutor:
         db = executor._db
         # Market A (primary): 70% — too high if it implies B
         run(db.execute(
-            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price, last_updated)
-               VALUES ('primary', 'c1', 'Win primary?', 1, 0.70, 0.30, datetime('now'))"""
+            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price,
+                                     clob_token_yes, clob_token_no, last_updated)
+               VALUES ('primary', 'c1', 'Win primary?', 1, 0.70, 0.30,
+                       'primary-yes', 'primary-no', datetime('now'))"""
         ), event_loop)
         # Market B (general): 60% — if A implies B, P(A) should be <= P(B)
         run(db.execute(
-            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price, last_updated)
-               VALUES ('general', 'c2', 'Win general?', 1, 0.60, 0.40, datetime('now'))"""
+            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price,
+                                     clob_token_yes, clob_token_no, last_updated)
+               VALUES ('general', 'c2', 'Win general?', 1, 0.60, 0.40,
+                       'general-yes', 'general-no', datetime('now'))"""
         ), event_loop)
         # Conditional relationship
         run(db.execute(
@@ -80,12 +84,16 @@ class TestArbitrageExecutor:
         """Same-event divergence should buy cheap and sell expensive."""
         db = executor._db
         run(db.execute(
-            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price, last_updated)
-               VALUES ('cheap', 'c1', 'Event?', 1, 0.45, 0.55, datetime('now'))"""
+            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price,
+                                     clob_token_yes, clob_token_no, last_updated)
+               VALUES ('cheap', 'c1', 'Event?', 1, 0.45, 0.55,
+                       'cheap-yes', 'cheap-no', datetime('now'))"""
         ), event_loop)
         run(db.execute(
-            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price, last_updated)
-               VALUES ('expensive', 'c2', 'Event?', 1, 0.55, 0.45, datetime('now'))"""
+            """INSERT INTO markets (id, condition_id, question, active, outcome_yes_price, outcome_no_price,
+                                     clob_token_yes, clob_token_no, last_updated)
+               VALUES ('expensive', 'c2', 'Event?', 1, 0.55, 0.45,
+                       'expensive-yes', 'expensive-no', datetime('now'))"""
         ), event_loop)
         run(db.execute(
             """INSERT INTO market_relationships
@@ -157,6 +165,21 @@ class TestArbitrageExecutor:
 
         pairs = run(executor.generate_arb_signals(), event_loop)
         assert len(pairs) == 0
+
+    def test_missing_execution_metadata_suppressed_before_bot(self, executor, event_loop):
+        db = executor._db
+        for mid, price in (("primary", 0.70), ("general", 0.60)):
+            run(db.execute(
+                """INSERT INTO markets
+                   (id, exchange, question, active, outcome_yes_price,
+                    outcome_no_price, last_updated)
+                   VALUES (?, 'polymarket', ?, 1, ?, ?, datetime('now'))""",
+                (mid, mid, price, 1 - price)), event_loop)
+        run(db.execute(
+            """INSERT INTO market_relationships
+               (market_id_a, market_id_b, relationship_type, strength, description)
+               VALUES ('primary','general','conditional',0.9,'A implies B')"""), event_loop)
+        assert run(executor.generate_arb_signals(), event_loop) == []
 
 
 # --- Category gate (2026-06-12): exempt books still respect category bans ---

--- a/tests/test_database_transaction.py
+++ b/tests/test_database_transaction.py
@@ -70,29 +70,23 @@ async def test_rollback_discards_only_its_own_writes(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_transaction_waits_out_legacy_autocommit_writer(tmp_path):
-    """A non-adopted writer mid-flight (implicit txn open, commit imminent)
-    must NOT have its half-written rows committed or rolled back by
-    transaction() — the exact bleed the guard exists to remove."""
+async def test_legacy_write_cannot_strand_shared_connection(tmp_path):
+    """A legacy writer cannot wedge later transaction() adopters."""
     db = await _fresh_db(tmp_path)
     try:
-        legacy_committed = asyncio.Event()
-
         async def legacy_writer():
             await db.execute("INSERT INTO t (k, v) VALUES ('legacy', 1)")
-            await asyncio.sleep(0.05)  # implicit txn stays open across a yield
-            await db.commit()
-            legacy_committed.set()
+            # Deliberately yield and omit the historical commit(). True
+            # autocommit makes the statement durable and leaves no wedge.
+            await asyncio.sleep(0.05)
 
         async def adopter():
-            await asyncio.sleep(0.01)  # let the legacy txn open first
+            await asyncio.sleep(0.01)
             async with db.transaction():
-                # By the time BEGIN IMMEDIATE ran, the legacy writer must
-                # have landed its own commit.
-                assert legacy_committed.is_set()
                 await db.execute("INSERT INTO t (k, v) VALUES ('adopted', 1)")
 
         await asyncio.gather(legacy_writer(), adopter())
+        assert db.db.in_transaction is False
         rows = await db.fetchall("SELECT k FROM t ORDER BY k")
         assert [r["k"] for r in rows] == ["adopted", "legacy"]
     finally:

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -576,10 +576,10 @@ def test_place_quote_pair_places_bid_then_ask_and_returns_both():
         order_seen = []
         bid = Order(market_id="mm", exchange="polymarket", token_id="yes",
                     side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.40,
-                    post_only=True, source="market_maker")
+                    post_only=True, source="market_maker", dry_run=False)
         ask = Order(market_id="mm", exchange="polymarket", token_id="no",
                     side=OrderSide.BUY, token=TokenType.NO, size=20.0, price=0.55,
-                    post_only=True, source="market_maker")
+                    post_only=True, source="market_maker", dry_run=False)
         async def _place(o):
             order_seen.append(o.token_id)
             return OrderResult(order_id=f"oid-{o.token_id}", market_id="mm",
@@ -589,4 +589,35 @@ def test_place_quote_pair_places_bid_then_ask_and_returns_both():
         bid_res, ask_res = await gw.place_quote_pair(bid, ask, exchange=ex)
         assert order_seen == ["yes", "no"]  # bid then ask
         assert bid_res.order_id == "oid-yes" and ask_res.order_id == "oid-no"
+    asyncio.run(run())
+
+
+def test_place_quote_pair_paper_quotes_rest_and_never_reach_the_client():
+    """Paper post-only quotes must NOT be placed: the client's paper branch
+    instant-fills into the shared PaperTrader book, where a two-sided quote's
+    legs merged into one blended phantom position that regrew every refresh
+    with no trades/fills provenance (the 2026-07-23 orphan-position factory).
+    They rest synthetically instead: pending, PAPER-prefixed ids (so the MM's
+    check_fills prunes and _cancel_quote skips them), and the exchange client
+    is never touched."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        bid = Order(market_id="mm", exchange="polymarket", token_id="yes",
+                    side=OrderSide.BUY, token=TokenType.YES, size=20.0, price=0.49,
+                    post_only=True, source="market_maker", dry_run=True)
+        ask = Order(market_id="mm", exchange="polymarket", token_id="no",
+                    side=OrderSide.BUY, token=TokenType.NO, size=20.0, price=0.53,
+                    post_only=True, source="market_maker", dry_run=True)
+        ex = MagicMock()
+        async def _place(o):
+            raise AssertionError("paper quote must never reach place_order")
+        ex.place_order = _place
+        gw = _gateway(db, ex)
+        bid_res, ask_res = await gw.place_quote_pair(bid, ask, exchange=ex)
+        for res in (bid_res, ask_res):
+            assert res.status == "pending"
+            assert res.is_paper is True
+            assert res.order_id.startswith("PAPER")
+        assert bid_res.order_id != ask_res.order_id
     asyncio.run(run())

--- a/tests/test_intelligence_eval_runner.py
+++ b/tests/test_intelligence_eval_runner.py
@@ -106,3 +106,38 @@ async def test_strict_schema_all_failures_yield_no_forecast():
     assert not result.succeeded
     assert result.final_forecast is None
     assert "unknown fields" in result.attempts[0].error
+
+
+@pytest.mark.asyncio
+async def test_extra_payload_enriches_requests_without_breaking_pairing():
+    """A claims_evidence arm sees episode payload + evidence in its requests,
+    while episode identity (hash) stays shared with the bare arm."""
+    episode = Episode("e", {"question": "q"})
+    bare = Adapter([{"prob_yes": .4, "action": "NO"}])
+    rich = Adapter([{"prob_yes": .6, "action": "YES"}])
+    claims = {"distilled_evidence": [{"claim": "c1", "source": "s"}]}
+    enriched = TreatmentSpec(
+        "claims", ArmSpec("claims-arm", "fake", rich),
+        ExplorationPolicy.SINGLE, 1, 42, extra_payload=claims)
+    results = await IntelligenceEvalRunner().run(
+        episode, [spec(bare, name="bare"), enriched])
+    assert len(results) == 2
+    assert "distilled_evidence" not in bare.requests[0].episode_payload
+    assert rich.requests[0].episode_payload["distilled_evidence"] == claims["distilled_evidence"]
+    assert rich.requests[0].episode_payload["question"] == "q"
+    # Pairing: both arms reference the same episode hash.
+    assert bare.requests[0].episode_hash == rich.requests[0].episode_hash
+
+
+@pytest.mark.asyncio
+async def test_extra_payload_reaches_critic_stage():
+    outputs = lambda request: {"prob_yes": .7, "action": "YES"}
+    rich = Adapter(outputs)
+    enriched = TreatmentSpec(
+        "claims_critic", ArmSpec("arm", "fake", rich),
+        ExplorationPolicy.SAMPLES_CRITIC, 2, 7,
+        extra_payload={"distilled_evidence": [{"claim": "c"}]})
+    await IntelligenceEvalRunner().run(Episode("e", {"q": 1}), [enriched])
+    stages = {r.stage for r in rich.requests}
+    assert stages == {"sample", "critic"}
+    assert all("distilled_evidence" in r.episode_payload for r in rich.requests)

--- a/tests/test_intelligence_eval_runner.py
+++ b/tests/test_intelligence_eval_runner.py
@@ -131,7 +131,8 @@ async def test_extra_payload_enriches_requests_without_breaking_pairing():
 
 @pytest.mark.asyncio
 async def test_extra_payload_reaches_critic_stage():
-    outputs = lambda request: {"prob_yes": .7, "action": "YES"}
+    def outputs(request):
+        return {"prob_yes": .7, "action": "YES"}
     rich = Adapter(outputs)
     enriched = TreatmentSpec(
         "claims_critic", ArmSpec("arm", "fake", rich),

--- a/tests/test_intelligence_eval_service.py
+++ b/tests/test_intelligence_eval_service.py
@@ -180,3 +180,41 @@ async def test_multi_market_rotation_family_dedup_and_successive_halving(tmp_pat
         assert cycle["selected_markets"] == 4
     finally:
         await db.close()
+
+
+async def test_claims_arm_skipped_without_claims_and_enriched_with(tmp_path):
+    """The claims_evidence arm drops out for claim-less markets and carries
+    distilled_evidence in its prompts when claims exist."""
+    db = Database(str(tmp_path / "eval-claims.db"))
+    await db.connect()
+    try:
+        settings = Settings()
+        settings.intelligence_eval.enabled = True
+        settings.intelligence_eval.markets_per_cycle = 1
+        settings.local_llm.enabled = True
+        client = LocalClient()
+        service = IntelligenceEvalService(db, settings, Discovery(), client)
+
+        # No claims in db: the claims arm must be dropped for this market.
+        kept = await service._attach_claims(service._treatments, "m1")
+        names = {spec.treatment_id for spec in kept}
+        assert "local_single_claims" not in names
+        assert "local_single" in names
+
+        # Seed a matched claim: the arm returns, enriched.
+        await db.execute(
+            """INSERT INTO distilled_claims
+               (content_hash, item_id, source, claim, entities, event_date,
+                markets_affected, model)
+               VALUES ('h1', 'i1', 'rss', 'A material claim.', '[]', '2026-07-24',
+                       '[{"market_id": "m1", "direction": "yes"}]', 'qwen3:8b')""")
+        await db.commit()
+        kept = await service._attach_claims(service._treatments, "m1")
+        by_name = {spec.treatment_id: spec for spec in kept}
+        assert "local_single_claims" in by_name
+        enriched = by_name["local_single_claims"]
+        assert enriched.extra_payload["distilled_evidence"][0]["claim"] == "A material claim."
+        # Bare arms stay untouched.
+        assert by_name["local_single"].extra_payload is None
+    finally:
+        await db.close()

--- a/tests/test_llm_costs_view.py
+++ b/tests/test_llm_costs_view.py
@@ -1,0 +1,63 @@
+"""Tests for the llm_costs_daily view — the unified cost/quota ledger.
+
+daily_stats.api_cost_estimate was never wired; the view joins the four real
+tracking tables so a day's inference bill is one query (2026-07-24 audit)."""
+
+import asyncio
+
+import pytest
+
+from auramaur.db.database import Database
+
+
+def test_llm_costs_daily_unifies_all_four_sources():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            "INSERT INTO agent_trader_costs (day, model_alias, calls, usd) "
+            "VALUES ('2026-07-24', 'gpro', 5, 0.10)")
+        await db.execute(
+            "INSERT INTO ibkr_etf_openai_attempts (model_alias, model, status, cost_usd, started_at) "
+            "VALUES ('luna', 'gpt-5.6-luna', 'ok', 0.02, '2026-07-24T10:00:00')")
+        await db.execute(
+            "INSERT INTO llm_call_counter (day, claude_calls) VALUES ('2026-07-24', 150)")
+        await db.execute(
+            "INSERT INTO local_llm_calls (purpose, model, status, created_at) "
+            "VALUES ('distill', 'qwen3:8b', 'ok', '2026-07-24T10:00:00')")
+        await db.commit()
+
+        rows = await db.fetchall(
+            "SELECT source, calls, cost_usd FROM llm_costs_daily "
+            "WHERE day = '2026-07-24' ORDER BY source")
+        by_source = {r["source"]: (r["calls"], round(r["cost_usd"], 4)) for r in rows}
+        assert by_source["gemini:gpro"] == (5, 0.10)
+        assert by_source["openai:luna"] == (1, 0.02)
+        assert by_source["claude_cli(quota)"] == (150, 0.0)
+        assert by_source["local:qwen3:8b"] == (1, 0.0)
+
+        total = await db.fetchone(
+            "SELECT ROUND(SUM(cost_usd), 4) AS usd FROM llm_costs_daily WHERE day='2026-07-24'")
+        assert total["usd"] == 0.12
+    asyncio.run(run())
+
+
+def test_migration_v40_creates_view_on_old_schema(tmp_path):
+    """A v39 database gains the view through the migration path."""
+    async def run():
+        path = str(tmp_path / "old.db")
+        db = Database(path)
+        await db.connect()
+        # Simulate a pre-v40 file: drop the view and stamp version 39.
+        await db.execute("DROP VIEW IF EXISTS llm_costs_daily")
+        await db.execute("UPDATE schema_version SET version = 39")
+        await db.commit()
+        await db.close()
+
+        db2 = Database(path)
+        await db2.connect()  # runs migrations
+        row = await db2.fetchone(
+            "SELECT name FROM sqlite_master WHERE type='view' AND name='llm_costs_daily'")
+        assert row is not None
+        await db2.close()
+    asyncio.run(run())

--- a/tests/test_llm_costs_view.py
+++ b/tests/test_llm_costs_view.py
@@ -5,8 +5,6 @@ tracking tables so a day's inference bill is one query (2026-07-24 audit)."""
 
 import asyncio
 
-import pytest
-
 from auramaur.db.database import Database
 
 

--- a/tests/test_nlp_cache_locking.py
+++ b/tests/test_nlp_cache_locking.py
@@ -94,7 +94,9 @@ async def test_cache_lock_does_not_rollback_sibling_transaction(monkeypatch):
     await db.execute("CREATE TABLE sibling_write (value TEXT)")
     await db.commit()
     await db.execute("INSERT INTO sibling_write VALUES ('must survive')")
-    assert db.db.in_transaction
+    # Shared Database uses true autocommit: this sibling write is already
+    # durable and cannot be rolled back by a cache failure.
+    assert not db.db.in_transaction
 
     original_execute = db.execute
 
@@ -108,10 +110,9 @@ async def test_cache_lock_does_not_rollback_sibling_transaction(monkeypatch):
 
     await NLPCache(db).put("key", "market", {"probability": 0.7}, 300)
 
-    assert db.db.in_transaction
+    assert not db.db.in_transaction
     row = await db.fetchone("SELECT value FROM sibling_write")
     assert row["value"] == "must survive"
-    await db.db.rollback()
     await db.close()
 
 

--- a/tests/test_quiet_feed.py
+++ b/tests/test_quiet_feed.py
@@ -183,3 +183,39 @@ def test_watchdog_alerts_on_stall_and_recovery():
     dog._check()
     assert len(alerts) == 2
     assert "recovered" in alerts[1]
+
+
+def test_watchdog_hard_exits_after_sustained_stall(monkeypatch):
+    alerts: list[str] = []
+    exited: list[bool] = []
+    dog = LoopWatchdog(stall_seconds=10.0, hard_exit_seconds=60.0,
+                       alert=alerts.append)
+    monkeypatch.setattr(LoopWatchdog, "_hard_exit",
+                        staticmethod(lambda: exited.append(True)))
+
+    dog.beat()
+    dog._last_beat -= 30.0  # stalled, but under the hard-exit bound
+    dog._check()
+    assert exited == [] and len(alerts) == 1  # normal stall alert only
+
+    dog._last_beat -= 40.0  # now 70s total — past hard_exit_seconds
+    dog._check()
+    assert exited == [True]
+    assert "exiting" in alerts[-1]
+
+
+def test_watchdog_hard_exit_disabled_and_not_during_shutdown(monkeypatch):
+    exited: list[bool] = []
+    monkeypatch.setattr(LoopWatchdog, "_hard_exit",
+                        staticmethod(lambda: exited.append(True)))
+
+    dog = LoopWatchdog(stall_seconds=10.0, hard_exit_seconds=0.0)
+    dog._last_beat -= 10_000.0
+    dog._check()
+    assert exited == []  # disabled by hard_exit_seconds <= 0
+
+    dog2 = LoopWatchdog(stall_seconds=10.0, hard_exit_seconds=60.0)
+    dog2.stop()  # clean shutdown in progress — never self-kill
+    dog2._last_beat -= 10_000.0
+    dog2._check()
+    assert exited == []

--- a/tests/test_rss_parse_guard.py
+++ b/tests/test_rss_parse_guard.py
@@ -1,0 +1,79 @@
+"""Tests for the RSS parse guard — feedparser.parse must never run on the
+event loop unbounded. (A pathological feed body observed 2026-07-23 parsed
+for ~25 minutes, freezing exits and risk checks for the duration.)"""
+
+import time
+
+import pytest
+
+from auramaur.data_sources import rss as rss_mod
+from auramaur.data_sources.rss import RSSSource
+
+
+class _FakeResponse:
+    def __init__(self, body: str):
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def text(self) -> str:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, body: str):
+        self._body = body
+        self.closed = False
+
+    def get(self, url, timeout=None):
+        return _FakeResponse(self._body)
+
+
+def _source_with_body(body: str) -> RSSSource:
+    src = RSSSource(feed_urls=["https://example.test/feed.xml"])
+    src._session = _FakeSession(body)  # type: ignore[assignment]
+    return src
+
+
+_FEED = """<?xml version="1.0"?>
+<rss version="2.0"><channel><title>t</title>
+<item><title>alpha beta headline</title><link>https://example.test/a</link>
+<description>alpha beta story</description></item>
+</channel></rss>"""
+
+
+@pytest.mark.asyncio
+async def test_normal_feed_still_parses():
+    src = _source_with_body(_FEED)
+    items = await src._fetch_feed("https://example.test/feed.xml", "alpha beta", 5)
+    assert len(items) == 1
+    assert "alpha" in items[0].title.lower()
+
+
+@pytest.mark.asyncio
+async def test_oversized_body_is_dropped(monkeypatch):
+    monkeypatch.setattr(rss_mod, "_MAX_FEED_BYTES", 100)
+    src = _source_with_body(_FEED + "x" * 200)
+    items = await src._fetch_feed("https://example.test/feed.xml", "", 5)
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_slow_parse_times_out_instead_of_blocking(monkeypatch):
+    monkeypatch.setattr(rss_mod, "_PARSE_TIMEOUT_SECONDS", 0.1)
+
+    def _slow_parse(body):
+        time.sleep(1.0)
+        raise AssertionError("parse should have been abandoned before this")
+
+    monkeypatch.setattr(rss_mod.feedparser, "parse", _slow_parse)
+    src = _source_with_body(_FEED)
+    items = await src._fetch_feed("https://example.test/feed.xml", "", 5)
+    assert items == []


### PR DESCRIPTION
## Summary
- prevent legacy SQLite writes from stranding the shared connection in an implicit transaction
- suppress arbitrage pairs missing required execution metadata before the bot loop
- persist key strategy funnel details and widen market-maker discovery while retaining existing safety filters
- serialize Claude CLI subprocesses, terminate timeouts, and retry empty evidence-distillation results
- add a reusable read-only evidence/lineage audit

## Production audit
Read-only inspection of `/app/state/auramaur.db` found:
- 9,555 completed ingestion runs, all marked OK
- 47,695 evidence observations across 122 markets and 14 sources
- 184 forecasts across 77 markets; 6 resolved
- 9,440 historical orphan evidence rows concentrated on July 22-23; current July 24 ingestion did not show the same pattern

No production data was modified and the running container was not restarted.

## Verification
- `python -m pytest -q -p no:cacheprovider --basetemp .pytest-evidence-v31-full2` — 1,476 passed, 3 skipped
- focused reliability/strategy suite — 150 passed, 1 skipped
- `python -m ruff check ...` — passed
- `git diff --check` — passed