### PR TITLE
fix(db): legacy commit() no-op — stops adopters' batches being landed early

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -1156,18 +1156,18 @@ class Database:
         return await cursor.fetchall()
 
     async def commit(self) -> None:
-        try:
-            await self.db.commit()
-        except Exception as exc:  # noqa: BLE001 — narrow re-raise below
-            if "no transaction is active" in str(exc).lower():
-                # A transaction() adopter's COMMIT already landed these rows
-                # (legacy commit interleaved with an explicit transaction on
-                # the shared connection). The data is durable; only this
-                # caller's notion of "its own" commit was stale. Full adopter
-                # migration (contention plan phase 5) retires this path.
-                log.debug("database.commit_already_landed")
-                return
-            raise
+        # Deliberate no-op. Under the autocommit connection every legacy
+        # execute() is already durable, so a legacy commit() has exactly one
+        # remaining effect: when it interleaves with a transaction() adopter's
+        # explicit BEGIN on the shared connection it COMMITS THE ADOPTER'S
+        # HALF-FINISHED BATCH — observed 31 times in 25 minutes on 2026-07-24
+        # (victims: intelligence_eval, heartbeat, trade_kalshi). A
+        # check-then-commit still races an adopter's BEGIN across the await
+        # boundary, so the only race-free form is to never issue the commit:
+        # transaction()'s own COMMIT (raw execute) is the sole legitimate one.
+        if self._db is not None and self._db._conn.in_transaction:
+            log.debug("database.legacy_commit_skipped_mid_transaction",
+                      active_owner=self._txn_owner or "unknown")
 
     async def rollback(self) -> None:
         await self.db.rollback()

--- a/tests/test_database_transaction.py
+++ b/tests/test_database_transaction.py
@@ -164,3 +164,23 @@ async def test_order_position_heartbeat_and_lineage_writes_serialize(tmp_path):
         assert db.db._conn.in_transaction is False
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_commit_never_lands_an_adopters_open_batch(tmp_path):
+    """Database.commit() must be a no-op while a transaction() adopter holds
+    an explicit BEGIN — a legacy commit mid-adoption used to land the
+    adopter's half-finished batch (31 bleeds in 25 min, 2026-07-24)."""
+    db = await _fresh_db(tmp_path)
+    try:
+        async with db.transaction(owner="adopter"):
+            await db.execute("INSERT INTO t (k, v) VALUES ('half', 1)")
+            # Legacy caller fires commit() mid-adoption.
+            await db.commit()
+            # The adopter's batch must still be open (not landed early).
+            assert db.db.in_transaction is True
+            await db.execute("INSERT INTO t (k, v) VALUES ('done', 1)")
+        rows = await db.fetchall("SELECT k FROM t ORDER BY k")
+        assert [r["k"] for r in rows] == ["done", "half"]
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary
- live probe after #352 found `transaction_commit_bled` firing 31x/25min: legacy `commit()` calls interleaving with `transaction()` adopters' explicit BEGINs and committing their half-finished batches (victims: intelligence_eval, heartbeat, trade_kalshi)
- under the autocommit connection a legacy `commit()` has no durability purpose left; check-then-commit still races the adopter's BEGIN, so `Database.commit()` becomes an unconditional no-op (debug-logged when it would have bled) — `transaction()`'s own raw COMMIT is the sole legitimate commit
- regression test locks the invariant

## Verification
- full suite green (1,483 passed), ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)