### PR TITLE
Harden strategy data delivery and edge harvesting

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -223,7 +223,15 @@ class AuramaurBot(
             try:
                 cash = getattr(self, '_last_known_cash', 0.0)
                 await engine.run_cycle(cash_available=cash)
+                from auramaur.monitoring.heartbeat import beat
+                await beat(self._components.db, "strategic", status="ok",
+                           interval_seconds=self.settings.intervals.analysis_seconds,
+                           detail={"exchange": name})
             except Exception as e:
+                from auramaur.monitoring.heartbeat import beat
+                await beat(self._components.db, "strategic", status="error",
+                           interval_seconds=self.settings.intervals.analysis_seconds,
+                           detail={"exchange": name, "error": str(e)[:300]})
                 show_error(f"Trading cycle failed ({name}): {e}")
 
             # Kalshi-only: concentrated-position rebalance (daily cap, intra-event trim).
@@ -1152,6 +1160,7 @@ class AuramaurBot(
             # where. This line makes "alive but idle" distinguishable from "hung",
             # and the first missing op after it localizes any future stall.
             log.info("market_maker.cycle_start")
+            cycle_started_at = datetime.now(timezone.utc)
             try:
                 # Watchdog: the per-op timeout inside run_cycle only covers the
                 # quote ops — the OUTER-loop Polymarket calls (market discovery,
@@ -1170,8 +1179,17 @@ class AuramaurBot(
                 except asyncio.TimeoutError:
                     log.warning("market_maker.op_timeout", op="get_markets",
                                 timeout=op_timeout)
+                    from auramaur.monitoring.heartbeat import beat
+                    await beat(self._components.db, "market_maker", status="error",
+                               interval_seconds=interval,
+                               detail={"error": "market discovery timeout"})
                     await asyncio.sleep(interval)
                     continue
+
+                from auramaur.data_edge import record_market_snapshot
+                await record_market_snapshot(
+                    self._components.db, "market_maker", markets,
+                    provider="polymarket")
 
                 # Run the MM cycle
                 results = await mm.run_cycle(markets)
@@ -1203,7 +1221,19 @@ class AuramaurBot(
                             level="warning",
                         )
 
+                from auramaur.data_edge import record_input_manifest
+                from auramaur.monitoring.heartbeat import beat
+                await record_input_manifest(
+                    self._components.db, "market_maker", cycle_started_at)
+                await beat(self._components.db, "market_maker", status="ok",
+                           entries=len(results), interval_seconds=interval,
+                           detail={"markets": len(markets), "quotes": len(results)})
+
             except Exception as e:
+                from auramaur.monitoring.heartbeat import beat
+                await beat(self._components.db, "market_maker", status="error",
+                           interval_seconds=interval,
+                           detail={"error": str(e)[:300]})
                 show_error(f"Market maker cycle failed: {e}")
             await asyncio.sleep(interval)
 

--- a/auramaur/data_edge.py
+++ b/auramaur/data_edge.py
@@ -33,6 +33,7 @@ class DataRequirement(BaseModel):
     min_items: int = 1
     required_fields: tuple[str, ...] = ()
     fail_closed: bool = True
+    source_time_required: bool = True
 
 
 class DataDelivery(BaseModel):
@@ -76,7 +77,10 @@ _BOOK = DataRequirement(
     component="order_book", max_age_seconds=15,
     required_fields=("best_bid", "best_ask"),
 )
-_CYCLE = DataRequirement(component="strategy_cycle", max_age_seconds=900, min_items=0)
+_CYCLE = DataRequirement(
+    component="strategy_cycle", max_age_seconds=900, min_items=0,
+    source_time_required=False,
+)
 
 REQUIREMENTS: dict[str, tuple[DataRequirement, ...]] = {
     "strategic": (_MARKETS, _EVIDENCE),
@@ -93,20 +97,41 @@ REQUIREMENTS: dict[str, tuple[DataRequirement, ...]] = {
     "weather_temp": (DataRequirement(component="weather_ensemble", max_age_seconds=3600), _MARKETS),
     "vol_anchor": (DataRequirement(component="spot_volatility", max_age_seconds=3600), _MARKETS),
     "oddlot_tender": (DataRequirement(component="edgar_filings", max_age_seconds=21600),),
-    "resolution_lens": (_MARKETS, _EVIDENCE),
-    "resolution_lens_kalshi": (_MARKETS, _EVIDENCE),
-    "term_structure": (_MARKETS, _EVIDENCE),
-    "agent_trader": (_MARKETS, _EVIDENCE),
+    "resolution_lens": (_MARKETS, _EVIDENCE.model_copy(update={"fail_closed": False})),
+    "resolution_lens_kalshi": (_MARKETS, _EVIDENCE.model_copy(update={"fail_closed": False})),
+    "term_structure": (_MARKETS,),
+    "agent_trader": (_MARKETS, DataRequirement(component="model_response", max_age_seconds=10800)),
     "long_horizon": (_MARKETS,),
     "entailment_arb": (_MARKETS,),
-    "ibkr_etf": (DataRequirement(component="equity_quote", max_age_seconds=120), _EVIDENCE),
-    "ibkr_multiasset": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_etf_paper": (DataRequirement(component="equity_quote", max_age_seconds=120), _EVIDENCE),
+    "ibkr_fx_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_futures_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_global_etf_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_international_equity_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_bond_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
+    "ibkr_options_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
     "kraken_treasury": (DataRequirement(component="crypto_quote", max_age_seconds=120), _EVIDENCE),
+    # Operational/non-trading workers. These have no market-data input
+    # contract, but naming them explicitly prevents the dangerous unknown-name
+    # fallback that used to make new strategies look healthy automatically.
+    "evidence_distiller": (_CYCLE,),
+    "interim_manager": (_CYCLE,),
+    "momentum_coupling": (DataRequirement(component="crypto_quote", max_age_seconds=120),),
 }
 
 
+STRATEGY_ALIASES: dict[str, str] = {
+    "KrakenPillar": "kraken_treasury",
+    "EvidenceDistiller": "evidence_distiller",
+}
+
+
+def canonical_strategy(strategy: str) -> str:
+    return STRATEGY_ALIASES.get(strategy, strategy)
+
+
 def requirements_for(strategy: str) -> tuple[DataRequirement, ...]:
-    return REQUIREMENTS.get(strategy, (_CYCLE,))
+    return REQUIREMENTS.get(canonical_strategy(strategy), ())
 
 
 def snapshot_id(*parts: object) -> str:
@@ -118,6 +143,7 @@ def snapshot_id(*parts: object) -> str:
 async def record_delivery(db, delivery: DataDelivery) -> None:
     """Persist one delivery without allowing monitoring to kill a strategy."""
     try:
+        delivery.strategy = canonical_strategy(delivery.strategy)
         throttle = _HEALTHY_THROTTLE_SECONDS.get(delivery.component, 0.0)
         key = (id(db), delivery.strategy, delivery.component)
         now_mono = time.monotonic()
@@ -149,3 +175,73 @@ async def record_delivery(db, delivery: DataDelivery) -> None:
     except Exception as exc:  # noqa: BLE001 - telemetry must be best effort
         log.debug("data_edge.record_failed", strategy=delivery.strategy,
                   component=delivery.component, error=str(exc))
+
+
+async def record_market_snapshot(db, strategy: str, markets, *,
+                                 provider: str = "discovery") -> str:
+    """Record the exact discovery result delivered to one consumer."""
+    observed = datetime.now(timezone.utc)
+    rows = list(markets or [])
+    missing = sum(
+        1 for market in rows
+        if getattr(market, "outcome_yes_price", None) is None
+        or getattr(market, "outcome_no_price", None) is None
+    )
+    sid = snapshot_id(strategy, provider, observed.isoformat(), len(rows))
+    await record_delivery(db, DataDelivery(
+        strategy=strategy, component="market_snapshot",
+        status="empty" if not rows else "partial" if missing else "ok",
+        provider=provider, snapshot_id=sid, source_at=observed,
+        item_count=len(rows),
+        required_fields=("outcome_yes_price", "outcome_no_price"),
+        missing_fields=(("outcome_prices",) if missing else ()),
+        detail={"missing_market_count": missing},
+    ))
+    return sid
+
+
+async def _record_input_manifest(db, strategy: str,
+                                 cycle_started_at: datetime) -> None:
+    """Persist the datasets that actually participated in one strategy cycle."""
+    canonical = canonical_strategy(strategy)
+    requirements = requirements_for(canonical)
+    components: list[dict] = []
+    healthy = bool(requirements)
+    for requirement in requirements:
+        row = await db.fetchone(
+            """SELECT component,status,provider,market_id,snapshot_id,source_at,
+                      age_seconds,item_count,missing_fields,fallback_used
+                 FROM strategy_data_deliveries
+                WHERE strategy=? AND component=? AND observed_at>=?
+                ORDER BY observed_at DESC,id DESC LIMIT 1""",
+            (canonical, requirement.component, cycle_started_at.isoformat()),
+        )
+        if row is None:
+            components.append({"component": requirement.component,
+                               "status": "unobserved"})
+            healthy = healthy and not requirement.fail_closed
+            continue
+        item = dict(row)
+        components.append(item)
+        if requirement.fail_closed and (
+                item["status"] != "ok"
+                or int(item["item_count"] or 0) < requirement.min_items
+                or (requirement.source_time_required and not item["source_at"])
+                or json.loads(item["missing_fields"] or "[]")):
+            healthy = False
+    await record_delivery(db, DataDelivery(
+        strategy=canonical, component="input_manifest",
+        status="ok" if healthy else "error",
+        source_at=datetime.now(timezone.utc), item_count=len(components),
+        detail={"cycle_started_at": cycle_started_at.isoformat(),
+                "components": components},
+    ))
+
+
+async def record_input_manifest(db, strategy: str,
+                                cycle_started_at: datetime) -> None:
+    """Best-effort wrapper: telemetry must never break a strategy cycle."""
+    try:
+        await _record_input_manifest(db, strategy, cycle_started_at)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("data_edge.manifest_failed", strategy=strategy, error=str(exc))

--- a/auramaur/data_edge.py
+++ b/auramaur/data_edge.py
@@ -68,6 +68,14 @@ class DataDelivery(BaseModel):
 # Explicit defaults. Strategies may override these with a ``data_requirements``
 # attribute; keeping the registry here makes readiness useful before every
 # pillar has bespoke telemetry.
+#
+# ``fail_closed=True`` is reserved for components a strategy records
+# UNCONDITIONALLY every cycle (market snapshots, cycle telemetry): for those,
+# a missing/expired record means the pipeline broke. Components recorded only
+# when a candidate/event materializes (per-market books, FRED cache misses,
+# weather ensembles, model calls, venue quotes outside market hours) are
+# ``fail_closed=False`` — absence means idle, not broken, and routing them to
+# FAIL would leave the criterion permanently red during normal quiet periods.
 _EVIDENCE = DataRequirement(component="evidence", max_age_seconds=48 * 3600)
 _MARKETS = DataRequirement(
     component="market_snapshot", max_age_seconds=300,
@@ -75,48 +83,58 @@ _MARKETS = DataRequirement(
 )
 _BOOK = DataRequirement(
     component="order_book", max_age_seconds=15,
-    required_fields=("best_bid", "best_ask"),
+    required_fields=("best_bid", "best_ask"), fail_closed=False,
 )
 _CYCLE = DataRequirement(
     component="strategy_cycle", max_age_seconds=900, min_items=0,
     source_time_required=False,
+)
+_FRED = DataRequirement(
+    component="fred_observations", max_age_seconds=3600, fail_closed=False,
+)
+# IBKR/venue quotes: recorded every cycle, but outside market hours the
+# honest record is "empty, market closed" — that must not read as failure.
+_VENUE_QUOTE = DataRequirement(
+    component="multiasset_quote", max_age_seconds=120, fail_closed=False,
 )
 
 REQUIREMENTS: dict[str, tuple[DataRequirement, ...]] = {
     "strategic": (_MARKETS, _EVIDENCE),
     "llm": (_MARKETS, _EVIDENCE),
     "technical": (_MARKETS, DataRequirement(component="price_history", max_age_seconds=300)),
-    "market_maker": (_BOOK,),
+    "market_maker": (_MARKETS, _BOOK),
     "arbitrage": (_MARKETS,),
     "bias_harvest": (_MARKETS, _BOOK),
-    "platform_consensus": (_MARKETS, DataRequirement(component="platform_forecasts", max_age_seconds=900)),
+    "platform_consensus": (_MARKETS, DataRequirement(component="platform_forecasts", max_age_seconds=900, fail_closed=False)),
     "cross_venue_arb": (DataRequirement(component="cross_venue_snapshot", max_age_seconds=30),),
     "informed_flow": (DataRequirement(component="venue_trades", max_age_seconds=120),),
-    "econ_indicator": (DataRequirement(component="fred_observations", max_age_seconds=3600), _MARKETS),
-    "settlement_arb": (DataRequirement(component="fred_observations", max_age_seconds=3600), _MARKETS),
-    "weather_temp": (DataRequirement(component="weather_ensemble", max_age_seconds=3600), _MARKETS),
-    "vol_anchor": (DataRequirement(component="spot_volatility", max_age_seconds=3600), _MARKETS),
+    "econ_indicator": (_FRED, _MARKETS),
+    "settlement_arb": (_FRED, _MARKETS),
+    "weather_temp": (DataRequirement(component="weather_ensemble", max_age_seconds=3600, fail_closed=False), _MARKETS),
+    "vol_anchor": (DataRequirement(component="spot_volatility", max_age_seconds=3600, fail_closed=False), _MARKETS),
     "oddlot_tender": (DataRequirement(component="edgar_filings", max_age_seconds=21600),),
     "resolution_lens": (_MARKETS, _EVIDENCE.model_copy(update={"fail_closed": False})),
     "resolution_lens_kalshi": (_MARKETS, _EVIDENCE.model_copy(update={"fail_closed": False})),
     "term_structure": (_MARKETS,),
-    "agent_trader": (_MARKETS, DataRequirement(component="model_response", max_age_seconds=10800)),
+    "agent_trader": (_MARKETS, DataRequirement(component="model_response", max_age_seconds=10800, fail_closed=False)),
     "long_horizon": (_MARKETS,),
     "entailment_arb": (_MARKETS,),
-    "ibkr_etf_paper": (DataRequirement(component="equity_quote", max_age_seconds=120), _EVIDENCE),
-    "ibkr_fx_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "ibkr_futures_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "ibkr_global_etf_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "ibkr_international_equity_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "ibkr_bond_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "ibkr_options_paper": (DataRequirement(component="multiasset_quote", max_age_seconds=120),),
-    "kraken_treasury": (DataRequirement(component="crypto_quote", max_age_seconds=120), _EVIDENCE),
+    "ibkr_etf_paper": (DataRequirement(component="equity_quote", max_age_seconds=120, fail_closed=False), _EVIDENCE),
+    "ibkr_fx_paper": (_VENUE_QUOTE,),
+    "ibkr_futures_paper": (_VENUE_QUOTE,),
+    "ibkr_global_etf_paper": (_VENUE_QUOTE,),
+    "ibkr_international_equity_paper": (_VENUE_QUOTE,),
+    "ibkr_bonds_paper": (_VENUE_QUOTE,),
+    "ibkr_options_paper": (_VENUE_QUOTE,),
+    "kraken_treasury": (DataRequirement(component="crypto_quote", max_age_seconds=120, fail_closed=False), _EVIDENCE),
     # Operational/non-trading workers. These have no market-data input
     # contract, but naming them explicitly prevents the dangerous unknown-name
     # fallback that used to make new strategies look healthy automatically.
     "evidence_distiller": (_CYCLE,),
     "interim_manager": (_CYCLE,),
-    "momentum_coupling": (DataRequirement(component="crypto_quote", max_age_seconds=120),),
+    # No delivery recorder yet — hold it to the cycle contract until one lands
+    # (a crypto_quote requirement with no emitter would fail unconditionally).
+    "momentum_coupling": (_CYCLE,),
 }
 
 
@@ -179,7 +197,14 @@ async def record_delivery(db, delivery: DataDelivery) -> None:
 
 async def record_market_snapshot(db, strategy: str, markets, *,
                                  provider: str = "discovery") -> str:
-    """Record the exact discovery result delivered to one consumer."""
+    """Record the exact discovery result delivered to one consumer.
+
+    A snapshot is usable when at least one market carries prices — venues
+    routinely include a few unpriced markets, and strategies skip those, so
+    "partial" (a hard readiness reason on fail-closed contracts) is reserved
+    for the degenerate case where rows arrived but NONE are priced. The
+    unpriced count is always surfaced in ``detail``.
+    """
     observed = datetime.now(timezone.utc)
     rows = list(markets or [])
     missing = sum(
@@ -187,14 +212,15 @@ async def record_market_snapshot(db, strategy: str, markets, *,
         if getattr(market, "outcome_yes_price", None) is None
         or getattr(market, "outcome_no_price", None) is None
     )
+    degraded = bool(rows) and missing == len(rows)
     sid = snapshot_id(strategy, provider, observed.isoformat(), len(rows))
     await record_delivery(db, DataDelivery(
         strategy=strategy, component="market_snapshot",
-        status="empty" if not rows else "partial" if missing else "ok",
+        status="empty" if not rows else "partial" if degraded else "ok",
         provider=provider, snapshot_id=sid, source_at=observed,
         item_count=len(rows),
         required_fields=("outcome_yes_price", "outcome_no_price"),
-        missing_fields=(("outcome_prices",) if missing else ()),
+        missing_fields=(("outcome_prices",) if degraded else ()),
         detail={"missing_market_count": missing},
     ))
     return sid

--- a/auramaur/data_sources/aggregator.py
+++ b/auramaur/data_sources/aggregator.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 _PUNCTUATION_RE = re.compile(r"[^\w\s]")
+_EVIDENCE_CACHE_MAX = 256
 
 
 def _normalise_title(title: str) -> str:
@@ -180,8 +181,20 @@ class Aggregator:
         # Never prolong a transient outage. Successful empty results may be
         # cached, but any timeout/error forces the next consumer to retry.
         if not statuses.intersection({"timeout", "error"}):
+            now_mono = time.monotonic()
+            # Bound the store, not just the TTL: expired entries (and, past a
+            # cap, the oldest live ones) are evicted on insert so a long-lived
+            # process can't accumulate one deep-copied item list per distinct
+            # query forever.
+            self._cache = {
+                k: v for k, v in self._cache.items()
+                if now_mono - v[0] <= self._cache_ttl_seconds
+            }
             self._cache[cache_key] = (
-                time.monotonic(), [item.model_copy(deep=True) for item in unique])
+                now_mono, [item.model_copy(deep=True) for item in unique])
+            while len(self._cache) > _EVIDENCE_CACHE_MAX:
+                oldest = min(self._cache, key=lambda k: self._cache[k][0])
+                del self._cache[oldest]
         if self.observer is not None:
             ranks = {item.id: rank for rank, item in enumerate(unique, start=1)}
             persisted = list({(item.source, item.id): item for item in all_items}.values())

--- a/auramaur/data_sources/aggregator.py
+++ b/auramaur/data_sources/aggregator.py
@@ -33,10 +33,13 @@ class Aggregator:
 
     def __init__(self, sources: list[DataSource],
                  observer: LineageObserver | None = None,
-                 source_timeout_seconds: float = 20.0) -> None:
+                 source_timeout_seconds: float = 20.0,
+                 cache_ttl_seconds: float = 60.0) -> None:
         self._sources = sources
         self.observer = observer
         self._source_timeout_seconds = source_timeout_seconds
+        self._cache_ttl_seconds = max(0.0, cache_ttl_seconds)
+        self._cache: dict[tuple[str, int, str | None], tuple[float, list[NewsItem]]] = {}
 
     @staticmethod
     def _source_matches_category(source: DataSource, category: str | None) -> bool:
@@ -71,6 +74,24 @@ class Aggregator:
         sources are only invoked when ``category`` matches their
         ``categories`` set; category-agnostic sources always fire.
         """
+
+        cache_key = (_normalise_title(query), limit_per_source, category)
+        cached = self._cache.get(cache_key)
+        if cached and time.monotonic() - cached[0] <= self._cache_ttl_seconds:
+            items = [item.model_copy(deep=True) for item in cached[1]]
+            if consumer and self.observer is not None:
+                from auramaur.data_edge import DataDelivery, record_delivery
+                published = [item.published_at for item in items if item.published_at]
+                await record_delivery(self.observer.db, DataDelivery(
+                    strategy=consumer, component="evidence",
+                    status="ok" if items else "empty", provider="aggregator_cache",
+                    market_id=market_id,
+                    snapshot_id=(snapshot_id or (items[0].ingestion_run_id if items else "")),
+                    source_at=max(published) if published else datetime.now(timezone.utc),
+                    item_count=len(items), fallback_used="ttl_cache",
+                    detail={"cache_age_seconds": round(time.monotonic() - cached[0], 3)},
+                ))
+            return items
 
         run_id = uuid.uuid4().hex
         started = datetime.now(tz=timezone.utc)
@@ -152,10 +173,15 @@ class Aggregator:
             return (recency * source_weight) + item.relevance_score
 
         unique.sort(key=_rank, reverse=True)
-
         observed_at = datetime.now(tz=timezone.utc).isoformat()
         for item in unique:
             item.ingestion_run_id = run_id
+        statuses = {row[2] for row in fetch_rows}
+        # Never prolong a transient outage. Successful empty results may be
+        # cached, but any timeout/error forces the next consumer to retry.
+        if not statuses.intersection({"timeout", "error"}):
+            self._cache[cache_key] = (
+                time.monotonic(), [item.model_copy(deep=True) for item in unique])
         if self.observer is not None:
             ranks = {item.id: rank for rank, item in enumerate(unique, start=1)}
             persisted = list({(item.source, item.id): item for item in all_items}.values())
@@ -197,7 +223,6 @@ class Aggregator:
         if consumer and self.observer is not None:
             from auramaur.data_edge import DataDelivery, record_delivery
 
-            statuses = {row[2] for row in fetch_rows}
             status = ("empty" if not unique else
                       "partial" if statuses & {"error", "timeout"} else "ok")
             published = [item.published_at for item in unique if item.published_at]

--- a/auramaur/data_sources/base.py
+++ b/auramaur/data_sources/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class NewsItem(BaseModel):
@@ -22,6 +22,14 @@ class NewsItem(BaseModel):
     keywords: list[str] = Field(default_factory=list)
     ingestion_run_id: str = ""
     information_mode: str = "production"  # production | shadow | paired
+
+    @field_validator("published_at")
+    @classmethod
+    def _published_at_is_utc_aware(cls, value: datetime) -> datetime:
+        """Normalize provider timestamps once at the ingestion boundary."""
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 @runtime_checkable

--- a/auramaur/exchange/alpaca_multiasset.py
+++ b/auramaur/exchange/alpaca_multiasset.py
@@ -66,10 +66,14 @@ class AlpacaMultiAssetQuotes:
             log.debug("alpaca_bridge.ibkr_bars_timeout", key=spec.key)
             return []
 
-    async def is_market_open(self, spec: InstrumentSpec) -> bool:
+    async def is_market_open(self, spec: InstrumentSpec, *, con_id: int = 0,
+                             now=None) -> bool:
         try:
+            check = (self._ibkr.is_market_open(spec, con_id=con_id, now=now)
+                     if con_id or now is not None
+                     else self._ibkr.is_market_open(spec))
             return await asyncio.wait_for(
-                self._ibkr.is_market_open(spec),
+                check,
                 timeout=self._IBKR_MISC_TIMEOUT_SECONDS)
         except (TimeoutError, asyncio.TimeoutError):
             log.debug("alpaca_bridge.ibkr_market_open_timeout", key=spec.key)

--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -19,6 +19,7 @@ GAMMA_API_BASE = "https://gamma-api.polymarket.com"
 # How long (seconds) to remember that a market_id returned 4xx, so we don't
 # re-hit the API every cycle for dead/orphaned IDs.
 _NEGATIVE_CACHE_TTL = 3600.0
+_DISCOVERY_CACHE_TTL = 15.0
 
 # Gamma sits behind Cloudflare. When CF throttles/challenges the client it can
 # half-close the socket (CLOSE_WAIT) and leave a read hanging indefinitely,
@@ -48,6 +49,7 @@ class GammaClient:
         self._session: aiohttp.ClientSession | None = None
         # market_id -> expiry timestamp for ids that returned 4xx
         self._negative_cache: dict[str, float] = {}
+        self._discovery_cache: dict[tuple, tuple[float, list[Market]]] = {}
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -75,6 +77,11 @@ class GammaClient:
         14-365d favorites) can fetch the right markets directly instead of the
         default top-100-by-volume page, which never contains them.
         """
+        cache_key = (active, limit, offset, order, ascending,
+                     end_date_min, end_date_max)
+        cached = self._discovery_cache.get(cache_key)
+        if cached and time.monotonic() - cached[0] <= _DISCOVERY_CACHE_TTL:
+            return [market.model_copy(deep=True) for market in cached[1]]
         session = await self._ensure_session()
         params = {
             "limit": limit,
@@ -101,6 +108,8 @@ class GammaClient:
                     markets.append(market)
 
             log.info("gamma.markets_fetched", count=len(markets))
+            self._discovery_cache[cache_key] = (
+                time.monotonic(), [market.model_copy(deep=True) for market in markets])
             return markets
 
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:

--- a/auramaur/exchange/gamma.py
+++ b/auramaur/exchange/gamma.py
@@ -20,6 +20,7 @@ GAMMA_API_BASE = "https://gamma-api.polymarket.com"
 # re-hit the API every cycle for dead/orphaned IDs.
 _NEGATIVE_CACHE_TTL = 3600.0
 _DISCOVERY_CACHE_TTL = 15.0
+_DISCOVERY_CACHE_MAX = 64
 
 # Gamma sits behind Cloudflare. When CF throttles/challenges the client it can
 # half-close the socket (CLOSE_WAIT) and leave a read hanging indefinitely,
@@ -77,8 +78,13 @@ class GammaClient:
         14-365d favorites) can fetch the right markets directly instead of the
         default top-100-by-volume page, which never contains them.
         """
+        # Bucket the date-window params to the hour: callers derive them from
+        # now() at second precision, so raw values would make every call a
+        # fresh key (a 0%-hit, never-evicted cache). An hour bucket is far
+        # coarser than the 15s TTL, so hits stay contemporaneous.
         cache_key = (active, limit, offset, order, ascending,
-                     end_date_min, end_date_max)
+                     None if end_date_min is None else end_date_min[:13],
+                     None if end_date_max is None else end_date_max[:13])
         cached = self._discovery_cache.get(cache_key)
         if cached and time.monotonic() - cached[0] <= _DISCOVERY_CACHE_TTL:
             return [market.model_copy(deep=True) for market in cached[1]]
@@ -108,8 +114,17 @@ class GammaClient:
                     markets.append(market)
 
             log.info("gamma.markets_fetched", count=len(markets))
+            now_mono = time.monotonic()
+            self._discovery_cache = {
+                k: v for k, v in self._discovery_cache.items()
+                if now_mono - v[0] <= _DISCOVERY_CACHE_TTL
+            }
             self._discovery_cache[cache_key] = (
-                time.monotonic(), [market.model_copy(deep=True) for market in markets])
+                now_mono, [market.model_copy(deep=True) for market in markets])
+            while len(self._discovery_cache) > _DISCOVERY_CACHE_MAX:
+                oldest = min(self._discovery_cache,
+                             key=lambda k: self._discovery_cache[k][0])
+                del self._discovery_cache[oldest]
             return markets
 
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:

--- a/auramaur/exchange/kalshi.py
+++ b/auramaur/exchange/kalshi.py
@@ -40,6 +40,7 @@ def _opt_float(v) -> float | None:
 
 # Kalshi basic tier: 20 reads/sec
 _RATE_LIMIT = 20
+_DISCOVERY_CACHE_TTL = 15.0
 
 # (connect, read) seconds applied to every Kalshi request. Without this a
 # stalled Cloudflare/Kalshi connection mid-body-read hangs forever — and since
@@ -76,6 +77,7 @@ class KalshiClient:
         # clients without it). Kalshi previously lacked it entirely, so its
         # orders were never monitored and their trade rows stayed 'pending'.
         self._live_pending: dict[str, Order] = {}
+        self._discovery_cache: dict[tuple[bool, int], tuple[float, list[Market]]] = {}
 
     def _init_api(self):
         """Lazily initialize the kalshi-python client."""
@@ -260,6 +262,10 @@ class KalshiClient:
 
     async def get_markets(self, active: bool = True, limit: int = 100) -> list[Market]:
         """Fetch markets from Kalshi API."""
+        cache_key = (active, limit)
+        cached = self._discovery_cache.get(cache_key)
+        if cached and time.monotonic() - cached[0] <= _DISCOVERY_CACHE_TTL:
+            return [market.model_copy(deep=True) for market in cached[1]]
         self._init_api()
         try:
             # Kalshi API caps events at 200
@@ -283,6 +289,8 @@ class KalshiClient:
                     break
 
             log.info("kalshi.markets_fetched", count=len(markets))
+            self._discovery_cache[cache_key] = (
+                time.monotonic(), [market.model_copy(deep=True) for market in markets])
             return markets
         except Exception as e:
             log.error("kalshi.fetch_error", error=str(e))

--- a/auramaur/monitoring/heartbeat.py
+++ b/auramaur/monitoring/heartbeat.py
@@ -81,6 +81,7 @@ async def run_pillar_once(db, pillar, *,
     """
     name = getattr(pillar, "name", type(pillar).__name__)
     started = time.monotonic()
+    cycle_started_at = datetime.now(timezone.utc)
     try:
         entered = await pillar.run_once()
     except Exception as e:
@@ -94,10 +95,6 @@ async def run_pillar_once(db, pillar, *,
             detail={"error": str(e)[:300]},
         ))
         raise
-    await beat(db, name, status="ok",
-               entries=int(entered) if isinstance(entered, (int, float)) else None,
-               interval_seconds=interval_seconds,
-               detail=getattr(pillar, "last_cycle_detail", None))
     from auramaur.data_edge import DataDelivery, record_delivery
     await record_delivery(db, DataDelivery(
         strategy=name, component="strategy_cycle", status="ok",
@@ -106,4 +103,12 @@ async def run_pillar_once(db, pillar, *,
         item_count=int(entered) if isinstance(entered, (int, float)) else 0,
         detail=getattr(pillar, "last_cycle_detail", None) or {},
     ))
+    # Record the cycle delivery before its manifest: operational workers whose
+    # only contract is strategy_cycle can then produce a truthful manifest.
+    from auramaur.data_edge import record_input_manifest
+    await record_input_manifest(db, name, cycle_started_at)
+    await beat(db, name, status="ok",
+               entries=int(entered) if isinstance(entered, (int, float)) else None,
+               interval_seconds=interval_seconds,
+               detail=getattr(pillar, "last_cycle_detail", None))
     return entered if isinstance(entered, int) else 0

--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -272,15 +272,12 @@ async def check_strategy_data_delivery(
 ) -> CriterionResult:
     """Verify the datasets consumed by recently-running strategies.
 
-    Missing telemetry is reported honestly as insufficient data. A hard
-    failure requires the latest record to actively report trouble: a failing
-    status, or fresh telemetry carrying over-age source data or too few
-    items. An old record alone is treated as unobserved, not failed —
-    conditional emitters (FRED cache hits, weather priced on demand) simply
-    stop recording between events, which says nothing about data health.
-    'partial' and 'empty' are honest deliveries, not delivery failures.
+    Active strategies fail closed on unknown contracts, missing required
+    telemetry, empty/partial required datasets, missing required fields, and
+    absent or stale source timestamps. This criterion is an execution-safety
+    assertion, not a provider-uptime dashboard.
     """
-    from auramaur.data_edge import requirements_for
+    from auramaur.data_edge import canonical_strategy, requirements_for
 
     heartbeats = await db.fetchall(
         "SELECT strategy,interval_seconds FROM strategy_heartbeats "
@@ -297,16 +294,22 @@ async def check_strategy_data_delivery(
     checked = 0
     for heartbeat in heartbeats:
         strategy = heartbeat["strategy"]
-        for requirement in requirements_for(strategy):
+        canonical = canonical_strategy(strategy)
+        requirements = requirements_for(strategy)
+        if not requirements:
+            failures.append(f"{strategy}=unknown data contract")
+            continue
+        for requirement in requirements:
             row = await db.fetchone(
                 """SELECT status,observed_at,age_seconds,item_count,missing_fields
                    FROM strategy_data_deliveries
                    WHERE strategy=? AND component=?
                    ORDER BY observed_at DESC LIMIT 1""",
-                (strategy, requirement.component))
+                (canonical, requirement.component))
             label = f"{strategy}:{requirement.component}"
             if row is None:
-                unobserved.append(label)
+                (failures if requirement.fail_closed else unobserved).append(
+                    f"{label}=unobserved")
                 continue
             checked += 1
             try:
@@ -324,14 +327,28 @@ async def check_strategy_data_delivery(
                 if row["status"] in ("stale", "timeout", "error", "unavailable"):
                     failures.append(f"{label}={row['status']} age={delivery_age:.0f}s")
                 else:
-                    unobserved.append(f"{label} (last seen {delivery_age:.0f}s ago)")
+                    target = failures if requirement.fail_closed else unobserved
+                    target.append(f"{label}=expired age={delivery_age:.0f}s")
                 continue
             source_age = row["age_seconds"]
-            if (row["status"] not in ("ok", "partial", "empty")
-                    or (source_age is not None and source_age > requirement.max_age_seconds)
-                    or (row["status"] == "ok"
-                        and int(row["item_count"] or 0) < requirement.min_items)):
-                failures.append(f"{label}={row['status']} age={delivery_age:.0f}s")
+            try:
+                missing_fields = json.loads(row["missing_fields"] or "[]")
+            except (TypeError, ValueError, json.JSONDecodeError):
+                missing_fields = ["invalid missing_fields metadata"]
+            reasons = []
+            if row["status"] != "ok":
+                reasons.append(str(row["status"]))
+            if requirement.source_time_required and source_age is None:
+                reasons.append("missing source time")
+            elif source_age is not None and source_age > requirement.max_age_seconds:
+                reasons.append(f"source age={source_age:.0f}s")
+            if int(row["item_count"] or 0) < requirement.min_items:
+                reasons.append(f"items={int(row['item_count'] or 0)}")
+            if missing_fields:
+                reasons.append("missing=" + ",".join(map(str, missing_fields)))
+            if reasons:
+                target = failures if requirement.fail_closed else unobserved
+                target.append(f"{label}=" + " ".join(reasons))
 
     if failures:
         return CriterionResult(

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -200,6 +200,8 @@ class AgentTraderPillar:
             return 0
         await self._ensure_schema()
         candidates = await self._candidates(cfg)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, candidates)
         if not candidates:
             log.info("agent_trader.no_candidates")
             return 0
@@ -267,6 +269,13 @@ class AgentTraderPillar:
         else:
             raw = await self._call_model(prompt, spec.model, spec.effort, cfg)
         decisions = parse_decisions(raw, cfg.max_entries_per_cycle)
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="model_response", status="ok",
+            provider=str(getattr(spec, "provider", "claude")),
+            market_id=alias, source_at=datetime.now(timezone.utc),
+            item_count=1, detail={"model": spec.model, "decisions": len(decisions)},
+        ))
 
         # The model actually saw and passed on these — remember the pass for
         # decline_ttl_hours. Only after a SUCCESSFUL call: a budget/timeout

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -120,6 +120,8 @@ class BiasHarvestPillar:
             return 0
 
         markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets)
         entered = 0
         for market in markets:
             if entered >= cfg.max_entries_per_cycle:
@@ -240,6 +242,7 @@ class BiasHarvestPillar:
             strategy=self.name, component="order_book",
             status="ok" if best_bid is not None and best_ask is not None else "empty",
             provider="polymarket_clob", market_id=market.id,
+            source_at=datetime.now(timezone.utc),
             item_count=len(book.bids) + len(book.asks),
             required_fields=("best_bid", "best_ask"),
         ))

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -83,6 +83,14 @@ class EconIndicatorPillar:
         if spec is None:
             return 0
         obs = await self._fred.get_observations(spec.fred_series, n=cfg.history_n)
+        from auramaur.data_edge import DataDelivery, record_delivery
+        observed = datetime.now(timezone.utc)
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="fred_observations",
+            status="ok" if obs else "empty", provider="fred",
+            market_id=spec.fred_series, source_at=observed,
+            item_count=len(obs),
+        ))
         if len(obs) < 4:
             log.debug("econ_indicator.thin_history", series=prefix, n=len(obs))
             return 0
