### PR TITLE
Add strategy-aware data edge contracts

### DIFF
--- a/auramaur/data_edge.py
+++ b/auramaur/data_edge.py
@@ -1,0 +1,151 @@
+"""Consumer-level data contracts and delivery telemetry.
+
+Provider uptime is not the same thing as a strategy receiving usable data.
+This module names the datasets each strategy consumes and records deliveries
+with event time, observation time, coverage, fallbacks, and snapshot identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Literal
+
+import structlog
+from pydantic import BaseModel, Field
+
+log = structlog.get_logger()
+
+_HEALTHY_THROTTLE_SECONDS = {"order_book": 15.0}
+_last_healthy_recorded: dict[tuple[int, str, str], float] = {}
+
+DeliveryStatus = Literal[
+    "ok", "empty", "stale", "partial", "timeout", "error", "unavailable"
+]
+
+
+class DataRequirement(BaseModel):
+    component: str
+    max_age_seconds: float
+    min_items: int = 1
+    required_fields: tuple[str, ...] = ()
+    fail_closed: bool = True
+
+
+class DataDelivery(BaseModel):
+    strategy: str
+    component: str
+    status: DeliveryStatus
+    provider: str = ""
+    market_id: str = ""
+    snapshot_id: str = ""
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    source_at: datetime | None = None
+    latency_ms: int = 0
+    item_count: int = 0
+    required_fields: tuple[str, ...] = ()
+    missing_fields: tuple[str, ...] = ()
+    fallback_used: str = ""
+    detail: dict = Field(default_factory=dict)
+
+    @property
+    def age_seconds(self) -> float | None:
+        if self.source_at is None:
+            return None
+        source = self.source_at
+        if source.tzinfo is None:
+            source = source.replace(tzinfo=timezone.utc)
+        observed = self.observed_at
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=timezone.utc)
+        return max(0.0, (observed - source).total_seconds())
+
+
+# Explicit defaults. Strategies may override these with a ``data_requirements``
+# attribute; keeping the registry here makes readiness useful before every
+# pillar has bespoke telemetry.
+_EVIDENCE = DataRequirement(component="evidence", max_age_seconds=48 * 3600)
+_MARKETS = DataRequirement(
+    component="market_snapshot", max_age_seconds=300,
+    required_fields=("outcome_yes_price", "outcome_no_price"),
+)
+_BOOK = DataRequirement(
+    component="order_book", max_age_seconds=15,
+    required_fields=("best_bid", "best_ask"),
+)
+_CYCLE = DataRequirement(component="strategy_cycle", max_age_seconds=900, min_items=0)
+
+REQUIREMENTS: dict[str, tuple[DataRequirement, ...]] = {
+    "strategic": (_MARKETS, _EVIDENCE),
+    "llm": (_MARKETS, _EVIDENCE),
+    "technical": (_MARKETS, DataRequirement(component="price_history", max_age_seconds=300)),
+    "market_maker": (_BOOK,),
+    "arbitrage": (_MARKETS,),
+    "bias_harvest": (_MARKETS, _BOOK),
+    "platform_consensus": (_MARKETS, DataRequirement(component="platform_forecasts", max_age_seconds=900)),
+    "cross_venue_arb": (DataRequirement(component="cross_venue_snapshot", max_age_seconds=30),),
+    "informed_flow": (DataRequirement(component="venue_trades", max_age_seconds=120),),
+    "econ_indicator": (DataRequirement(component="fred_observations", max_age_seconds=3600), _MARKETS),
+    "settlement_arb": (DataRequirement(component="fred_observations", max_age_seconds=3600), _MARKETS),
+    "weather_temp": (DataRequirement(component="weather_ensemble", max_age_seconds=3600), _MARKETS),
+    "vol_anchor": (DataRequirement(component="spot_volatility", max_age_seconds=3600), _MARKETS),
+    "oddlot_tender": (DataRequirement(component="edgar_filings", max_age_seconds=21600),),
+    "resolution_lens": (_MARKETS, _EVIDENCE),
+    "resolution_lens_kalshi": (_MARKETS, _EVIDENCE),
+    "term_structure": (_MARKETS, _EVIDENCE),
+    "agent_trader": (_MARKETS, _EVIDENCE),
+    "long_horizon": (_MARKETS,),
+    "entailment_arb": (_MARKETS,),
+    "ibkr_etf": (DataRequirement(component="equity_quote", max_age_seconds=120), _EVIDENCE),
+    "ibkr_multiasset": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "kraken_treasury": (DataRequirement(component="crypto_quote", max_age_seconds=120), _EVIDENCE),
+}
+
+
+def requirements_for(strategy: str) -> tuple[DataRequirement, ...]:
+    return REQUIREMENTS.get(strategy, (_CYCLE,))
+
+
+def snapshot_id(*parts: object) -> str:
+    """Stable identity for observations intended to be contemporaneous."""
+    payload = "\x1f".join(str(part) for part in parts)
+    return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:24]
+
+
+async def record_delivery(db, delivery: DataDelivery) -> None:
+    """Persist one delivery without allowing monitoring to kill a strategy."""
+    try:
+        throttle = _HEALTHY_THROTTLE_SECONDS.get(delivery.component, 0.0)
+        key = (id(db), delivery.strategy, delivery.component)
+        now_mono = time.monotonic()
+        if (delivery.status == "ok" and throttle > 0
+                and now_mono - _last_healthy_recorded.get(key, -throttle) < throttle):
+            return
+        observed = delivery.observed_at.astimezone(timezone.utc)
+        source = delivery.source_at
+        if source is not None:
+            source = (source.replace(tzinfo=timezone.utc) if source.tzinfo is None
+                      else source.astimezone(timezone.utc))
+        async with db.transaction(owner="data_edge"):
+            await db.execute(
+                """INSERT INTO strategy_data_deliveries
+               (delivery_id,strategy,component,status,provider,market_id,snapshot_id,
+                observed_at,source_at,age_seconds,latency_ms,item_count,
+                required_fields,missing_fields,fallback_used,detail)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (uuid.uuid4().hex, delivery.strategy, delivery.component,
+                 delivery.status, delivery.provider, delivery.market_id,
+                 delivery.snapshot_id, observed.isoformat(),
+                 source.isoformat() if source else None, delivery.age_seconds,
+                 max(0, delivery.latency_ms), max(0, delivery.item_count),
+                 json.dumps(delivery.required_fields), json.dumps(delivery.missing_fields),
+                delivery.fallback_used, json.dumps(delivery.detail, default=str)[:4000]),
+            )
+        if delivery.status == "ok" and throttle > 0:
+            _last_healthy_recorded[key] = now_mono
+    except Exception as exc:  # noqa: BLE001 - telemetry must be best effort
+        log.debug("data_edge.record_failed", strategy=delivery.strategy,
+                  component=delivery.component, error=str(exc))

