### PR TITLE
fix(ibkr): bound the bridge's IBKR quote attempt — unentitled tickers hang

### DIFF
--- a/auramaur/exchange/alpaca_multiasset.py
+++ b/auramaur/exchange/alpaca_multiasset.py
@@ -14,6 +14,8 @@ IEX and keep waiting on IBKR entitlements.
 
 from __future__ import annotations
 
+import asyncio
+
 import structlog
 
 from auramaur.exchange.equity_market_data import AlpacaIEXMarketData
@@ -35,10 +37,21 @@ class AlpacaMultiAssetQuotes:
         # except the quote path stays IBKR's (history needs no subscription).
         return getattr(self._ibkr, name)
 
+    # The IBKR attempt must be BOUNDED: an unentitled instrument's ticker can
+    # await forever, and before this bound the whole multiasset task hung on
+    # the first eligible stock quote (2026-07-24 15:12 — heartbeats silent for
+    # 2h across restarts; the preflight never hit it because it wraps quotes
+    # in wait_for). On timeout we fall through to Alpaca exactly as on error.
+    _IBKR_QUOTE_TIMEOUT_SECONDS = 15.0
+
     async def get_quote(self, spec: InstrumentSpec) -> MarketDataQuote | None:
         quote = None
         try:
-            quote = await self._ibkr.get_quote(spec)
+            quote = await asyncio.wait_for(
+                self._ibkr.get_quote(spec),
+                timeout=self._IBKR_QUOTE_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_quote_timeout", key=spec.key)
         except Exception as exc:  # noqa: BLE001 — fallback path handles it
             log.debug("alpaca_bridge.ibkr_quote_error", key=spec.key,
                       error=str(exc)[:120])

--- a/tests/test_alpaca_multiasset_bridge.py
+++ b/tests/test_alpaca_multiasset_bridge.py
@@ -153,3 +153,25 @@ def test_quote_fresh_tolerates_small_forward_clock_skew():
     absurd = MarketDataQuote("SPY", 1, 2, now + 60.0, 0, "USD", 1.0,
                              source="alpaca_iex")
     assert book._quote_fresh(absurd) is False
+
+
+def test_hung_ibkr_quote_times_out_and_falls_back_to_alpaca(monkeypatch):
+    """An unentitled instrument's IBKR ticker can await forever — before the
+    bound, the first eligible stock quote hung the entire multiasset task
+    (2026-07-24, heartbeats silent 2h+). The bridge must time out and serve
+    Alpaca instead."""
+    async def run():
+        class HangingIBKR(FakeIBKR):
+            async def get_quote(self, spec):
+                await asyncio.Event().wait()  # never resolves
+
+        monkeypatch.setattr(
+            AlpacaMultiAssetQuotes, "_IBKR_QUOTE_TIMEOUT_SECONDS", 0.05)
+        alpaca = FakeAlpaca(EquityQuote(628.10, 628.15, time.time(), "alpaca_iex"))
+        bridge = AlpacaMultiAssetQuotes(HangingIBKR(None), alpaca)
+        quote = await asyncio.wait_for(bridge.get_quote(SPY), timeout=5)
+        assert quote is not None and quote.source == "alpaca_iex"
+        # Non-stock instruments time out to None rather than hanging.
+        quote = await asyncio.wait_for(bridge.get_quote(GBPJPY), timeout=5)
+        assert quote is None
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- follow-up to #354/#355: the bridge awaited `ibkr.get_quote` unbounded; an unentitled instrument's ticker never resolves, and the moment registry eligibility unblocked, the multiasset task hung on its first stock quote (all four book heartbeats silent 2h+ across restarts — caught by heartbeat monitoring, event loop unaffected)
- the preflight was immune because it wraps quotes in `wait_for`; the bridge now bounds the IBKR attempt at 15s and falls through to Alpaca exactly as on error
- regression test simulates a never-resolving IBKR quote

## Verification
- bridge suite 8/8 green, repo-wide ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)