### PR TITLE
fix(ibkr): bound the by-con-id quote path — held-position marks hung

### DIFF
--- a/auramaur/exchange/alpaca_multiasset.py
+++ b/auramaur/exchange/alpaca_multiasset.py
@@ -67,6 +67,34 @@ class AlpacaMultiAssetQuotes:
             int(getattr(quote, "con_id", 0) or 0),
             spec.currency, spec.multiplier, source="alpaca_iex")
 
+    async def get_quote_by_con_id(self, spec: InstrumentSpec, con_id: int):
+        """Held-position mark path — the pillar quotes open positions by
+        con_id (ibkr_multiasset_paper.py:330), which delegation previously
+        passed through UNBOUNDED: with the UUP position open, the mark hung
+        the whole multiasset task exactly like the discovery path did
+        (2026-07-24 17:42 boot — zero cycle events, heartbeats silent).
+        Same bound + Alpaca fallback as get_quote."""
+        quote = None
+        try:
+            quote = await asyncio.wait_for(
+                self._ibkr.get_quote_by_con_id(spec, con_id),
+                timeout=self._IBKR_QUOTE_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_conid_quote_timeout", key=spec.key)
+        except Exception as exc:  # noqa: BLE001 — fallback path handles it
+            log.debug("alpaca_bridge.ibkr_conid_quote_error", key=spec.key,
+                      error=str(exc)[:120])
+        if quote is not None and getattr(quote, "source", "") == "ibkr_live":
+            return quote
+        if spec.kind is not ContractKind.STOCK or spec.currency != "USD":
+            return quote
+        eq = await self._alpaca.get_quote(spec.symbol)
+        if eq is None:
+            return quote
+        return MarketDataQuote(
+            spec.key, eq.bid, eq.ask, eq.timestamp, int(con_id or 0),
+            spec.currency, spec.multiplier, source="alpaca_iex")
+
     async def close(self) -> None:
         await self._alpaca.close()
         await self._ibkr.close()

--- a/tests/test_alpaca_multiasset_bridge.py
+++ b/tests/test_alpaca_multiasset_bridge.py
@@ -175,3 +175,25 @@ def test_hung_ibkr_quote_times_out_and_falls_back_to_alpaca(monkeypatch):
         quote = await asyncio.wait_for(bridge.get_quote(GBPJPY), timeout=5)
         assert quote is None
     asyncio.run(run())
+
+
+def test_hung_conid_quote_times_out_and_falls_back(monkeypatch):
+    """The held-position mark path quotes by con_id; delegation passed it
+    through unbounded and the UUP mark hung the task (2026-07-24 17:42)."""
+    async def run():
+        class HangingIBKR(FakeIBKR):
+            async def get_quote_by_con_id(self, spec, con_id):
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            AlpacaMultiAssetQuotes, "_IBKR_QUOTE_TIMEOUT_SECONDS", 0.05)
+        alpaca = FakeAlpaca(EquityQuote(28.5, 28.52, time.time(), "alpaca_iex"))
+        bridge = AlpacaMultiAssetQuotes(HangingIBKR(None), alpaca)
+        quote = await asyncio.wait_for(
+            bridge.get_quote_by_con_id(SPY, 756733), timeout=5)
+        assert quote is not None and quote.source == "alpaca_iex"
+        assert quote.con_id == 756733
+        quote = await asyncio.wait_for(
+            bridge.get_quote_by_con_id(GBPJPY, 14321015), timeout=5)
+        assert quote is None
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- #358 bounded the discovery quote path; the held-position mark path (`get_quote_by_con_id`, ibkr_multiasset_paper.py:330) still delegated through unbounded, and with the UUP position open it hung the multiasset task on the first cycle of the fixed boot
- same 15s bound + Alpaca IEX fallback for USD stocks, con_id preserved; regression test with a never-resolving by-con-id quote

## Verification
- bridge suite 9/9 green, repo-wide ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)