--- a/auramaur/data_quality.py
+++ b/auramaur/data_quality.py
@@ -30,6 +30,25 @@ async def audit_data_contracts(db: Database) -> list[ContractViolation]:
         ("incomplete_ingestion",
          "SELECT COUNT(*) n FROM ingestion_runs WHERE completed_at IS NULL OR status='running'",
          "persisted ingestion row is incomplete"),
+        ("unlinked_strategic_forecast",
+         """SELECT COUNT(*) n FROM forecast_snapshots
+            WHERE strategy_source='strategic' AND evidence_run_ids='[]'""",
+         "strategic forecast has no point-in-time evidence lineage"),
+        ("weak_timestamp_ranked_first",
+         """SELECT COUNT(*) n FROM evidence_observations
+            WHERE rank_position=1 AND timestamp_quality IN ('unknown','provider_seen')""",
+         "top-ranked evidence has weak publication-time semantics"),
+        ("invalid_delivery_age",
+         """SELECT COUNT(*) n FROM strategy_data_deliveries
+            WHERE age_seconds < 0 OR latency_ms < 0 OR item_count < 0""",
+         "strategy delivery contains invalid age, latency, or coverage"),
+        ("failed_latest_delivery",
+         """SELECT COUNT(*) n FROM strategy_data_deliveries d
+            WHERE d.id=(SELECT d2.id FROM strategy_data_deliveries d2
+                        WHERE d2.strategy=d.strategy AND d2.component=d.component
+                        ORDER BY d2.observed_at DESC,d2.id DESC LIMIT 1)
+              AND d.status NOT IN ('ok','empty')""",
+         "latest strategy-facing dataset delivery is unhealthy"),
     ]
     violations = []
     for name, sql, detail in checks:

--- a/auramaur/data_quality.py
+++ b/auramaur/data_quality.py
@@ -30,14 +30,24 @@ async def audit_data_contracts(db: Database) -> list[ContractViolation]:
         ("incomplete_ingestion",
          "SELECT COUNT(*) n FROM ingestion_runs WHERE completed_at IS NULL OR status='running'",
          "persisted ingestion row is incomplete"),
+        # Both lineage checks bound themselves to rows written after delivery
+        # telemetry began (the v44 deploy): earlier rows predate the contract
+        # and would otherwise count as violations forever. MIN(observed_at)
+        # over an empty deliveries table is NULL, which flags nothing.
         ("unlinked_strategic_forecast",
          """SELECT COUNT(*) n FROM forecast_snapshots
-            WHERE strategy_source='strategic' AND evidence_run_ids='[]'""",
+            WHERE strategy_source='strategic' AND evidence_run_ids='[]'
+              AND datetime(observed_at) >=
+                  (SELECT MIN(datetime(observed_at)) FROM strategy_data_deliveries)""",
          "strategic forecast has no point-in-time evidence lineage"),
+        # 'provider_seen' is a deliberate stamp on official sources (BLS/BEA/
+        # EIA) and a legitimate first rank; only 'unknown' is a contract gap.
         ("weak_timestamp_ranked_first",
          """SELECT COUNT(*) n FROM evidence_observations
-            WHERE rank_position=1 AND timestamp_quality IN ('unknown','provider_seen')""",
-         "top-ranked evidence has weak publication-time semantics"),
+            WHERE rank_position=1 AND timestamp_quality='unknown'
+              AND datetime(observed_at) >=
+                  (SELECT MIN(datetime(observed_at)) FROM strategy_data_deliveries)""",
+         "top-ranked evidence has unknown publication-time semantics"),
         ("invalid_delivery_age",
          """SELECT COUNT(*) n FROM strategy_data_deliveries
             WHERE age_seconds < 0 OR latency_ms < 0 OR item_count < 0""",

--- a/auramaur/data_sources/aggregator.py
+++ b/auramaur/data_sources/aggregator.py
@@ -145,14 +145,11 @@ class Aggregator:
                 pub = pub.replace(tzinfo=timezone.utc)
             age_hours = max((now - pub).total_seconds() / 3600, 0.01)
             # Preserve the production ranking formula. Timestamp quality is
-            # captured for offline trials, not allowed to alter proven books.
+            # captured for offline trials, not allowed to alter proven books;
+            # the LLM-facing evidence_ranker applies the quality weight.
             recency = 1.0 / age_hours
             source_weight = authority(item.source, item.url)
-            timestamp_weight = {
-                "exact": 1.0, "inferred": 0.75,
-                "provider_seen": 0.45, "unknown": 0.20,
-            }.get(item.timestamp_quality, 0.20)
-            return (recency * timestamp_weight * source_weight) + item.relevance_score
+            return (recency * source_weight) + item.relevance_score
 
         unique.sort(key=_rank, reverse=True)
 

--- a/auramaur/data_sources/aggregator.py
+++ b/auramaur/data_sources/aggregator.py
@@ -32,9 +32,11 @@ class Aggregator:
     source_name: str = "aggregator"
 
     def __init__(self, sources: list[DataSource],
-                 observer: LineageObserver | None = None) -> None:
+                 observer: LineageObserver | None = None,
+                 source_timeout_seconds: float = 20.0) -> None:
         self._sources = sources
         self.observer = observer