@@ -92,6 +100,9 @@ class EconIndicatorPillar:
             return 0
 
         bins = await self._kalshi.get_markets_by_series(prefix)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, bins,
+                                     provider="kalshi")
         period = self._nearest_period(bins)
         if period is None:
             return 0

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -438,13 +438,17 @@ class TradingEngine(CycleOrchestrationMixin):
             1 for market in markets
             if market.outcome_yes_price is None or market.outcome_no_price is None
         )
+        # Mirrors record_market_snapshot: a few unpriced markets are routine
+        # and skipped by strategies; "partial" (a hard readiness reason) is
+        # reserved for a snapshot where NOTHING is priced.
+        degraded = bool(markets) and missing_prices == len(markets)
         await record_delivery(self.db, DataDelivery(
             strategy="strategic", component="market_snapshot",
-            status=("empty" if not markets else "partial" if missing_prices else "ok"),
+            status=("empty" if not markets else "partial" if degraded else "ok"),
             provider=self.exchange_name or "discovery", snapshot_id=sid,
             source_at=observed, item_count=len(markets),
             required_fields=("outcome_yes_price", "outcome_no_price"),
-            missing_fields=(("outcome_prices",) if missing_prices else ()),
+            missing_fields=(("outcome_prices",) if degraded else ()),
             detail={"missing_market_count": missing_prices},
         ))
         await record_delivery(self.db, DataDelivery(

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -433,6 +433,8 @@ class EntailmentArbPillar:
         if not cfg.enabled:
             return 0
         markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets)
         good = [m for m in markets if self._real_book(m)]
         by_id = {m.id: m for m in good}
 

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -135,7 +135,7 @@ class IBKRETFPaperPillar:
                     self._evidence_cache[query] = await self._aggregator.gather(
                         query, limit_per_source=3, category="finance",
                         market_id=symbol, market_price=reference_price,
-                        consumer="ibkr_etf")
+                        consumer=self.name)
                 items = self._evidence_cache[query]
             except Exception as exc:  # noqa: BLE001
                 log.warning("ibkr_etf.paper.evidence_error", symbol=symbol,
@@ -364,6 +364,14 @@ class IBKRETFPaperPillar:
                 continue
             if getattr(quote, "source", "ibkr_live") not in {"ibkr_live", "alpaca_iex"}:
                 continue
+            from auramaur.data_edge import DataDelivery, record_delivery
+            quote_at = datetime.fromtimestamp(float(quote.timestamp), timezone.utc)
+            await record_delivery(self._db, DataDelivery(
+                strategy=self.name, component="equity_quote", status="ok",
+                provider=getattr(quote, "source", "ibkr_live"),
+                market_id=symbol, source_at=quote_at, item_count=1,
+                required_fields=("bid", "ask"),
+            ))
             mid = (quote.bid + quote.ask) / 2
             await self._resolve_forecasts(symbol)
             spread_bps = (quote.ask - quote.bid) / mid * 10_000

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -319,6 +319,8 @@ class IBKRMultiAssetPaperBook:
         unmarked_positions = set(positions)
         entries = 0
         error = ""
+        valid_quotes = 0
+        quote_sources: set[str] = set()
         candidates: list = []
         for spec in selected:
             try:
@@ -332,6 +334,8 @@ class IBKRMultiAssetPaperBook:
                     else await self._client.get_quote(spec))
                 if quote is None or not self._quote_fresh(quote):
                     continue
