### PR TITLE
fix(ibkr): bound the bridge's entire delegated await surface

### DIFF
--- a/auramaur/exchange/alpaca_multiasset.py
+++ b/auramaur/exchange/alpaca_multiasset.py
@@ -32,10 +32,58 @@ class AlpacaMultiAssetQuotes:
         self._ibkr = ibkr
         self._alpaca = alpaca
 
+    # Every IBKR await the pillar makes must be BOUNDED. Bounding piecemeal
+    # was whack-a-mole: get_quote (#358), then get_quote_by_con_id (#360),
+    # then the task hung a third time on the next unbounded call in the
+    # cycle (2026-07-24 19:40 boot: 'connected' then silence, zero 10089s —
+    # hung before any quote request, i.e. in bars/market-open/fx). History
+    # gets a longer bound than quotes; each timeout degrades to the value
+    # that makes the caller SKIP the instrument rather than fabricate data.
+    _IBKR_HISTORY_TIMEOUT_SECONDS = 30.0
+    _IBKR_MISC_TIMEOUT_SECONDS = 10.0
+
     def __getattr__(self, name):
-        # resolve/is_market_open/get_daily_bars/get_fx_to_usd/... — everything
-        # except the quote path stays IBKR's (history needs no subscription).
+        # Non-await surface (readonly flag, etc.) delegates; the pillar's
+        # await surface is wrapped explicitly below.
         return getattr(self._ibkr, name)
+
+    async def get_daily_bars(self, spec: InstrumentSpec, duration: str = "3 M"):
+        try:
+            return await asyncio.wait_for(
+                self._ibkr.get_daily_bars(spec, duration),
+                timeout=self._IBKR_HISTORY_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_bars_timeout", key=spec.key)
+            return []
+
+    async def get_daily_bars_by_con_id(self, spec: InstrumentSpec, con_id: int,
+                                       duration: str = "3 M"):
+        try:
+            return await asyncio.wait_for(
+                self._ibkr.get_daily_bars_by_con_id(spec, con_id, duration),
+                timeout=self._IBKR_HISTORY_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_bars_timeout", key=spec.key)
+            return []
+
+    async def is_market_open(self, spec: InstrumentSpec) -> bool:
+        try:
+            return await asyncio.wait_for(
+                self._ibkr.is_market_open(spec),
+                timeout=self._IBKR_MISC_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_market_open_timeout", key=spec.key)
+            # Fail open: the bounded quote paths still gate actual fills.
+            return True
+
+    async def get_fx_to_usd(self, currency: str) -> float | None:
+        try:
+            return await asyncio.wait_for(
+                self._ibkr.get_fx_to_usd(currency),
+                timeout=self._IBKR_MISC_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError):
+            log.debug("alpaca_bridge.ibkr_fx_timeout", currency=currency)
+            return None
 
     # The IBKR attempt must be BOUNDED: an unentitled instrument's ticker can
     # await forever, and before this bound the whole multiasset task hung on

--- a/tests/test_alpaca_multiasset_bridge.py
+++ b/tests/test_alpaca_multiasset_bridge.py
@@ -197,3 +197,32 @@ def test_hung_conid_quote_times_out_and_falls_back(monkeypatch):
             bridge.get_quote_by_con_id(GBPJPY, 14321015), timeout=5)
         assert quote is None
     asyncio.run(run())
+
+
+def test_every_pillar_await_is_bounded(monkeypatch):
+    """Bounding piecemeal was whack-a-mole (#358 quotes, #360 by-con-id, then
+    a third hang in the bars path). Every IBKR await the pillar makes must
+    time out to a skip-this-instrument value, never hang the task."""
+    async def run():
+        class HangingIBKR(FakeIBKR):
+            async def get_quote(self, spec): await asyncio.Event().wait()
+            async def get_quote_by_con_id(self, spec, con_id): await asyncio.Event().wait()
+            async def get_daily_bars(self, spec, duration="3 M"): await asyncio.Event().wait()
+            async def get_daily_bars_by_con_id(self, spec, con_id, duration="3 M"):
+                await asyncio.Event().wait()
+            async def is_market_open(self, spec): await asyncio.Event().wait()
+            async def get_fx_to_usd(self, currency): await asyncio.Event().wait()
+
+        monkeypatch.setattr(AlpacaMultiAssetQuotes, "_IBKR_QUOTE_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(AlpacaMultiAssetQuotes, "_IBKR_HISTORY_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(AlpacaMultiAssetQuotes, "_IBKR_MISC_TIMEOUT_SECONDS", 0.05)
+        bridge = AlpacaMultiAssetQuotes(HangingIBKR(None), FakeAlpaca(None))
+        assert await asyncio.wait_for(bridge.get_daily_bars(SPY), timeout=5) == []
+        assert await asyncio.wait_for(
+            bridge.get_daily_bars_by_con_id(SPY, 756733), timeout=5) == []
+        assert await asyncio.wait_for(bridge.is_market_open(SPY), timeout=5) is True
+        assert await asyncio.wait_for(bridge.get_fx_to_usd("JPY"), timeout=5) is None
+        assert await asyncio.wait_for(bridge.get_quote(GBPJPY), timeout=5) is None
+        assert await asyncio.wait_for(
+            bridge.get_quote_by_con_id(GBPJPY, 1), timeout=5) is None
+    asyncio.run(run())


### PR DESCRIPTION
Third multiasset hang after #358/#360 — the next unbounded delegated call stalled the cycle before any quote request. Every IBKR await the pillar makes is now explicitly bounded with skip-the-instrument degradation (history 30s -> [], is_market_open 10s -> True, fx 10s -> None, quotes 15s -> Alpaca). Regression test hangs the full surface. 40 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)