+        self._source_timeout_seconds = source_timeout_seconds
 
     @staticmethod
     def _source_matches_category(source: DataSource, category: str | None) -> bool:
@@ -60,6 +62,8 @@ class Aggregator:
         category: str | None = None,
         market_id: str = "",
         market_price: float | None = None,
+        consumer: str = "",
+        snapshot_id: str = "",
     ) -> list[NewsItem]:
         """Fetch from matching sources concurrently, deduplicate, and rank.
 
@@ -70,20 +74,30 @@ class Aggregator:
 
         run_id = uuid.uuid4().hex
         started = datetime.now(tz=timezone.utc)
+        gather_started = time.monotonic()
         fetch_rows: list[tuple] = []
 
         async def _safe_fetch(source: DataSource) -> list[NewsItem]:
             source_name = getattr(source, "source_name", str(source))
             before = time.monotonic()
             try:
-                items = await source.fetch(query, limit=limit_per_source)
+                async with asyncio.timeout(self._source_timeout_seconds):
+                    items = await source.fetch(query, limit=limit_per_source)
                 mode = getattr(source, "information_mode", "production")
                 for item in items:
                     item.information_mode = mode
-                fetch_rows.append((run_id, source_name, "ok", len(items),
+                fetch_rows.append((run_id, source_name, "ok" if items else "empty", len(items),
                                    round((time.monotonic() - before) * 1000), "",
                                    datetime.now(tz=timezone.utc).isoformat(), mode))
                 return items
+            except TimeoutError as exc:
+                fetch_rows.append((run_id, source_name, "timeout", 0,
+                                   round((time.monotonic() - before) * 1000), str(exc)[:500],
+                                   datetime.now(tz=timezone.utc).isoformat(),
+                                   getattr(source, "information_mode", "production")))
+                logger.warning("aggregator_source_timeout", source=source_name,
+                               timeout_seconds=self._source_timeout_seconds)
+                return []
             except Exception as exc:
                 fetch_rows.append((run_id, source_name, "error", 0,
                                    round((time.monotonic() - before) * 1000), str(exc)[:500],
@@ -134,7 +148,11 @@ class Aggregator:
             # captured for offline trials, not allowed to alter proven books.
             recency = 1.0 / age_hours
             source_weight = authority(item.source, item.url)
-            return (recency * source_weight) + item.relevance_score
+            timestamp_weight = {
+                "exact": 1.0, "inferred": 0.75,
+                "provider_seen": 0.45, "unknown": 0.20,
+            }.get(item.timestamp_quality, 0.20)
+            return (recency * timestamp_weight * source_weight) + item.relevance_score
 
         unique.sort(key=_rank, reverse=True)
 
@@ -179,6 +197,23 @@ class Aggregator:
             category=category,
             active_sources=len(active_sources),
         )
+        if consumer and self.observer is not None:
+            from auramaur.data_edge import DataDelivery, record_delivery
+
+            statuses = {row[2] for row in fetch_rows}
+            status = ("empty" if not unique else
+                      "partial" if statuses & {"error", "timeout"} else "ok")
+            published = [item.published_at for item in unique if item.published_at]
+            source_at = max(published) if published else None
+            await record_delivery(self.observer.db, DataDelivery(
+                strategy=consumer, component="evidence", status=status,
+                provider="aggregator", market_id=market_id,
+                snapshot_id=snapshot_id or run_id, source_at=source_at,
+                item_count=len(unique), latency_ms=round(
+                    (time.monotonic() - gather_started) * 1000),
+                detail={"run_id": run_id, "active_sources": len(active_sources),
+                        "source_statuses": sorted(statuses)},
+            ))
         return unique
 
     # Implement the DataSource protocol's fetch as well, delegating to gather

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -280,6 +280,43 @@ class Database:
             await self._migrate_v41_to_v42()
         if from_version < 43:
             await self._migrate_v42_to_v43()
+        if from_version < 44:
+            await self._migrate_v43_to_v44()
+
+    async def _migrate_v43_to_v44(self) -> None:
+        """Add consumer-level data delivery telemetry."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS strategy_data_deliveries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                delivery_id TEXT NOT NULL, strategy TEXT NOT NULL,
+                component TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN
+                    ('ok','empty','stale','partial','timeout','error','unavailable')),
+                provider TEXT NOT NULL DEFAULT '', market_id TEXT NOT NULL DEFAULT '',
+                snapshot_id TEXT NOT NULL DEFAULT '', observed_at TEXT NOT NULL,
+                source_at TEXT, age_seconds REAL, latency_ms INTEGER NOT NULL DEFAULT 0,
+                item_count INTEGER NOT NULL DEFAULT 0,
+                required_fields TEXT NOT NULL DEFAULT '[]',
+                missing_fields TEXT NOT NULL DEFAULT '[]',
+                fallback_used TEXT NOT NULL DEFAULT '', detail TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE INDEX IF NOT EXISTS idx_strategy_delivery_consumer_time
+                ON strategy_data_deliveries(strategy, component, observed_at);
+            CREATE INDEX IF NOT EXISTS idx_strategy_delivery_status_time
+                ON strategy_data_deliveries(status, observed_at);
+            CREATE INDEX IF NOT EXISTS idx_strategy_delivery_snapshot
+                ON strategy_data_deliveries(snapshot_id);
+            CREATE TABLE IF NOT EXISTS strategy_heartbeats (
+                strategy TEXT PRIMARY KEY,
+                last_beat_at TEXT NOT NULL DEFAULT (datetime('now')),
+                status TEXT NOT NULL DEFAULT 'ok', entries INTEGER,
+                cycles INTEGER NOT NULL DEFAULT 0, interval_seconds REAL,
+                detail TEXT NOT NULL DEFAULT ''
+            );
+            UPDATE schema_version SET version = 44;
+        """)
+        await self._db.commit()
+        log.info("database.migrated", from_version=43, to_version=44)
 
     async def _migrate_v42_to_v43(self) -> None:
         """Prospective, versioned and execution-supported edge evidence."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 43
