### PR TITLE
Make strategy evaluation fair and reproducible

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -276,6 +276,19 @@ class Database:
             await self._migrate_v39_to_v40()
         if from_version < 41:
             await self._migrate_v40_to_v41()
+        if from_version < 42:
+            await self._migrate_v41_to_v42()
+
+    async def _migrate_v41_to_v42(self) -> None:
+        """Make ambiguous historical attribution explicit."""
+        await self._db.execute(
+            "UPDATE pnl_ledger SET strategy_source = 'legacy_unattributed' "
+            "WHERE strategy_source IS NULL OR strategy_source = ''"
+        )
+        await self._db.execute("UPDATE schema_version SET version = 42")
+        await self._db.commit()
+        log.info("database.migrated", from_version=41, to_version=42)
+
 
     async def _migrate_v40_to_v41(self) -> None:
         await self._db.executescript("""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 41
+SCHEMA_VERSION = 42
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -95,7 +95,7 @@ class GraduationLadder:
         # decision. See GraduationConfig.strategy_level_strategies.
         if strategy in self._settings.graduation.strategy_level_strategies:
             rows = await self._db.fetchall(
-                """SELECT market_id, is_paper, SUM(pnl) AS pnl
+                """SELECT market_id, is_paper, SUM(pnl - fees) AS pnl
                    FROM pnl_ledger
                    WHERE strategy_source = ?
                      AND realized_at >= datetime('now', ?)
@@ -105,7 +105,7 @@ class GraduationLadder:
             )
         else:
             rows = await self._db.fetchall(
-                """SELECT market_id, is_paper, SUM(pnl) AS pnl
+                """SELECT market_id, is_paper, SUM(pnl - fees) AS pnl
                    FROM pnl_ledger
                    WHERE strategy_source = ? AND category = ?
                      AND realized_at >= datetime('now', ?)
@@ -200,9 +200,9 @@ class GraduationLadder:
         rows = await self._db.fetchall(
             """SELECT strategy_source AS strategy, category,
                  SUM(CASE WHEN is_paper = 0 THEN 1 ELSE 0 END) AS live_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 0 THEN pnl ELSE 0 END), 0) AS live_pnl,
+                 COALESCE(SUM(CASE WHEN is_paper = 0 THEN pnl - fees ELSE 0 END), 0) AS live_pnl,
                  SUM(CASE WHEN is_paper = 1 THEN 1 ELSE 0 END) AS paper_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 1 THEN pnl ELSE 0 END), 0) AS paper_pnl
