### PR TITLE
fix(orders): attribute adopted resting orders from the ledger, not MM

### DIFF
--- a/auramaur/exchange/client.py
+++ b/auramaur/exchange/client.py
@@ -642,6 +642,23 @@ class PolymarketClient:
                     if created_raw not in (None, "")
                     else datetime.now(timezone.utc)
                 )
+                # The CLOB API doesn't echo our `source`. The gateway pre-writes
+                # a trades row (with strategy_source) for every order it places,
+                # so the ledger is the authority; only orders with no row at all
+                # are true unknowns. The old fallback hardcoded "market_maker"
+                # ("only the MM rests limits") — false since the 2026-07-24
+                # promotions armed bias_harvest/term_structure/opus, whose
+                # resting entries were then booked to the MM's live record.
+                source = "adopted_unknown"
+                try:
+                    row = await self._paper.db.fetchone(
+                        "SELECT strategy_source FROM trades WHERE order_id = ?",
+                        (oid,))
+                    if row and row["strategy_source"]:
+                        source = row["strategy_source"]
+                except Exception as e:  # noqa: BLE001 — attribution must not block adoption
+                    log.debug("order.reconcile_source_lookup_failed",
+                              order_id=oid, error=str(e)[:80])
                 self._live_pending[oid] = Order(
                     market_id=str(o.get("market") or o.get("asset_id") or ""),
                     exchange="polymarket",
@@ -652,15 +669,7 @@ class PolymarketClient:
                     order_type=OrderType.LIMIT,
                     dry_run=False,
                     created_at=created,
-                    # The CLOB API doesn't echo our `source`, so a prior-session
-                    # orphan would otherwise reach the monitor's fallback INSERT
-                    # sourceless and get tagged 'order_monitor', masking the real
-                    # book. A live *resting GTC limit* can only come from the
-                    # market maker in the current regime — directional books are
-                    # paper-forced, arb is both-or-nothing immediate, exits cross
-                    # the spread (taker). So attribute reconciled orphans to the
-                    # MM. NOTE: revisit if any other live book ever rests limits.
-                    source="market_maker",
+                    source=source,
                 )
                 count += 1
             except (TypeError, ValueError) as e:

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -153,6 +153,18 @@ async def test_reconcile_open_orders_imports_orphans(client):
     ]
     client._clob_client = mock_clob
 
+    # Attribution authority is the gateway's pre-written trades row: orphan-1
+    # was placed by bias_harvest; orphan-2 has no row (true prior-session
+    # unknown). The old hardcoded "market_maker" default booked every other
+    # promoted live book's resting entries to the MM's record.
+    async def fetchone(sql, params=()):
+        if "strategy_source" in sql and params and params[0] == "orphan-1":
+            return {"strategy_source": "bias_harvest"}
+        if "strategy_source" in sql:
+            return None
+        return {"net": 0}
+    client._paper.db.fetchone = fetchone
+
     with patch.object(type(client), "_is_live_enabled", return_value=True):
         n = await client.reconcile_open_orders()
 
@@ -164,11 +176,8 @@ async def test_reconcile_open_orders_imports_orphans(client):
     assert buy.token_id == "tokA"
     # created_at parsed from the order's unix timestamp (not "now")
     assert buy.created_at.year == 1970
-    # Reconciled orphans are attributed to the market maker (the only live book
-    # that leaves resting GTC limits) so the monitor's fill INSERT doesn't mask
-    # them as the generic 'order_monitor' fallback.
-    assert buy.source == "market_maker"
-    assert client._live_pending["orphan-2"].source == "market_maker"
+    assert buy.source == "bias_harvest"
+    assert client._live_pending["orphan-2"].source == "adopted_unknown"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `reconcile_open_orders` hardcoded `source="market_maker"` for adopted resting orders; since the promotions armed bias_harvest/term_structure/opus (which rest live limit entries), their fills were being booked to the MM's live record — the same record governance decisions are made on
- attribution now resolves from the gateway's pre-written trades row (the ledger is the authority); true unknowns get `adopted_unknown` instead of polluting any strategy's book
- updated the lifecycle test to cover both paths

## Verification
- order lifecycle/tracking/monitor suites green; repo-wide ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)