+                valid_quotes += 1
+                quote_sources.add(str(getattr(quote, "source", "")))
                 if held and int(quote.con_id) != held_con_id:
                     raise RuntimeError(
                         f"held contract mismatch: expected {held_con_id}, got {quote.con_id}")
@@ -442,6 +446,16 @@ class IBKRMultiAssetPaperBook:
                  last_error=excluded.last_error, updated_at=datetime('now')""",
             (self.book.value, next_cursor, error))
         await self._db.commit()
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="multiasset_quote",
+            status=("ok" if valid_quotes else "error" if error else "empty"),
+            provider="+".join(sorted(quote_sources)), market_id=self.book.value,
+            source_at=datetime.now(timezone.utc) if valid_quotes else None,
+            item_count=valid_quotes,
+            required_fields=("bid", "ask", "timestamp"),
+            detail={"selected": len(selected), "last_error": error},
+        ))
         await self._record_daily_mark()
         await self._record_research_signals()
         loss_exposure = await self._loss_exposure()

--- a/auramaur/strategy/informed_flow.py
+++ b/auramaur/strategy/informed_flow.py
@@ -112,12 +112,18 @@ class KalshiTradeTape:
 
     def __init__(self, exchange) -> None:
         self._exchange = exchange  # a KalshiExchange exposing get_trades()
+        self.last_count = 0
+        self.last_ok = False
 
     async def informed_flow(self, ticker: str, *, limit: int = 200,
                             **kwargs) -> InformedFlowSignal:
         try:
             trades = await self._exchange.get_trades(ticker, limit=limit)
+            self.last_count = len(trades or [])
+            self.last_ok = True
         except Exception as e:
+            self.last_count = 0
+            self.last_ok = False
             log.debug("informed_flow.fetch_failed", ticker=ticker, error=str(e))
             return _NO_SIGNAL
         return detect_informed_flow(trades or [], **kwargs)

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -76,6 +76,9 @@ class InformedFlowPillar:
                 min_close_ts, max_close_ts, limit=cfg.scan_limit)
         else:  # fallback (e.g. a discovery without the windowed fetch / tests)
             markets = await self._kalshi.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets,
+                                     provider="kalshi")
         entered = 0
         for market in markets:
             if entered >= cfg.max_entries_per_cycle:
@@ -137,6 +140,15 @@ class InformedFlowPillar:
             min_sample=cfg.min_abnormal_sample, size_mult=cfg.size_mult,
             min_dominance=cfg.min_dominance,
         )
+        from auramaur.data_edge import DataDelivery, record_delivery
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="venue_trades",
+            status=("ok" if self._tape.last_ok and self._tape.last_count
+                    else "empty" if self._tape.last_ok else "error"),
+            provider="kalshi", market_id=market.ticker,
+            source_at=datetime.now(timezone.utc) if self._tape.last_ok else None,
+            item_count=self._tape.last_count,
+        ))
         if not flow.has_signal or flow.informed_side is None:
             return False
 

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -199,6 +199,9 @@ class LongHorizonPillar:
             # A discovery without the date-window kwargs (older client / test stub):
             # fall back to the plain scan so the pillar still runs.
             out = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, out,
+                                     provider=self._venue)
         return out
 
     # ------------------------------------------------------------------

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -305,6 +305,7 @@ class MarketMaker:
                 strategy=self.name, component="order_book",
                 status="ok" if book.bids and book.asks else "empty",
                 provider="polymarket_clob", market_id=market.id,
+                source_at=datetime.now(timezone.utc),
                 item_count=len(book.bids) + len(book.asks),
                 required_fields=("best_bid", "best_ask"),
                 missing_fields=(() if book.bids and book.asks

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from auramaur.strategy.protocols import ExecutionMode
 
 import json
+from datetime import datetime, timezone
 
 import structlog
 
@@ -91,6 +92,13 @@ class OddLotTenderPillar:
         if not cfg.enabled:
             return 0
         filings = await self._edgar.recent_tender_filings(days=cfg.lookback_days)
+        from auramaur.data_edge import DataDelivery, record_delivery
+        observed = datetime.now(timezone.utc)
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="edgar_filings",
+            status="ok" if filings else "empty", provider="edgar",
+            source_at=observed, item_count=len(filings),
+        ))
         found = 0
         analyzed = 0
         for f in filings:

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -71,6 +71,8 @@ class PlatformConsensusPillar:
             return 0
 
         markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets)
 
         eligible_markets = []
         for m in markets:
@@ -227,6 +229,18 @@ class PlatformConsensusPillar:
                 market_id=market.id,
                 error=str(e),
             )
+
+        from auramaur.data_edge import DataDelivery, record_delivery
+        forecasts = manifold_items + metaculus_items
+        observed = datetime.now(timezone.utc)
+        published = [item.published_at for item in forecasts if item.published_at]
+        await record_delivery(self._db, DataDelivery(
+            strategy=self.name, component="platform_forecasts",
+            status="ok" if forecasts else "empty",
+            provider="manifold+metaculus", market_id=market.id,
+            source_at=max(published) if published else observed,
+            item_count=len(forecasts),
+        ))
 
         best_match = None
         best_overlap = 0.0

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -579,6 +579,9 @@ class ResolutionLensPillar:
                      close_window=len(markets) - lexical_n)
         else:
             markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(
+            self._db, self.name, markets, provider=self._exchange_name)
         markets = await self._prioritize_known_gaps(markets, cfg)
         calls = 0
         entered = 0

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -34,6 +34,7 @@ from auramaur.strategy.protocols import ExecutionMode
 
 import json
 import re
+from datetime import datetime, timezone
 
 import structlog
 
@@ -235,6 +236,9 @@ class SettlementArbPillar:
         self._fred_cycle_cache = {}
         self._stages = {}
         markets = await self._candidates()
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets,
+                                     provider="db+kalshi")
         entered = 0
         with_pred = 0
         for m in markets:
@@ -407,7 +411,8 @@ class SettlementArbPillar:
             await record_delivery(self._db, DataDelivery(
                 strategy=self.name, component="fred_observations",
                 status="ok" if cache[series] else "empty", provider="fred",
-                market_id=series, item_count=len(cache[series] or []),
+                market_id=series, source_at=datetime.now(timezone.utc),
+                item_count=len(cache[series] or []),
             ))
         return cache[series]
 

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -378,7 +378,13 @@ class TermStructurePillar:
         # Widest ladders first — the most opinion per read.
         out.sort(key=lambda fs: (len(fs[1]), sum(m.volume for m in fs[1])),
                  reverse=True)
-        return out[: cfg.max_families]
+        selected = out[: cfg.max_families]
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(
+            self._db, self.name,
+            [market for _, markets in selected for market in markets],
+        )
+        return selected
 
     def _eligible(self, market: Market, cfg) -> bool:
         if not market.active:

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -207,7 +207,8 @@ class VolAnchorPillar:
         await record_delivery(self._db, DataDelivery(
             strategy=self.name, component="spot_volatility",
             status="ok" if len(closes) >= 10 else "partial",
-            provider="coingecko", market_id=cg_id, item_count=len(closes),
+            provider="coingecko", market_id=cg_id,
+            source_at=datetime.now(timezone.utc), item_count=len(closes),
         ))
         if len(closes) < 10:
             return None
@@ -315,6 +316,8 @@ class VolAnchorPillar:
                 continue
             kind, strike, deadline = parsed
             out.append((asset, kind, strike, deadline, m))
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, out)
         return out
 
     def _eligible(self, market: Market, cfg) -> bool:

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -317,7 +317,11 @@ class VolAnchorPillar:
             kind, strike, deadline = parsed
             out.append((asset, kind, strike, deadline, m))
         from auramaur.data_edge import record_market_snapshot
-        await record_market_snapshot(self._db, self.name, out)
+        # Record the delivered discovery result, not the (asset, kind, strike,
+        # deadline, Market) candidate tuples — the recorder reads price fields
+        # off Market models, and an empty candidate list after filtering is
+        # strategy selectivity, not a data-delivery failure.
+        await record_market_snapshot(self._db, self.name, raw)
         return out
 
     def _eligible(self, market: Market, cfg) -> bool:

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
 
-from datetime import timezone
+from datetime import datetime, timezone
 
 import structlog
 
@@ -52,6 +52,8 @@ class WeatherTempPillar:
         if not cfg.enabled or self._weather is None:
             return 0
         markets = await self._discovery.get_markets(limit=cfg.scan_limit)
+        from auramaur.data_edge import record_market_snapshot
+        await record_market_snapshot(self._db, self.name, markets)
         entered = 0
         for m in markets:
             if entered >= cfg.max_entries_per_cycle:
@@ -89,7 +91,8 @@ class WeatherTempPillar:
         await record_delivery(self._db, DataDelivery(
             strategy=self.name, component="weather_ensemble",
             status="ok" if members else "empty", provider="openmeteo",
-            market_id=market.id, item_count=len(members),
+            market_id=market.id, source_at=datetime.now(timezone.utc),
+            item_count=len(members),
             detail={"target": spec.target.isoformat(), "city": spec.city},
         ))
         model_p = bin_probability(members, spec.lo, spec.hi)

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -21,6 +21,7 @@ import asyncio
 import math
 import time
 import uuid
+from datetime import datetime, timezone
 
 import structlog
 
@@ -737,6 +738,15 @@ class KrakenPillar:
                     log.warning("kraken.directional.orphan_no_price", pair=pair,
                                 note="held position Kraken won't price; manual close may be needed")
                 continue
+            db = self._db()
+            if db is not None:
+                from auramaur.data_edge import DataDelivery, record_delivery
+                await record_delivery(db, DataDelivery(
+                    strategy="kraken_treasury", component="crypto_quote",
+                    status="ok", provider="kraken", market_id=pair,
+                    source_at=datetime.now(timezone.utc), item_count=1,
+                    required_fields=("price",), detail={"price": price},
+                ))
             holding = pair in self._dir_long
             mom: float | None = None
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -2,6 +2,8 @@
 graceful per-source failure. (Individual fetchers hit external APIs; the
 aggregator is the pure orchestration logic that actually matters.)"""
 