+                 COALESCE(SUM(CASE WHEN is_paper = 1 THEN pnl - fees ELSE 0 END), 0) AS paper_pnl
                FROM pnl_ledger
                WHERE realized_at >= datetime('now', ?)
                GROUP BY 1, 2 ORDER BY 1, 2""",

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -10,6 +10,7 @@ execution gateway, the allocator). Method-local imports moved with the methods.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import TYPE_CHECKING
 
 import structlog
@@ -28,6 +29,23 @@ from auramaur.strategy.signals import taker_fee_rate
 
 if TYPE_CHECKING:
     from auramaur.strategy.protocols import TradeCandidate
+
+def select_rotating_ranked(
+    ranked: list[tuple[Market, float]],
+    limit: int,
+    rotation_slot: int,
+) -> list[tuple[Market, float]]:
+    """Select reproducibly from the best 2x candidates while rotating access."""
+    if limit <= 0:
+        return []
+    band = ranked[:limit * 2]
+    return sorted(
+        band,
+        key=lambda item: hashlib.sha256(
+            f"{rotation_slot}|{item[0].id}".encode()
+        ).digest(),
+    )[:limit]
+
 
 log = structlog.get_logger()
 
@@ -263,7 +281,6 @@ class CycleOrchestrationMixin:
 
         # Smart ranking — prioritize markets most likely to be mispriced
         from auramaur.strategy.market_selector import rank_markets
-        import random
 
         price_history = await self._get_price_history(hours=24)
         ranked = rank_markets(fresh_candidates, price_history=price_history)
@@ -289,11 +306,19 @@ class CycleOrchestrationMixin:
                 event_counts[event_key] = count + 1
         ranked = deduped
 
-        # Shuffle within similar scores to avoid always picking the same ones
+        # Deterministically rotate within the top 2x band. This retains the
+        # quality floor and gives candidates comparable access over time.
         if len(ranked) > max_markets:
-            top_batch = ranked[:max_markets * 2]
-            random.shuffle(top_batch)
-            ranked = top_batch
+            rotation_seconds = max(
+                1, int(self.settings.nlp.selection_rotation_seconds))
+            rotation_slot = int(time.time() // rotation_seconds)
+            selected = select_rotating_ranked(ranked, max_markets, rotation_slot)
+            rotation_band = ranked[:max_markets * 2]
+            selected_ids_rotating = {market.id for market, _ in selected}
+            ranked = selected + [
+                item for item in rotation_band
+                if item[0].id not in selected_ids_rotating
+            ]
 
         # Promote news-flagged markets to the front of the batch so fresh
         # headlines get evaluated first. News flagging replaces the old

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -135,19 +135,40 @@ graduation:
   mode: "enforce"
   min_markets: 100
   window_days: 90
+  # Slow-cadence experiments use a pre-registered strategy-wide evidence bar.
+  min_markets_overrides:
+    agent_trader_haiku: 30
+    agent_trader_sonnet: 30
+    agent_trader_opus: 30
+    agent_trader_gflash: 30
+    agent_trader_g35flash: 30
+    agent_trader_gpro: 30
+    long_horizon: 30
+    long_horizon_kalshi: 30
+    term_structure: 30
+    vol_anchor: 30
+    informed_flow: 30
+    entailment_arb: 30
+    cross_venue_arb: 30
+    settlement_arb: 30
+    resolution_lens: 30
+    resolution_lens_kalshi: 30
+    platform_consensus: 30
+  strategy_level_strategies:
+    ["agent_trader_haiku", "agent_trader_sonnet", "agent_trader_opus",
+     "agent_trader_gflash", "agent_trader_g35flash", "agent_trader_gpro",
+     "long_horizon", "long_horizon_kalshi", "term_structure", "vol_anchor",
+     "informed_flow", "entailment_arb", "cross_venue_arb", "settlement_arb",
+     "resolution_lens", "resolution_lens_kalshi", "platform_consensus"]
   confidence_z: 1.645
   min_mean_pnl_lower_bound: 0.0
   probation_multiplier: 0.5
   cache_seconds: 300
   # Structural/two-sided strategies bypass the ladder.
   exempt_strategies: ["arbitrage", "market_maker", "order_monitor"]
-  # Unproven-spray breadth cap (open PAPER positions across ALL cells before
-  # new unproven entries are skipped). Raised from the 100 default after the
-  # Kalshi paper-book restoration legitimately re-added a large block of open
-  # positions overnight and froze every unproven cell (including a pillar on
-  # its first day). Still a hard ceiling — exploration concentrates, it just
-  # doesn't get starved by bookkeeping repairs.
-  max_unproven_positions: 175
+  # Disabled: one high-volume book must not starve unrelated experiments.
+  # Pillar and portfolio/risk ceilings remain enforced.
+  max_unproven_positions: 0
 
 information_graduation:
   # Shadow sources earn forecast influence, never capital directly.
@@ -189,6 +210,7 @@ nlp:
   api_intensity: "low"
   skip_second_opinion: false
   max_markets_per_cycle: 5
+  selection_rotation_seconds: 3600
   evidence_per_source: 5
   daily_claude_call_budget: 175
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -281,6 +281,8 @@ class NLPConfig(BaseModel):
     api_intensity: Literal["low", "medium", "full_blast"] = "medium"
     skip_second_opinion: bool = False
     max_markets_per_cycle: int = 10
+    # Deterministic exploration rotation for the top-ranked candidate band.
+    selection_rotation_seconds: int = 3600
     evidence_per_source: int = 3
     daily_claude_call_budget: int = 100
     # Slice of the daily budget held back for pin_claude callers (the proven

--- a/tests/test_candidate_dispositions.py
+++ b/tests/test_candidate_dispositions.py
@@ -5,7 +5,7 @@ import pytest
 
 from auramaur.db.database import Database
 from auramaur.monitoring.candidate_dispositions import CandidateDispositionCycle
-from auramaur.strategy.engine_cycle import CycleOrchestrationMixin
+from auramaur.strategy.engine_cycle import CycleOrchestrationMixin, select_rotating_ranked
 
 
 def test_candidate_cycle_persists_terminal_rows_and_counts():
@@ -98,3 +98,22 @@ def test_candidate_cycle_prunes_expired_detail_and_summary_rows():
             "SELECT 1 FROM candidate_dispositions WHERE cycle_id='fresh-cycle'") is not None
         await db.close()
     asyncio.run(run())
+
+
+def test_rotating_selection_is_reproducible_and_changes_slots():
+    class Market:
+        def __init__(self, market_id):
+            self.id = market_id
+
+    ranked = [(Market(f"m{i}"), float(20 - i)) for i in range(12)]
+    first = select_rotating_ranked(ranked, 5, rotation_slot=100)
+    replay = select_rotating_ranked(ranked, 5, rotation_slot=100)
+    next_slot = select_rotating_ranked(ranked, 5, rotation_slot=101)
+
+    assert [m.id for m, _ in first] == [m.id for m, _ in replay]
+    assert [m.id for m, _ in first] != [m.id for m, _ in next_slot]
+    assert {m.id for m, _ in first} <= {f"m{i}" for i in range(10)}
+
+
+def test_rotating_selection_honors_zero_limit():
+    assert select_rotating_ranked([], 0, rotation_slot=1) == []

--- a/tests/test_database_transaction.py
+++ b/tests/test_database_transaction.py
@@ -184,3 +184,21 @@ async def test_legacy_commit_never_lands_an_adopters_open_batch(tmp_path):
         assert [r["k"] for r in rows] == ["done", "half"]
     finally:
         await db.close()
+
+
+async def test_v42_labels_ambiguous_legacy_attribution():
+    db = Database(":memory:")
+    await db.connect()
+    await db.execute(
+        """INSERT INTO pnl_ledger
+           (market_id, kind, pnl, strategy_source, source_ref)
+           VALUES ('old-market', 'settlement', -2.5, '', 'old-ref')"""
+    )
+    await db._migrate_v41_to_v42()
+    version = await db.fetchone("SELECT version FROM schema_version")
+    row = await db.fetchone(
+        "SELECT strategy_source FROM pnl_ledger WHERE source_ref='old-ref'"
+    )
+    assert version["version"] == 42
+    assert row["strategy_source"] == "legacy_unattributed"
+    await db.close()

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -362,3 +362,25 @@ def test_strategy_level_election_aggregates_categories():
         await db.close()
     asyncio.run(run())
 
+
+
+def test_graduation_uses_pnl_net_of_fees():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        for i in range(5):
+            await db.execute(
+                """INSERT INTO pnl_ledger
+                   (market_id, venue, category, strategy_source, kind, token,
+                    qty, pnl, fees, is_paper, source_ref)
+                   VALUES (?, 'kraken', 'crypto', 'fee_test', 'sell', 'YES',
+                           1, 1, 2, 1, ?)""",
+                (f"fee-{i}", f"fee-ref-{i}"),
+            )
+        ladder = GraduationLadder(db, _settings(min_markets=5))
+        decision = await ladder.decide("fee_test", "crypto")
+        assert decision.status == "paper_negative"
+        assert decision.force_paper is True
+        await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add deterministic hourly rotation within the top-ranked candidate band
- give slow-cadence experiments pre-registered 30-market strategy-wide graduation contracts
- remove the shared paper-position cap that could starve unrelated strategies
- evaluate and report graduation P&L net of recorded fees
- migrate ambiguous blank ledger attribution to explicit legacy_unattributed records
- advance schema to v42 and retain candidate disposition observability from v41

## Runtime migration
The active local runtime database was backed up and successfully migrated from v39 to v42. The migration relabeled 86 ambiguous historical rows without guessing their strategy. Runtime database files and backups are not included in this PR.

## Verification
- ruff check .
- git diff --check
- full backend suite: 1500 passed, 3 skipped
- post-review focused suite: 55 passed