### PR TITLE
fix(ibkr): tolerate small forward clock skew in quote freshness

### DIFF
--- a/auramaur/monitoring/ibkr_multiasset_preflight.py
+++ b/auramaur/monitoring/ibkr_multiasset_preflight.py
@@ -88,7 +88,9 @@ async def preflight(settings, db, *, client=None, timeout_seconds: float | None 
                                             has_history=True, error="no executable BBO")
                     return f"{spec.key}: no executable BBO", None, None
                 age = time.time() - float(quote.timestamp)
-                if age < 0 or age > cfg.multiasset_max_quote_age_seconds:
+                # Tolerate small forward clock skew (see _quote_fresh): Alpaca
+                # server stamps can lead this host by ~1s.
+                if age < -5 or age > cfg.multiasset_max_quote_age_seconds:
                     await record_validation(db, spec, contract,
                                             quote_source=getattr(quote, "source", "none"),
                                             has_history=True, error="stale BBO")

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -126,8 +126,11 @@ class IBKRMultiAssetPaperBook:
         age = time.time() - float(quote.timestamp)
         # alpaca_iex is real-time IEX bid/ask — credible for PAPER fills with
         # its provenance recorded (2026-07-24 bridge); delayed/frozen stay out.
+        # Small NEGATIVE age is normal cross-server clock skew (Alpaca stamps
+        # ran ~1s ahead of this host and the strict 0 bound rejected 29/35
+        # instruments as "stale (-1s old)"); only implausible skew is invalid.
         return (getattr(quote, "source", "") in ("ibkr_live", "alpaca_iex")
-                and 0 <= age <= self._settings.ibkr.multiasset_max_quote_age_seconds)
+                and -5 <= age <= self._settings.ibkr.multiasset_max_quote_age_seconds)
 
     @staticmethod
     def _serialize_spec(spec: InstrumentSpec) -> str:

--- a/tests/test_alpaca_multiasset_bridge.py
+++ b/tests/test_alpaca_multiasset_bridge.py
@@ -138,3 +138,18 @@ def test_registry_marks_alpaca_sourced_stock_eligible(tmp_path):
         finally:
             await db.close()
     asyncio.run(run())
+
+
+def test_quote_fresh_tolerates_small_forward_clock_skew():
+    from auramaur.strategy.ibkr_multiasset_paper import IBKRMultiAssetPaperBook
+    from config.settings import Settings
+
+    book = IBKRMultiAssetPaperBook.__new__(IBKRMultiAssetPaperBook)
+    book._settings = Settings()
+    now = time.time()
+    ahead = MarketDataQuote("SPY", 1, 2, now + 1.0, 0, "USD", 1.0,
+                            source="alpaca_iex")
+    assert book._quote_fresh(ahead) is True  # ~1s server-ahead stamp is normal
+    absurd = MarketDataQuote("SPY", 1, 2, now + 60.0, 0, "USD", 1.0,
+                             source="alpaca_iex")
+    assert book._quote_fresh(absurd) is False


### PR DESCRIPTION
## Summary
- Alpaca server timestamps run ~1s ahead of the host clock; the strict `age >= 0` freshness bound rejected 29/35 global_etf instruments as "stale BBO (-1s old)" at the first bridged preflight (#354 follow-up)
- allow up to 5s forward skew in the preflight probe and the paper fill gate; implausible skew remains invalid
- adds a regression test for server-ahead stamps

## Verification
- 19 tests green across the bridge + preflight suites; repo-wide ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)