+from datetime import datetime, timezone
+
 import pytest
 
 from auramaur.data_sources.aggregator import Aggregator
@@ -15,9 +17,11 @@ class _FakeSource:
         self._items = items
         self._raises = raises
         self.fetched = False
+        self.fetch_count = 0
 
     async def fetch(self, query, limit=20):
         self.fetched = True
+        self.fetch_count += 1
         if self._raises:
             raise RuntimeError("source boom")
         return list(self._items)
@@ -78,3 +82,31 @@ async def test_dedup_by_normalised_title():
     agg = Aggregator([a, b])
     out = await agg.gather("q", category=None)
     assert len(out) == 1
+
+
+@pytest.mark.asyncio
+async def test_ttl_cache_coalesces_equivalent_evidence_reads():
+    source = _FakeSource("wire", [_item("wire", "Headline")])
+    agg = Aggregator([source], cache_ttl_seconds=60)
+    first = await agg.gather("Big News!", category="finance")
+    second = await agg.gather("big news", category="finance")
+    assert source.fetch_count == 1
+    assert first[0].ingestion_run_id == second[0].ingestion_run_id
+    assert first[0] is not second[0]
+
+
+@pytest.mark.asyncio
+async def test_transient_source_failure_is_never_cached():
+    source = _FakeSource("wire", [], raises=True)
+    agg = Aggregator([source], cache_ttl_seconds=60)
+    assert await agg.gather("query") == []
+    assert await agg.gather("query") == []
+    assert source.fetch_count == 2
+
+
+def test_news_item_normalizes_naive_provider_time_to_utc():
+    item = NewsItem(
+        id="n1", source="provider", title="Headline",
+        published_at=datetime(2026, 7, 24, 12, 0),
+    )
+    assert item.published_at.tzinfo is timezone.utc