+SCHEMA_VERSION = 44
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -213,6 +213,36 @@ CREATE TABLE IF NOT EXISTS source_fetches (
     item_count INTEGER NOT NULL DEFAULT 0, latency_ms INTEGER NOT NULL DEFAULT 0,
     error TEXT DEFAULT '', observed_at TEXT NOT NULL,
     information_mode TEXT NOT NULL DEFAULT 'production', PRIMARY KEY (run_id, source)
+);
+
+CREATE TABLE IF NOT EXISTS strategy_data_deliveries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    delivery_id TEXT NOT NULL,
+    strategy TEXT NOT NULL,
+    component TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN
+        ('ok','empty','stale','partial','timeout','error','unavailable')),
+    provider TEXT NOT NULL DEFAULT '', market_id TEXT NOT NULL DEFAULT '',
+    snapshot_id TEXT NOT NULL DEFAULT '', observed_at TEXT NOT NULL,
+    source_at TEXT, age_seconds REAL, latency_ms INTEGER NOT NULL DEFAULT 0,
+    item_count INTEGER NOT NULL DEFAULT 0,
+    required_fields TEXT NOT NULL DEFAULT '[]',
+    missing_fields TEXT NOT NULL DEFAULT '[]',
+    fallback_used TEXT NOT NULL DEFAULT '', detail TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_strategy_delivery_consumer_time
+    ON strategy_data_deliveries(strategy, component, observed_at);
+CREATE INDEX IF NOT EXISTS idx_strategy_delivery_status_time
+    ON strategy_data_deliveries(status, observed_at);
+CREATE INDEX IF NOT EXISTS idx_strategy_delivery_snapshot
+    ON strategy_data_deliveries(snapshot_id);
+
+CREATE TABLE IF NOT EXISTS strategy_heartbeats (
+    strategy TEXT PRIMARY KEY,
+    last_beat_at TEXT NOT NULL DEFAULT (datetime('now')),
+    status TEXT NOT NULL DEFAULT 'ok', entries INTEGER,
+    cycles INTEGER NOT NULL DEFAULT 0, interval_seconds REAL,
+    detail TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS evidence_observations (

--- a/auramaur/lineage_observer.py
+++ b/auramaur/lineage_observer.py
@@ -126,7 +126,8 @@ class LineageObserver:
                 "(id,query,category,market_id,started_at,completed_at,status,active_sources,raw_items,unique_items) "
                 "VALUES (?,?,?,?,?,?,?,?,?,?)",
                 (run_id, query, category, market_id, started_at, observed_at,
-                 "partial" if any(row[2] == "error" for row in fetch_rows) else "ok",
+                 "partial" if any(row[2] in {"error", "timeout"}
+                                  for row in fetch_rows) else "ok",
                  len(active_sources), raw_items,
                  sum(i["rank_position"] is not None for i in items)),
             )

--- a/auramaur/monitoring/heartbeat.py
+++ b/auramaur/monitoring/heartbeat.py
@@ -17,6 +17,8 @@ Read-only consumers (the web dashboard) read this table via their normal
 from __future__ import annotations
 
 import json
+import time
+from datetime import datetime, timezone
 
 import structlog
 
@@ -78,15 +80,30 @@ async def run_pillar_once(db, pillar, *,
     loop's own error handling still runs.
     """
     name = getattr(pillar, "name", type(pillar).__name__)
+    started = time.monotonic()
     try:
         entered = await pillar.run_once()
     except Exception as e:
         await beat(db, name, status="error",
                    interval_seconds=interval_seconds,
                    detail={"error": str(e)[:300]})
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(db, DataDelivery(
+            strategy=name, component="strategy_cycle", status="error",
+            latency_ms=round((time.monotonic() - started) * 1000),
+            detail={"error": str(e)[:300]},
+        ))
         raise
     await beat(db, name, status="ok",
                entries=int(entered) if isinstance(entered, (int, float)) else None,
                interval_seconds=interval_seconds,
                detail=getattr(pillar, "last_cycle_detail", None))
+    from auramaur.data_edge import DataDelivery, record_delivery
+    await record_delivery(db, DataDelivery(
+        strategy=name, component="strategy_cycle", status="ok",
+        source_at=datetime.now(timezone.utc),
+        latency_ms=round((time.monotonic() - started) * 1000),
+        item_count=int(entered) if isinstance(entered, (int, float)) else 0,
+        detail=getattr(pillar, "last_cycle_detail", None) or {},
+    ))
     return entered if isinstance(entered, int) else 0

--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -267,6 +267,78 @@ async def check_data_sources(
     )
 
 
+async def check_strategy_data_delivery(
+    db: Database, *, since: datetime,
+) -> CriterionResult:
+    """Verify the datasets consumed by recently-running strategies.
+
+    Missing telemetry is reported honestly as insufficient data; once a
+    component has emitted, stale or failed deliveries are a hard failure.
+    """
+    from auramaur.data_edge import requirements_for
+
+    heartbeats = await db.fetchall(
+        "SELECT strategy,interval_seconds FROM strategy_heartbeats "
+        "WHERE datetime(last_beat_at) >= datetime(?)", (since.isoformat(),))
+    if not heartbeats:
+        return CriterionResult(
+            name="strategy_data_delivery", status="INSUFFICIENT_DATA",
+            value="0 active strategies", threshold="fresh required datasets",
+            detail="no recent strategy heartbeats")
+
+    now = datetime.now(timezone.utc)
+    failures: list[str] = []
+    unobserved: list[str] = []
+    checked = 0
+    for heartbeat in heartbeats:
+        strategy = heartbeat["strategy"]
+        for requirement in requirements_for(strategy):
+            row = await db.fetchone(
+                """SELECT status,observed_at,age_seconds,item_count,missing_fields
+                   FROM strategy_data_deliveries
+                   WHERE strategy=? AND component=?
+                   ORDER BY observed_at DESC LIMIT 1""",
+                (strategy, requirement.component))
+            label = f"{strategy}:{requirement.component}"
+            if row is None:
+                unobserved.append(label)
+                continue
+            checked += 1
+            try:
+                observed = datetime.fromisoformat(
+                    row["observed_at"].replace("Z", "+00:00"))
+                if observed.tzinfo is None:
+                    observed = observed.replace(tzinfo=timezone.utc)
+                delivery_age = max(0.0, (now - observed).total_seconds())
+            except (TypeError, ValueError):
+                failures.append(f"{label}=bad timestamp")
+                continue
+            allowed = max(requirement.max_age_seconds,
+                          float(heartbeat["interval_seconds"] or 0) * 2)
+            source_age = row["age_seconds"]
+            if (row["status"] != "ok" or delivery_age > allowed
+                    or (source_age is not None and source_age > requirement.max_age_seconds)
+                    or int(row["item_count"] or 0) < requirement.min_items):
+                failures.append(f"{label}={row['status']} age={delivery_age:.0f}s")
+
+    if failures:
+        return CriterionResult(
+            name="strategy_data_delivery", status="FAIL",
+            value=f"{len(failures)} unhealthy datasets",
+            threshold="all observed requirements fresh and complete",
+            detail="; ".join(failures[:12]), n_samples=checked)
+    if unobserved:
+        return CriterionResult(
+            name="strategy_data_delivery", status="INSUFFICIENT_DATA",
+            value=f"{len(unobserved)} datasets not yet observed",
+            threshold="telemetry for every required dataset",
+            detail=", ".join(unobserved[:12]), n_samples=checked)
+    return CriterionResult(
+        name="strategy_data_delivery", status="PASS",
+        value=f"{checked} datasets fresh", threshold="all requirements fresh",
+        n_samples=checked)
+
+
 # ---------------------------------------------------------------------------
 # Criterion 3 — risk gate pass rate
 # ---------------------------------------------------------------------------
@@ -591,6 +663,7 @@ async def evaluate_readiness(
     criteria = [
         await check_cycle_health(log_file, since_window),
         await check_data_sources(db, since_24h=since_24h, since_window=since_window),
+        await check_strategy_data_delivery(db, since=since_24h),
         await check_pass_rate(db, since=since_window, exchange=exchange),
         await check_brier_absolute(db, since=since_window),
         await check_brier_vs_market(db, since=since_window),

--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -272,8 +272,13 @@ async def check_strategy_data_delivery(
 ) -> CriterionResult:
     """Verify the datasets consumed by recently-running strategies.
 
-    Missing telemetry is reported honestly as insufficient data; once a
-    component has emitted, stale or failed deliveries are a hard failure.
+    Missing telemetry is reported honestly as insufficient data. A hard
+    failure requires the latest record to actively report trouble: a failing
+    status, or fresh telemetry carrying over-age source data or too few
+    items. An old record alone is treated as unobserved, not failed —
+    conditional emitters (FRED cache hits, weather priced on demand) simply
+    stop recording between events, which says nothing about data health.
+    'partial' and 'empty' are honest deliveries, not delivery failures.
     """
     from auramaur.data_edge import requirements_for
 
@@ -315,10 +320,17 @@ async def check_strategy_data_delivery(
                 continue
             allowed = max(requirement.max_age_seconds,
                           float(heartbeat["interval_seconds"] or 0) * 2)
+            if delivery_age > allowed:
+                if row["status"] in ("stale", "timeout", "error", "unavailable"):
+                    failures.append(f"{label}={row['status']} age={delivery_age:.0f}s")
+                else:
+                    unobserved.append(f"{label} (last seen {delivery_age:.0f}s ago)")
+                continue
             source_age = row["age_seconds"]
-            if (row["status"] != "ok" or delivery_age > allowed
+            if (row["status"] not in ("ok", "partial", "empty")
                     or (source_age is not None and source_age > requirement.max_age_seconds)
-                    or int(row["item_count"] or 0) < requirement.min_items):
+                    or (row["status"] == "ok"
+                        and int(row["item_count"] or 0) < requirement.min_items)):
                 failures.append(f"{label}={row['status']} age={delivery_age:.0f}s")
 
     if failures:

--- a/auramaur/nlp/evidence_ranker.py
+++ b/auramaur/nlp/evidence_ranker.py
@@ -24,6 +24,12 @@ log = structlog.get_logger()
 
 # Recency half-life in hours: a story this old counts for half a fresh one.
 _RECENCY_HALFLIFE_HOURS = 36.0
+_TIMESTAMP_QUALITY_WEIGHT = {
+    "exact": 1.0,
+    "inferred": 0.75,
+    "provider_seen": 0.45,
+    "unknown": 0.20,
+}
 
 
 def _recency_decay(item: NewsItem, now: datetime) -> float:
@@ -63,7 +69,9 @@ def rank_evidence(
 
     scored: list[tuple[float, NewsItem]] = []
     for item, r in zip(items, rel):
-        score = _recency_decay(item, now) * authority(item.source, item.url) * (1.0 + r)
+        timestamp_weight = _TIMESTAMP_QUALITY_WEIGHT.get(item.timestamp_quality, 0.20)
+        score = (_recency_decay(item, now) * timestamp_weight
+                 * authority(item.source, item.url) * (1.0 + r))
         scored.append((score, item))
 
     scored.sort(key=lambda x: x[0], reverse=True)

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -235,6 +235,14 @@ class BiasHarvestPillar:
             log.debug("bias_harvest.book_fetch_failed", market_id=market.id, error=str(e))
             return None
         best_bid, best_ask = book.best_bid, book.best_ask
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="order_book",
+            status="ok" if best_bid is not None and best_ask is not None else "empty",
+            provider="polymarket_clob", market_id=market.id,
+            item_count=len(book.bids) + len(book.asks),
+            required_fields=("best_bid", "best_ask"),
+        ))
         if best_bid is None or best_ask is None:
             return None
         if (best_ask - best_bid) < cfg.maker_min_spread:

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -141,6 +141,16 @@ class CrossVenueArbPillar:
         except Exception as e:
             log.debug("cross_venue.scan_error", error=str(e))
             return []
+        from auramaur.data_edge import DataDelivery, record_delivery, snapshot_id
+        observed = datetime.now(timezone.utc)
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="cross_venue_snapshot",
+            status="ok" if poly and kalshi else "partial",
+            provider="polymarket+kalshi",
+            snapshot_id=snapshot_id("cross_venue", observed.isoformat()),
+            source_at=observed, item_count=len(poly) + len(kalshi),
+            detail={"polymarket": len(poly), "kalshi": len(kalshi)},
+        ))
         poly = [m for m in poly if self._real_book(m)]
         kalshi = [m for m in kalshi if self._real_book(m)]
         pairs: list[tuple[Market, Market, float]] = []

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -414,6 +414,31 @@ class TradingEngine(CycleOrchestrationMixin):
                 "DELETE FROM price_history WHERE recorded_at < datetime('now', '-30 days')"
             )
 
+        # Consumer telemetry uses one snapshot id for the market rows and their
+        # contemporaneous price-history points, making as-of joins explicit.
+        from auramaur.data_edge import DataDelivery, record_delivery, snapshot_id
+        observed = datetime.now(timezone.utc)
+        sid = snapshot_id(self.exchange_name, observed.isoformat(), len(markets))
+        missing_prices = sum(
+            1 for market in markets
+            if market.outcome_yes_price is None or market.outcome_no_price is None
+        )
+        await record_delivery(self.db, DataDelivery(
+            strategy="strategic", component="market_snapshot",
+            status=("empty" if not markets else "partial" if missing_prices else "ok"),
+            provider=self.exchange_name or "discovery", snapshot_id=sid,
+            source_at=observed, item_count=len(markets),
+            required_fields=("outcome_yes_price", "outcome_no_price"),
+            missing_fields=(("outcome_prices",) if missing_prices else ()),
+            detail={"missing_market_count": missing_prices},
+        ))
+        await record_delivery(self.db, DataDelivery(
+            strategy="technical", component="price_history",
+            status="empty" if not markets else "ok",
+            provider=self.exchange_name or "discovery", snapshot_id=sid,
+            source_at=observed, item_count=len(markets),
+        ))
+
         return markets
 
     @staticmethod
@@ -596,6 +621,7 @@ class TradingEngine(CycleOrchestrationMixin):
             items = await self.aggregator.gather(
                 query, limit_per_source=per_query_limit, category=market.category or None,
                 market_id=market.id, market_price=market.outcome_yes_price,
+                consumer=strategy_source or "llm",
             )
             for item in items:
                 if item.id not in seen_ids:

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -413,6 +413,13 @@ class TradingEngine(CycleOrchestrationMixin):
             await self.db.execute(
                 "DELETE FROM price_history WHERE recorded_at < datetime('now', '-30 days')"
             )
+            # Delivery telemetry is high-volume (per-book, per-gather rows);
+            # readiness only reads latest-row and 24h windows, so 14 days is
+            # ample for debugging while bounding growth.
+            await self.db.execute(
+                "DELETE FROM strategy_data_deliveries "
+                "WHERE observed_at < datetime('now', '-14 days')"
+            )
 
         # Consumer telemetry uses one snapshot id for the market rows and their
         # contemporaneous price-history points, making as-of joins explicit.

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import uuid
 from typing import TYPE_CHECKING
 
 import structlog
@@ -580,6 +581,7 @@ class CycleOrchestrationMixin:
         _EVIDENCE_CONCURRENCY = 6
         sem = asyncio.Semaphore(_EVIDENCE_CONCURRENCY)
         clob_lock = asyncio.Lock()
+        evidence_snapshot_id = uuid.uuid4().hex
 
         async def _gather_market_evidence(market) -> tuple[str, list] | None:
             if self._is_junk_market(market):
@@ -617,6 +619,8 @@ class CycleOrchestrationMixin:
                     for query in queries:
                         items = await self.aggregator.gather(
                             query, limit_per_source=per_query_limit, category=market.category or None,
+                            market_id=market.id, market_price=market.outcome_yes_price,
+                            consumer="strategic", snapshot_id=evidence_snapshot_id,
                         )
                         for item in items:
                             if item.id not in seen_ids:
@@ -643,9 +647,14 @@ class CycleOrchestrationMixin:
 
         gathered = await asyncio.gather(*[_gather_market_evidence(m) for m in markets])
         evidence_map: dict[str, list] = {}
+        evidence_run_ids: dict[str, list[str]] = {}
         for _res in gathered:
             if _res is not None:
                 evidence_map[_res[0]] = _res[1]
+                evidence_run_ids[_res[0]] = sorted({
+                    item.ingestion_run_id for item in _res[1]
+                    if item.ingestion_run_id
+                })
 
         # Filter to markets with evidence gathered
         batch_markets = [m for m in markets if m.id in evidence_map]
@@ -733,7 +742,7 @@ class CycleOrchestrationMixin:
                         market_yes_price=market.outcome_yes_price,
                         market_no_price=market.outcome_no_price,
                         observed_at=_dt.now(_tz.utc).isoformat(),
-                        evidence_run_ids=[],
+                        evidence_run_ids=evidence_run_ids.get(market.id, []),
                         model=getattr(getattr(self, "analyzer", None), "_model", ""),
                         strategy_source="strategic",
                         config=self.settings.nlp.model_dump(mode="json"),

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -133,7 +133,9 @@ class IBKRETFPaperPillar:
             try:
                 if query not in self._evidence_cache:
                     self._evidence_cache[query] = await self._aggregator.gather(
-                        query, limit_per_source=3, category="finance")
+                        query, limit_per_source=3, category="finance",
+                        market_id=symbol, market_price=reference_price,
+                        consumer="ibkr_etf")
                 items = self._evidence_cache[query]
             except Exception as exc:  # noqa: BLE001
                 log.warning("ibkr_etf.paper.evidence_error", symbol=symbol,

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -299,6 +299,18 @@ class MarketMaker:
         # Fetch YES order book to determine BBO
         book = await self._exchange.get_order_book(market.clob_token_yes)
 
+        if getattr(self, "_db", None) is not None:
+            from auramaur.data_edge import DataDelivery, record_delivery
+            await record_delivery(self._db, DataDelivery(
+                strategy=self.name, component="order_book",
+                status="ok" if book.bids and book.asks else "empty",
+                provider="polymarket_clob", market_id=market.id,
+                item_count=len(book.bids) + len(book.asks),
+                required_fields=("best_bid", "best_ask"),
+                missing_fields=(() if book.bids and book.asks
+                                else ("best_bid", "best_ask")),
+            ))
+
         if not book.bids or not book.asks:
             log.debug("market_maker.empty_book", market_id=market.id)
             return None, "empty_book"

--- a/auramaur/strategy/pipeline_analyzer.py
+++ b/auramaur/strategy/pipeline_analyzer.py
@@ -95,6 +95,8 @@ class PipelineAnalyzer:
                 for query in queries:
                     items = await self.aggregator.gather(
                         query, limit_per_source=3, category=market.category or None,
+                        market_id=market.id, market_price=market.outcome_yes_price,
+                        consumer="strategic",
                     )
                     for item in items:
                         if item.id not in seen_ids:
@@ -194,6 +196,8 @@ class PipelineAnalyzer:
         for query in queries:
             items = await self.aggregator.gather(
                 query, limit_per_source=per_query_limit, category=market.category or None,
+                market_id=market.id, market_price=market.outcome_yes_price,
+                consumer="llm",
             )
             for item in items:
                 if item.id not in seen_ids:

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -336,7 +336,9 @@ class ResolutionLensPillar:
             per_q = max(1, self._settings.nlp.evidence_per_source)
             for q in (queries or [m.question])[:3]:
                 for it in await self._aggregator.gather(
-                        q, limit_per_source=per_q, category=m.category or None):
+                        q, limit_per_source=per_q, category=m.category or None,
+                        market_id=m.id, market_price=m.outcome_yes_price,
+                        consumer=self.name):
                     if it.id not in seen:
                         seen.add(it.id)
                         items.append(it)

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -403,6 +403,12 @@ class SettlementArbPillar:
             return await self._fred.get_observations(series, n=history_n)
         if series not in cache:
             cache[series] = await self._fred.get_observations(series, n=history_n)
+            from auramaur.data_edge import DataDelivery, record_delivery
+            await record_delivery(self._db, DataDelivery(
+                strategy=self.name, component="fred_observations",
+                status="ok" if cache[series] else "empty", provider="fred",
+                market_id=series, item_count=len(cache[series] or []),
+            ))
         return cache[series]
 
     async def _maybe_enter(self, m, pred: dict) -> bool:

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -203,6 +203,12 @@ class VolAnchorPillar:
                         error=str(e)[:120])
             return None
         closes = [p[1] for p in (data.get("prices") or []) if p and p[1]]
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="spot_volatility",
+            status="ok" if len(closes) >= 10 else "partial",
+            provider="coingecko", market_id=cg_id, item_count=len(closes),
+        ))
         if len(closes) < 10:
             return None
         rets = [math.log(closes[i] / closes[i - 1])

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -85,6 +85,13 @@ class WeatherTempPillar:
         cfg = self._settings.weather_temp
         members = await self._weather.daily_ensemble(
             spec.lat, spec.lon, spec.target, spec.kind, spec.unit)
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="weather_ensemble",
+            status="ok" if members else "empty", provider="openmeteo",
+            market_id=market.id, item_count=len(members),
+            detail={"target": spec.target.isoformat(), "city": spec.city},
+        ))
         model_p = bin_probability(members, spec.lo, spec.hi)
         if model_p is None:
             return False

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -1038,7 +1038,9 @@ class KrakenPillar:
             evidence: list = []
             seen: set[str] = set()
             for q in queries:
-                items = await aggregator.gather(q, limit_per_source=3, category="crypto")
+                items = await aggregator.gather(
+                    q, limit_per_source=3, category="crypto",
+                    market_id=pair, consumer="kraken_treasury")
                 for it in items:
                     if it.id not in seen:
                         seen.add(it.id)

--- a/tests/test_data_edge.py
+++ b/tests/test_data_edge.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.data_edge import (
+    DataDelivery,
+    _last_healthy_recorded,
+    record_delivery,
+    snapshot_id,
+)
+from auramaur.data_sources.aggregator import Aggregator
+from auramaur.db.database import Database
+from auramaur.monitoring.readiness import check_strategy_data_delivery
+
+
+@pytest.fixture
+async def db(tmp_path):
+    instance = Database(str(tmp_path / "edge.db"))
+    await instance.connect()
+    yield instance
+    await instance.close()
+
+
+@pytest.mark.asyncio
+async def test_record_delivery_persists_point_in_time_metadata(db):
+    source_at = datetime.now(timezone.utc) - timedelta(seconds=4)
+    await record_delivery(db, DataDelivery(
+        strategy="market_maker", component="order_book", status="ok",
+        provider="clob", snapshot_id="snap", source_at=source_at,
+        item_count=2, required_fields=("best_bid", "best_ask"),
+    ))
+    row = await db.fetchone("SELECT * FROM strategy_data_deliveries")
+    assert row["strategy"] == "market_maker"
+    assert row["snapshot_id"] == "snap"
+    assert 3 <= row["age_seconds"] <= 6
+
+
+@pytest.mark.asyncio
+async def test_aggregator_outer_deadline_marks_timeout(db):
+    class Slow:
+        source_name = "slow"
+        categories = None
+
+        async def fetch(self, query, limit=20):
+            await asyncio.sleep(0.2)
+            return []
+
+        async def close(self):
+            return None
+
+    class Observer:
+        def __init__(self):
+            self.db = db
+            self.rows = None
+
+        def ingestion(self, **kwargs):
+            self.rows = kwargs["fetch_rows"]
+
+        async def close(self):
+            return None
+
+    observer = Observer()
+    out = await Aggregator(
+        [Slow()], observer, source_timeout_seconds=0.01).gather("q")
+    assert out == []
+    assert observer.rows[0][2] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_fails_stale_observed_requirement(db):
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    await record_delivery(db, DataDelivery(
+        strategy="market_maker", component="order_book", status="stale",
+        source_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        item_count=1,
+    ))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "FAIL"
+    assert "market_maker:order_book" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_parses_sqlite_heartbeat_timestamp(db):
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) "
+        "VALUES ('market_maker',datetime('now'),30)")
+    await record_delivery(db, DataDelivery(
+        strategy="market_maker", component="order_book", status="stale",
+        source_at=datetime.now(timezone.utc) - timedelta(minutes=10), item_count=1))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "FAIL"
+
+
+@pytest.mark.asyncio
+async def test_healthy_book_pulses_are_throttled_but_failure_is_kept(db):
+    _last_healthy_recorded.clear()
+    healthy = DataDelivery(
+        strategy="market_maker", component="order_book", status="ok",
+        item_count=2)
+    await record_delivery(db, healthy)
+    await record_delivery(db, healthy)
+    await record_delivery(db, healthy.model_copy(update={"status": "timeout"}))
+    row = await db.fetchone(
+        "SELECT COUNT(*) n FROM strategy_data_deliveries "
+        "WHERE strategy='market_maker' AND component='order_book'")
+    assert row["n"] == 2
+
+
+def test_snapshot_id_is_stable_and_order_sensitive():
+    assert snapshot_id("a", 1) == snapshot_id("a", 1)
+    assert snapshot_id("a", 1) != snapshot_id(1, "a")

--- a/tests/test_data_edge.py
+++ b/tests/test_data_edge.py
@@ -101,6 +101,46 @@ async def test_strategy_readiness_parses_sqlite_heartbeat_timestamp(db):
 
 
 @pytest.mark.asyncio
+async def test_strategy_readiness_treats_old_healthy_record_as_unobserved(db):
+    """Conditional emitters (FRED cache hits, weather priced on demand) stop
+    recording between events; an aged 'ok' record is missing telemetry, not a
+    delivery failure."""
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('settlement_arb',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    await db.execute(
+        "INSERT INTO strategy_data_deliveries "
+        "(delivery_id,strategy,component,status,observed_at,item_count) "
+        "VALUES ('d1','settlement_arb','fred_observations','ok',?,5)",
+        (old.isoformat(),))
+    await db.execute(
+        "INSERT INTO strategy_data_deliveries "
+        "(delivery_id,strategy,component,status,observed_at,item_count) "
+        "VALUES ('d2','settlement_arb','market_snapshot','ok',?,10)",
+        (datetime.now(timezone.utc).isoformat(),))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "INSUFFICIENT_DATA"
+    assert "settlement_arb:fred_observations" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_accepts_fresh_partial_delivery(db):
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    await record_delivery(db, DataDelivery(
+        strategy="market_maker", component="order_book", status="partial",
+        source_at=datetime.now(timezone.utc), item_count=0))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "PASS"
+
+
+@pytest.mark.asyncio
 async def test_healthy_book_pulses_are_throttled_but_failure_is_kept(db):
     _last_healthy_recorded.clear()
     healthy = DataDelivery(

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -501,16 +501,17 @@ async def test_divergence_fail_when_median_high(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_readiness_aggregates_all_eight_criteria(db: Database, tmp_path):
+async def test_evaluate_readiness_aggregates_all_nine_criteria(db: Database, tmp_path):
     log_file = tmp_path / "auramaur.log"
     log_file.write_text("")
     report = await evaluate_readiness(db, log_file=log_file, exchange="kalshi", days=7)
-    assert len(report.criteria) == 8
+    assert len(report.criteria) == 9
     assert not report.overall_pass
     names = [c.name for c in report.criteria]
     assert names == [
         "cycle_health",
         "data_sources",
+        "strategy_data_delivery",
         "pass_rate",
         "brier_absolute",
         "brier_vs_market",


### PR DESCRIPTION
## Summary

- add explicit per-strategy data requirements and durable consumer-level delivery telemetry
- repair strategic batch evidence lineage and attach forecasts to real ingestion runs
- bound aggregator source calls and distinguish empty, partial, timeout, and error outcomes
- account for timestamp quality in evidence ranking
- add common snapshot identities for contemporaneous market and price observations
- instrument shared evidence, market snapshots, price history, books, cross-venue data, FRED, weather, volatility, IBKR ETF, Kraken, and every pillar cycle
- add strategy-aware readiness and stronger point-in-time contract auditing
- coalesce healthy high-frequency book telemetry while retaining every unhealthy observation

## Database

Adds schema migration v43 -> v44 with the strategy_data_deliveries table and durable strategy_heartbeats registration.

## Safety

- no live-trading gates changed
- delivery monitoring is best-effort and cannot terminate strategy execution
- missing or unhealthy strategy data is surfaced through readiness rather than silently treated as healthy

## Verification

- full suite: 1,504 passed, 3 skipped
- final focused regression: 47 passed
- ruff: passed
- git diff --check: passed