### PR TITLE
Require prospective evidence for strategy graduation

### DIFF
--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Literal
 
@@ -116,11 +118,12 @@ class ExecutionGateway:
         capped = await self._exceeds_market_cap(order, is_live=is_live)
         if capped is not None:
             return ExecutionResult(status="skipped", reason=capped)
-        await self._capture_decision(intent, order)
+        decision_id = await self._capture_decision(intent, order)
         return await self._place_and_record(
             order, strategy_source=intent.signal.strategy_source,
             signal_id=getattr(intent.signal, "id", None),
-            exchange=self.exchange, exchange_name=self.exchange_name)
+            exchange=self.exchange, exchange_name=self.exchange_name,
+            decision_id=decision_id)
 
     async def _exceeds_market_cap(self, order: Order, *, is_live: bool) -> str | None:
         """Aggregate per-(market, token) stake cap. Returns a skip-reason string
@@ -201,29 +204,57 @@ class ExecutionGateway:
             order, strategy_source=strategy_source, signal_id=None,
             exchange=exchange, exchange_name=exchange_name)
 
-    async def _capture_decision(self, intent: TradeIntent, order: Order) -> None:
-        """Persist the immutable executable decision before submission."""
+    async def _capture_decision(self, intent: TradeIntent, order: Order) -> int | None:
+        """Persist a parameter-frozen executable decision before submission."""
         try:
+            source = intent.signal.strategy_source or "llm"
+            section_name = (
+                "agent_trader" if source.startswith("agent_trader_") else
+                "technical" if source.startswith("technical_") else
+                "nlp" if source in {"llm", "news_speed"} else source
+            )
+            section = getattr(self.settings, section_name, None)
+            section_payload = (section.model_dump(mode="json")
+                               if hasattr(section, "model_dump") else {})
+            contract = {
+                "strategy_source": source,
+                "strategy_config": section_payload,
+                "risk": {
+                    "min_edge_pct": self.settings.risk.min_edge_pct,
+                    "max_spread_pct": self.settings.risk.max_spread_pct,
+                    "confidence_floor": self.settings.risk.confidence_floor,
+                },
+            }
+            config_json = json.dumps(contract, sort_keys=True, separators=(",", ":"))
+            strategy_version = hashlib.sha256(config_json.encode()).hexdigest()
+            book = await self.db.fetchone(
+                """SELECT best_bid,best_ask FROM orderbook_snapshots
+                   WHERE market_id=? AND (?='' OR token_id=?)
+                   ORDER BY recorded_at DESC LIMIT 1""",
+                (order.market_id, order.token_id or "", order.token_id or ""),
+            )
             coefficient = 0.0 if order.post_only else taker_fee_rate(
                 order.exchange or self.exchange_name, intent.market.category)
             fee = order.size * coefficient * order.price * (1.0 - order.price)
-            await DecisionTracker(self.db).capture(
-                market_id=order.market_id,
-                strategy_source=intent.signal.strategy_source or "llm",
-                signal_id=getattr(intent.signal, "id", None),
-                side=order.side.value,
+            family = intent.market.neg_risk_market_id or intent.market.id
+            venue = order.exchange or self.exchange_name
+            return await DecisionTracker(self.db).capture(
+                market_id=order.market_id, strategy_source=source,
+                signal_id=getattr(intent.signal, "id", None), side=order.side.value,
                 fair_probability=intent.signal.claude_prob,
                 reference_price=intent.signal.market_prob,
                 executable_price=order.price,
-                best_bid=None,
-                best_ask=None,
-                requested_size=order.size * order.price,
-                fee_estimate=fee,
+                best_bid=None if book is None else book["best_bid"],
+                best_ask=None if book is None else book["best_ask"],
+                requested_size=order.size * order.price, fee_estimate=fee,
+                venue=venue, event_family=family, strategy_version=strategy_version,
+                cohort_id=f"{venue}:{family}", config_json=config_json,
+                holdout_warmup_days=self.settings.graduation.holdout_warmup_days,
+                is_paper=order.dry_run,
             )
         except Exception as exc:
-            # Research telemetry may never block an approved trade.
-            log.warning("gateway.decision_capture_failed",
-                        market_id=order.market_id, error=str(exc))
+            log.warning("gateway.decision_capture_failed", error=str(exc),
+                        market_id=order.market_id)
 
     async def submit_paired(
         self,
@@ -373,13 +404,32 @@ class ExecutionGateway:
 
     async def _place_and_record(
         self, order: Order, *, strategy_source: str, signal_id,
-        exchange: ExchangeClient, exchange_name: str,
+        exchange: ExchangeClient, exchange_name: str, decision_id: int | None = None,
     ) -> ExecutionResult:
         """Place a built order, then log slippage, record the fill, and mirror
         to ``trades``. Shared by the single-leg, paired, and exit paths.
         """
         result = await exchange.place_order(order)
         show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=exchange_name, error_message=result.error_message, market_id=order.market_id)
+        if (decision_id is not None and result.status in _FILLED_STATUSES
+                and result.filled_size > 0):
+            evidence = "venue_fill"
+            if result.is_paper:
+                snap = await self.db.fetchone(
+                    "SELECT best_bid,best_ask FROM decision_snapshots WHERE id=?",
+                    (decision_id,),
+                )
+                price = result.filled_price or order.price
+                crossed = bool(snap) and (
+                    (order.side == OrderSide.BUY and snap["best_ask"] is not None
+                     and price >= float(snap["best_ask"]))
+                    or (order.side == OrderSide.SELL and snap["best_bid"] is not None
+                        and price <= float(snap["best_bid"]))
+                )
+                evidence = "book_cross" if crossed else "synthetic"
+            await DecisionTracker(self.db).mark_fill(
+                decision_id, filled_price=result.filled_price or order.price,
+                evidence=evidence)
         return await self._record_result(
             order, result, strategy_source=strategy_source,
             signal_id=signal_id, exchange_name=exchange_name)

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -278,6 +278,50 @@ class Database:
             await self._migrate_v40_to_v41()
         if from_version < 42:
             await self._migrate_v41_to_v42()
+        if from_version < 43:
+            await self._migrate_v42_to_v43()
+
+    async def _migrate_v42_to_v43(self) -> None:
+        """Prospective, versioned and execution-supported edge evidence."""
+        additions = {
+            "decision_snapshots": (
+                ("venue", "TEXT NOT NULL DEFAULT ''"),
+                ("event_family", "TEXT NOT NULL DEFAULT ''"),
+                ("strategy_version", "TEXT NOT NULL DEFAULT ''"),
+                ("cohort_id", "TEXT NOT NULL DEFAULT ''"),
+                ("is_holdout", "INTEGER NOT NULL DEFAULT 0"),
+                ("fill_evidence", "TEXT NOT NULL DEFAULT 'unverified'"),
+                ("filled_price", "REAL"),
+                ("is_paper", "INTEGER NOT NULL DEFAULT 1"),
+            ),
+            "evaluation_runs": (
+                ("treatment_payload_json", "TEXT NOT NULL DEFAULT '{}'"),
+                ("treatment_payload_hash", "TEXT NOT NULL DEFAULT ''"),
+            ),
+        }
+        for table, columns in additions.items():
+            existing = {row["name"] for row in
+                        await self.fetchall(f"PRAGMA table_info({table})")}
+            for name, definition in columns:
+                if name not in existing:
+                    await self._db.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS strategy_experiments (
+                strategy_version TEXT PRIMARY KEY,
+                strategy_source TEXT NOT NULL,
+                config_json TEXT NOT NULL,
+                registered_at TEXT NOT NULL DEFAULT (datetime('now')),
+                holdout_starts_at TEXT NOT NULL,
+                UNIQUE(strategy_source, strategy_version));
+            CREATE INDEX IF NOT EXISTS idx_strategy_experiments_source
+                ON strategy_experiments(strategy_source, registered_at);
+            CREATE INDEX IF NOT EXISTS idx_decision_experiment
+                ON decision_snapshots(strategy_version,is_holdout,fill_evidence,observed_at);
+            UPDATE schema_version SET version = 43;
+        """)
+        await self._db.commit()
+        log.info("database.migrated", from_version=42, to_version=43)
 
     async def _migrate_v41_to_v42(self) -> None:
         """Make ambiguous historical attribution explicit."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 42
+SCHEMA_VERSION = 43
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -430,6 +430,14 @@ CREATE TABLE IF NOT EXISTS decision_snapshots (
     best_ask REAL,
     requested_size REAL NOT NULL DEFAULT 0,
     fee_estimate REAL NOT NULL DEFAULT 0,
+    venue TEXT NOT NULL DEFAULT '',
+    event_family TEXT NOT NULL DEFAULT '',
+    strategy_version TEXT NOT NULL DEFAULT '',
+    cohort_id TEXT NOT NULL DEFAULT '',
+    is_holdout INTEGER NOT NULL DEFAULT 0,
+    fill_evidence TEXT NOT NULL DEFAULT 'unverified',
+    is_paper INTEGER NOT NULL DEFAULT 1,
+    filled_price REAL,
     filled INTEGER NOT NULL DEFAULT 0,
     observed_at TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(signal_id, strategy_source)
@@ -437,6 +445,17 @@ CREATE TABLE IF NOT EXISTS decision_snapshots (
 CREATE INDEX IF NOT EXISTS idx_decision_market_time
     ON decision_snapshots(market_id, observed_at);
 
+
+CREATE TABLE IF NOT EXISTS strategy_experiments (
+    strategy_version TEXT PRIMARY KEY,
+    strategy_source TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    registered_at TEXT NOT NULL DEFAULT (datetime('now')),
+    holdout_starts_at TEXT NOT NULL,
+    UNIQUE(strategy_source, strategy_version)
+);
+CREATE INDEX IF NOT EXISTS idx_strategy_experiments_source
+    ON strategy_experiments(strategy_source, registered_at);
 CREATE TABLE IF NOT EXISTS decision_marks (
     decision_id INTEGER NOT NULL,
     horizon_seconds INTEGER NOT NULL,
@@ -966,6 +985,8 @@ CREATE TABLE IF NOT EXISTS evaluation_runs (
     tool_calls INTEGER NOT NULL DEFAULT 0,
     duration_ms INTEGER NOT NULL DEFAULT 0,
     compute_seconds REAL NOT NULL DEFAULT 0,
+    treatment_payload_json TEXT NOT NULL DEFAULT '{}',
+    treatment_payload_hash TEXT NOT NULL DEFAULT '',
     error TEXT NOT NULL DEFAULT '',
     started_at TEXT NOT NULL,
     completed_at TEXT

--- a/auramaur/evaluation/domain.py
+++ b/auramaur/evaluation/domain.py
@@ -80,6 +80,8 @@ class EvaluationRun(FrozenRecord):
     error: str = ""
     started_at: datetime
     completed_at: datetime | None = None
+    treatment_payload_json: str = "{}"
+    treatment_payload_hash: str = ""
 
     _started_utc = field_validator("started_at")(_utc)
     _completed_utc = field_validator("completed_at")(

--- a/auramaur/evaluation/service.py
+++ b/auramaur/evaluation/service.py
@@ -257,6 +257,13 @@ class IntelligenceEvalService:
         attempt_count = failed_count = 0
         compute_seconds = 0.0
         for treatment, result in zip(treatments, results, strict=True):
+            treatment_payload = dict(payload)
+            if treatment.extra_payload is not None:
+                treatment_payload.update(_plain(treatment.extra_payload))
+            treatment_payload_json = json.dumps(
+                treatment_payload, sort_keys=True, separators=(",", ":"))
+            treatment_payload_hash = hashlib.sha256(
+                treatment_payload_json.encode()).hexdigest()
             run_id = hashlib.sha256(
                 f"{snapshot.episode_hash}:{treatment.treatment_id}".encode()).hexdigest()
             duration_ms = sum(int(attempt.telemetry.get("duration_ms", 0))
@@ -275,6 +282,8 @@ class IntelligenceEvalService:
                 prompt_version=self._cfg.prompt_version,
                 output_schema_version=self._cfg.output_schema_version,
                 status=status, duration_ms=duration_ms,
+                treatment_payload_json=treatment_payload_json,
+                treatment_payload_hash=treatment_payload_hash,
                 compute_seconds=duration_ms / 1000, error=errors,
                 started_at=now, completed_at=datetime.now(timezone.utc),
             ))

--- a/auramaur/evaluation/store.py
+++ b/auramaur/evaluation/store.py
@@ -48,13 +48,21 @@ class EvaluationStore:
 
     async def put_run(self, run: EvaluationRun) -> None:
         async with self._db.transaction():
+            existing = await self._db.fetchone(
+                "SELECT treatment_payload_hash FROM evaluation_runs WHERE run_id=?",
+                (run.run_id,),
+            )
+            if (existing is not None
+                    and existing["treatment_payload_hash"] != run.treatment_payload_hash):
+                raise ValueError("immutable treatment payload conflict")
             await self._db.execute(
                 """INSERT INTO evaluation_runs
                    (run_id, arm_name, model, quantization, exploration_policy,
                     seed, prompt_version, output_schema_version, status,
                     input_tokens, output_tokens, tool_calls, duration_ms,
-                    compute_seconds, error, started_at, completed_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    compute_seconds, treatment_payload_json, treatment_payload_hash,
+                    error, started_at, completed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(run_id) DO UPDATE SET status=excluded.status,
                     input_tokens=excluded.input_tokens, output_tokens=excluded.output_tokens,
                     tool_calls=excluded.tool_calls, duration_ms=excluded.duration_ms,
@@ -64,7 +72,8 @@ class EvaluationStore:
                  run.exploration_policy, run.seed, run.prompt_version,
                  run.output_schema_version, run.status.value, run.input_tokens,
                  run.output_tokens, run.tool_calls, run.duration_ms,
-                 run.compute_seconds, run.error, _ts(run.started_at),
+                 run.compute_seconds, run.treatment_payload_json,
+                 run.treatment_payload_hash, run.error, _ts(run.started_at),
                  None if run.completed_at is None else _ts(run.completed_at)),
             )
 