--- a/tests/test_alpaca_multiasset_bridge.py
+++ b/tests/test_alpaca_multiasset_bridge.py
@@ -226,3 +226,20 @@ def test_every_pillar_await_is_bounded(monkeypatch):
         assert await asyncio.wait_for(
             bridge.get_quote_by_con_id(GBPJPY, 1), timeout=5) is None
     asyncio.run(run())
+
+
+def test_market_open_forwards_held_contract_identity():
+    async def run():
+        seen = {}
+
+        class IBKR:
+            async def is_market_open(self, spec, *, con_id=0, now=None):
+                seen.update(con_id=con_id, now=now)
+                return False
+
+        bridge = AlpacaMultiAssetQuotes(IBKR(), FakeAlpaca(None))
+        marker = object()
+        assert not await bridge.is_market_open(SPY, con_id=756733, now=marker)
+        assert seen == {"con_id": 756733, "now": marker}
+
+    asyncio.run(run())

--- a/tests/test_data_edge.py
+++ b/tests/test_data_edge.py
@@ -9,6 +9,7 @@ from auramaur.data_edge import (
     DataDelivery,
     _last_healthy_recorded,
     record_delivery,
+    record_market_snapshot,
     snapshot_id,
 )
 from auramaur.data_sources.aggregator import Aggregator
@@ -71,19 +72,21 @@ async def test_aggregator_outer_deadline_marks_timeout(db):
 
 @pytest.mark.asyncio
 async def test_strategy_readiness_fails_stale_observed_requirement(db):
+    """A fresh record actively reporting 'stale' on a fail-closed contract
+    (term_structure's per-cycle market snapshot) is a hard failure."""
     await db.execute(
         "INSERT INTO strategy_heartbeats "
-        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        "(strategy,last_beat_at,interval_seconds) VALUES ('term_structure',?,30)",
         (datetime.now(timezone.utc).isoformat(),))
     await record_delivery(db, DataDelivery(
-        strategy="market_maker", component="order_book", status="stale",
+        strategy="term_structure", component="market_snapshot", status="stale",
         source_at=datetime.now(timezone.utc) - timedelta(minutes=10),
         item_count=1,
     ))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
     assert result.status == "FAIL"
-    assert "market_maker:order_book" in result.detail
+    assert "term_structure:market_snapshot" in result.detail
 
 
 @pytest.mark.asyncio
@@ -91,9 +94,9 @@ async def test_strategy_readiness_parses_sqlite_heartbeat_timestamp(db):
     await db.execute(
         "INSERT INTO strategy_heartbeats "
         "(strategy,last_beat_at,interval_seconds) "
-        "VALUES ('market_maker',datetime('now'),30)")
+        "VALUES ('term_structure',datetime('now'),30)")
     await record_delivery(db, DataDelivery(
-        strategy="market_maker", component="order_book", status="stale",
+        strategy="term_structure", component="market_snapshot", status="stale",
         source_at=datetime.now(timezone.utc) - timedelta(minutes=10), item_count=1))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