@@ -161,18 +170,23 @@ class EvaluationStore:
     async def summary(self) -> list[dict]:
         """Read-only per-arm resolved scorecard for CLI/reporting consumers."""
         rows = await self._db.fetchall(
-            """WITH ranked AS (
+            """WITH resolved AS (
                  SELECT u.*, ROW_NUMBER() OVER (
                    PARTITION BY u.arm,u.event_family
                    ORDER BY u.observed_at ASC,u.forecast_key ASC) AS rn
                  FROM unified_forecast_evidence u
                  WHERE u.stream='intelligence_eval' AND u.outcome IS NOT NULL
+               ), ranked AS (SELECT * FROM resolved WHERE rn=1),
+               arm_count AS (SELECT COUNT(DISTINCT arm) AS n FROM ranked),
+               paired AS (
+                 SELECT event_family FROM ranked GROUP BY event_family
+                 HAVING COUNT(DISTINCT arm)=(SELECT n FROM arm_count)
                )
                SELECT arm AS arm_name,model,COUNT(*) AS forecasts,
                       AVG((probability-outcome)*(probability-outcome)) AS brier,
                       AVG((market_probability-outcome)*
                           (market_probability-outcome)) AS market_brier,
                       SUM(abstained) AS abstains
-                 FROM ranked WHERE rn=1
+                 FROM ranked JOIN paired USING(event_family)
                 GROUP BY arm,model ORDER BY brier ASC""")
         return [dict(row) for row in rows]

--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import random
 import uuid
 
 import structlog
@@ -154,42 +153,31 @@ class PaperTrader:
 
 
     async def check_fills(self, current_prices: dict[str, float]) -> list[OrderResult]:
-        """Check pending limit orders for simulated fills.
+        """Fill maker orders only after strict trade-through evidence.
 
-        Fill probability depends on distance from midpoint:
-        closer to midpoint = lower fill probability.
+        Merely touching the limit is not evidence that our queue position
+        executed, so no random fill credit is awarded.
         """
         filled: list[OrderResult] = []
         remaining: list[tuple[Order, str]] = []
-
         for order, order_id in self.pending_orders:
             market_price = current_prices.get(order.market_id)
             if market_price is None:
                 remaining.append((order, order_id))
                 continue
-
-            # Simulate fill: BUY fills if market price drops to our limit
-            # SELL fills if market price rises to our limit
-            should_fill = False
-            if order.side == OrderSide.BUY and market_price <= order.price:
-                should_fill = True
-            elif order.side == OrderSide.SELL and market_price >= order.price:
-                should_fill = True
-
-            # Add probabilistic element: closer to midpoint = less likely
+            should_fill = (
+                order.side == OrderSide.BUY and market_price < order.price
+            ) or (
+                order.side == OrderSide.SELL and market_price > order.price
+            )
             if should_fill:
-                # 70-100% fill probability based on price distance
-                fill_prob = 0.7 + random.random() * 0.3
-                if random.random() < fill_prob:
-                    result = await self.execute(order)
-                    result.order_id = order_id
-                    result.status = "filled"
-                    filled.append(result)
-                    log.info("paper.limit_filled", order_id=order_id, price=order.price)
-                    continue
-
+                result = await self.execute(order)
+                result.order_id = order_id
+                result.status = "filled"
+                filled.append(result)
+                log.info("paper.limit_filled", order_id=order_id, price=order.price)
+                continue
             remaining.append((order, order_id))
-
         self.pending_orders = remaining
         return filled
 

--- a/auramaur/research/polymarket_strategies.py
+++ b/auramaur/research/polymarket_strategies.py
@@ -6,6 +6,7 @@ remain behind the normal strategy protocol, risk manager, and graduation gate.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from dataclasses import dataclass
@@ -209,21 +210,48 @@ class DecisionTracker:
         side: str, fair_probability: float, reference_price: float,
         executable_price: float | None, best_bid: float | None,
         best_ask: float | None, requested_size: float, fee_estimate: float,
-        filled: bool = False,
-    ) -> None:
+        venue: str = "", event_family: str = "", strategy_version: str = "",
+        cohort_id: str = "", config_json: str = "{}", is_paper: bool = True,
+        holdout_warmup_days: int = 0,
+    ) -> int | None:
+        if not strategy_version:
+            strategy_version = hashlib.sha256(
+                f"legacy:{strategy_source}:{config_json}".encode()).hexdigest()
+        await self.db.execute(
+            """INSERT OR IGNORE INTO strategy_experiments
+               (strategy_version,strategy_source,config_json,holdout_starts_at)
+               VALUES (?,?,?,datetime('now', ?))""",
+            (strategy_version, strategy_source, config_json,
+             f"+{max(0, holdout_warmup_days)} days"),
+        )
         await self.db.execute(
             """INSERT OR IGNORE INTO decision_snapshots
                (market_id, strategy_source, signal_id, side, fair_probability,
                 reference_price, executable_price, best_bid, best_ask,
-                requested_size, fee_estimate, filled)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                requested_size, fee_estimate, venue, event_family,
+                strategy_version, cohort_id, is_paper, is_holdout)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       CASE WHEN datetime('now') >= (SELECT holdout_starts_at
+                         FROM strategy_experiments WHERE strategy_version=?)
+                       THEN 1 ELSE 0 END)""",
             (market_id, strategy_source, signal_id, side, fair_probability,
              reference_price, executable_price, best_bid, best_ask,
-             requested_size, fee_estimate, int(filled)),
+             requested_size, fee_estimate, venue, event_family,
+             strategy_version, cohort_id, int(is_paper), strategy_version),
         )