@@ -102,9 +105,29 @@ async def test_strategy_readiness_parses_sqlite_heartbeat_timestamp(db):
 
 @pytest.mark.asyncio
 async def test_strategy_readiness_fails_old_required_record(db):
-    """Conditional emitters (FRED cache hits, weather priced on demand) stop
-    recording between events; an aged 'ok' record is missing telemetry, not a
-    delivery failure."""
+    """Fail-closed contracts are for components recorded unconditionally every
+    cycle: an expired record there means the pipeline stopped delivering."""
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('term_structure',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    await db.execute(
+        "INSERT INTO strategy_data_deliveries "
+        "(delivery_id,strategy,component,status,observed_at,item_count) "
+        "VALUES ('d1','term_structure','market_snapshot','ok',?,10)",
+        (old.isoformat(),))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "FAIL"
+    assert "term_structure:market_snapshot" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_tolerates_aged_conditional_record(db):
+    """Fail-open contracts (FRED cache hits, per-market books) record only
+    when an event materializes; an aged 'ok' record is missing telemetry, not
+    a delivery failure — it must not turn the criterion red."""
     await db.execute(
         "INSERT INTO strategy_heartbeats "
         "(strategy,last_beat_at,interval_seconds) VALUES ('settlement_arb',?,30)",
@@ -115,14 +138,12 @@ async def test_strategy_readiness_fails_old_required_record(db):
         "(delivery_id,strategy,component,status,observed_at,item_count) "
         "VALUES ('d1','settlement_arb','fred_observations','ok',?,5)",
         (old.isoformat(),))
-    await db.execute(
-        "INSERT INTO strategy_data_deliveries "
-        "(delivery_id,strategy,component,status,observed_at,item_count) "
-        "VALUES ('d2','settlement_arb','market_snapshot','ok',?,10)",
-        (datetime.now(timezone.utc).isoformat(),))
+    await record_delivery(db, DataDelivery(
+        strategy="settlement_arb", component="market_snapshot", status="ok",
+        source_at=datetime.now(timezone.utc), item_count=10))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
-    assert result.status == "FAIL"
+    assert result.status == "INSUFFICIENT_DATA"
     assert "settlement_arb:fred_observations" in result.detail
 
 
@@ -130,10 +151,10 @@ async def test_strategy_readiness_fails_old_required_record(db):
 async def test_strategy_readiness_rejects_fresh_partial_delivery(db):
     await db.execute(
         "INSERT INTO strategy_heartbeats "
-        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        "(strategy,last_beat_at,interval_seconds) VALUES ('term_structure',?,30)",
         (datetime.now(timezone.utc).isoformat(),))
     await record_delivery(db, DataDelivery(
-        strategy="market_maker", component="order_book", status="partial",
+        strategy="term_structure", component="market_snapshot", status="partial",
         source_at=datetime.now(timezone.utc), item_count=0))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
@@ -144,10 +165,10 @@ async def test_strategy_readiness_rejects_fresh_partial_delivery(db):
 async def test_strategy_readiness_rejects_missing_source_timestamp(db):
     await db.execute(
         "INSERT INTO strategy_heartbeats "
-        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        "(strategy,last_beat_at,interval_seconds) VALUES ('term_structure',?,30)",
         (datetime.now(timezone.utc).isoformat(),))
     await record_delivery(db, DataDelivery(
-        strategy="market_maker", component="order_book", status="ok",
+        strategy="term_structure", component="market_snapshot", status="ok",
         item_count=2))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
@@ -185,3 +206,26 @@ async def test_healthy_book_pulses_are_throttled_but_failure_is_kept(db):
 def test_snapshot_id_is_stable_and_order_sensitive():
     assert snapshot_id("a", 1) == snapshot_id("a", 1)
     assert snapshot_id("a", 1) != snapshot_id(1, "a")
+
+
+class _Mkt:
+    def __init__(self, yes=None, no=None):
+        self.outcome_yes_price = yes
+        self.outcome_no_price = no
+
+
+@pytest.mark.asyncio
+async def test_market_snapshot_partial_only_when_nothing_priced(db):
+    """A few unpriced markets are routine (strategies skip them): the snapshot
+    is 'ok' while at least one market is priced, 'partial' only when rows
+    arrived but none are usable."""
+    await record_market_snapshot(db, "term_structure",
+                                 [_Mkt(0.4, 0.6), _Mkt()], provider="t1")
+    await record_market_snapshot(db, "term_structure",
+                                 [_Mkt(), _Mkt()], provider="t2")
+    rows = await db.fetchall(
+        "SELECT provider,status,detail FROM strategy_data_deliveries "
+        "WHERE component='market_snapshot' ORDER BY provider")
+    assert [(r["provider"], r["status"]) for r in rows] == [
+        ("t1", "ok"), ("t2", "partial")]
+    assert '"missing_market_count": 1' in rows[0]["detail"]

--- a/tests/test_data_edge.py
+++ b/tests/test_data_edge.py
@@ -101,7 +101,7 @@ async def test_strategy_readiness_parses_sqlite_heartbeat_timestamp(db):
 
 
 @pytest.mark.asyncio
-async def test_strategy_readiness_treats_old_healthy_record_as_unobserved(db):
+async def test_strategy_readiness_fails_old_required_record(db):
     """Conditional emitters (FRED cache hits, weather priced on demand) stop
     recording between events; an aged 'ok' record is missing telemetry, not a
     delivery failure."""
@@ -122,12 +122,12 @@ async def test_strategy_readiness_treats_old_healthy_record_as_unobserved(db):
         (datetime.now(timezone.utc).isoformat(),))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