-        # Deliberately durable at the decision boundary. This path is currently
-        # low-volume; if capture moves into a high-frequency scanner, batch it
-        # behind a non-blocking writer rather than adding latency here.
+        await self.db.commit()
+        row = await self.db.fetchone(
+            "SELECT id FROM decision_snapshots WHERE signal_id IS ? "
+            "AND strategy_source=? ORDER BY id DESC LIMIT 1",
+            (signal_id, strategy_source),
+        )
+        return int(row["id"]) if row else None
+
+    async def mark_fill(self, decision_id: int, *, filled_price: float,
+                        evidence: str) -> None:
+        await self.db.execute(
+            "UPDATE decision_snapshots SET filled=1,filled_price=?,fill_evidence=? "
+            "WHERE id=?", (filled_price, evidence, decision_id))
         await self.db.commit()
 
     async def mark(self, decision_id: int, horizon_seconds: int, *,

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -28,6 +28,8 @@ Safety properties:
 """
 
 from __future__ import annotations
+from datetime import datetime
+from statistics import NormalDist
 
 import math
 import time
@@ -133,9 +135,71 @@ class GraduationLadder:
             "paper_lcb": lower_bound(paper),
         }
 
+    async def _prospective_stats(self, strategy: str, category: str) -> dict:
+        """Independent-family, executable, locked-holdout evidence."""
+        cfg = self._settings.graduation
+        evidence = list(cfg.credible_fill_evidence)
+        marks = ", ".join("?" for _ in evidence)
+        filters = ""
+        tail: list[object] = []
+        if cfg.require_executable_fills:
+            filters += f" AND d.filled = 1 AND d.fill_evidence IN ({marks})"
+            tail.extend(evidence)
+        if strategy not in cfg.strategy_level_strategies:
+            filters += " AND COALESCE(m.category, '') = ?"
+            tail.append(category)
+        rows = await self._db.fetchall(
+            f"""WITH latest AS (
+                    SELECT strategy_version FROM strategy_experiments
+                    WHERE strategy_source = ? ORDER BY registered_at DESC LIMIT 1
+                ), pnl AS (
+                    SELECT market_id, is_paper, SUM(pnl - fees) AS net_pnl
+                    FROM pnl_ledger WHERE strategy_source = ?
+                    GROUP BY market_id, is_paper
+                )
+                SELECT d.market_id, d.is_paper, d.observed_at,
+                       COALESCE(NULLIF(d.event_family, ''), d.market_id) AS family,
+                       ((d.reference_price-o.outcome)*(d.reference_price-o.outcome)
+                        -(d.fair_probability-o.outcome)*(d.fair_probability-o.outcome)) AS brier_edge,
+                       COALESCE(p.net_pnl, 0) AS net_pnl
+                FROM decision_snapshots d
+                JOIN latest x ON x.strategy_version = d.strategy_version
+                JOIN market_outcomes o ON o.event_key=lower(d.venue)||':'||d.market_id
+                LEFT JOIN markets m ON m.id=d.market_id
+                LEFT JOIN pnl p ON p.market_id=d.market_id AND p.is_paper=d.is_paper
+                WHERE d.strategy_source=? AND d.is_holdout=1
+                  AND d.observed_at >= datetime('now', ?) {filters}
+                ORDER BY d.observed_at, d.id""",
+            (strategy, strategy, strategy, f"-{int(cfg.window_days)} days", *tail),
+        )
+        grouped: dict[int, dict[str, dict]] = {0: {}, 1: {}}
+        for row in rows or []:
+            grouped[int(bool(row["is_paper"]))].setdefault(row["family"], row)
+        alpha = cfg.familywise_alpha / max(1, cfg.max_hypotheses*cfg.sequential_looks_per_window)
+        z = max(cfg.confidence_z, NormalDist().inv_cdf(1.0-alpha))
+
+        def summarize(items: list[dict]) -> dict:
+            pnl = [float(r["net_pnl"] or 0) for r in items]
+            brier = [float(r["brier_edge"] or 0) for r in items]
+            def lcb(values: list[float]) -> float:
+                if len(values) < 2:
+                    return float("-inf")
+                mean = sum(values)/len(values)
+                variance = sum((x-mean)**2 for x in values)/(len(values)-1)
+                return mean-z*math.sqrt(variance/len(values))
+            dates = [datetime.fromisoformat(str(r["observed_at"]).replace("Z", "+00:00")) for r in items]
+            return {"n": len(items), "pnl": sum(pnl), "lcb": lcb(pnl),
+                    "brier_lcb": lcb(brier),
+                    "days": (max(dates)-min(dates)).days if len(dates)>1 else 0,
+                    "regimes": len({(d.year, d.month) for d in dates})}
+        live = summarize(list(grouped[0].values()))
+        paper = summarize(list(grouped[1].values()))
+        return ({f"live_{k}": v for k, v in live.items()} |
+                {f"paper_{k}": v for k, v in paper.items()})
     async def _paper_breadth(self) -> int:
         """Concurrent open PAPER/exploratory positions — the spray breadth. Cached
         for cache_seconds (a soft cap doesn't need an exact live count)."""
+
         now = time.monotonic()
         if self._breadth and now - self._breadth[0] < self._settings.graduation.cache_seconds:
             return self._breadth[1]
@@ -150,45 +214,46 @@ class GraduationLadder:
 
     async def _compute(self, strategy: str, category: str) -> CellDecision:
         cfg = self._settings.graduation
-        s = await self._cell_stats(strategy, category)
-        # Per-strategy evidence bar (falls back to the global min_markets):
-        # slow-accruing books earn evaluation at a reachable n instead of
-        # feeding a gate only high-volume books can clear. The statistical
-        # contract is unchanged — the one-sided LCB still must clear zero,
-        # it just gets computed once n is plausible for the book's cadence.
+        s = (await self._prospective_stats(strategy, category)
+             if cfg.prospective_only else await self._cell_stats(strategy, category))
         min_markets = cfg.min_markets_overrides.get(strategy, cfg.min_markets)
+        min_evidence = cfg.min_paired_forecasts or min_markets
 
-        if s["live_n"] >= min_markets:
-            if s["live_lcb"] > cfg.min_mean_pnl_lower_bound:
+        def qualifies(mode: str) -> bool:
+            return (s[f"{mode}_n"] >= min_evidence
+                    and s.get(f"{mode}_days", 0) >= cfg.min_calendar_days
+                    and s.get(f"{mode}_regimes", 1) >= cfg.min_regime_months
+                    and s[f"{mode}_lcb"] > cfg.min_mean_pnl_lower_bound
+                    and (not cfg.require_market_brier_edge
+                         or s.get(f"{mode}_brier_lcb", float("-inf")) > 0))
+
+        def evidence_reason(mode: str) -> str:
+            return (f"{s[f'{mode}_n']} independent families; "
+                    f"{s.get(f'{mode}_days', 0)}d/"
+                    f"{s.get(f'{mode}_regimes', 1)} regimes; "
+                    f"P&L LCB ${s[f'{mode}_lcb']:+.3f}; "
+                    f"Brier-edge LCB "
+                    f"{s.get(f'{mode}_brier_lcb', float('-inf')):+.4f}")
+
+        if s["live_n"] >= min_evidence:
+            if qualifies("live"):
                 return _LIVE_FULL
-            return CellDecision(
-                True, 1.0, "demoted",
-                f"live evidence insufficient (mean-P&L LCB ${s['live_lcb']:+.3f}; "
-                f"${s['live_pnl']:+.2f} over {s['live_n']} independent markets)")
-        if s["paper_n"] >= min_markets:
-            if s["paper_lcb"] > cfg.min_mean_pnl_lower_bound:
-                return CellDecision(
-                    False, cfg.probation_multiplier, "probation",
-                    f"graduated from paper (mean-P&L LCB ${s['paper_lcb']:+.3f}; "
-                    f"${s['paper_pnl']:+.2f} over {s['paper_n']} independent markets)")
-            return CellDecision(
-                True, 1.0, "paper_negative",
-                f"paper evidence insufficient (mean-P&L LCB ${s['paper_lcb']:+.3f}; "
-                f"${s['paper_pnl']:+.2f} over {s['paper_n']} independent markets)")
-        # Unproven (still exploring). Restrict the spray: if the open paper book is
-        # already at the breadth cap, skip NEW unproven entries (size x0) so
-        # exploration concentrates instead of spraying. Restriction only — proven/
-        # probation/exempt cells and exits are never affected.
+            return CellDecision(True, 1.0, "demoted",
+                                f"live evidence insufficient ({evidence_reason('live')})")
+        if s["paper_n"] >= min_evidence:
+            if qualifies("paper"):
+                return CellDecision(False, cfg.probation_multiplier, "probation",
+                                    f"graduated from paper ({evidence_reason('paper')})")
+            return CellDecision(True, 1.0, "paper_negative",
+                                f"paper evidence insufficient ({evidence_reason('paper')})")
         cap = cfg.max_unproven_positions
         if cap > 0 and await self._paper_breadth() >= cap:
-            return CellDecision(
-                True, 0.0, "unproven_capped",
-                f"unproven spray cap hit (>= {cap} open paper positions) — "
-                f"concentrating; skip new unproven entry")
-        return CellDecision(
-            True, 1.0, "unproven",
-            f"insufficient record (live {s['live_n']}, paper {s['paper_n']} "
-            f"< {cfg.min_markets} markets in {cfg.window_days}d)")
+            return CellDecision(True, 0.0, "unproven_capped",
+                                f"unproven spray cap hit (>= {cap} open paper positions) — "
+                                "concentrating; skip new unproven entry")
+        return CellDecision(True, 1.0, "unproven",
+                            f"insufficient record (live {s['live_n']}, paper {s['paper_n']} "
+                            f"< {min_evidence} independent families in {cfg.window_days}d)")
 
     # ------------------------------------------------------------------
     # Reporting (CLI)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -161,6 +161,20 @@ graduation:
      "informed_flow", "entailment_arb", "cross_venue_arb", "settlement_arb",
      "resolution_lens", "resolution_lens_kalshi", "platform_consensus"]
   confidence_z: 1.645
+  # Prospective proof contract: old/backfilled rows remain reportable but cannot
+  # graduate a strategy whose parameters and execution provenance were not frozen.
+  prospective_only: true
+  require_market_brier_edge: true
+  require_executable_fills: true
+  min_calendar_days: 30
+  min_regime_months: 2
+  holdout_warmup_days: 14
+  familywise_alpha: 0.05
+  max_hypotheses: 50
+  sequential_looks_per_window: 90
+  min_paired_forecasts: 30
+  credible_fill_evidence: ["venue_fill", "book_cross", "trade_through"]
+
   min_mean_pnl_lower_bound: 0.0
   probation_multiplier: 0.5
   cache_seconds: 300

--- a/config/settings.py
+++ b/config/settings.py
@@ -1119,6 +1119,22 @@ class GraduationConfig(BaseModel):
     # audit: weather_temp alone at 140; the next-best cells accrue 30-45),
     # so every other book's paper evidence fed a gate it could never clear.
     # Keyed by strategy_source; unlisted strategies use min_markets. The
+    # Strong prospective edge contract. Tracked defaults enable it; class
+    # defaults remain permissive for isolated callers and legacy test fixtures.
+    prospective_only: bool = False
+    require_market_brier_edge: bool = False
+    require_executable_fills: bool = False
+    min_calendar_days: int = 0
+    min_regime_months: int = 1
+    holdout_warmup_days: int = 0
+    familywise_alpha: float = 0.05
+    max_hypotheses: int = 1
+    sequential_looks_per_window: int = 1
+    credible_fill_evidence: list[str] = ["venue_fill", "book_cross", "trade_through"]
+    # Minimum number of paired forecast-vs-market observations; zero inherits
+    # the strategy's min_markets threshold.
+    min_paired_forecasts: int = 0
+
     # tracked default stays empty — fresh clones keep the strict bar.
     min_markets_overrides: dict[str, int] = {}
     # Strategies elected at STRATEGY grain: evidence aggregates across all


### PR DESCRIPTION
## Summary
- freeze versioned strategy contracts and immutable treatment payloads before evaluation
- require independent event-family evidence, matched-market Brier edge, net P&L, executable fill provenance, calendar duration, regime coverage, and multiplicity-adjusted confidence before graduation
- compare intelligence arms only on their paired resolved-family intersection and replace random paper maker fills with strict trade-through fills
- add idempotent schema v43 migration and provenance fields for cohorts, holdouts, fills, and experiment versions

## Verification
- python -m ruff check auramaur config/settings.py
- python -m pytest -q -p no:cacheprovider --basetemp .pytest-tmp-edge (1500 passed, 3 skipped)
- focused post-immutability run: 46 passed
- local runtime database backed up previously and migrated from schema v42 to v43

Assisted-by: Claude (Anthropic)