-    assert result.status == "INSUFFICIENT_DATA"
+    assert result.status == "FAIL"
     assert "settlement_arb:fred_observations" in result.detail
 
 
 @pytest.mark.asyncio
-async def test_strategy_readiness_accepts_fresh_partial_delivery(db):
+async def test_strategy_readiness_rejects_fresh_partial_delivery(db):
     await db.execute(
         "INSERT INTO strategy_heartbeats "
         "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
@@ -137,7 +137,34 @@ async def test_strategy_readiness_accepts_fresh_partial_delivery(db):
         source_at=datetime.now(timezone.utc), item_count=0))
     result = await check_strategy_data_delivery(
         db, since=datetime.now(timezone.utc) - timedelta(hours=1))
-    assert result.status == "PASS"
+    assert result.status == "FAIL"
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_rejects_missing_source_timestamp(db):
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('market_maker',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    await record_delivery(db, DataDelivery(
+        strategy="market_maker", component="order_book", status="ok",
+        item_count=2))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "FAIL"
+    assert "missing source time" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_strategy_readiness_rejects_unknown_strategy_contract(db):
+    await db.execute(
+        "INSERT INTO strategy_heartbeats "
+        "(strategy,last_beat_at,interval_seconds) VALUES ('new_book',?,30)",
+        (datetime.now(timezone.utc).isoformat(),))
+    result = await check_strategy_data_delivery(
+        db, since=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert result.status == "FAIL"
+    assert "unknown data contract" in result.detail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make strategy data-delivery readiness fail closed for unknown, missing, stale, partial, empty, or field-incomplete required inputs
- add canonical/per-book contracts, consumer-specific delivery telemetry, and best-effort per-cycle input manifests
- repair IBKR held-contract market-hours forwarding and normalize provider timestamps to UTC for the Kraken evidence path
- add bounded evidence and market-discovery TTL caches while ensuring transient failures are never cached
- reduce SQLite contention by throttling delivery-history pruning and add core engine / market-maker heartbeats

## Operational findings addressed

- IBKR multi-asset cycles failed on `is_market_open(..., con_id=...)`
- Kraken LLM views failed on mixed naive/aware evidence datetimes
- successful cycle heartbeats previously did not prove required inputs were delivered
- IBKR books could mask one another under a shared contract name
- repeated Gamma, Kalshi, and evidence fan-out calls duplicated edge-harvesting work

## Validation

- `python -m ruff check auramaur tests/test_data_edge.py tests/test_aggregator.py tests/test_alpaca_multiasset_bridge.py`
- full suite: `1513 passed, 3 skipped`
- final focused regression suite: `58 passed`
- `git diff --check`

## Deployment note

This PR changes observability/readiness and harvesting behavior but does not alter the three-gate live-order safety model. The running trading container has not been restarted or redeployed as part of this PR.