### PR TITLE
Migrate portable strategy decision seams

### DIFF
--- a/auramaur/experiments/migration.py
+++ b/auramaur/experiments/migration.py
@@ -27,32 +27,32 @@ class MigrationStatus(str, Enum):
 # TargetPosition: routing, paired legs, quoting inventory, and off-PM assets use
 # contracts that retain their production semantics.
 MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
-    "core_trading": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "news_reactor": (MigrationTrack.ROUTING, MigrationStatus.PLANNED),
+    "core_trading": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "news_reactor": (MigrationTrack.ROUTING, MigrationStatus.MIGRATED),
     "kraken": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
     "arbitrage": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
     "bias_harvest": (
         MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED
     ),
-    "platform_consensus": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "long_horizon": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "agent_trader": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "agent_trader_kalshi": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "term_structure": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "vol_anchor": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "informed_flow": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
+    "platform_consensus": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "long_horizon": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "agent_trader": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "agent_trader_kalshi": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "term_structure": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "vol_anchor": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "informed_flow": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "entailment_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
     "cross_venue_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
-    "econ_indicator": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "interim_manager": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "settlement_arb": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "weather_temp": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
-    "resolution_lens": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
+    "econ_indicator": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "interim_manager": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "settlement_arb": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "weather_temp": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
+    "resolution_lens": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "resolution_lens_kalshi": (
-        MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED
+        MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED
     ),
     "oddlot_tender": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
-    "momentum_coupling": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.PLANNED),
+    "momentum_coupling": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "market_maker": (MigrationTrack.QUOTING, MigrationStatus.SPECIALIZED_PLANNED),
     "ibkr_etf_paper": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
     "ibkr_multiasset": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),

--- a/auramaur/experiments/strategies/agent_trader.py
+++ b/auramaur/experiments/strategies/agent_trader.py
@@ -1,0 +1,157 @@
+"""Pure proposal formation for the model-driven agent trader."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class AgentTraderRejection(str, Enum):
+    INVALID_INPUT = "invalid_input"
+    INSUFFICIENT_EDGE = "insufficient_edge"
+
+
+@dataclass(frozen=True)
+class AgentTraderRules:
+    min_edge_pts: float
+    stake_usd: float
+    source_tag: str
+
+
+@dataclass(frozen=True)
+class AgentTraderInputs:
+    market_id: str
+    question: str
+    market_yes: float
+    prob_yes: float
+    thesis: str
+
+
+@dataclass(frozen=True)
+class AgentTraderProposal:
+    market_id: str
+    question: str
+    buy_yes: bool
+    instrument_id: str
+    probability_yes: float
+    market_probability: float
+    edge_percent: float
+    entry_price: float
+    target_quantity: float
+    max_notional: float
+    thesis: str
+    source_tag: str
+
+
+@dataclass(frozen=True)
+class AgentTraderAssessment:
+    proposal: AgentTraderProposal | None
+    rejection: AgentTraderRejection | None = None
+
+
+def parse_decisions(raw: str, max_entries: int) -> list[dict]:
+    """Parse model JSON defensively; malformed opinions fail closed."""
+    if max_entries <= 0:
+        return []
+    text = raw.strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start < 0 or end <= start:
+        return []
+    try:
+        payload = json.loads(text[start:end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return []
+    decisions = payload.get("decisions")
+    if not isinstance(decisions, list):
+        return []
+    result: list[dict] = []
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            continue
+        market_id = str(decision.get("market_id", "")).strip()
+        thesis = str(decision.get("thesis", "")).strip()
+        try:
+            probability = float(decision.get("prob_yes"))
+        except (TypeError, ValueError):
+            continue
+        if not market_id or not thesis or not math.isfinite(probability):
+            continue
+        if not 0.0 < probability < 1.0:
+            continue
+        result.append({
+            "market_id": market_id,
+            "prob_yes": probability,
+            "thesis": thesis,
+        })
+        if len(result) >= max_entries:
+            break
+    return result
+
+
+def assess_agent_trader(
+    inputs: AgentTraderInputs, rules: AgentTraderRules
+) -> AgentTraderAssessment:
+    values = (inputs.market_yes, inputs.prob_yes, rules.min_edge_pts, rules.stake_usd)
+    if (
+        not inputs.market_id
+        or not inputs.question
+        or not inputs.thesis.strip()
+        or not rules.source_tag
+        or any(not math.isfinite(value) for value in values)
+        or not 0.0 < inputs.market_yes < 1.0
+        or not 0.0 < inputs.prob_yes < 1.0
+        or rules.min_edge_pts < 0.0
+        or rules.stake_usd <= 0.0
+    ):
+        return AgentTraderAssessment(None, AgentTraderRejection.INVALID_INPUT)
+    edge_pts = abs(inputs.prob_yes - inputs.market_yes) * 100.0
+    if edge_pts < rules.min_edge_pts:
+        return AgentTraderAssessment(None, AgentTraderRejection.INSUFFICIENT_EDGE)
+    buy_yes = inputs.prob_yes > inputs.market_yes
+    entry_price = inputs.market_yes if buy_yes else 1.0 - inputs.market_yes
+    return AgentTraderAssessment(AgentTraderProposal(
+        market_id=inputs.market_id,
+        question=inputs.question,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        probability_yes=inputs.prob_yes,
+        market_probability=inputs.market_yes,
+        edge_percent=edge_pts,
+        entry_price=entry_price,
+        target_quantity=rules.stake_usd / entry_price,
+        max_notional=rules.stake_usd,
+        thesis=inputs.thesis[:500],
+        source_tag=rules.source_tag,
+    ))
+
+
+@dataclass(frozen=True)
+class AgentTraderExperiment:
+    rules: AgentTraderRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        del portfolio
+        details = snapshot.feature("agent_trader_opinion")
+        assessment = assess_agent_trader(AgentTraderInputs(
+            market_id=snapshot.market_id,
+            question=str(details["question"]),
+            market_yes=snapshot.price("YES"),
+            prob_yes=float(details["prob_yes"]),
+            thesis=str(details["thesis"]),
+        ), self.rules)
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.entry_price,
+            rationale=proposal.thesis,
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/core_trading.py
+++ b/auramaur/experiments/strategies/core_trading.py
@@ -1,0 +1,221 @@
+"""Pure proposal formation for the core LLM trading family."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class CoreTradingRejection(str, Enum):
+    INVALID_PROBABILITY = "invalid_probability"
+    NO_EDGE = "no_edge"
+    INVERTED_SEMANTICS = "inverted_semantics"
+    FEES_CONSUME_EDGE = "fees_consume_edge"
+
+
+@dataclass(frozen=True)
+class CoreTradingRules:
+    blend_second_opinion: bool
+    reject_suspicious_negation: bool
+    compute_quality: bool
+    max_notional: float
+    require_positive_net_edge: bool = True
+
+
+@dataclass(frozen=True)
+class CoreTradingInputs:
+    market_id: str
+    question: str
+    market_probability: float
+    model_probability: float
+    confidence: str
+    second_opinion_probability: float | None
+    divergence: float | None
+    reasoning: str
+    evidence_count: int
+    hours_to_resolution: float | None
+    fee_rate: float
+
+
+@dataclass(frozen=True)
+class CoreTradingProposal:
+    market_id: str
+    instrument_id: str
+    side: str
+    market_probability: float
+    model_probability: float
+    edge_percent: float
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+    quality: float | None
+    evidence_summary: str
+
+
+@dataclass(frozen=True)
+class CoreTradingAssessment:
+    proposal: CoreTradingProposal | None
+    rejection: CoreTradingRejection | None = None
+
+
+def blend_estimates(
+    primary: float,
+    second_opinion: float | None,
+    market_probability: float,
+    primary_confidence: str = "MEDIUM",
+) -> float:
+    del market_probability  # retained in the stable production helper signature
+    if second_opinion is None:
+        return primary
+    divergence = abs(primary - second_opinion)
+    primary_weight = {
+        "HIGH": 0.75,
+        "MEDIUM_HIGH": 0.675,
+        "MEDIUM": 0.60,
+        "MEDIUM_LOW": 0.525,
+        "LOW": 0.45,
+    }.get(primary_confidence, 0.60)
+    if divergence < 0.05:
+        return primary * primary_weight + second_opinion * (1 - primary_weight)
+    if divergence > 0.25:
+        midpoint = (primary + second_opinion) / 2
+        shrink = min(0.3, divergence - 0.25)
+        return midpoint * (1 - shrink) + 0.5 * shrink
+    return primary * primary_weight + second_opinion * (1 - primary_weight)
+
+
+def has_inverted_semantics(question: str) -> bool:
+    patterns = (
+        r"\bnot\b", r"\bnever\b", r"\bfail(?:s|ed)? to\b",
+        r"\bwon'?t\b", r"\bunable to\b", r"\bfalls? short\b",
+        r"\bno longer\b", r"\bavoid\b",
+    )
+    return any(re.search(pattern, question.lower()) for pattern in patterns)
+
+
+def compute_signal_quality(
+    edge: float,
+    confidence: str,
+    divergence: float | None,
+    evidence_count: int,
+    hours_to_resolution: float | None,
+) -> float:
+    edge_score = min(1.0, abs(edge) / 20.0)
+    conf_score = {
+        "HIGH": 1.0, "MEDIUM_HIGH": 0.85, "MEDIUM": 0.7,
+        "MEDIUM_LOW": 0.55, "LOW": 0.4,
+    }.get(confidence, 0.5)
+    div_score = 1.0 if divergence is None else max(0.0, 1.0 - divergence * 4)
+    ev_score = min(1.0, 0.2 + evidence_count * 0.08)
+    time_score = 0.5
+    if hours_to_resolution is not None and hours_to_resolution > 0:
+        time_score = max(
+            0.2, 1.0 - math.log(hours_to_resolution / 24 + 1) / 6
+        )
+    return round(
+        edge_score * 0.30
+        + conf_score * 0.25
+        + div_score * 0.20
+        + ev_score * 0.15
+        + time_score * 0.10,
+        3,
+    )
+
+
+def assess_core_trading(
+    inputs: CoreTradingInputs,
+    rules: CoreTradingRules,
+) -> CoreTradingAssessment:
+    probabilities = (
+        inputs.market_probability,
+        inputs.model_probability,
+        inputs.second_opinion_probability,
+    )
+    if any(
+        value is not None and (not math.isfinite(value) or not 0.0 <= value <= 1.0)
+        for value in probabilities
+    ) or not math.isfinite(inputs.fee_rate) or inputs.fee_rate < 0:
+        return CoreTradingAssessment(None, CoreTradingRejection.INVALID_PROBABILITY)
+
+    model_probability = inputs.model_probability
+    if rules.blend_second_opinion:
+        model_probability = blend_estimates(
+            model_probability,
+            inputs.second_opinion_probability,
+            inputs.market_probability,
+            inputs.confidence,
+        )
+    raw_edge = model_probability - inputs.market_probability
+    if raw_edge == 0 or (
+        not rules.blend_second_opinion and abs(raw_edge) < 0.001
+    ):
+        return CoreTradingAssessment(None, CoreTradingRejection.NO_EDGE)
+    side = "BUY" if raw_edge > 0 else "SELL"
+    absolute_edge = abs(raw_edge)
+    if (
+        rules.reject_suspicious_negation
+        and absolute_edge > 0.25
+        and has_inverted_semantics(inputs.question)
+    ):
+        return CoreTradingAssessment(None, CoreTradingRejection.INVERTED_SEMANTICS)
+    net_edge = (
+        absolute_edge
+        - inputs.fee_rate
+        * inputs.market_probability
+        * (1.0 - inputs.market_probability)
+    )
+    if rules.require_positive_net_edge and net_edge <= 0:
+        return CoreTradingAssessment(None, CoreTradingRejection.FEES_CONSUME_EDGE)
+    quality = None
+    if rules.compute_quality:
+        quality = compute_signal_quality(
+            net_edge * 100,
+            inputs.confidence,
+            inputs.divergence,
+            inputs.evidence_count,
+            inputs.hours_to_resolution,
+        )
+    reference_price = (
+        inputs.market_probability if side == "BUY"
+        else 1.0 - inputs.market_probability
+    )
+    return CoreTradingAssessment(CoreTradingProposal(
+        market_id=inputs.market_id,
+        instrument_id=f"{inputs.market_id}:{'YES' if side == 'BUY' else 'NO'}",
+        side=side,
+        market_probability=inputs.market_probability,
+        model_probability=model_probability,
+        edge_percent=net_edge * 100,
+        reference_price=reference_price,
+        target_quantity=rules.max_notional / reference_price,
+        max_notional=rules.max_notional,
+        quality=quality,
+        evidence_summary=inputs.reasoning[:500],
+    ))
+
+
+@dataclass(frozen=True)
+class CoreTradingExperiment:
+    rules: CoreTradingRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        del portfolio
+        assessment = assess_core_trading(
+            CoreTradingInputs(**snapshot.feature("core_trading_inputs")), self.rules
+        )
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale=proposal.evidence_summary or "core trading probability edge",
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/econ_indicator.py
+++ b/auramaur/experiments/strategies/econ_indicator.py
@@ -1,0 +1,109 @@
+"""Pure economic-indicator candidate decision used by lab and production."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class EconIndicatorRejection(str, Enum):
+    INSUFFICIENT_EDGE = "insufficient_edge"
+    IMPLAUSIBLE_DIVERGENCE = "implausible_divergence"
+    ALREADY_ENTERED_OR_HELD = "already_entered_or_held"
+
+
+@dataclass(frozen=True)
+class EconIndicatorInputs:
+    market_id: str
+    market_probability: float
+    model_probability: float
+    required_edge: float
+    max_divergence: float
+    already_entered_or_held: bool
+
+
+@dataclass(frozen=True)
+class EconIndicatorProposal:
+    market_id: str
+    buy_yes: bool
+    instrument_id: str
+    market_probability: float
+    model_probability: float
+    signal_probability: float
+    edge_percent: float
+
+
+@dataclass(frozen=True)
+class EconIndicatorAssessment:
+    proposal: EconIndicatorProposal | None
+    rejection: EconIndicatorRejection | None = None
+
+
+def assess_econ_indicator(inputs: EconIndicatorInputs) -> EconIndicatorAssessment:
+    """Turn a priced ladder member into a direction, without side effects."""
+    edge = inputs.model_probability - inputs.market_probability
+    if abs(edge) < inputs.required_edge:
+        return EconIndicatorAssessment(
+            None, EconIndicatorRejection.INSUFFICIENT_EDGE
+        )
+    if abs(edge) > inputs.max_divergence:
+        return EconIndicatorAssessment(
+            None, EconIndicatorRejection.IMPLAUSIBLE_DIVERGENCE
+        )
+    if inputs.already_entered_or_held:
+        return EconIndicatorAssessment(
+            None, EconIndicatorRejection.ALREADY_ENTERED_OR_HELD
+        )
+    buy_yes = edge > 0
+    return EconIndicatorAssessment(EconIndicatorProposal(
+        market_id=inputs.market_id,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        market_probability=inputs.market_probability,
+        model_probability=inputs.model_probability,
+        signal_probability=max(0.01, min(0.99, inputs.model_probability)),
+        edge_percent=abs(edge) * 100.0,
+    ))
+
+
+@dataclass(frozen=True)
+class EconIndicatorExperiment:
+    """Portable target generator for a pre-priced economic ladder member."""
+
+    stake_usd: float
+
+    async def evaluate(
+        self,
+        snapshot: MarketSnapshot,
+        portfolio: PortfolioSnapshot,
+    ) -> list[TargetPosition]:
+        details = snapshot.feature("econ_indicator_inputs")
+        assessment = assess_econ_indicator(EconIndicatorInputs(
+            market_id=snapshot.market_id,
+            market_probability=float(details["market_probability"]),
+            model_probability=float(details["model_probability"]),
+            required_edge=float(details["required_edge"]),
+            max_divergence=float(details["max_divergence"]),
+            already_entered_or_held=(
+                bool(details["already_entered_or_held"])
+                or bool(portfolio.quantities().get(snapshot.market_id + ":YES", 0.0))
+                or bool(portfolio.quantities().get(snapshot.market_id + ":NO", 0.0))
+            ),
+        ))
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        price = (
+            proposal.market_probability
+            if proposal.buy_yes
+            else 1.0 - proposal.market_probability
+        )
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=self.stake_usd / price,
+            reference_price=price,
+            rationale="economic indicator distribution versus market",
+            max_notional=self.stake_usd,
+        )]

--- a/auramaur/experiments/strategies/informed_flow.py
+++ b/auramaur/experiments/strategies/informed_flow.py
@@ -1,0 +1,156 @@
+"""Pure informed-flow candidate assessment shared by every runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class InformedFlowRejection(str, Enum):
+    INACTIVE = "inactive"
+    WRONG_VENUE = "wrong_venue"
+    MISSING_TICKER = "missing_ticker"
+    OUTSIDE_PRICE_BAND = "outside_price_band"
+    INSUFFICIENT_LIQUIDITY = "insufficient_liquidity"
+    BLOCKED_CATEGORY = "blocked_category"
+    MISSING_RESOLUTION_TIME = "missing_resolution_time"
+    OUTSIDE_RESOLUTION_WINDOW = "outside_resolution_window"
+    ALREADY_ENTERED_OR_HELD = "already_entered_or_held"
+    NO_INFORMED_FLOW = "no_informed_flow"
+
+
+@dataclass(frozen=True)
+class InformedFlowRules:
+    band_lo: float
+    band_hi: float
+    min_liquidity: float
+    min_hours_to_resolution: float
+    max_days_to_resolution: float
+    uplift: float
+    stake_usd: float
+
+
+@dataclass(frozen=True)
+class InformedFlowInputs:
+    market_id: str
+    venue: str
+    ticker: str | None
+    active: bool
+    market_probability: float
+    liquidity: float
+    blocked_category: bool
+    hours_to_resolution: float | None
+    already_entered_or_held: bool
+    has_signal: bool
+    informed_side: str | None
+    abnormal_count: int
+    baseline_size: float
+    signal_volume: float
+    sample: int
+
+
+@dataclass(frozen=True)
+class InformedFlowProposal:
+    market_id: str
+    buy_yes: bool
+    instrument_id: str
+    market_probability: float
+    model_probability: float
+    edge_percent: float
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+    evidence_summary: str
+
+
+@dataclass(frozen=True)
+class InformedFlowAssessment:
+    proposal: InformedFlowProposal | None
+    rejection: InformedFlowRejection | None = None
+
+
+def informed_flow_eligibility(
+    inputs: InformedFlowInputs, rules: InformedFlowRules
+) -> InformedFlowRejection | None:
+    """Apply cheap deterministic gates before trade-tape acquisition."""
+    if not inputs.active:
+        return InformedFlowRejection.INACTIVE
+    if inputs.venue != "kalshi":
+        return InformedFlowRejection.WRONG_VENUE
+    if not inputs.ticker:
+        return InformedFlowRejection.MISSING_TICKER
+    if not rules.band_lo <= inputs.market_probability <= rules.band_hi:
+        return InformedFlowRejection.OUTSIDE_PRICE_BAND
+    if inputs.liquidity < rules.min_liquidity:
+        return InformedFlowRejection.INSUFFICIENT_LIQUIDITY
+    if inputs.blocked_category:
+        return InformedFlowRejection.BLOCKED_CATEGORY
+    if inputs.hours_to_resolution is None:
+        return InformedFlowRejection.MISSING_RESOLUTION_TIME
+    if (
+        inputs.hours_to_resolution < rules.min_hours_to_resolution
+        or inputs.hours_to_resolution > rules.max_days_to_resolution * 24.0
+    ):
+        return InformedFlowRejection.OUTSIDE_RESOLUTION_WINDOW
+    return None
+
+
+def assess_informed_flow(
+    inputs: InformedFlowInputs, rules: InformedFlowRules
+) -> InformedFlowAssessment:
+    rejection = informed_flow_eligibility(inputs, rules)
+    if rejection is not None:
+        return InformedFlowAssessment(None, rejection)
+    if inputs.already_entered_or_held:
+        return InformedFlowAssessment(None, InformedFlowRejection.ALREADY_ENTERED_OR_HELD)
+    if not inputs.has_signal or inputs.informed_side not in {"yes", "no"}:
+        return InformedFlowAssessment(None, InformedFlowRejection.NO_INFORMED_FLOW)
+
+    buy_yes = inputs.informed_side == "yes"
+    probability = (
+        min(0.99, inputs.market_probability + rules.uplift)
+        if buy_yes else max(0.01, inputs.market_probability - rules.uplift)
+    )
+    reference_price = inputs.market_probability if buy_yes else 1 - inputs.market_probability
+    return InformedFlowAssessment(InformedFlowProposal(
+        market_id=inputs.market_id,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        market_probability=inputs.market_probability,
+        model_probability=probability,
+        edge_percent=rules.uplift * 100,
+        reference_price=reference_price,
+        target_quantity=rules.stake_usd / reference_price,
+        max_notional=rules.stake_usd,
+        evidence_summary=(
+            f"Informed-flow follow: {inputs.abnormal_count} abnormal trades "
+            f"({inputs.signal_volume:.0f} contracts) on the "
+            f"{inputs.informed_side.upper()} side vs a "
+            f"{inputs.baseline_size:.0f}-size baseline (n={inputs.sample})."
+        ),
+    ))
+
+
+@dataclass(frozen=True)
+class InformedFlowExperiment:
+    rules: InformedFlowRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        del portfolio
+        assessment = assess_informed_flow(
+            InformedFlowInputs(**snapshot.feature("informed_flow_inputs")), self.rules
+        )
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale=proposal.evidence_summary,
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/interim_manager.py
+++ b/auramaur/experiments/strategies/interim_manager.py
@@ -1,0 +1,222 @@
+"""Pure proposal assessment for the interim-manager strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from math import isfinite
+
+
+class InterimManagerRejection(str, Enum):
+    EXPIRED = "expired"
+    THESIS_TOO_SHORT = "thesis_too_short"
+    DELEGATED = "delegated"
+    SUNSET_REACHED = "sunset_reached"
+    POSITION_CAP = "position_cap"
+    ENTRY_LIMIT = "entry_limit"
+    INSUFFICIENT_EDGE = "insufficient_edge"
+    INVALID_INPUT = "invalid_input"
+
+
+@dataclass(frozen=True)
+class InterimManagerRules:
+    proposal_ttl_hours: float
+    max_open_positions: int
+    min_robust_edge: float
+    default_uncertainty_buffer: float
+    slippage_buffer: float
+    liquidity_penalty: float
+    thin_liquidity_usd: float
+    correlation_penalty_per_position: float
+    stake_usd: float
+    paper: bool
+    min_thesis_chars: int = 40
+
+
+@dataclass(frozen=True)
+class InterimManagerInputs:
+    proposal_id: int
+    market_id: str
+    thesis: str
+    side: str
+    fair_probability: float
+    requested_stake_usd: float
+    market_yes_price: float
+    market_liquidity: float
+    category: str
+    created_at: datetime | None
+    sunset_at: datetime | None
+    as_of: datetime
+    delegated_to: str | None
+    open_positions: int
+    open_positions_in_category: int
+    fee_rate: float
+    confidence_lo: float | None = None
+    confidence_hi: float | None = None
+    max_entry_price: float | None = None
+
+
+@dataclass(frozen=True)
+class InterimManagerProposal:
+    proposal_id: int
+    market_id: str
+    buy_yes: bool
+    fair_probability: float
+    market_probability: float
+    entry_price: float
+    robust_edge: float
+    robust_edge_detail: str
+    requested_stake_usd: float
+    force_paper: bool
+    thesis: str
+
+
+@dataclass(frozen=True)
+class InterimManagerAssessment:
+    proposal: InterimManagerProposal | None
+    rejection: InterimManagerRejection | None = None
+    reason: str = ""
+    retryable: bool = False
+    robust_edge: float | None = None
+    decision_price: float | None = None
+
+
+def _aware(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def assess_interim_manager(
+    inputs: InterimManagerInputs,
+    rules: InterimManagerRules,
+) -> InterimManagerAssessment:
+    """Apply the charter's deterministic gates and construct a proposal."""
+    now = _aware(inputs.as_of)
+    created = _aware(inputs.created_at)
+    sunset = _aware(inputs.sunset_at)
+    numeric = (
+        inputs.fair_probability,
+        inputs.requested_stake_usd,
+        inputs.market_yes_price,
+        inputs.market_liquidity,
+        inputs.fee_rate,
+    )
+    if now is None or not all(isfinite(value) for value in numeric):
+        return InterimManagerAssessment(
+            None, InterimManagerRejection.INVALID_INPUT, "invalid numeric input"
+        )
+    if not 0.0 < inputs.market_yes_price < 1.0:
+        return InterimManagerAssessment(
+            None, InterimManagerRejection.INVALID_INPUT, "invalid market price"
+        )
+    if created is not None and (now - created).total_seconds() > (
+        rules.proposal_ttl_hours * 3600.0
+    ):
+        return InterimManagerAssessment(
+            None, InterimManagerRejection.EXPIRED, "proposal ttl elapsed"
+        )
+    thesis = inputs.thesis.strip()
+    if len(thesis) < rules.min_thesis_chars:
+        return InterimManagerAssessment(
+            None,
+            InterimManagerRejection.THESIS_TOO_SHORT,
+            "charter: no nameable mispricing mechanism",
+        )
+    if inputs.delegated_to is not None:
+        return InterimManagerAssessment(
+            None,
+            InterimManagerRejection.DELEGATED,
+            f"delegated to {inputs.delegated_to}",
+        )
+    if sunset is not None and now >= sunset:
+        return InterimManagerAssessment(
+            None, InterimManagerRejection.SUNSET_REACHED, "thesis sunset reached"
+        )
+    if inputs.open_positions >= rules.max_open_positions:
+        return InterimManagerAssessment(
+            None,
+            InterimManagerRejection.POSITION_CAP,
+            "position cap reached",
+            retryable=True,
+        )
+
+    buy_yes = inputs.side.upper() == "BUY"
+    entry_price = (
+        inputs.market_yes_price if buy_yes else 1.0 - inputs.market_yes_price
+    )
+    if (
+        inputs.max_entry_price is not None
+        and entry_price > inputs.max_entry_price + 1e-9
+    ):
+        return InterimManagerAssessment(
+            None,
+            InterimManagerRejection.ENTRY_LIMIT,
+            f"entry {entry_price:.3f} above limit {inputs.max_entry_price:.3f}",
+        )
+
+    gross = (
+        inputs.fair_probability - inputs.market_yes_price
+        if buy_yes
+        else inputs.market_yes_price - inputs.fair_probability
+    )
+    if (
+        inputs.confidence_lo is not None
+        and inputs.confidence_hi is not None
+        and inputs.confidence_hi >= inputs.confidence_lo
+    ):
+        uncertainty = (inputs.confidence_hi - inputs.confidence_lo) / 2.0
+    else:
+        uncertainty = rules.default_uncertainty_buffer
+    fee = (
+        inputs.fee_rate
+        * inputs.market_yes_price
+        * (1.0 - inputs.market_yes_price)
+    )
+    liquidity = (
+        rules.liquidity_penalty
+        if inputs.market_liquidity < rules.thin_liquidity_usd
+        else 0.0
+    )
+    correlation = (
+        rules.correlation_penalty_per_position * inputs.open_positions_in_category
+    )
+    robust = (
+        gross
+        - uncertainty
+        - fee
+        - rules.slippage_buffer
+        - liquidity
+        - correlation
+    )
+    detail = (
+        f"gross {gross:+.3f} − unc {uncertainty:.3f} − fee {fee:.3f} "
+        f"− slip {rules.slippage_buffer:.3f} − liq {liquidity:.3f} "
+        f"− corr {correlation:.3f}"
+    )
+    if robust < rules.min_robust_edge:
+        return InterimManagerAssessment(
+            None,
+            InterimManagerRejection.INSUFFICIENT_EDGE,
+            f"robust edge {robust:+.3f} < {rules.min_robust_edge:.3f} ({detail})",
+            robust_edge=robust,
+            decision_price=entry_price,
+        )
+    return InterimManagerAssessment(
+        InterimManagerProposal(
+            proposal_id=inputs.proposal_id,
+            market_id=inputs.market_id,
+            buy_yes=buy_yes,
+            fair_probability=max(0.01, min(0.99, inputs.fair_probability)),
+            market_probability=inputs.market_yes_price,
+            entry_price=entry_price,
+            robust_edge=robust,
+            robust_edge_detail=detail,
+            requested_stake_usd=min(rules.stake_usd, inputs.requested_stake_usd),
+            force_paper=rules.paper,
+            thesis=thesis,
+        )
+    )

--- a/auramaur/experiments/strategies/long_horizon.py
+++ b/auramaur/experiments/strategies/long_horizon.py
@@ -1,0 +1,160 @@
+"""Pure long-horizon favorite-underpricing candidate assessment."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+def calibrated_fair(price: float, slope: float) -> float:
+    p = min(max(price, 1e-6), 1.0 - 1e-6)
+    logit = math.log(p / (1.0 - p))
+    return 1.0 / (1.0 + math.exp(-slope * logit))
+
+
+class LongHorizonRejection(str, Enum):
+    OUT_OF_BAND = "out_of_band"
+    INACTIVE = "inactive"
+    WRONG_VENUE = "wrong_venue"
+    INSUFFICIENT_LIQUIDITY = "insufficient_liquidity"
+    BLOCKED_CATEGORY = "blocked_category"
+    MISSING_END = "missing_end"
+    TOO_SOON = "too_soon"
+    TOO_FAR = "too_far"
+    ALREADY_ENTERED_OR_HELD = "already_entered_or_held"
+    INSUFFICIENT_EDGE = "insufficient_edge"
+
+
+@dataclass(frozen=True)
+class LongHorizonRules:
+    venue: str
+    band_lo: float
+    band_hi: float
+    slope: float
+    min_edge: float
+    stake_usd: float
+    min_liquidity: float
+    min_days_to_resolution: float
+    max_days_to_resolution: float
+    source_tag: str
+
+
+@dataclass(frozen=True)
+class LongHorizonInputs:
+    market_id: str
+    yes_price: float
+    active: bool
+    venue: str
+    liquidity: float
+    category_blocked: bool
+    end_at: datetime | None
+    as_of: datetime
+    already_entered_or_held: bool
+
+
+@dataclass(frozen=True)
+class LongHorizonProposal:
+    market_id: str
+    buy_yes: bool
+    instrument_id: str
+    favored_price: float
+    market_probability: float
+    fair_probability: float
+    edge_percent: float
+    entry_price: float
+    target_quantity: float
+    max_notional: float
+    source_tag: str
+
+
+@dataclass(frozen=True)
+class LongHorizonAssessment:
+    proposal: LongHorizonProposal | None
+    rejection: LongHorizonRejection | None = None
+
+
+def assess_long_horizon(
+    inputs: LongHorizonInputs, rules: LongHorizonRules
+) -> LongHorizonAssessment:
+    p_yes = inputs.yes_price
+    if not 0.0 < p_yes < 1.0:
+        return LongHorizonAssessment(None, LongHorizonRejection.OUT_OF_BAND)
+    p_fav = max(p_yes, 1.0 - p_yes)
+    if not rules.band_lo <= p_fav <= rules.band_hi:
+        return LongHorizonAssessment(None, LongHorizonRejection.OUT_OF_BAND)
+    if not inputs.active:
+        return LongHorizonAssessment(None, LongHorizonRejection.INACTIVE)
+    if (inputs.venue or "polymarket") != rules.venue:
+        return LongHorizonAssessment(None, LongHorizonRejection.WRONG_VENUE)
+    if inputs.liquidity < rules.min_liquidity:
+        return LongHorizonAssessment(None, LongHorizonRejection.INSUFFICIENT_LIQUIDITY)
+    if inputs.category_blocked:
+        return LongHorizonAssessment(None, LongHorizonRejection.BLOCKED_CATEGORY)
+    if inputs.end_at is None:
+        return LongHorizonAssessment(None, LongHorizonRejection.MISSING_END)
+    end_at = inputs.end_at
+    if end_at.tzinfo is None or end_at.utcoffset() is None:
+        end_at = end_at.replace(tzinfo=timezone.utc)
+    days_left = (end_at - inputs.as_of).total_seconds() / 86400.0
+    if days_left < rules.min_days_to_resolution:
+        return LongHorizonAssessment(None, LongHorizonRejection.TOO_SOON)
+    if days_left > rules.max_days_to_resolution:
+        return LongHorizonAssessment(None, LongHorizonRejection.TOO_FAR)
+    if inputs.already_entered_or_held:
+        return LongHorizonAssessment(None, LongHorizonRejection.ALREADY_ENTERED_OR_HELD)
+    buy_yes = p_yes >= 0.5
+    fair_fav = calibrated_fair(p_fav, rules.slope)
+    edge = fair_fav - p_fav
+    if edge < rules.min_edge:
+        return LongHorizonAssessment(None, LongHorizonRejection.INSUFFICIENT_EDGE)
+    fair_yes = min(0.99, fair_fav) if buy_yes else max(0.01, 1.0 - fair_fav)
+    entry = p_yes if buy_yes else 1.0 - p_yes
+    return LongHorizonAssessment(LongHorizonProposal(
+        market_id=inputs.market_id,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        favored_price=p_fav,
+        market_probability=p_yes,
+        fair_probability=fair_yes,
+        edge_percent=edge * 100.0,
+        entry_price=entry,
+        target_quantity=rules.stake_usd / entry,
+        max_notional=rules.stake_usd,
+        source_tag=rules.source_tag,
+    ))
+
+
+@dataclass(frozen=True)
+class LongHorizonExperiment:
+    rules: LongHorizonRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        del portfolio
+        details = snapshot.feature("long_horizon_inputs")
+        assessment = assess_long_horizon(LongHorizonInputs(
+            market_id=snapshot.market_id,
+            yes_price=float(details["yes_price"]),
+            active=bool(details["active"]),
+            venue=snapshot.venue,
+            liquidity=float(details["liquidity"]),
+            category_blocked=bool(details["category_blocked"]),
+            end_at=datetime.fromisoformat(details["end_at"]) if details["end_at"] else None,
+            as_of=snapshot.observed_at,
+            already_entered_or_held=bool(details["already_entered_or_held"]),
+        ), self.rules)
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.entry_price,
+            rationale="long-horizon structural underconfidence",
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/momentum_coupling.py
+++ b/auramaur/experiments/strategies/momentum_coupling.py
@@ -1,0 +1,149 @@
+"""Pure spot-to-prediction momentum-coupling decisions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class CouplingRejection(str, Enum):
+    MOVE_TOO_SMALL = "move_too_small"
+    STRIKE_MISSING = "strike_missing"
+    NOT_NEAR_MONEY = "not_near_money"
+    PINNED_MARKET = "pinned_market"
+
+
+@dataclass(frozen=True)
+class CouplingRules:
+    move_threshold_pct: float
+    near_money_pct: float
+    max_position_usd: float
+
+
+@dataclass(frozen=True)
+class CouplingCandidate:
+    market_id: str
+    question: str
+    yes_price: float
+
+
+@dataclass(frozen=True)
+class CouplingInputs:
+    asset: str
+    spot: float
+    move_pct: float
+    candidates: tuple[CouplingCandidate, ...]
+
+
+@dataclass(frozen=True)
+class CouplingProposal:
+    market_id: str
+    question: str
+    asset: str
+    spot: float
+    move_pct: float
+    strike: float
+    market_probability: float
+    fair_probability: float
+    edge_percent: float
+    direction: str
+    target_quantity: float
+    max_notional: float
+    confidence: str
+
+
+@dataclass(frozen=True)
+class CouplingAssessment:
+    proposal: CouplingProposal | None
+    rejection: CouplingRejection | None = None
+
+
+def extract_strike(question: str) -> float | None:
+    match = re.search(r"\$?([\d,]{4,})", question)
+    if not match:
+        return None
+    strike = float(match.group(1).replace(",", ""))
+    return strike if strike > 0 else None
+
+
+def assess_momentum_coupling(
+    inputs: CouplingInputs,
+    rules: CouplingRules,
+) -> CouplingAssessment:
+    """Choose the first eligible market and form its complete proposal."""
+    if abs(inputs.move_pct) < rules.move_threshold_pct:
+        return CouplingAssessment(None, CouplingRejection.MOVE_TOO_SMALL)
+    last_rejection = CouplingRejection.STRIKE_MISSING
+    for candidate in inputs.candidates:
+        strike = extract_strike(candidate.question)
+        if strike is None:
+            last_rejection = CouplingRejection.STRIKE_MISSING
+            continue
+        if abs(strike - inputs.spot) / inputs.spot > rules.near_money_pct:
+            last_rejection = CouplingRejection.NOT_NEAR_MONEY
+            continue
+        if not 0.10 < candidate.yes_price < 0.90:
+            last_rejection = CouplingRejection.PINNED_MARKET
+            continue
+        direction = "BUY_YES" if inputs.move_pct > 0 else "BUY_NO"
+        signed_shift = (1 if inputs.move_pct > 0 else -1) * min(
+            abs(inputs.move_pct) / 100.0 * 5, 0.15
+        )
+        fair = max(0.02, min(0.98, candidate.yes_price + signed_shift))
+        execution_price = (
+            candidate.yes_price if direction == "BUY_YES" else 1.0 - candidate.yes_price
+        )
+        return CouplingAssessment(CouplingProposal(
+            market_id=candidate.market_id,
+            question=candidate.question,
+            asset=inputs.asset,
+            spot=inputs.spot,
+            move_pct=inputs.move_pct,
+            strike=strike,
+            market_probability=candidate.yes_price,
+            fair_probability=fair,
+            edge_percent=abs(fair - candidate.yes_price) * 100.0,
+            direction=direction,
+            target_quantity=rules.max_position_usd / execution_price,
+            max_notional=rules.max_position_usd,
+            confidence="HIGH" if abs(inputs.move_pct) >= 1.0 else "MEDIUM",
+        ))
+    return CouplingAssessment(None, last_rejection)
+
+
+@dataclass(frozen=True)
+class MomentumCouplingExperiment:
+    rules: CouplingRules
+
+    async def evaluate(
+        self,
+        snapshot: MarketSnapshot,
+        portfolio: PortfolioSnapshot,
+    ) -> list[TargetPosition]:
+        del portfolio
+        details = snapshot.feature("momentum_coupling_inputs")
+        result = assess_momentum_coupling(CouplingInputs(
+            asset=str(details["asset"]),
+            spot=float(details["spot"]),
+            move_pct=float(details["move_pct"]),
+            candidates=tuple(CouplingCandidate(
+                market_id=str(item["market_id"]),
+                question=str(item["question"]),
+                yes_price=float(item["yes_price"]),
+            ) for item in details["candidates"]),
+        ), self.rules)
+        if result.proposal is None:
+            return []
+        proposal = result.proposal
+        token = "YES" if proposal.direction == "BUY_YES" else "NO"
+        price = proposal.market_probability if token == "YES" else 1 - proposal.market_probability
+        return [TargetPosition(
+            instrument_id=f"{proposal.market_id}:{token}",
+            target_quantity=proposal.target_quantity,
+            reference_price=price,
+            rationale=f"{proposal.asset} momentum {proposal.move_pct:+.3f}%",
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/news_reactor.py
+++ b/auramaur/experiments/strategies/news_reactor.py
@@ -1,0 +1,147 @@
+"""Pure market-routing decisions for news-reactor experiments."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+
+STOP_WORDS = frozenset({
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "it", "its", "are", "was", "were",
+    "be", "been", "being", "have", "has", "had", "do", "does", "did",
+    "will", "would", "could", "should", "may", "might", "shall", "not", "no",
+    "nor", "so", "if", "then", "than", "that", "this", "these", "those",
+    "what", "which", "who", "whom", "how", "when", "where", "why", "all",
+    "each", "every", "both", "few", "more", "most", "other", "some", "such",
+    "only", "own", "same", "very", "just", "about", "above", "after", "again",
+    "against", "before", "below", "between", "during", "into", "through", "under",
+    "until", "over", "out", "up", "down", "off", "here", "there", "new", "says",
+    "said", "also", "as", "can", "get", "got", "one", "two", "now", "still",
+    "s", "t", "re", "ve", "d", "ll", "m",
+})
+NEWS_FLUFF = frozenset({
+    "breaking", "update", "live", "latest", "report", "reports", "exclusive",
+    "developing", "just", "watch", "opinion", "analysis", "sources", "source",
+    "officials", "official", "according",
+})
+GENERIC_TITLE_WORDS = frozenset({
+    "cheap", "best", "good", "great", "new", "old", "big", "small", "hot",
+    "top", "bad", "nice", "fun", "cool", "easy", "hard", "fast", "slow",
+    "free", "rich", "poor", "young", "full", "short", "long", "yes", "no",
+    "now", "soon", "next", "last", "first", "final", "early", "late", "happy",
+    "sad", "real", "fake", "true", "false", "every", "any", "much", "many",
+    "some", "few", "less", "more", "here", "there", "why", "how", "who",
+    "what", "when", "where", "thanks", "sorry", "hello", "goodbye", "welcome",
+    "please", "stuff", "things", "ways", "reasons", "signs", "tips",
+})
+PROPER_NOUN_RE = re.compile(r"[A-Z][a-z]{2,}")
+
+
+@dataclass(frozen=True)
+class NewsMarketCandidate:
+    market_id: str
+    question: str
+    description: str
+    category: str
+    active: bool
+    liquidity: float
+    volume: float
+
+
+@dataclass(frozen=True)
+class NewsReactorRules:
+    min_liquidity: float = 2000.0
+    min_proper_nouns: int = 1
+    blocked_categories: frozenset[str] = frozenset({"esports", "sports"})
+
+
+@dataclass(frozen=True)
+class NewsMarketProposal:
+    market_id: str
+    headline: str
+    activity: float
+    matched_proper_nouns: tuple[str, ...]
+    rationale: str
+
+
+def extract_proper_nouns(title: str) -> list[str]:
+    result: list[str] = []
+    for token in re.findall(r"[A-Za-z']+", title):
+        lower = token.lower()
+        if lower in STOP_WORDS or lower in NEWS_FLUFF or lower in GENERIC_TITLE_WORDS:
+            continue
+        if PROPER_NOUN_RE.fullmatch(token) or (token.isupper() and len(token) >= 2):
+            result.append(token)
+    return result
+
+
+def extract_search_terms(title: str) -> list[str]:
+    raw_tokens = re.findall(r"[A-Za-z']+", title)
+    proper_nouns: list[str] = []
+    keywords: list[str] = []
+    for token in raw_tokens:
+        lower = token.lower()
+        if lower in STOP_WORDS or lower in NEWS_FLUFF:
+            continue
+        capital = bool(PROPER_NOUN_RE.fullmatch(token) or (token.isupper() and len(token) >= 2))
+        if capital and lower in GENERIC_TITLE_WORDS:
+            capital = False
+        if capital:
+            proper_nouns.append(token)
+        elif lower not in GENERIC_TITLE_WORDS:
+            keywords.append(token)
+    queries: list[str] = []
+    if proper_nouns:
+        queries.append(" ".join(proper_nouns[:4]))
+    if proper_nouns and keywords:
+        queries.append(f"{proper_nouns[0]} {' '.join(keywords[:2])}")
+    if not proper_nouns and keywords:
+        queries.append(" ".join(keywords[:3]))
+    unique: list[str] = []
+    seen: set[str] = set()
+    for query in queries:
+        if query.lower() not in seen:
+            seen.add(query.lower())
+            unique.append(query)
+    return unique or [" ".join(raw_tokens[:3])]
+
+
+def form_news_market_proposal(
+    headline: str,
+    candidate: NewsMarketCandidate,
+    rules: NewsReactorRules,
+) -> NewsMarketProposal | None:
+    """Return a reproducible routing proposal, failing closed on invalid input."""
+    if (
+        not headline.strip()
+        or not candidate.market_id
+        or rules.min_proper_nouns < 0
+        or not math.isfinite(rules.min_liquidity)
+        or rules.min_liquidity < 0.0
+        or not math.isfinite(candidate.liquidity)
+        or not math.isfinite(candidate.volume)
+        or candidate.liquidity < 0.0
+        or candidate.volume < 0.0
+        or not candidate.active
+        or candidate.category.strip().lower() in rules.blocked_categories
+    ):
+        return None
+    proper_nouns = extract_proper_nouns(headline)
+    if len(proper_nouns) < rules.min_proper_nouns:
+        return None
+    activity = max(candidate.liquidity, candidate.volume)
+    if activity < rules.min_liquidity:
+        return None
+    market_text = f"{candidate.question} {candidate.description}".lower()
+    matched = tuple(noun for noun in proper_nouns if noun.lower() in market_text)
+    if not matched:
+        return None
+    return NewsMarketProposal(
+        market_id=candidate.market_id,
+        headline=headline,
+        activity=activity,
+        matched_proper_nouns=matched,
+        rationale=f"news match: {', '.join(matched)}",
+    )

--- a/auramaur/experiments/strategies/platform_consensus.py
+++ b/auramaur/experiments/strategies/platform_consensus.py
@@ -1,0 +1,201 @@
+"""Pure platform-consensus decisions shared by research and production."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+_STOP_WORDS = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "will", "be", "been",
+    "to", "of", "in", "for", "on", "at", "by", "or", "and", "it", "its",
+    "this", "that", "with", "from", "as", "do", "does", "did", "not", "no",
+    "yes", "has", "have", "had", "can", "could", "would", "should", "may",
+    "if", "but", "so", "than", "then", "what", "which", "who", "whom",
+    "how", "when", "where", "why", "before", "after", "during", "between",
+    "next",
+})
+
+
+def _word_overlap_score(text_a: str, text_b: str) -> float:
+    """Match questions without importing the production strategy graph."""
+    words_a = set(re.findall(r"[a-z0-9]+", text_a.lower())) - _STOP_WORDS
+    words_b = set(re.findall(r"[a-z0-9]+", text_b.lower())) - _STOP_WORDS
+    if not words_a or not words_b:
+        return 0.0
+    return len(words_a & words_b) / min(len(words_a), len(words_b))
+
+
+@dataclass(frozen=True)
+class ConsensusRules:
+    min_liquidity: float
+    min_hours_to_resolution: float
+    max_days_to_resolution: float
+    match_threshold: float
+    min_edge: float
+    min_manifold_bettors: int
+    min_manifold_liquidity: float
+    min_metaculus_forecasters: int
+    stake_usd: float
+
+
+@dataclass(frozen=True)
+class ConsensusForecast:
+    title: str
+    content: str
+    source: str
+
+
+@dataclass(frozen=True)
+class ConsensusInputs:
+    market_id: str
+    question: str
+    market_probability: float
+    active: bool
+    liquidity_or_volume: float
+    category_blocked: bool
+    end_at: datetime | None
+    as_of: datetime
+    fee: float
+    forecasts: tuple[ConsensusForecast, ...]
+
+
+@dataclass(frozen=True)
+class ConsensusProposal:
+    market_id: str
+    instrument_id: str
+    consensus_source: str
+    consensus_probability: float
+    market_probability: float
+    overlap: float
+    buy_yes: bool
+    confidence: str
+    edge_percent: float
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+    evidence_summary: str
+
+
+def clean_title(title: str) -> str:
+    return re.sub(r"^\[(?:Manifold|Metaculus):\s*\d+%\]\s*", "", title).strip()
+
+
+def parse_probability(title: str) -> float | None:
+    match = re.match(r"^\[(?:Manifold|Metaculus):\s*(\d+)%\]", title)
+    if match is None:
+        return None
+    value = float(match.group(1)) / 100.0
+    return value if 0.0 <= value <= 1.0 else None
+
+
+def forecast_quality_ok(forecast: ConsensusForecast, rules: ConsensusRules) -> bool:
+    content = forecast.content or ""
+    if forecast.source == "Manifold":
+        bettors = re.search(r"Unique bettors:\s*([\d,]+)", content)
+        liquidity = re.search(r"Liquidity:\s*\$([\d,]+(?:\.\d+)?)", content)
+        return bool(
+            bettors
+            and liquidity
+            and int(bettors.group(1).replace(",", "")) >= rules.min_manifold_bettors
+            and float(liquidity.group(1).replace(",", "")) >= rules.min_manifold_liquidity
+        )
+    if forecast.source != "Metaculus":
+        return False
+    forecasters = re.search(r"Forecasters:\s*([\d,]+)", content)
+    return bool(
+        forecasters
+        and int(forecasters.group(1).replace(",", ""))
+        >= rules.min_metaculus_forecasters
+    )
+
+
+def assess_platform_consensus(
+    inputs: ConsensusInputs, rules: ConsensusRules
+) -> ConsensusProposal | None:
+    """Return a proposal without fetching, persistence, risk, or execution."""
+    if not inputs.active or inputs.liquidity_or_volume < rules.min_liquidity:
+        return None
+    if inputs.category_blocked or inputs.end_at is None:
+        return None
+    end_at = inputs.end_at
+    if end_at.tzinfo is None or end_at.utcoffset() is None:
+        end_at = end_at.replace(tzinfo=timezone.utc)
+    hours_left = (end_at - inputs.as_of).total_seconds() / 3600.0
+    if not rules.min_hours_to_resolution <= hours_left <= rules.max_days_to_resolution * 24:
+        return None
+    best: ConsensusForecast | None = None
+    best_overlap = 0.0
+    for forecast in inputs.forecasts:
+        if not forecast_quality_ok(forecast, rules):
+            continue
+        overlap = _word_overlap_score(inputs.question, clean_title(forecast.title))
+        if overlap > best_overlap:
+            best, best_overlap = forecast, overlap
+    if best is None or best_overlap < rules.match_threshold:
+        return None
+    probability = parse_probability(best.title)
+    if probability is None:
+        return None
+    edge = probability - inputs.market_probability
+    if abs(edge) < rules.min_edge + inputs.fee:
+        return None
+    buy_yes = edge > 0
+    title = clean_title(best.title)
+    evidence = (
+        f"Platform consensus follower: found matching market on {best.source} "
+        f"('{title[:80]}') with consensus probability {probability:.0%}. "
+        f"Market price is {inputs.market_probability:.0%}. Edge: {abs(edge):.1%}. "
+        f"Word overlap: {best_overlap:.2f}."
+    )
+    reference = inputs.market_probability if buy_yes else 1 - inputs.market_probability
+    return ConsensusProposal(
+        market_id=inputs.market_id,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        consensus_source=best.source,
+        consensus_probability=probability,
+        market_probability=inputs.market_probability,
+        overlap=best_overlap,
+        buy_yes=buy_yes,
+        confidence="high" if best_overlap >= 0.8 else "medium",
+        edge_percent=abs(edge) * 100,
+        reference_price=reference,
+        target_quantity=rules.stake_usd / reference,
+        max_notional=rules.stake_usd,
+        evidence_summary=evidence,
+    )
+
+
+@dataclass(frozen=True)
+class PlatformConsensusExperiment:
+    rules: ConsensusRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        del portfolio
+        data = snapshot.feature("platform_consensus_inputs")
+        proposal = assess_platform_consensus(ConsensusInputs(
+            market_id=snapshot.market_id,
+            question=str(data["question"]),
+            market_probability=float(data["market_probability"]),
+            active=bool(data["active"]),
+            liquidity_or_volume=float(data["liquidity_or_volume"]),
+            category_blocked=bool(data["category_blocked"]),
+            end_at=datetime.fromisoformat(data["end_at"]) if data["end_at"] else None,
+            as_of=snapshot.observed_at,
+            fee=float(data["fee"]),
+            forecasts=tuple(ConsensusForecast(**item) for item in data["forecasts"]),
+        ), self.rules)
+        if proposal is None:
+            return []
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale=proposal.evidence_summary,
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/resolution_lens.py
+++ b/auramaur/experiments/strategies/resolution_lens.py
@@ -1,0 +1,125 @@
+"""Pure proposal formation for resolution-criteria mispricing experiments."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+@dataclass(frozen=True)
+class ResolutionLensCandidate:
+    market_id: str
+    market_probability: float
+    fair_probability: float
+    gap_score: float
+    mechanism: str
+
+
+@dataclass(frozen=True)
+class ResolutionLensRules:
+    min_entry_price: float
+    high_conf_gap_score: float
+    stake_usd: float
+
+
+@dataclass(frozen=True)
+class ResolutionLensProposal:
+    market_id: str
+    fair_probability: float
+    market_probability: float
+    edge_percent: float
+    buy_yes: bool
+    high_confidence: bool
+    evidence_summary: str
+    mispricing_reason: str
+    instrument_id: str
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+
+
+def form_resolution_lens_proposal(
+    candidate: ResolutionLensCandidate,
+    rules: ResolutionLensRules,
+) -> ResolutionLensProposal | None:
+    """Turn an already-grounded lens candidate into bounded desired exposure."""
+    values = (
+        candidate.market_probability,
+        candidate.fair_probability,
+        candidate.gap_score,
+        rules.min_entry_price,
+        rules.high_conf_gap_score,
+        rules.stake_usd,
+    )
+    if (
+        not candidate.market_id
+        or not candidate.mechanism.strip()
+        or any(not math.isfinite(value) for value in values)
+        or not 0.0 <= candidate.market_probability <= 1.0
+        or not 0.0 <= candidate.fair_probability <= 1.0
+        or candidate.gap_score < 0.0
+        or not 0.0 <= rules.min_entry_price <= 1.0
+        or rules.high_conf_gap_score < 0.0
+        or rules.stake_usd <= 0.0
+    ):
+        return None
+
+    edge = candidate.fair_probability - candidate.market_probability
+    if edge == 0.0:
+        return None
+    buy_yes = edge > 0.0
+    if buy_yes and candidate.market_probability < rules.min_entry_price:
+        return None
+    reference_price = (
+        candidate.market_probability if buy_yes else 1.0 - candidate.market_probability
+    )
+    if not 0.0 < reference_price < 1.0:
+        return None
+    side = "YES" if buy_yes else "NO"
+    mechanism = candidate.mechanism.strip()
+    return ResolutionLensProposal(
+        market_id=candidate.market_id,
+        fair_probability=candidate.fair_probability,
+        market_probability=candidate.market_probability,
+        edge_percent=abs(edge) * 100.0,
+        buy_yes=buy_yes,
+        high_confidence=candidate.gap_score >= rules.high_conf_gap_score,
+        evidence_summary=f"Resolution lens (gap {candidate.gap_score:.2f}): {mechanism}",
+        mispricing_reason=f"behavioral: {mechanism}",
+        instrument_id=f"{candidate.market_id}:{side}",
+        reference_price=reference_price,
+        target_quantity=rules.stake_usd / reference_price,
+        max_notional=rules.stake_usd,
+    )
+
+
+@dataclass(frozen=True)
+class ResolutionLensExperiment:
+    rules: ResolutionLensRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot,
+    ) -> list[TargetPosition]:
+        del portfolio
+        value = snapshot.feature("resolution_lens_candidate")
+        proposal = form_resolution_lens_proposal(
+            ResolutionLensCandidate(
+                market_id=snapshot.market_id,
+                market_probability=float(value["market_probability"]),
+                fair_probability=float(value["fair_probability"]),
+                gap_score=float(value["gap_score"]),
+                mechanism=str(value["mechanism"]),
+            ),
+            self.rules,
+        )
+        if proposal is None:
+            return []
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale=proposal.evidence_summary,
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/experiments/strategies/settlement_arb.py
+++ b/auramaur/experiments/strategies/settlement_arb.py
@@ -1,0 +1,92 @@
+"""Pure published-outcome settlement-lag proposal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+def _bin_half_width(threshold: float) -> float:
+    text = f"{threshold:.10f}".rstrip("0")
+    decimals = len(text.split(".")[1]) if "." in text else 0
+    return 0.5 * (10.0 ** -decimals)
+
+
+def is_satisfied(value: float, operator: str, threshold: float) -> bool:
+    if operator == ">=":
+        return value >= threshold
+    if operator == ">":
+        return value > threshold
+    if operator == "<=":
+        return value <= threshold
+    if operator == "<":
+        return value < threshold
+    if operator == "==":
+        return abs(value - threshold) < _bin_half_width(threshold) + 1e-12
+    return False
+
+
+@dataclass(frozen=True)
+class SettlementProposal:
+    market_id: str
+    buy_yes: bool
+    fair_probability: float
+    market_probability: float
+    edge_percent: float
+    published_value: float
+    evidence_summary: str
+    target: TargetPosition
+
+
+def settlement_proposal(
+    *, market_id: str, yes_price: float, no_price: float, published_value: float,
+    indicator: str, reference_period: str, operator: str, threshold: float,
+    min_edge: float, stake_usd: float,
+) -> SettlementProposal | None:
+    yes_locked = is_satisfied(published_value, operator, threshold)
+    fair = 1.0 if yes_locked else 0.0
+    edge = fair - yes_price
+    if abs(edge) < min_edge:
+        return None
+    buy_yes = edge > 0
+    price = yes_price if buy_yes else no_price
+    if price <= 0:
+        return None
+    evidence = (
+        f"settlement_arb: {indicator} {reference_period} = {published_value:.2f} "
+        f"{operator} {threshold} -> {'YES' if yes_locked else 'NO'} locked"
+    )
+    return SettlementProposal(
+        market_id=market_id, buy_yes=buy_yes, fair_probability=fair,
+        market_probability=yes_price, edge_percent=abs(edge) * 100.0,
+        published_value=published_value, evidence_summary=evidence,
+        target=TargetPosition(
+            instrument_id=f"{market_id}:{'YES' if buy_yes else 'NO'}",
+            target_quantity=stake_usd / price,
+            reference_price=price,
+            rationale="official print already determines the criterion",
+            max_notional=stake_usd,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class SettlementArbExperiment:
+    min_edge: float
+    stake_usd: float
+
+    async def evaluate(self, snapshot: MarketSnapshot,
+                       portfolio: PortfolioSnapshot) -> list[TargetPosition]:
+        del portfolio
+        data = snapshot.feature("settlement_predicate")
+        proposal = settlement_proposal(
+            market_id=snapshot.market_id,
+            yes_price=snapshot.price(f"{snapshot.market_id}:YES"),
+            no_price=snapshot.price(f"{snapshot.market_id}:NO"),
+            published_value=float(data["published_value"]),
+            indicator=str(data["indicator"]), reference_period=str(data["reference_period"]),
+            operator=str(data["operator"]), threshold=float(data["threshold"]),
+            min_edge=self.min_edge, stake_usd=self.stake_usd,
+        )
+        return [proposal.target] if proposal else []

--- a/auramaur/experiments/strategies/term_structure.py
+++ b/auramaur/experiments/strategies/term_structure.py
@@ -1,0 +1,103 @@
+"""Pure candidate selection and target generation for deadline ladders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+@dataclass(frozen=True)
+class TermStructureCandidate:
+    market_id: str
+    market_probability: float
+    model_probability: float
+    liquidity: float
+    claimed: bool = False
+
+
+@dataclass(frozen=True)
+class TermStructureRules:
+    min_edge_percent: float
+    min_liquidity: float
+    max_entries: int
+    stake_usd: float
+
+
+@dataclass(frozen=True)
+class TermStructureProposal:
+    market_id: str
+    buy_yes: bool
+    instrument_id: str
+    market_probability: float
+    fair_probability: float
+    edge_percent: float
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+
+
+def select_term_structure_proposals(
+    candidates: list[TermStructureCandidate],
+    rules: TermStructureRules,
+) -> list[TermStructureProposal]:
+    """Select the largest executable curve gaps using production semantics."""
+    eligible: list[tuple[float, TermStructureCandidate]] = []
+    for candidate in candidates:
+        gap = abs(candidate.model_probability - candidate.market_probability) * 100.0
+        if (
+            candidate.claimed
+            or candidate.liquidity < rules.min_liquidity
+            or gap < rules.min_edge_percent
+        ):
+            continue
+        eligible.append((gap, candidate))
+    eligible.sort(key=lambda item: item[0], reverse=True)
+    proposals: list[TermStructureProposal] = []
+    for gap, candidate in eligible[: rules.max_entries]:
+        buy_yes = candidate.model_probability > candidate.market_probability
+        reference_price = (
+            candidate.market_probability if buy_yes else 1.0 - candidate.market_probability
+        )
+        if not 0.0 < reference_price < 1.0:
+            continue
+        proposals.append(TermStructureProposal(
+            market_id=candidate.market_id,
+            buy_yes=buy_yes,
+            instrument_id=f"{candidate.market_id}:{'YES' if buy_yes else 'NO'}",
+            market_probability=candidate.market_probability,
+            fair_probability=candidate.model_probability,
+            edge_percent=gap,
+            reference_price=reference_price,
+            target_quantity=rules.stake_usd / reference_price,
+            max_notional=rules.stake_usd,
+        ))
+    return proposals
+
+
+@dataclass(frozen=True)
+class TermStructureExperiment:
+    rules: TermStructureRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot,
+    ) -> list[TargetPosition]:
+        del portfolio
+        details = snapshot.feature("term_structure_candidates")
+        proposals = select_term_structure_proposals(
+            [TermStructureCandidate(
+                market_id=str(item["market_id"]),
+                market_probability=float(item["market_probability"]),
+                model_probability=float(item["model_probability"]),
+                liquidity=float(item["liquidity"]),
+                claimed=bool(item.get("claimed", False)),
+            ) for item in details],
+            self.rules,
+        )
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale="deadline-ladder curve mispricing",
+            max_notional=proposal.max_notional,
+        ) for proposal in proposals]

--- a/auramaur/experiments/strategies/vol_anchor.py
+++ b/auramaur/experiments/strategies/vol_anchor.py
@@ -1,0 +1,286 @@
+"""Pure deterministic candidate-to-proposal logic for vol-anchor markets."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+_ASSETS = {
+    "bitcoin": "bitcoin",
+    "btc": "bitcoin",
+    "ethereum": "ethereum",
+    "eth": "ethereum",
+    "solana": "solana",
+    "sol": "solana",
+    "xrp": "ripple",
+    "dogecoin": "dogecoin",
+    "doge": "dogecoin",
+}
+_MONTHS = {
+    month.lower(): index + 1
+    for index, month in enumerate(
+        [
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December",
+        ]
+    )
+}
+_STRIKE = r"\$([0-9][0-9,]*(?:\.[0-9]+)?)"
+_DATE = r"([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s*(\d{4}))?"
+_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("touch_up", re.compile(rf"\b(?:reach|hit)\s+{_STRIKE}.*\bby\s+{_DATE}\s*\??\s*$", re.I)),
+    ("touch_down", re.compile(rf"\b(?:dip|fall|drop)\s+to\s+{_STRIKE}.*\bby\s+{_DATE}\s*\??\s*$", re.I)),
+    ("above", re.compile(rf"\bbe\s+above\s+{_STRIKE}\s+on\s+{_DATE}\s*\??\s*$", re.I)),
+    ("below", re.compile(rf"\bbe\s+below\s+{_STRIKE}\s+on\s+{_DATE}\s*\??\s*$", re.I)),
+)
+
+
+def _phi(value: float) -> float:
+    return 0.5 * (1.0 + math.erf(value / math.sqrt(2.0)))
+
+
+def touch_prob(spot: float, barrier: float, sigma: float, t_years: float) -> float:
+    if spot <= 0 or barrier <= 0 or sigma <= 0 or t_years <= 0:
+        return 0.0
+    distance = math.log(barrier / spot)
+    drift = -0.5 * sigma * sigma
+    if distance == 0:
+        return 1.0
+    if distance < 0:
+        distance, drift = -distance, -drift
+    scaled_time = sigma * math.sqrt(t_years)
+    probability = _phi((drift * t_years - distance) / scaled_time) + math.exp(
+        2.0 * drift * distance / (sigma * sigma)
+    ) * _phi((-drift * t_years - distance) / scaled_time)
+    return min(1.0, max(0.0, probability))
+
+
+def terminal_above_prob(
+    spot: float, strike: float, sigma: float, t_years: float
+) -> float:
+    if spot <= 0 or strike <= 0 or sigma <= 0 or t_years <= 0:
+        return 0.0
+    scaled_time = sigma * math.sqrt(t_years)
+    distance = (
+        math.log(spot / strike) - 0.5 * sigma * sigma * t_years
+    ) / scaled_time
+    return min(1.0, max(0.0, _phi(distance)))
+
+
+def blended_sigma(
+    realized: float, anchor: float, t_years: float, tau_years: float
+) -> float:
+    weight = math.exp(-t_years / max(tau_years, 1e-6))
+    return anchor + (realized - anchor) * weight
+
+
+def parse_threshold(
+    question: str, *, default_year: int | None = None
+) -> tuple[str, float, datetime] | None:
+    for kind, pattern in _PATTERNS:
+        match = pattern.search((question or "").strip())
+        if match is None:
+            continue
+        try:
+            strike = float(match.group(1).replace(",", ""))
+            month = _MONTHS.get(match.group(2).lower())
+            if month is None:
+                continue
+            year = int(match.group(4)) if match.group(4) else (
+                default_year or datetime.now(timezone.utc).year
+            )
+            deadline = datetime(year, month, int(match.group(3)), tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        return kind, strike, deadline
+    return None
+
+
+def detect_asset(question: str) -> str | None:
+    lowered = (question or "").lower()
+    for keyword, asset in _ASSETS.items():
+        if re.search(rf"\b{keyword}\b", lowered):
+            return asset
+    return None
+
+
+class VolAnchorRejection(str, Enum):
+    INACTIVE = "inactive"
+    WRONG_VENUE = "wrong_venue"
+    INSUFFICIENT_LIQUIDITY = "insufficient_liquidity"
+    INVALID_MARKET_PRICE = "invalid_market_price"
+    BLOCKED_CATEGORY = "blocked_category"
+    UNSUPPORTED_MARKET = "unsupported_market"
+    MISSING_ASSET_STATE = "missing_asset_state"
+    EXPIRED = "expired"
+    MISSING_ANCHOR = "missing_anchor"
+    INSUFFICIENT_EDGE = "insufficient_edge"
+    ALREADY_HELD = "already_held"
+
+
+@dataclass(frozen=True)
+class VolAnchorRules:
+    min_liquidity: float
+    min_edge_pts: float
+    stake_usd: float
+    tau_years: float
+    long_run_vol: dict[str, float]
+
+
+@dataclass(frozen=True)
+class VolAnchorInputs:
+    market_id: str
+    question: str
+    yes_price: float
+    no_price: float
+    active: bool
+    venue: str
+    liquidity: float
+    category_blocked: bool
+    as_of: datetime
+    spot: float | None
+    realized_vol: float | None
+    already_held: bool
+    term_sigma: float | None = None
+
+
+@dataclass(frozen=True)
+class VolAnchorProposal:
+    market_id: str
+    asset: str
+    kind: str
+    strike: float
+    deadline: datetime
+    spot: float
+    realized_vol: float
+    sigma: float
+    sigma_source: str
+    fair_probability: float
+    market_probability: float
+    edge_percent: float
+    buy_yes: bool
+    instrument_id: str
+    target_quantity: float
+    max_notional: float
+
+
+@dataclass(frozen=True)
+class VolAnchorAssessment:
+    proposal: VolAnchorProposal | None
+    rejection: VolAnchorRejection | None = None
+
+
+def assess_vol_anchor(
+    inputs: VolAnchorInputs, rules: VolAnchorRules
+) -> VolAnchorAssessment:
+    """Return the same proposal for research, replay, shadow, and production."""
+    if not inputs.active:
+        return VolAnchorAssessment(None, VolAnchorRejection.INACTIVE)
+    if (inputs.venue or "polymarket") != "polymarket":
+        return VolAnchorAssessment(None, VolAnchorRejection.WRONG_VENUE)
+    if inputs.liquidity < rules.min_liquidity:
+        return VolAnchorAssessment(None, VolAnchorRejection.INSUFFICIENT_LIQUIDITY)
+    if not 0.02 <= inputs.yes_price <= 0.98:
+        return VolAnchorAssessment(None, VolAnchorRejection.INVALID_MARKET_PRICE)
+    if inputs.category_blocked:
+        return VolAnchorAssessment(None, VolAnchorRejection.BLOCKED_CATEGORY)
+    asset = detect_asset(inputs.question)
+    parsed = parse_threshold(inputs.question, default_year=inputs.as_of.year)
+    if asset is None or parsed is None:
+        return VolAnchorAssessment(None, VolAnchorRejection.UNSUPPORTED_MARKET)
+    if inputs.spot is None or inputs.realized_vol is None:
+        return VolAnchorAssessment(None, VolAnchorRejection.MISSING_ASSET_STATE)
+    kind, strike, deadline = parsed
+    t_years = (deadline - inputs.as_of).total_seconds() / (365.0 * 86400.0)
+    if t_years <= 0:
+        return VolAnchorAssessment(None, VolAnchorRejection.EXPIRED)
+    anchor = rules.long_run_vol.get(asset, 0.0)
+    if anchor <= 0:
+        return VolAnchorAssessment(None, VolAnchorRejection.MISSING_ANCHOR)
+    sigma = inputs.term_sigma
+    sigma_source = "deribit_iv"
+    if sigma is None:
+        sigma = blended_sigma(inputs.realized_vol, anchor, t_years, rules.tau_years)
+        sigma_source = "blend"
+    if kind in ("touch_up", "touch_down"):
+        fair = touch_prob(inputs.spot, strike, sigma, t_years)
+    elif kind == "above":
+        fair = terminal_above_prob(inputs.spot, strike, sigma, t_years)
+    else:
+        fair = 1.0 - terminal_above_prob(inputs.spot, strike, sigma, t_years)
+    edge = abs(fair - inputs.yes_price) * 100.0
+    if edge < rules.min_edge_pts:
+        return VolAnchorAssessment(None, VolAnchorRejection.INSUFFICIENT_EDGE)
+    if inputs.already_held:
+        return VolAnchorAssessment(None, VolAnchorRejection.ALREADY_HELD)
+    buy_yes = fair > inputs.yes_price
+    entry_price = inputs.yes_price if buy_yes else inputs.no_price
+    return VolAnchorAssessment(VolAnchorProposal(
+        market_id=inputs.market_id,
+        asset=asset,
+        kind=kind,
+        strike=strike,
+        deadline=deadline,
+        spot=inputs.spot,
+        realized_vol=inputs.realized_vol,
+        sigma=sigma,
+        sigma_source=sigma_source,
+        fair_probability=fair,
+        market_probability=inputs.yes_price,
+        edge_percent=edge,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        target_quantity=rules.stake_usd / entry_price,
+        max_notional=rules.stake_usd,
+    ))
+
+
+@dataclass(frozen=True)
+class VolAnchorExperiment:
+    rules: VolAnchorRules
+
+    async def evaluate(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> list[TargetPosition]:
+        details = snapshot.feature("vol_anchor_inputs")
+        assessment = assess_vol_anchor(
+            VolAnchorInputs(
+                market_id=snapshot.market_id,
+                question=str(details["question"]),
+                yes_price=float(details["yes_price"]),
+                no_price=float(details["no_price"]),
+                active=bool(details["active"]),
+                venue=snapshot.venue,
+                liquidity=float(details["liquidity"]),
+                category_blocked=bool(details["category_blocked"]),
+                as_of=snapshot.observed_at,
+                spot=details.get("spot"),
+                realized_vol=details.get("realized_vol"),
+                already_held=bool(details["already_held"]),
+                term_sigma=details.get("term_sigma"),
+            ),
+            self.rules,
+        )
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        entry_price = snapshot.price(proposal.instrument_id)
+        current = portfolio.quantities().get(proposal.instrument_id, 0.0)
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=max(current, proposal.target_quantity),
+            reference_price=entry_price,
+            rationale=(
+                f"vol-anchor {proposal.kind}: {proposal.sigma_source} sigma "
+                f"{proposal.sigma:.3f}, fair {proposal.fair_probability:.3f}"
+            ),
+            max_notional=max(
+                proposal.max_notional,
+                max(current, proposal.target_quantity) * entry_price,
+            ),
+        )]

--- a/auramaur/experiments/strategies/weather_temp.py
+++ b/auramaur/experiments/strategies/weather_temp.py
@@ -1,0 +1,127 @@
+"""Pure weather-temperature candidate assessment for every runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+
+class WeatherTempRejection(str, Enum):
+    NO_MODEL_PRICE = "no_model_price"
+    INSUFFICIENT_EDGE = "insufficient_edge"
+    IMPLAUSIBLE_DIVERGENCE = "implausible_divergence"
+    ALREADY_ENTERED_OR_HELD = "already_entered_or_held"
+
+
+@dataclass(frozen=True)
+class WeatherTempRules:
+    required_edge: float
+    max_divergence: float
+    stake_usd: float
+
+
+@dataclass(frozen=True)
+class WeatherTempInputs:
+    market_id: str
+    market_probability: float
+    model_probability: float | None
+    member_count: int
+    city: str
+    temperature_kind: str
+    already_entered_or_held: bool
+
+
+@dataclass(frozen=True)
+class WeatherTempProposal:
+    market_id: str
+    buy_yes: bool
+    instrument_id: str
+    market_probability: float
+    model_probability: float
+    edge_percent: float
+    reference_price: float
+    target_quantity: float
+    max_notional: float
+    evidence_summary: str
+
+
+@dataclass(frozen=True)
+class WeatherTempAssessment:
+    proposal: WeatherTempProposal | None
+    rejection: WeatherTempRejection | None = None
+
+
+def assess_weather_temp(
+    inputs: WeatherTempInputs,
+    rules: WeatherTempRules,
+) -> WeatherTempAssessment:
+    model_probability = inputs.model_probability
+    if model_probability is None:
+        return WeatherTempAssessment(None, WeatherTempRejection.NO_MODEL_PRICE)
+    edge = model_probability - inputs.market_probability
+    if abs(edge) < rules.required_edge:
+        return WeatherTempAssessment(None, WeatherTempRejection.INSUFFICIENT_EDGE)
+    if abs(edge) > rules.max_divergence:
+        return WeatherTempAssessment(None, WeatherTempRejection.IMPLAUSIBLE_DIVERGENCE)
+    if inputs.already_entered_or_held:
+        return WeatherTempAssessment(None, WeatherTempRejection.ALREADY_ENTERED_OR_HELD)
+
+    buy_yes = edge > 0
+    reference_price = (
+        inputs.market_probability if buy_yes else 1.0 - inputs.market_probability
+    )
+    return WeatherTempAssessment(WeatherTempProposal(
+        market_id=inputs.market_id,
+        buy_yes=buy_yes,
+        instrument_id=f"{inputs.market_id}:{'YES' if buy_yes else 'NO'}",
+        market_probability=inputs.market_probability,
+        model_probability=model_probability,
+        edge_percent=abs(edge) * 100.0,
+        reference_price=reference_price,
+        target_quantity=rules.stake_usd / reference_price,
+        max_notional=rules.stake_usd,
+        evidence_summary=(
+            f"GEFS ensemble P(bin)={model_probability:.2f} "
+            f"({inputs.member_count} members) vs market "
+            f"{inputs.market_probability:.2f} for {inputs.city} "
+            f"{inputs.temperature_kind} temp."
+        ),
+    ))
+
+
+@dataclass(frozen=True)
+class WeatherTempExperiment:
+    rules: WeatherTempRules
+
+    async def evaluate(
+        self,
+        snapshot: MarketSnapshot,
+        portfolio: PortfolioSnapshot,
+    ) -> list[TargetPosition]:
+        del portfolio
+        details = snapshot.feature("weather_temp_inputs")
+        raw_model = details["model_probability"]
+        assessment = assess_weather_temp(
+            WeatherTempInputs(
+                market_id=snapshot.market_id,
+                market_probability=float(details["market_probability"]),
+                model_probability=None if raw_model is None else float(raw_model),
+                member_count=int(details["member_count"]),
+                city=str(details["city"]),
+                temperature_kind=str(details["temperature_kind"]),
+                already_entered_or_held=bool(details["already_entered_or_held"]),
+            ),
+            self.rules,
+        )
+        if assessment.proposal is None:
+            return []
+        proposal = assessment.proposal
+        return [TargetPosition(
+            instrument_id=proposal.instrument_id,
+            target_quantity=proposal.target_quantity,
+            reference_price=proposal.reference_price,
+            rationale=proposal.evidence_summary,
+            max_notional=proposal.max_notional,
+        )]

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -34,7 +34,6 @@ settlement-based, like bias_harvest/long_horizon.
 from __future__ import annotations
 
 import asyncio
-import json
 import tempfile
 from datetime import datetime, timedelta, timezone
 
@@ -44,6 +43,12 @@ from auramaur.strategy.protocols import ExecutionMode
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.experiments.strategies.agent_trader import (
+    AgentTraderInputs,
+    AgentTraderRules,
+    assess_agent_trader,
+    parse_decisions,
+)
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 
 log = structlog.get_logger()
@@ -118,41 +123,6 @@ CREATE TABLE IF NOT EXISTS agent_trader_theses (
     created_at TEXT DEFAULT (datetime('now'))
 )
 """
-
-
-def parse_decisions(raw: str, max_entries: int) -> list[dict]:
-    """Tolerant parse of the model's JSON: accepts fenced/prefixed output,
-    drops malformed entries, clamps probabilities, caps the count. Returns
-    ``[]`` on anything unparseable — a bad LLM reply must never crash a cycle."""
-    text = raw.strip()
-    start, end = text.find("{"), text.rfind("}")
-    if start < 0 or end <= start:
-        return []
-    try:
-        payload = json.loads(text[start:end + 1])
-    except (json.JSONDecodeError, ValueError):
-        return []
-    decisions = payload.get("decisions")
-    if not isinstance(decisions, list):
-        return []
-    out: list[dict] = []
-    for d in decisions:
-        if not isinstance(d, dict):
-            continue
-        market_id = str(d.get("market_id", "")).strip()
-        thesis = str(d.get("thesis", "")).strip()
-        try:
-            prob = float(d.get("prob_yes"))
-        except (TypeError, ValueError):
-            continue
-        if not market_id or not thesis:
-            continue
-        if not (0.0 < prob < 1.0):
-            continue
-        out.append({"market_id": market_id, "prob_yes": prob, "thesis": thesis})
-        if len(out) >= max_entries:
-            break
-    return out
 
 
 class AgentTraderPillar:
@@ -597,14 +567,26 @@ class AgentTraderPillar:
 
     async def _try_enter(self, alias: str, market: Market, decision: dict,
                          cfg) -> bool:
-        prob_yes = decision["prob_yes"]
-        market_yes = market.outcome_yes_price
-        edge_pts = abs(prob_yes - market_yes) * 100.0
-        if edge_pts < cfg.min_edge_pts:
+        assessment = assess_agent_trader(AgentTraderInputs(
+            market_id=market.id,
+            question=market.question,
+            market_yes=market.outcome_yes_price,
+            prob_yes=decision["prob_yes"],
+            thesis=decision["thesis"],
+        ), AgentTraderRules(
+            min_edge_pts=cfg.min_edge_pts,
+            stake_usd=cfg.stake_usd,
+            source_tag=self.cell(alias),
+        ))
+        if assessment.proposal is None:
             log.debug("agent_trader.edge_below_floor", alias=alias,
-                      market_id=market.id, edge=round(edge_pts, 1))
+                      market_id=market.id, rejection=assessment.rejection)
             return False
-        side = OrderSide.BUY if prob_yes > market_yes else OrderSide.SELL
+        proposal = assessment.proposal
+        prob_yes = proposal.probability_yes
+        market_yes = proposal.market_probability
+        edge_pts = proposal.edge_percent
+        side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
 
         # ONE POSITION PER MARKET, across the whole bot. Settlement attribution
         # is market-level earliest-entrant-wins (ledger._ENTRY_STRATEGY_SQL), so
@@ -621,7 +603,7 @@ class AgentTraderPillar:
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0)""",
                 (alias, self.cell(alias), market.id, market.question,
                  "YES" if side == OrderSide.BUY else "NO",
-                 prob_yes, market_yes, decision["thesis"][:500]),
+                 prob_yes, market_yes, proposal.thesis),
             )
             await self._db.commit()
             log.info("agent_trader.market_claimed", alias=alias,
@@ -635,10 +617,10 @@ class AgentTraderPillar:
             claude_confidence=Confidence.MEDIUM,
             market_prob=market_yes,
             edge=edge_pts,
-            evidence_summary=decision["thesis"][:500],
+            evidence_summary=proposal.thesis,
             recommended_side=side,
-            strategy_source=self.cell(alias),
-            mispricing_reason=decision["thesis"][:300],
+            strategy_source=proposal.source_tag,
+            mispricing_reason=proposal.thesis[:300],
         )
         await self._persist_signal(signal, market)
 
@@ -667,7 +649,7 @@ class AgentTraderPillar:
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (alias, self.cell(alias), market.id, market.question,
              res.order.token.value,
-             prob_yes, market_yes, decision["thesis"][:500], size),
+             prob_yes, market_yes, proposal.thesis, size),
         )
         await self._db.commit()
         log.info("agent_trader.entered", alias=alias, market_id=market.id,

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -25,6 +25,11 @@ import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.experiments.strategies.econ_indicator import (
+    EconIndicatorInputs,
+    EconIndicatorRejection,
+    assess_econ_indicator,
+)
 from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.econ_pricing import (
     estimate_distribution,
@@ -172,26 +177,28 @@ class EconIndicatorPillar:
     async def _enter_if_edge(self, market: Market, model_p: float) -> bool:
         cfg = self._settings.econ_indicator
         market_p = market.outcome_yes_price
-        edge = model_p - market_p
-        if abs(edge) < self._required_edge(market):
-            return False
-        # Implausible-disagreement guard: a random-walk nowcast that disagrees
-        # with the market by a huge margin is naive (the crowd prices forward
-        # info the model lacks), not an edge — trust the market and skip.
-        if abs(edge) > cfg.max_divergence:
+        assessment = assess_econ_indicator(EconIndicatorInputs(
+            market_id=market.id,
+            market_probability=market_p,
+            model_probability=model_p,
+            required_edge=self._required_edge(market),
+            max_divergence=cfg.max_divergence,
+            already_entered_or_held=await self._already_entered_or_held(market.id),
+        ))
+        if assessment.rejection == EconIndicatorRejection.IMPLAUSIBLE_DIVERGENCE:
             log.info("econ_indicator.implausible_divergence", market_id=market.id,
                      model_p=round(model_p, 3), market_p=round(market_p, 3))
+        if assessment.proposal is None:
             return False
-        if await self._already_entered_or_held(market.id):
-            return False
-        side = OrderSide.BUY if edge > 0 else OrderSide.SELL  # SELL -> Kalshi buys NO
+        proposal = assessment.proposal
+        side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
         signal = Signal(
             market_id=market.id,
             market_question=market.question,
-            claude_prob=max(0.01, min(0.99, model_p)),
+            claude_prob=proposal.signal_probability,
             claude_confidence=Confidence.MEDIUM,
             market_prob=market_p,
-            edge=abs(edge) * 100.0,
+            edge=proposal.edge_percent,
             evidence_summary=(
                 f"Econ-indicator model P(above)={model_p:.2f} vs market "
                 f"{market_p:.2f} from {spec_for_series(market.ticker.split('-')[0]).fred_series} history."

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -19,6 +19,11 @@ import structlog
 from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
 from auramaur.killswitch import kill_switch_present
 from auramaur.exchange.models import Market, OrderSide, Signal
+from auramaur.experiments.strategies.core_trading import (
+    CoreTradingInputs,
+    CoreTradingRules,
+    assess_core_trading,
+)
 from auramaur.monitoring.display import (
     show_cycle_summary,
     show_risk_decision,
@@ -749,21 +754,38 @@ class CycleOrchestrationMixin:
                     )
             market_prob = market.outcome_yes_price
 
-            # Edge calculation (same as detect_edge)
+            # Pure proposal formation; strategic intentionally retains its
+            # historic direct estimate (no second-opinion blend/negation gate).
             raw_edge = claude_prob - market_prob
             log.info("strategic.edge_calc", market_id=market.id,
                      claude=round(claude_prob, 3), market=round(market_prob, 3),
                      raw_edge=round(raw_edge, 3))
-            if abs(raw_edge) < 0.001:
-                continue
-            side = OrderSide.BUY if raw_edge > 0 else OrderSide.SELL
             # Taker fee coefficient applies to per-contract P*(1-P), not a flat
             # percentage. Polymarket is per-category (see taker_fee_rate); this
             # is a crossing execution path so the taker rate is the right one.
             fee_rate = taker_fee_rate(
                 market.exchange or self.exchange_name, market.category, exchange_fees,
                 actual_fee_rate=market.fee_rate, fees_enabled=market.fees_enabled)
-            edge = abs(raw_edge) - fee_rate * market_prob * (1.0 - market_prob)
+            assessment = assess_core_trading(
+                CoreTradingInputs(
+                    market_id=market.id,
+                    question=market.question,
+                    market_probability=market_prob,
+                    model_probability=claude_prob,
+                    confidence=batch_result.confidence,
+                    second_opinion_probability=batch_result.second_opinion_prob,
+                    divergence=batch_result.divergence,
+                    reasoning=batch_result.reasoning,
+                    evidence_count=0,
+                    hours_to_resolution=None,
+                    fee_rate=fee_rate,
+                ),
+                CoreTradingRules(False, False, False, 1.0, False),
+            )
+            if assessment.proposal is None:
+                continue
+            proposal = assessment.proposal
+            side = OrderSide(proposal.side)
 
             signal = Signal(
                 market_id=market.id,
@@ -771,10 +793,10 @@ class CycleOrchestrationMixin:
                 claude_prob=claude_prob,
                 claude_confidence=Confidence(batch_result.confidence),
                 market_prob=market_prob,
-                edge=edge * 100,
+                edge=proposal.edge_percent,
                 second_opinion_prob=batch_result.second_opinion_prob,
                 divergence=batch_result.divergence,
-                evidence_summary=batch_result.reasoning[:500],
+                evidence_summary=proposal.evidence_summary,
                 recommended_side=side,
             )
 

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -24,6 +24,12 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.informed_flow import (
+    InformedFlowInputs,
+    InformedFlowRules,
+    assess_informed_flow,
+    informed_flow_eligibility,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.strategy.informed_flow import KalshiTradeTape
@@ -98,40 +104,55 @@ class InformedFlowPillar:
     # ------------------------------------------------------------------
 
     def _eligible(self, market: Market) -> bool:
-        cfg = self._settings.informed_flow
-        if not market.active:
-            return False
-        if (market.exchange or "kalshi") != "kalshi":
-            return False
-        if not market.ticker:
-            return False  # need the ticker to pull the tape
-        p_yes = market.outcome_yes_price
-        if not (cfg.band_lo <= p_yes <= cfg.band_hi):
-            return False  # extremes: ATS is noise / already near-resolved
-        if market.liquidity < cfg.min_liquidity:
-            return False
         hit = blocked_category_hit(set(self._settings.risk.blocked_categories),
                                    market.question, market.description, market.category)
         if hit:
             log.debug("informed_flow.skip_category", market_id=market.id, category=hit)
-            return False
-        if market.end_date is None:
-            return False
+        return informed_flow_eligibility(
+            self._proposal_inputs(market, blocked=bool(hit)),
+            self._proposal_rules(),
+        ) is None
+
+    def _proposal_rules(self) -> InformedFlowRules:
+        cfg = self._settings.informed_flow
+        return InformedFlowRules(
+            band_lo=cfg.band_lo, band_hi=cfg.band_hi,
+            min_liquidity=cfg.min_liquidity,
+            min_hours_to_resolution=cfg.min_hours_to_resolution,
+            max_days_to_resolution=cfg.max_days_to_resolution,
+            uplift=cfg.uplift, stake_usd=cfg.stake_usd,
+        )
+
+    def _proposal_inputs(self, market: Market, *, blocked: bool = False,
+                         already: bool = False, flow=None) -> InformedFlowInputs:
         end = market.end_date
-        if end.tzinfo is None:
+        if end is not None and end.tzinfo is None:
             end = end.replace(tzinfo=timezone.utc)
-        hours_left = (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
-        if hours_left < cfg.min_hours_to_resolution:
-            return False
-        if hours_left > cfg.max_days_to_resolution * 24.0:
-            return False
-        return True
+        hours_left = (
+            (end - datetime.now(timezone.utc)).total_seconds() / 3600.0
+            if end is not None else None
+        )
+        return InformedFlowInputs(
+            market_id=market.id, venue=market.exchange or "kalshi",
+            ticker=market.ticker, active=market.active,
+            market_probability=market.outcome_yes_price,
+            liquidity=market.liquidity, blocked_category=blocked,
+            hours_to_resolution=hours_left,
+            already_entered_or_held=already,
+            has_signal=bool(flow and flow.has_signal),
+            informed_side=flow.informed_side if flow else None,
+            abnormal_count=flow.abnormal_count if flow else 0,
+            baseline_size=flow.baseline_size if flow else 0.0,
+            signal_volume=flow.signal_volume if flow else 0.0,
+            sample=flow.sample if flow else 0,
+        )
 
     async def _try_enter(self, market: Market) -> bool:
         cfg = self._settings.informed_flow
         if not self._eligible(market):
             return False
-        if await self._already_entered_or_held(market.id):
+        already = await self._already_entered_or_held(market.id)
+        if already:
             return False
 
         # Only NOW pull the tape (bounded API cost) and detect informed flow.
@@ -149,28 +170,26 @@ class InformedFlowPillar:
             source_at=datetime.now(timezone.utc) if self._tape.last_ok else None,
             item_count=self._tape.last_count,
         ))
-        if not flow.has_signal or flow.informed_side is None:
+        proposal = assess_informed_flow(
+            self._proposal_inputs(market, already=already, flow=flow),
+            self._proposal_rules(),
+        ).proposal
+        if proposal is None:
             return False
 
-        fav_is_yes = flow.informed_side == "yes"
+        fav_is_yes = proposal.buy_yes
         p_yes = market.outcome_yes_price
         # Forecast-free: follow the informed side with a small uplift (stays under
         # the 0.05 divergence-filter floor so a MEDIUM-confidence follow isn't
         # blocked, as in bias_harvest).
-        claude_prob = (min(0.99, p_yes + cfg.uplift) if fav_is_yes
-                       else max(0.01, p_yes - cfg.uplift))
         signal = Signal(
             market_id=market.id,
             market_question=market.question,
-            claude_prob=claude_prob,
+            claude_prob=proposal.model_probability,
             claude_confidence=Confidence.MEDIUM,
             market_prob=p_yes,
-            edge=cfg.uplift * 100.0,
-            evidence_summary=(
-                f"Informed-flow follow: {flow.abnormal_count} abnormal trades "
-                f"({flow.signal_volume:.0f} contracts) on the {flow.informed_side.upper()} "
-                f"side vs a {flow.baseline_size:.0f}-size baseline (n={flow.sample})."
-            ),
+            edge=proposal.edge_percent,
+            evidence_summary=proposal.evidence_summary,
             recommended_side=OrderSide.BUY if fav_is_yes else OrderSide.SELL,
             strategy_source="informed_flow",
             mispricing_reason=(

--- a/auramaur/strategy/interim_manager.py
+++ b/auramaur/strategy/interim_manager.py
@@ -19,11 +19,17 @@ Two rules make it self-retiring:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.interim_manager import (
+    InterimManagerInputs,
+    InterimManagerRejection,
+    InterimManagerRules,
+    assess_interim_manager,
+)
 from auramaur.exchange.models import Confidence, OrderSide, Signal
 from auramaur.risk.graduation import GraduationLadder
 from auramaur.strategy.classifier import ensure_category
@@ -32,7 +38,6 @@ from auramaur.strategy.protocols import ExecutionMode
 log = structlog.get_logger()
 
 _GRADUATED = {"live", "probation"}
-_MIN_THESIS_CHARS = 40
 
 
 class InterimManagerPillar:
@@ -112,20 +117,10 @@ class InterimManagerPillar:
     # ------------------------------------------------------------------
 
     async def _decide_one(self, p: dict, owned: dict[str, str]) -> bool:
+        from auramaur.strategy.signals import taker_fee_rate
+
         cfg = self._settings.interim_manager
         pid = p["id"]
-
-        created = self._parse_ts(p.get("created_at"))
-        if created is not None and datetime.now(timezone.utc) - created > timedelta(
-                hours=cfg.proposal_ttl_hours):
-            await self._resolve(pid, "expired", "proposal ttl elapsed")
-            return False
-
-        thesis = (p.get("thesis") or "").strip()
-        if len(thesis) < _MIN_THESIS_CHARS:
-            await self._resolve(pid, "skipped",
-                                "charter: no nameable mispricing mechanism")
-            return False
 
         venue = p["venue"]
         discovery = self._discoveries.get(venue)
@@ -141,55 +136,68 @@ class InterimManagerPillar:
 
         category = ensure_category(market.question, market.description,
                                    market.category)
-        if category in owned:
-            await self._resolve(pid, "skipped", f"delegated to {owned[category]}")
-            return False
-
-        # Machine-checkable sunset: an information/time bound the proposer set.
-        sunset = self._parse_ts(p.get("sunset_at"))
-        if sunset is not None and datetime.now(timezone.utc) >= sunset:
-            await self._resolve(pid, "expired", "thesis sunset reached")
-            return False
-
         open_now = await self._open_positions()
-        if open_now >= cfg.max_open_positions:
-            log.info("interim_manager.position_cap", open=open_now)
-            return False  # stays pending; retried next cycle
-
-        side = OrderSide.BUY if str(p["side"]).upper() == "BUY" else OrderSide.SELL
-
-        # Entry-price limit: the mechanical guard that protects the edge.
-        # Expressed as the max price PAID for the side taken (BUY pays the
-        # YES price; SELL pays the NO price).
-        entry_price = (market.outcome_yes_price if side == OrderSide.BUY
-                       else 1.0 - market.outcome_yes_price)
-        max_entry = p.get("max_entry_price")
-        if max_entry is not None and entry_price > float(max_entry) + 1e-9:
-            await self._resolve(
-                pid, "skipped",
-                f"entry {entry_price:.3f} above limit {float(max_entry):.3f}")
+        assessment = assess_interim_manager(
+            InterimManagerInputs(
+                proposal_id=pid, market_id=market.id,
+                thesis=p.get("thesis") or "", side=str(p["side"]),
+                fair_probability=float(p["fair_prob"]),
+                requested_stake_usd=float(p["stake_usd"]),
+                market_yes_price=float(market.outcome_yes_price),
+                market_liquidity=float(market.liquidity or 0), category=category,
+                created_at=self._parse_ts(p.get("created_at")),
+                sunset_at=self._parse_ts(p.get("sunset_at")),
+                as_of=datetime.now(timezone.utc), delegated_to=owned.get(category),
+                open_positions=open_now,
+                open_positions_in_category=await self._open_positions_in_category(category),
+                fee_rate=taker_fee_rate(market.exchange or "kalshi", category),
+                confidence_lo=float(p["confidence_lo"]) if p.get("confidence_lo") is not None else None,
+                confidence_hi=float(p["confidence_hi"]) if p.get("confidence_hi") is not None else None,
+                max_entry_price=float(p["max_entry_price"]) if p.get("max_entry_price") is not None else None,
+            ),
+            InterimManagerRules(
+                proposal_ttl_hours=cfg.proposal_ttl_hours,
+                max_open_positions=cfg.max_open_positions,
+                min_robust_edge=cfg.min_robust_edge,
+                default_uncertainty_buffer=cfg.default_uncertainty_buffer,
+                slippage_buffer=cfg.slippage_buffer,
+                liquidity_penalty=cfg.liquidity_penalty,
+                thin_liquidity_usd=cfg.thin_liquidity_usd,
+                correlation_penalty_per_position=cfg.correlation_penalty_per_position,
+                stake_usd=cfg.stake_usd, paper=cfg.paper,
+            ),
+        )
+        if assessment.proposal is None:
+            if assessment.robust_edge is not None:
+                await self._db.execute(
+                    "UPDATE manager_proposals SET robust_edge = ?, decision_price = ? "
+                    "WHERE id = ?",
+                    (round(assessment.robust_edge, 4), assessment.decision_price, pid),
+                )
+                await self._db.commit()
+            if assessment.rejection == InterimManagerRejection.POSITION_CAP:
+                log.info("interim_manager.position_cap", open=open_now)
+                return False
+            expired = assessment.rejection in {
+                InterimManagerRejection.EXPIRED,
+                InterimManagerRejection.SUNSET_REACHED,
+            }
+            await self._resolve(pid, "expired" if expired else "skipped", assessment.reason)
             return False
-
-        # Robust-edge gate: the edge must survive every haircut. Conservative
-        # about apparent edges built on weak estimates (charter decision rule).
-        robust, detail = await self._robust_edge(p, market, category, side)
+        proposal = assessment.proposal
         await self._db.execute(
             "UPDATE manager_proposals SET robust_edge = ?, decision_price = ? "
-            "WHERE id = ?", (round(robust, 4), entry_price, pid))
+            "WHERE id = ?", (round(proposal.robust_edge, 4), proposal.entry_price, pid))
         await self._db.commit()
-        if robust < cfg.min_robust_edge:
-            await self._resolve(
-                pid, "skipped",
-                f"robust edge {robust:+.3f} < {cfg.min_robust_edge:.3f} ({detail})")
-            return False
+        side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
         signal = Signal(
             market_id=market.id,
             market_question=market.question,
-            claude_prob=max(0.01, min(0.99, float(p["fair_prob"]))),
+            claude_prob=proposal.fair_probability,
             claude_confidence=Confidence.MEDIUM,
             market_prob=market.outcome_yes_price,
             edge=abs(float(p["fair_prob"]) - market.outcome_yes_price) * 100.0,
-            evidence_summary=f"[interim_manager proposal {pid}] {thesis}"[:500],
+            evidence_summary=f"[interim_manager proposal {pid}] {proposal.thesis}"[:500],
             recommended_side=side,
             strategy_source=self.name,
         )
@@ -198,8 +206,8 @@ class InterimManagerPillar:
             await self._resolve(pid, "skipped", f"risk: {decision.reason}"[:200])
             return False
 
-        size = min(decision.position_size, cfg.stake_usd, float(p["stake_usd"]))
-        force_paper = cfg.paper or getattr(decision, "force_paper", False)
+        size = min(decision.position_size, proposal.requested_stake_usd)
+        force_paper = proposal.force_paper or getattr(decision, "force_paper", False)
         res = await gateway.submit(TradeIntent(
             signal=signal, market=market, size_dollars=size,
             force_paper=force_paper))
@@ -221,31 +229,6 @@ class InterimManagerPillar:
         return True
 
     # ------------------------------------------------------------------
-
-    async def _robust_edge(self, p: dict, market, category: str,
-                           side: OrderSide) -> tuple[float, str]:
-        """fair − executable − uncertainty − fees − slippage − liquidity −
-        correlation. Returns (edge, haircut breakdown for the audit trail)."""
-        from auramaur.strategy.signals import taker_fee_rate
-        cfg = self._settings.interim_manager
-        fair = float(p["fair_prob"])
-        mid = market.outcome_yes_price
-        gross = (fair - mid) if side == OrderSide.BUY else (mid - fair)
-
-        lo, hi = p.get("confidence_lo"), p.get("confidence_hi")
-        if lo is not None and hi is not None and float(hi) >= float(lo):
-            uncertainty = (float(hi) - float(lo)) / 2.0
-        else:
-            uncertainty = cfg.default_uncertainty_buffer
-        fee = taker_fee_rate(market.exchange or "kalshi", category) * mid * (1.0 - mid)
-        liq = (cfg.liquidity_penalty
-               if float(market.liquidity or 0) < cfg.thin_liquidity_usd else 0.0)
-        corr = (cfg.correlation_penalty_per_position
-                * await self._open_positions_in_category(category))
-        edge = gross - uncertainty - fee - cfg.slippage_buffer - liq - corr
-        detail = (f"gross {gross:+.3f} − unc {uncertainty:.3f} − fee {fee:.3f} "
-                  f"− slip {cfg.slippage_buffer:.3f} − liq {liq:.3f} − corr {corr:.3f}")
-        return edge, detail
 
     # Counted through `signals`, but this pillar NEVER writes a signals row —
     # every other pillar does, so the join silently returned 0 forever. That

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -31,7 +31,6 @@ enters a market already held by any strategy/mode.
 from __future__ import annotations
 
 import asyncio
-import math
 from datetime import datetime, timezone
 
 import structlog
@@ -48,22 +47,21 @@ from auramaur.exchange.models import (
 )
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.strategy.protocols import ExecutionMode
+from auramaur.experiments.strategies.long_horizon import (
+    LongHorizonInputs,
+    LongHorizonRules,
+    assess_long_horizon,
+    calibrated_fair as _calibrated_fair,
+)
 
 log = structlog.get_logger()
+
+# Compatibility export for callers and tests; the implementation is portable.
+calibrated_fair = _calibrated_fair
 
 # Per-position mark fetch during the decay sweep. Bounded: an unbounded
 # await on a venue call has hung this bot's event loop three times.
 _MARK_FETCH_TIMEOUT_SECONDS = 10.0
-
-
-def calibrated_fair(price: float, slope: float) -> float:
-    """Slope-corrected fair probability for a price, in logit space:
-    ``true_logit = slope * logit(price)`` (arXiv 2602.19520). For a favorite
-    (price > 0.5) and slope > 1 this returns a value ABOVE the price — the
-    documented long-horizon underpricing. Pure function (the tested core)."""
-    p = min(max(price, 1e-6), 1.0 - 1e-6)
-    logit = math.log(p / (1.0 - p))
-    return 1.0 / (1.0 + math.exp(-slope * logit))
 
 
 class LongHorizonPillar:
@@ -335,18 +333,48 @@ class LongHorizonPillar:
 
     async def _try_enter(self, market: Market) -> bool:
         cfg = self._settings.long_horizon
-        fav = self._favored(market)
-        if fav is None or not self._eligible(market):
+        venue_excludes = (cfg.kalshi_exclude_categories if self._venue == "kalshi"
+                          else cfg.exclude_categories)
+        excluded = set(self._settings.risk.blocked_categories) | set(venue_excludes)
+        category_blocked = blocked_category_hit(
+            excluded, market.question, market.description, market.category
+        ) is not None
+        min_liquidity = (cfg.kalshi_min_liquidity if self._venue == "kalshi"
+                         else cfg.min_liquidity)
+        max_days = (cfg.kalshi_max_days_to_resolution if self._venue == "kalshi"
+                    else cfg.max_days_to_resolution)
+        assessment = assess_long_horizon(
+            LongHorizonInputs(
+                market_id=market.id,
+                yes_price=market.outcome_yes_price,
+                active=market.active,
+                venue=market.exchange or "polymarket",
+                liquidity=market.liquidity,
+                category_blocked=category_blocked,
+                end_at=market.end_date,
+                as_of=datetime.now(timezone.utc),
+                already_entered_or_held=await self._already_entered_or_held(market.id),
+            ),
+            LongHorizonRules(
+                venue=self._venue,
+                band_lo=cfg.band_lo,
+                band_hi=cfg.band_hi,
+                slope=cfg.slope,
+                min_edge=cfg.min_edge,
+                stake_usd=cfg.stake_usd,
+                min_liquidity=min_liquidity,
+                min_days_to_resolution=cfg.min_days_to_resolution,
+                max_days_to_resolution=max_days,
+                source_tag=self._tag,
+            ),
+        )
+        proposal = assessment.proposal
+        if proposal is None:
             return False
-        if await self._already_entered_or_held(market.id):
-            return False
-        p_fav, fav_is_yes = fav
-
-        edge_fav = calibrated_fair(p_fav, cfg.slope) - p_fav
-        if edge_fav < cfg.min_edge:
-            return False  # correction too small at this price to clear cost
-
-        signal = self._build_signal(market, p_fav, fav_is_yes, edge_fav)
+        edge_fav = proposal.edge_percent / 100.0
+        signal = self._build_signal(
+            market, proposal.favored_price, proposal.buy_yes, edge_fav
+        )
         await self._persist_signal(signal, market)
 
         # Full risk gate — all checks apply; never bypassed.

--- a/auramaur/strategy/momentum_coupling.py
+++ b/auramaur/strategy/momentum_coupling.py
@@ -13,13 +13,16 @@ filter (that's scoped to LLM disagreement, which this isn't).
 
 from __future__ import annotations
 
-import re
 import time
 from collections import defaultdict
 
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.momentum_coupling import (
+    CouplingCandidate, CouplingInputs, CouplingProposal, CouplingRules,
+    assess_momentum_coupling,
+)
 from auramaur.strategy.protocols import ExecutionMode
 
 log = structlog.get_logger()
@@ -86,18 +89,22 @@ class MomentumCouplingPillar:
             markets = await self._gamma.search_markets(f"{_NAME[asset]} above", limit=20)
         except Exception:
             return
-        for m in markets:
-            mt = re.search(r"\$?([\d,]{4,})", m.question)
-            if not mt:
-                continue
-            strike = float(mt.group(1).replace(",", ""))
-            if strike <= 0 or abs(strike - spot) / spot > cfg.near_money_pct:
-                continue  # only near-the-money markets are spot-sensitive
-            if not (0.10 < m.outcome_yes_price < 0.90):
-                continue  # skip pinned markets — prob must be live to move with spot
-            direction = "BUY_YES" if move > 0 else "BUY_NO"
+        assessment = assess_momentum_coupling(
+            CouplingInputs(
+                asset=asset, spot=spot, move_pct=move,
+                candidates=tuple(CouplingCandidate(
+                    market_id=m.id, question=m.question,
+                    yes_price=m.outcome_yes_price,
+                ) for m in markets),
+            ),
+            CouplingRules(cfg.move_threshold_pct, cfg.near_money_pct, cfg.max_position_usd),
+        )
+        proposal = assessment.proposal
+        if proposal is not None:
+            m = next(m for m in markets if m.id == proposal.market_id)
+            direction = proposal.direction
             log.info("coupling.signal", asset=asset, move_pct=round(move, 2), spot=round(spot),
-                     market=m.question[:50], strike=strike,
+                     market=m.question[:50], strike=proposal.strike,
                      market_prob=round(m.outcome_yes_price, 3), direction=direction,
                      size_usd=cfg.max_position_usd, execute=cfg.execute)
             if self._console:
@@ -106,10 +113,9 @@ class MomentumCouplingPillar:
                     f"'{m.question[:38]}' (prob {m.outcome_yes_price:.2f})"
                     + ("" if cfg.execute else " [dim](detect-only)[/]"))
             if cfg.execute:
-                await self._execute(m, direction, move)
-            break  # one signal per asset per cycle
+                await self._execute(m, proposal)
 
-    async def _execute(self, market, direction: str, move: float) -> None:
+    async def _execute(self, market, proposal: CouplingProposal) -> None:
         """Place the coupling trade through the ExecutionGateway (execute=True).
 
         The momentum signal is framed as a spot-implied prob nudge vs the market,
@@ -125,15 +131,13 @@ class MomentumCouplingPillar:
             log.warning("coupling.no_route", reason="no risk/client/db/pnl; detect-only")
             return
         from auramaur.exchange.models import Signal, OrderSide, Confidence
-        mp = market.outcome_yes_price
-        shift = (1 if direction == "BUY_YES" else -1) * min(abs(move) / 100.0 * 5, 0.15)
-        claude_prob = max(0.02, min(0.98, mp + shift))
+        mp = proposal.market_probability
         signal = Signal(
             market_id=market.id, market_question=market.question,
-            claude_prob=claude_prob, market_prob=mp,
-            claude_confidence=Confidence.HIGH if abs(move) >= 1.0 else Confidence.MEDIUM,
-            edge=abs(claude_prob - mp) * 100,
-            recommended_side=OrderSide.BUY if direction == "BUY_YES" else OrderSide.SELL,
+            claude_prob=proposal.fair_probability, market_prob=mp,
+            claude_confidence=Confidence(proposal.confidence),
+            edge=proposal.edge_percent,
+            recommended_side=OrderSide.BUY if proposal.direction == "BUY_YES" else OrderSide.SELL,
             strategy_source="momentum_coupling")
         cash = getattr(self._bot, "_last_known_cash", None) if self._bot else None
         try:
@@ -150,7 +154,7 @@ class MomentumCouplingPillar:
                 signal=signal, market=market,
                 size_dollars=decision.position_size,
                 force_paper=getattr(decision, "force_paper", False)))
-            log.warning("coupling.executed", market=market.id, direction=direction,
+            log.warning("coupling.executed", market=market.id, direction=proposal.direction,
                         size=decision.position_size, status=res.status,
                         is_paper=res.result.is_paper if res.result else None)
         except Exception as e:  # noqa: BLE001

--- a/auramaur/strategy/news_reactor.py
+++ b/auramaur/strategy/news_reactor.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from typing import TYPE_CHECKING
 
 import structlog
+
+from auramaur.experiments.strategies.news_reactor import (
+    NewsMarketCandidate,
+    NewsReactorRules,
+    extract_proper_nouns,
+    extract_search_terms,
+    form_news_market_proposal,
+)
 
 from auramaur.strategy.protocols import ExecutionMode
 
@@ -21,49 +28,6 @@ if TYPE_CHECKING:
     from auramaur.nlp.news_triage import MaterialityTriage
 
 log = structlog.get_logger()
-
-# Common English stop words to strip from headlines before building search terms.
-_STOP_WORDS: set[str] = {
-    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
-    "of", "with", "by", "from", "is", "it", "its", "are", "was", "were",
-    "be", "been", "being", "have", "has", "had", "do", "does", "did",
-    "will", "would", "could", "should", "may", "might", "shall",
-    "not", "no", "nor", "so", "if", "then", "than", "that", "this",
-    "these", "those", "what", "which", "who", "whom", "how", "when",
-    "where", "why", "all", "each", "every", "both", "few", "more",
-    "most", "other", "some", "such", "only", "own", "same", "very",
-    "just", "about", "above", "after", "again", "against", "before",
-    "below", "between", "during", "into", "through", "under", "until",
-    "over", "out", "up", "down", "off", "here", "there", "new", "says",
-    "said", "also", "as", "can", "get", "got", "one", "two", "now",
-    "still", "s", "t", "re", "ve", "d", "ll", "m",
-}
-
-# Words that are generic news fluff — not useful for Polymarket search.
-_NEWS_FLUFF: set[str] = {
-    "breaking", "update", "live", "latest", "report", "reports",
-    "exclusive", "developing", "just", "watch", "opinion", "analysis",
-    "sources", "source", "officials", "official", "according",
-}
-
-# Common words that start sentences and get spuriously classified as proper
-# nouns because the RSS headline title-cases them. Matching against these
-# lets clickbait like "Cheap stuff that doesn't suck" promote "Cheap" to a
-# proper noun and turn into a false market match. Keep lowercase.
-_GENERIC_TITLE_WORDS: set[str] = {
-    "cheap", "best", "good", "great", "new", "old", "big", "small",
-    "hot", "top", "bad", "nice", "fun", "cool", "easy", "hard", "fast",
-    "slow", "free", "rich", "poor", "young", "full", "short", "long",
-    "yes", "no", "now", "soon", "next", "last", "first", "final",
-    "early", "late", "happy", "sad", "real", "fake", "true", "false",
-    "every", "any", "much", "many", "some", "few", "less", "more",
-    "here", "there", "why", "how", "who", "what", "when", "where",
-    "thanks", "sorry", "hello", "goodbye", "welcome", "please",
-    "cheap", "stuff", "things", "ways", "reasons", "signs", "tips",
-}
-
-# Regex to detect capitalised proper-noun-like tokens.
-_PROPER_NOUN_RE = re.compile(r"[A-Z][a-z]{2,}")
 
 
 class NewsReactor:
@@ -290,67 +254,11 @@ class NewsReactor:
         "Fed raises interest rates by 50 basis points" -> ["Fed interest rates", "Fed basis points"]
         "Russia launches new offensive in Ukraine" -> ["Russia Ukraine", "Russia offensive Ukraine"]
         """
-        # Tokenise, stripping punctuation.
-        raw_tokens = re.findall(r"[A-Za-z']+", title)
-
-        proper_nouns: list[str] = []
-        keywords: list[str] = []
-
-        # The first token of a headline is almost always title-cased even if
-        # it's a generic word ("Cheap", "Best", "New"), so ignore its casing
-        # when deciding whether it's a real proper noun — fall through to the
-        # generic-title-words filter below.
-        for idx, token in enumerate(raw_tokens):
-            lower = token.lower()
-            if lower in _STOP_WORDS or lower in _NEWS_FLUFF:
-                continue
-            # Don't treat sentence-starting title-case as a proper noun.
-            treat_as_capital = (_PROPER_NOUN_RE.fullmatch(token) or (token.isupper() and len(token) >= 2))
-            if treat_as_capital and lower in _GENERIC_TITLE_WORDS:
-                treat_as_capital = False
-            if treat_as_capital:
-                proper_nouns.append(token)
-            elif lower not in _GENERIC_TITLE_WORDS:
-                keywords.append(token)
-
-        # Build search queries.
-        queries: list[str] = []
-
-        # Query 1: proper nouns together (most targeted).
-        if proper_nouns:
-            queries.append(" ".join(proper_nouns[:4]))
-
-        # Query 2: first proper noun + first couple of keywords.
-        if proper_nouns and keywords:
-            queries.append(f"{proper_nouns[0]} {' '.join(keywords[:2])}")
-
-        # Query 3: just keywords if no proper nouns.
-        if not proper_nouns and keywords:
-            queries.append(" ".join(keywords[:3]))
-
-        # Deduplicate while preserving order.
-        seen: set[str] = set()
-        unique: list[str] = []
-        for q in queries:
-            q_lower = q.lower()
-            if q_lower not in seen:
-                seen.add(q_lower)
-                unique.append(q)
-
-        return unique or [" ".join(raw_tokens[:3])]
+        return extract_search_terms(title)
 
     def _extract_proper_nouns(self, title: str) -> list[str]:
         """Return just the real proper nouns in a headline, for match validation."""
-        proper_nouns: list[str] = []
-        for token in re.findall(r"[A-Za-z']+", title):
-            lower = token.lower()
-            if lower in _STOP_WORDS or lower in _NEWS_FLUFF:
-                continue
-            if lower in _GENERIC_TITLE_WORDS:
-                continue
-            if _PROPER_NOUN_RE.fullmatch(token) or (token.isupper() and len(token) >= 2):
-                proper_nouns.append(token)
-        return proper_nouns
+        return extract_proper_nouns(title)
 
     @staticmethod
     def _market_text(m: Market) -> str:
@@ -365,11 +273,23 @@ class NewsReactor:
         unrelated markets just because the Gamma API search returned
         fuzzy results.
         """
-        proper_nouns = self._extract_proper_nouns(item.title)
-        if not proper_nouns:
-            return False
-        mtext = self._market_text(market)
-        return any(p.lower() in mtext for p in proper_nouns)
+        return form_news_market_proposal(
+            item.title,
+            NewsMarketCandidate(
+                market_id=market.id,
+                question=market.question or "",
+                description=market.description or "",
+                category="",
+                active=True,
+                liquidity=max(float(market.liquidity or 0), self._min_liquidity),
+                volume=float(market.volume or 0),
+            ),
+            NewsReactorRules(
+                min_liquidity=self._min_liquidity,
+                min_proper_nouns=self._min_proper_nouns,
+                blocked_categories=frozenset(),
+            ),
+        ) is not None
 
     async def _find_related_markets(
         self, item: NewsItem,
@@ -400,14 +320,24 @@ class NewsReactor:
                     log.debug("news_reactor.search_exchange_error", exchange=name, error=str(e))
                     continue
                 for m in markets:
-                    # Kalshi reports thin top-of-book liquidity and high volume;
-                    # fall back to volume when liquidity is zero so we don't
-                    # filter out active Kalshi markets.
-                    activity = max(m.liquidity or 0, m.volume or 0)
-                    if (m.active
-                            and activity >= self._min_liquidity
-                            and m.id not in all_markets
-                            and self._match_is_credible(item, m)):
+                    proposal = form_news_market_proposal(
+                        item.title,
+                        NewsMarketCandidate(
+                            market_id=m.id,
+                            question=m.question or "",
+                            description=m.description or "",
+                            category=getattr(m, "category", "") or "",
+                            active=bool(m.active),
+                            liquidity=float(m.liquidity or 0),
+                            volume=float(m.volume or 0),
+                        ),
+                        NewsReactorRules(
+                            min_liquidity=self._min_liquidity,
+                            min_proper_nouns=self._min_proper_nouns,
+                            blocked_categories=self.BLOCKED_CATEGORIES,
+                        ),
+                    )
+                    if proposal is not None and m.id not in all_markets:
                         all_markets[m.id] = m
             ranked = sorted(all_markets.values(), key=lambda m: m.liquidity, reverse=True)
             return (name, ranked[: self._max_markets_per_story])

--- a/auramaur/strategy/platform_consensus.py
+++ b/auramaur/strategy/platform_consensus.py
@@ -18,7 +18,14 @@ from auramaur.exchange.models import (
     Signal,
 )
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
-from auramaur.strategy.arbitrage_scanner import _word_overlap_score
+from auramaur.experiments.strategies.platform_consensus import (
+    ConsensusForecast,
+    ConsensusInputs,
+    ConsensusRules,
+    assess_platform_consensus,
+    clean_title,
+    parse_probability,
+)
 from auramaur.strategy.protocols import ExecutionMode
 from auramaur.strategy.signals import taker_fee_rate
 
@@ -186,13 +193,10 @@ class PlatformConsensusPillar:
         return int(row["n"]) if row else 0
 
     def _get_clean_title(self, title: str) -> str:
-        return re.sub(r"^\[(?:Manifold|Metaculus):\s*\d+%\]\s*", "", title).strip()
+        return clean_title(title)
 
     def _parse_probability_from_title(self, title: str) -> float | None:
-        m = re.match(r"^\[(?:Manifold|Metaculus):\s*(\d+)%\]", title)
-        if m:
-            return float(m.group(1)) / 100.0
-        return None
+        return parse_probability(title)
 
     @staticmethod
     def _quality_ok(item, source_name: str, cfg) -> bool:
@@ -248,44 +252,7 @@ class PlatformConsensusPillar:
             item_count=len(forecasts),
         ))
 
-        best_match = None
-        best_overlap = 0.0
-        source_name = ""
-
-        # Process Manifold matches
-        for item in manifold_items:
-            if not self._quality_ok(item, "Manifold", cfg):
-                continue
-            clean_title = self._get_clean_title(item.title)
-            overlap = _word_overlap_score(market.question, clean_title)
-            if overlap > best_overlap:
-                best_overlap = overlap
-                best_match = item
-                source_name = "Manifold"
-
-        # Process Metaculus matches
-        for item in metaculus_items:
-            if not self._quality_ok(item, "Metaculus", cfg):
-                continue
-            clean_title = self._get_clean_title(item.title)
-            overlap = _word_overlap_score(market.question, clean_title)
-            if overlap > best_overlap:
-                best_overlap = overlap
-                best_match = item
-                source_name = "Metaculus"
-
-        if best_match is None or best_overlap < cfg.match_threshold:
-            return False
-
-        prob = self._parse_probability_from_title(best_match.title)
-        if prob is None:
-            return False
-
         market_p = market.outcome_yes_price
-        edge = prob - market_p
-        abs_edge = abs(edge)
-
-        # Calculate required edge (including fee)
         fee = (
             taker_fee_rate(
                 market.exchange or "polymarket",
@@ -295,38 +262,66 @@ class PlatformConsensusPillar:
             * market_p
             * (1.0 - market_p)
         )
-        required_edge = cfg.min_edge + fee
-
-        if abs_edge < required_edge:
+        blocked = set(self._settings.risk.blocked_categories)
+        proposal = assess_platform_consensus(
+            ConsensusInputs(
+                market_id=market.id,
+                question=market.question,
+                market_probability=market_p,
+                active=market.active,
+                liquidity_or_volume=max(market.liquidity or 0.0, market.volume or 0.0),
+                category_blocked=blocked_category_hit(
+                    blocked, market.question, market.description, market.category
+                ),
+                end_at=market.end_date,
+                as_of=observed,
+                fee=fee,
+                forecasts=tuple(
+                    ConsensusForecast(item.title, item.content or "", source)
+                    for source, items in (
+                        ("Manifold", manifold_items),
+                        ("Metaculus", metaculus_items),
+                    )
+                    for item in items
+                ),
+            ),
+            ConsensusRules(
+                min_liquidity=cfg.min_liquidity,
+                min_hours_to_resolution=cfg.min_hours_to_resolution,
+                max_days_to_resolution=cfg.max_days_to_resolution,
+                match_threshold=cfg.match_threshold,
+                min_edge=cfg.min_edge,
+                min_manifold_bettors=cfg.min_manifold_bettors,
+                min_manifold_liquidity=cfg.min_manifold_liquidity,
+                min_metaculus_forecasters=cfg.min_metaculus_forecasters,
+                stake_usd=cfg.stake_usd,
+            ),
+        )
+        if proposal is None:
             return False
-
-        recommended_side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+        recommended_side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
 
         log.info(
             "platform_consensus.signal_detected",
             market_id=market.id,
             market_question=market.question[:50],
-            consensus_source=source_name,
-            consensus_prob=round(prob, 3),
+            consensus_source=proposal.consensus_source,
+            consensus_prob=round(proposal.consensus_probability, 3),
             market_prob=round(market_p, 3),
-            edge=round(abs_edge * 100, 2),
+            edge=round(proposal.edge_percent, 2),
             side=recommended_side.value,
         )
 
         signal = Signal(
             market_id=market.id,
             market_question=market.question,
-            claude_prob=prob,
+            claude_prob=proposal.consensus_probability,
             claude_confidence=Confidence.HIGH
-            if best_overlap >= 0.8
+            if proposal.confidence == "high"
             else Confidence.MEDIUM,
             market_prob=market_p,
-            edge=abs_edge * 100.0,
-            evidence_summary=(
-                f"Platform consensus follower: found matching market on {source_name} "
-                f"('{self._get_clean_title(best_match.title)[:80]}') with consensus probability {prob:.0%}. "
-                f"Market price is {market_p:.0%}. Edge: {abs_edge:.1%}. Word overlap: {best_overlap:.2f}."
-            ),
+            edge=proposal.edge_percent,
+            evidence_summary=proposal.evidence_summary,
             recommended_side=recommended_side,
             strategy_source=self.name,
         )

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -43,6 +43,11 @@ from auramaur.exchange.models import (
     OrderSide,
     Signal,
 )
+from auramaur.experiments.strategies.resolution_lens import (
+    ResolutionLensCandidate,
+    ResolutionLensRules,
+    form_resolution_lens_proposal,
+)
 
 log = structlog.get_logger()
 
@@ -674,28 +679,42 @@ class ResolutionLensPillar:
         # cut the cell to 100% win in-sample. SELL longshot plays (overpriced
         # 'permanent'/'announce' YES) sit below this floor by construction and
         # are deliberately exempt. edge > 0 ⇒ BUY YES at ~outcome_yes_price.
-        if (edge > 0 and cfg.min_entry_price > 0.0
-                and m.outcome_yes_price < cfg.min_entry_price):
-            log.info("lens.below_entry_floor", market_id=m.id,
-                     yes_price=round(m.outcome_yes_price, 3),
-                     floor=cfg.min_entry_price)
+        proposal = form_resolution_lens_proposal(
+            ResolutionLensCandidate(
+                market_id=m.id,
+                market_probability=m.outcome_yes_price,
+                fair_probability=fair,
+                gap_score=score,
+                mechanism=mech,
+            ),
+            ResolutionLensRules(
+                min_entry_price=cfg.min_entry_price,
+                high_conf_gap_score=cfg.high_conf_gap_score,
+                stake_usd=cfg.stake_usd,
+            ),
+        )
+        if proposal is None:
+            if edge > 0 and m.outcome_yes_price < cfg.min_entry_price:
+                log.info("lens.below_entry_floor", market_id=m.id,
+                         yes_price=round(m.outcome_yes_price, 3),
+                         floor=cfg.min_entry_price)
             return False
         signal = Signal(
             market_id=m.id,
             market_question=m.question,
-            claude_prob=fair,
+            claude_prob=proposal.fair_probability,
             # A concrete, named fine-print mechanism with a high gap_score is
             # the one class of LLM divergence with a documented win record —
             # HIGH here both reflects that and clears the divergence filter
             # (which exists to block UNexplained mid-band disagreement).
-            claude_confidence=Confidence.HIGH if score >= cfg.high_conf_gap_score
+            claude_confidence=Confidence.HIGH if proposal.high_confidence
             else Confidence.MEDIUM,
-            market_prob=m.outcome_yes_price,
-            edge=abs(edge) * 100.0,
-            evidence_summary=f"Resolution lens (gap {score:.2f}): {mech}",
-            recommended_side=OrderSide.BUY if edge > 0 else OrderSide.SELL,
+            market_prob=proposal.market_probability,
+            edge=proposal.edge_percent,
+            evidence_summary=proposal.evidence_summary,
+            recommended_side=OrderSide.BUY if proposal.buy_yes else OrderSide.SELL,
             strategy_source=self._source_tag,
-            mispricing_reason=f"behavioral: {mech}",
+            mispricing_reason=proposal.mispricing_reason,
         )
         decision = await self._risk.evaluate(signal, m)
         if not decision.approved or decision.position_size <= 0:

--- a/auramaur/strategy/settlement_arb.py
+++ b/auramaur/strategy/settlement_arb.py
@@ -31,6 +31,10 @@ un-repriced market (the easy fill) is never wrongly excluded.
 from __future__ import annotations
 
 from auramaur.strategy.protocols import ExecutionMode
+from auramaur.experiments.strategies.settlement_arb import (
+    is_satisfied as _is_satisfied,
+    settlement_proposal,
+)
 
 import json
 import re
@@ -46,6 +50,8 @@ from auramaur.strategy.econ_pricing import (
     kalshi_macro_predicate,
     spec_for_series,
 )
+
+is_satisfied = _is_satisfied  # backward-compatible public import
 
 log = structlog.get_logger()
 
@@ -143,35 +149,6 @@ def indicator_at_period(
         return (ordered[idx][1] - ordered[idx - 1][1]) * spec.scale
 
     return None
-
-
-def _bin_half_width(threshold: float) -> float:
-    """Half-width of the point-bin centered on ``threshold``, derived from the
-    threshold's own decimal precision (Kalshi econ point-bins are one grid step
-    wide: 3.8 -> the [3.75, 3.85) bin, half-width 0.05). Needed because the
-    indicator is computed CONTINUOUSLY from FRED (e.g. CPI YoY = 3.7841%), so an
-    exact ``== 3.8`` test never matches and every point-bin would price fair=0.
-    """
-    s = f"{threshold:.10f}".rstrip("0")
-    decimals = len(s.split(".")[1]) if "." in s else 0
-    return 0.5 * (10.0 ** -decimals)
-
-
-def is_satisfied(value: float, operator: str, threshold: float) -> bool:
-    """Does the published value satisfy the YES criterion?"""
-    if operator == ">=":
-        return value >= threshold
-    if operator == ">":
-        return value > threshold
-    if operator == "<=":
-        return value <= threshold
-    if operator == "<":
-        return value < threshold
-    if operator == "==":
-        # Point-bin: YES iff the continuous indicator rounds INTO this bin, i.e.
-        # falls within half a grid step of the threshold — not exact equality.
-        return abs(value - threshold) < _bin_half_width(threshold) + 1e-12
-    return False
 
 
 class SettlementArbPillar:
@@ -455,27 +432,28 @@ class SettlementArbPillar:
         if spec.report_round_to:
             value = round(value / spec.report_round_to) * spec.report_round_to
 
-        yes_locked = is_satisfied(value, pred["operator"], pred["threshold"])
         yes_price = m.outcome_yes_price
         # Fair is a HARD 0/1 — the print already decided it. The lag is the edge:
         # only trade the un-converged distance. Same edge-sign convention as the
         # graduated resolution_lens: edge>0 -> long YES (BUY); edge<0 -> short YES
         # = long NO (SELL). |edge| < min_edge means the market already converged.
-        fair = 1.0 if yes_locked else 0.0
-        edge = fair - yes_price
-        if abs(edge) < cfg.min_edge:
+        proposal = settlement_proposal(
+            market_id=m.id, yes_price=yes_price,
+            no_price=m.outcome_no_price, published_value=value,
+            indicator=pred["indicator"], reference_period=pred["reference_period"],
+            operator=pred["operator"], threshold=pred["threshold"],
+            min_edge=cfg.min_edge, stake_usd=cfg.stake_usd,
+        )
+        if proposal is None:
             self._bump("converged")
             return False  # already converged — no lag to capture
-        side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+        side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
 
         signal = Signal(
-            market_id=m.id, claude_prob=fair,
+            market_id=m.id, claude_prob=proposal.fair_probability,
             claude_confidence=Confidence.HIGH, market_prob=yes_price,
-            edge=abs(edge) * 100.0,
-            evidence_summary=(f"settlement_arb: {pred['indicator']} "
-                              f"{pred['reference_period']} = {value:.2f} "
-                              f"{pred['operator']} {pred['threshold']} -> "
-                              f"{'YES' if yes_locked else 'NO'} locked"),
+            edge=proposal.edge_percent,
+            evidence_summary=proposal.evidence_summary,
             recommended_side=side,
             strategy_source="settlement_arb",
             mispricing_reason="structural: official print already determines the criterion",
@@ -498,6 +476,6 @@ class SettlementArbPillar:
             self._bump("submit_failed")
         if ok:
             log.info("settlement_arb.entered", market_id=m.id, side=side.value,
-                     locked="YES" if yes_locked else "NO", value=round(value, 2),
+                     locked="YES" if proposal.buy_yes else "NO", value=round(value, 2),
                      market_price=round(yes_price, 3), paper=getattr(res.result, "is_paper", True))
         return ok

--- a/auramaur/strategy/signals.py
+++ b/auramaur/strategy/signals.py
@@ -8,6 +8,11 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.experiments.strategies.core_trading import (
+    CoreTradingInputs,
+    CoreTradingRules,
+    assess_core_trading,
+)
 from auramaur.nlp.analyzer import AnalysisResult
 
 log = structlog.get_logger()
@@ -190,42 +195,6 @@ def detect_edge(
     raw_prob = analysis.calibrated_probability if analysis.calibrated_probability is not None else analysis.probability
     market_prob = market.outcome_yes_price
 
-    # Blend with second opinion using confidence-weighted averaging
-    claude_prob = _blend_estimates(
-        raw_prob, analysis.second_opinion_prob, market_prob,
-        primary_confidence=analysis.confidence,
-    )
-
-    # Detect inverted semantics — if the question is negated, Claude may
-    # have estimated the affirmative while the market trades the negation.
-    # When edge is suspiciously large (>25%) and semantics look inverted,
-    # skip the signal entirely rather than risk a miscalibrated trade.
-    inverted = _has_inverted_semantics(market.question)
-
-    # Raw edge
-    edge = claude_prob - market_prob
-
-    # Determine side
-    if edge > 0:
-        recommended_side = OrderSide.BUY
-    elif edge < 0:
-        recommended_side = OrderSide.SELL
-        edge = abs(edge)
-    else:
-        return None
-
-    if inverted and edge > 0.25:
-        log.warning(
-            "signal.inverted_semantics",
-            market_id=market.id,
-            question=market.question[:100],
-            claude_prob=f"{claude_prob:.3f}",
-            market_prob=f"{market_prob:.3f}",
-            edge_pct=f"{edge * 100:.1f}%",
-            hint="Question appears negated and edge is suspiciously large — skipping",
-        )
-        return None
-
     # Adjust for exchange-specific fees. The configured rate is a *coefficient*
     # on the per-contract fee P*(1-P) (Kalshi's actual formula), not a flat
     # percentage haircut: 0.07 -> at most ~1.75pt (at P=0.5), ~1.1pt at the
@@ -237,50 +206,55 @@ def detect_edge(
     fee_rate = taker_fee_rate(
         market.exchange, market.category, exchange_fees,
         actual_fee_rate=market.fee_rate, fees_enabled=market.fees_enabled)
-    net_edge = edge - fee_rate * market_prob * (1.0 - market_prob)
-
-    if net_edge <= 0:
-        return None
-
-    # Compute hours to resolution for signal quality
     hours_to_res = None
     if market.end_date is not None:
         end = market.end_date if market.end_date.tzinfo else market.end_date.replace(tzinfo=timezone.utc)
         hours_to_res = max(0, (end - datetime.now(timezone.utc)).total_seconds() / 3600)
 
-    # Evidence count from the reasoning length as proxy
     evidence_count = len(analysis.key_factors) if analysis.key_factors else 0
-
-    quality = _compute_signal_quality(
-        net_edge * 100,
-        analysis.confidence,
-        analysis.divergence,
-        evidence_count,
-        hours_to_res,
+    assessment = assess_core_trading(
+        CoreTradingInputs(
+            market_id=market.id,
+            question=market.question,
+            market_probability=market_prob,
+            model_probability=raw_prob,
+            confidence=analysis.confidence,
+            second_opinion_probability=analysis.second_opinion_prob,
+            divergence=analysis.divergence,
+            reasoning=analysis.reasoning,
+            evidence_count=evidence_count,
+            hours_to_resolution=hours_to_res,
+            fee_rate=fee_rate,
+        ),
+        CoreTradingRules(True, True, True, 1.0),
     )
+    if assessment.proposal is None:
+        return None
+    proposal = assessment.proposal
+    recommended_side = OrderSide(proposal.side)
 
     signal = Signal(
         market_id=market.id,
         market_question=market.question,
-        claude_prob=claude_prob,
+        claude_prob=proposal.model_probability,
         claude_confidence=Confidence(analysis.confidence),
         market_prob=market_prob,
-        edge=net_edge * 100,  # Store as percentage
+        edge=proposal.edge_percent,
         second_opinion_prob=analysis.second_opinion_prob,
         divergence=analysis.divergence,
-        evidence_summary=analysis.reasoning[:500],
+        evidence_summary=proposal.evidence_summary,
         recommended_side=recommended_side,
-        recommended_size=quality,  # Repurpose as signal quality score
+        recommended_size=proposal.quality,
     )
 
     log.debug(
         "signal.detected",
         market_id=market.id,
-        claude_prob=f"{claude_prob:.3f}",
+        claude_prob=f"{proposal.model_probability:.3f}",
         market_prob=f"{market_prob:.3f}",
         edge_pct=f"{signal.edge:.1f}%",
         side=recommended_side.value,
-        quality=quality,
+        quality=proposal.quality,
     )
 
     # Flag suspiciously large edges — likely a calibration problem, not alpha
@@ -289,7 +263,7 @@ def detect_edge(
             "signal.suspicious_edge",
             market_id=market.id,
             edge_pct=f"{signal.edge:.1f}%",
-            claude_prob=f"{claude_prob:.3f}",
+            claude_prob=f"{proposal.model_probability:.3f}",
             market_prob=f"{market_prob:.3f}",
             hint="Edge >30% is rare — check if market question semantics are inverted or if Claude is miscalibrated",
         )

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -47,6 +47,11 @@ import structlog
 from auramaur.strategy.protocols import ExecutionMode
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.term_structure import (
+    TermStructureCandidate,
+    TermStructureRules,
+    select_term_structure_proposals,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 
@@ -596,7 +601,8 @@ class TermStructurePillar:
     async def _trade_curve(self, fam: str, strikes: list[Market], thesis: str,
                            probs: dict[str, float], cfg) -> int:
         entered = 0
-        gaps = []
+        candidates = []
+        markets_by_id = {market.id: market for market in strikes}
         for m in strikes:
             if m.id not in probs:
                 continue
@@ -624,13 +630,25 @@ class TermStructurePillar:
                  int(claimed), int(liquid), disposition),
             )
             if disposition == "candidate":
-                gaps.append((gap, m))
+                candidates.append(TermStructureCandidate(
+                    market_id=m.id,
+                    market_probability=m.outcome_yes_price,
+                    model_probability=probs[m.id],
+                    liquidity=m.liquidity,
+                    claimed=claimed,
+                ))
         await self._db.commit()
-        gaps.sort(reverse=True, key=lambda g: g[0])
-        for gap, market in gaps:
-            if entered >= cfg.max_entries_per_family:
-                break
-            if await self._try_enter(market, probs[market.id], thesis, cfg):
+        proposals = select_term_structure_proposals(candidates, TermStructureRules(
+            min_edge_percent=cfg.min_edge_pts,
+            min_liquidity=cfg.min_liquidity,
+            max_entries=cfg.max_entries_per_family,
+            stake_usd=cfg.stake_usd,
+        ))
+        for proposal in proposals:
+            market = markets_by_id[proposal.market_id]
+            if await self._try_enter(
+                market, proposal.fair_probability, thesis, cfg
+            ):
                 entered += 1
         return entered
 

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -47,6 +47,12 @@ from auramaur.strategy.protocols import ExecutionMode
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
 from auramaur.data_sources.deribit_iv import DeribitIVSource
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
+from auramaur.experiments.strategies.vol_anchor import (
+    VolAnchorInputs,
+    VolAnchorProposal,
+    VolAnchorRules,
+    assess_vol_anchor,
+)
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 
 log = structlog.get_logger()
@@ -246,6 +252,13 @@ class VolAnchorPillar:
         now = datetime.now(timezone.utc)
         entered = 0
         priced = 0
+        rules = VolAnchorRules(
+            min_liquidity=cfg.min_liquidity,
+            min_edge_pts=cfg.min_edge_pts,
+            stake_usd=cfg.stake_usd,
+            tau_years=cfg.tau_years,
+            long_run_vol=dict(cfg.long_run_vol),
+        )
         for cg_id, kind, strike, deadline, market in candidates:
             if entered >= cfg.max_entries_per_cycle:
                 break
@@ -255,37 +268,38 @@ class VolAnchorPillar:
             t_years = (deadline - now).total_seconds() / (365.0 * 86400.0)
             if t_years <= 0:
                 continue
-            anchor = cfg.long_run_vol.get(cg_id, 0.0)
-            if anchor <= 0:
-                continue
-            sigma = None
-            sigma_src = "blend"
+            term_sigma = None
             if self._iv_source is not None:
-                sigma = await self._iv_source.term_sigma(cg_id, t_years)
-                if sigma is not None:
-                    sigma_src = "deribit_iv"
-            if sigma is None:
-                # Fallback = the calibrated estimate (pre-Deribit behavior).
-                sigma = blended_sigma(realized, anchor, t_years, cfg.tau_years)
-            if kind in ("touch_up", "touch_down"):
-                fair = touch_prob(spot, strike, sigma, t_years)
-            elif kind == "above":
-                fair = terminal_above_prob(spot, strike, sigma, t_years)
-            else:  # below
-                fair = 1.0 - terminal_above_prob(spot, strike, sigma, t_years)
+                term_sigma = await self._iv_source.term_sigma(cg_id, t_years)
+            claimed = await self._market_claimed(market.id)
+            assessment = assess_vol_anchor(VolAnchorInputs(
+                market_id=market.id,
+                question=market.question,
+                yes_price=market.outcome_yes_price,
+                no_price=market.outcome_no_price,
+                active=market.active,
+                venue=market.exchange or "polymarket",
+                liquidity=market.liquidity,
+                category_blocked=False,
+                as_of=now,
+                spot=spot,
+                realized_vol=realized,
+                already_held=claimed,
+                term_sigma=term_sigma,
+            ), rules)
+            if assessment.proposal is None:
+                continue
+            proposal = assessment.proposal
             priced += 1
-            edge_pts = abs(fair - market.outcome_yes_price) * 100.0
             log.info("vol_anchor.priced", market_id=market.id, asset=cg_id,
                      kind=kind, strike=strike, spot=round(spot, 2),
-                     sigma=round(sigma, 3), sigma_src=sigma_src,
+                     sigma=round(proposal.sigma, 3),
+                     sigma_src=proposal.sigma_source,
                      realized=round(realized, 3),
-                     fair=round(fair, 3), market=market.outcome_yes_price,
-                     edge=round(edge_pts, 1))
-            if edge_pts < cfg.min_edge_pts:
-                continue
-            if await self._market_claimed(market.id):
-                continue
-            if await self._try_enter(market, fair, sigma, realized, kind, cfg):
+                     fair=round(proposal.fair_probability, 3),
+                     market=market.outcome_yes_price,
+                     edge=round(proposal.edge_percent, 1))
+            if await self._try_enter(market, proposal, cfg):
                 entered += 1
         log.info("vol_anchor.cycle", candidates=len(candidates), priced=priced,
                  entered=entered)
@@ -362,8 +376,13 @@ class VolAnchorPillar:
             (market_id,))
         return row is not None
 
-    async def _try_enter(self, market: Market, fair: float, sigma: float,
-                         realized: float, kind: str, cfg) -> bool:
+    async def _try_enter(
+        self, market: Market, proposal: VolAnchorProposal, cfg
+    ) -> bool:
+        fair = proposal.fair_probability
+        sigma = proposal.sigma
+        realized = proposal.realized_vol
+        kind = proposal.kind
         market_yes = market.outcome_yes_price
         side = OrderSide.BUY if fair > market_yes else OrderSide.SELL
         signal = Signal(

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -16,6 +16,12 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.weather_temp import (
+    WeatherTempInputs,
+    WeatherTempRejection,
+    WeatherTempRules,
+    assess_weather_temp,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.classifier import ensure_category
 from auramaur.strategy.weather_pricing import (
@@ -99,27 +105,33 @@ class WeatherTempPillar:
         if model_p is None:
             return False
         market_p = market.outcome_yes_price
-        edge = model_p - market_p
         # Always log model vs market — this is the measurement record.
         log.info("weather_temp.priced", market_id=market.id, city=spec.city,
                  kind=spec.kind, model_p=round(model_p, 3), market_p=round(market_p, 3),
                  members=len(members))
-        if abs(edge) < self._required_edge(market):
-            return False
-        if abs(edge) > cfg.max_divergence:
+        assessment = assess_weather_temp(
+            WeatherTempInputs(
+                market_id=market.id, market_probability=market_p,
+                model_probability=model_p, member_count=len(members),
+                city=spec.city, temperature_kind=spec.kind,
+                already_entered_or_held=await self._already_entered_or_held(market.id),
+            ),
+            WeatherTempRules(required_edge=self._required_edge(market),
+                             max_divergence=cfg.max_divergence, stake_usd=cfg.stake_usd),
+        )
+        if assessment.rejection == WeatherTempRejection.IMPLAUSIBLE_DIVERGENCE:
             log.info("weather_temp.implausible_divergence", market_id=market.id,
                      model_p=round(model_p, 3), market_p=round(market_p, 3))
+        if assessment.proposal is None:
             return False
-        if await self._already_entered_or_held(market.id):
-            return False
-        side = OrderSide.BUY if edge > 0 else OrderSide.SELL
+        proposal = assessment.proposal
+        side = OrderSide.BUY if proposal.buy_yes else OrderSide.SELL
         signal = Signal(
             market_id=market.id, market_question=market.question,
-            claude_prob=max(0.01, min(0.99, model_p)),
+            claude_prob=max(0.01, min(0.99, proposal.model_probability)),
             claude_confidence=Confidence.MEDIUM, market_prob=market_p,
-            edge=abs(edge) * 100.0,
-            evidence_summary=(f"GEFS ensemble P(bin)={model_p:.2f} ({len(members)} members) "
-                              f"vs market {market_p:.2f} for {spec.city} {spec.kind} temp."),
+            edge=proposal.edge_percent,
+            evidence_summary=proposal.evidence_summary,
             recommended_side=side, strategy_source="weather_temp",
         )
         await self._persist_signal(signal, market)

--- a/docs/plans/experiment-platform-refactor.md
+++ b/docs/plans/experiment-platform-refactor.md
@@ -202,11 +202,12 @@ and slippage. It rejects out-of-order or duplicate events, unavailable features,
 unpriced holdings, mismatched target reference prices, unavailable cash, and
 non-finite financial values. It is not an order-book or queue simulator.
 
-Bias harvest is the migrated proof of concept. Its complete deterministic
-candidate-to-proposal decision is portable, while every live-sensitive risk,
-gateway, persistence, order-lifecycle, and accounting operation remains in
-production. The remaining registry entries are explicitly planned on portable
-or specialized tracks.
+Bias harvest and every portable directional strategy now delegate deterministic
+proposal formation. News reactor delegates its pure routing decision and hands
+the eventual trade choice to the separately migrated core-trading decision.
+Every live-sensitive risk, gateway, persistence, order-lifecycle, and accounting
+operation remains in production. Paired, quoting, and external-asset entries
+remain explicitly planned on specialized tracks.
 
 ## Full-set migration sequence
 
@@ -234,6 +235,6 @@ deterministic seam to a pure contract, focused old/new decision coverage passes,
 and its existing execution-contract suite still passes. The status does not
 claim that the contract is supported by the generic replay runtime.
 
-Bias harvest currently satisfies that decision-seam gate. The following stack
-layers migrate portable directional/routing seams, paired and quoting
-contracts, and external-asset contracts in independently reviewable changes.
+All portable directional and routing entries satisfy that decision-seam gate.
+The following stack layers migrate paired/quoting and external-asset contracts
+in independently reviewable changes.

--- a/tests/test_experiment_agent_trader.py
+++ b/tests/test_experiment_agent_trader.py
@@ -1,0 +1,121 @@
+"""Portable proposal parity for the shared Polymarket/Kalshi agent trader."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.exchange.models import Market
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.agent_trader import (
+    AgentTraderAssessment,
+    AgentTraderExperiment,
+    AgentTraderInputs,
+    AgentTraderRejection,
+    AgentTraderRules,
+    assess_agent_trader,
+    parse_decisions,
+)
+from auramaur.strategy.agent_trader import AgentTraderPillar
+
+
+@pytest.mark.parametrize(
+    ("venue", "source"),
+    [("polymarket", "agent_trader_opus"),
+     ("kalshi", "agent_trader_opus_kalshi")],
+)
+def test_shared_venue_proposal_parity(venue: str, source: str) -> None:
+    rules = AgentTraderRules(min_edge_pts=5.0, stake_usd=10.0, source_tag=source)
+    proposal = assess_agent_trader(AgentTraderInputs(
+        market_id="m1", question="Will it happen?", market_yes=0.30,
+        prob_yes=0.55, thesis="The announced mechanism is underpriced.",
+    ), rules).proposal
+    assert proposal is not None
+    assert proposal.buy_yes
+    assert proposal.edge_percent == pytest.approx(25.0)
+    assert proposal.source_tag == source
+
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    snapshot = MarketSnapshot(
+        observed_at=now, sequence=1, market_id="m1", venue=venue,
+        prices=(PricePoint(instrument_id="YES", price=0.30),),
+        features=(FeatureValue(
+            name="agent_trader_opinion",
+            payload={"question": "Will it happen?", "prob_yes": 0.55,
+                     "thesis": "The announced mechanism is underpriced."},
+            source="model-opinion", observed_at=now, available_at=now,
+        ),), data_version="test-v1",
+    )
+    targets = asyncio.run(AgentTraderExperiment(rules).evaluate(
+        snapshot,
+        PortfolioSnapshot(observed_at=now, cash=100.0, equity=100.0),
+    ))
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "m1:YES"
+    assert targets[0].target_quantity == pytest.approx(10.0 / 0.30)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("market_yes", float("nan")),
+    ("market_yes", 0.0),
+    ("prob_yes", float("inf")),
+    ("prob_yes", 1.0),
+    ("thesis", ""),
+])
+def test_invalid_opinions_fail_closed(field: str, value: object) -> None:
+    values = dict(market_id="m1", question="Q?", market_yes=0.3,
+                  prob_yes=0.6, thesis="concrete evidence")
+    values[field] = value
+    result = assess_agent_trader(
+        AgentTraderInputs(**values),
+        AgentTraderRules(5.0, 10.0, "agent_trader_opus"),
+    )
+    assert result.proposal is None
+    assert result.rejection == AgentTraderRejection.INVALID_INPUT
+
+
+def test_parser_rejects_nonfinite_model_probability() -> None:
+    raw = '{"decisions":[{"market_id":"m1","prob_yes":NaN,"thesis":"x"}]}'
+    assert parse_decisions(raw, 1) == []
+
+
+@pytest.mark.asyncio
+async def test_production_entry_delegates_to_pure_assessment(monkeypatch) -> None:
+    pillar = object.__new__(AgentTraderPillar)
+    pillar._cell_suffix = "_kalshi"
+    pillar._risk = SimpleNamespace(evaluate=None)
+    monkeypatch.setattr(
+        "auramaur.strategy.agent_trader.assess_agent_trader",
+        lambda *_: AgentTraderAssessment(
+            None, AgentTraderRejection.INSUFFICIENT_EDGE),
+    )
+    entered = await pillar._try_enter(
+        "opus",
+        Market(id="m1", question="Q?", exchange="kalshi",
+               outcome_yes_price=0.3, outcome_no_price=0.7),
+        {"prob_yes": 0.9, "thesis": "x"},
+        SimpleNamespace(min_edge_pts=5.0, stake_usd=10.0),
+    )
+    assert entered is False
+
+
+def test_pure_module_has_no_live_runtime_imports() -> None:
+    source = Path("auramaur/experiments/strategies/agent_trader.py").read_text()
+    imports = {
+        node.module or ""
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = ("auramaur.broker", "auramaur.db", "auramaur.exchange",
+                 "auramaur.strategy")
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_experiment_core_trading.py
+++ b/tests/test_experiment_core_trading.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from auramaur.exchange.models import Market
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.core_trading import (
+    CoreTradingExperiment,
+    CoreTradingInputs,
+    CoreTradingRejection,
+    CoreTradingRules,
+    assess_core_trading,
+)
+from auramaur.nlp.analyzer import AnalysisResult
+from auramaur.strategy.signals import detect_edge, taker_fee_rate
+
+
+NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+LEGACY_RULES = CoreTradingRules(True, True, True, 1.0)
+
+
+def _inputs(**changes) -> CoreTradingInputs:
+    values = dict(
+        market_id="m1",
+        question="Will X happen?",
+        market_probability=0.4,
+        model_probability=0.7,
+        confidence="HIGH",
+        second_opinion_probability=0.65,
+        divergence=0.05,
+        reasoning="two independent sources support the forecast",
+        evidence_count=2,
+        hours_to_resolution=48.0,
+        fee_rate=0.05,
+    )
+    values.update(changes)
+    return CoreTradingInputs(**values)
+
+
+@pytest.mark.parametrize("market_probability, model_probability", [(0.4, 0.7), (0.7, 0.4)])
+def test_pure_proposal_matches_production_signal(market_probability, model_probability):
+    market = Market(
+        id="m1",
+        question="Will X happen?",
+        outcome_yes_price=market_probability,
+        outcome_no_price=1 - market_probability,
+    )
+    analysis = AnalysisResult(
+        probability=model_probability,
+        confidence="HIGH",
+        reasoning="two independent sources support the forecast",
+        key_factors=["one", "two"],
+        second_opinion_prob=0.65,
+        divergence=0.05,
+    )
+    signal = detect_edge(market, analysis)
+    assessment = assess_core_trading(_inputs(
+        market_probability=market_probability,
+        model_probability=model_probability,
+        fee_rate=taker_fee_rate(market.exchange, market.category),
+        hours_to_resolution=None,
+    ), LEGACY_RULES)
+    assert signal is not None and assessment.proposal is not None
+    proposal = assessment.proposal
+    assert proposal.side == signal.recommended_side.value
+    assert proposal.model_probability == pytest.approx(signal.claude_prob)
+    assert proposal.edge_percent == pytest.approx(signal.edge)
+    assert proposal.quality == signal.recommended_size
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        ({"model_probability": float("nan")}, CoreTradingRejection.INVALID_PROBABILITY),
+        ({"model_probability": 0.4, "second_opinion_probability": None}, CoreTradingRejection.NO_EDGE),
+        ({"question": "Will X not happen?", "model_probability": 0.9,
+          "second_opinion_probability": None}, CoreTradingRejection.INVERTED_SEMANTICS),
+        ({"model_probability": 0.405, "second_opinion_probability": None,
+          "fee_rate": 0.1}, CoreTradingRejection.FEES_CONSUME_EDGE),
+    ],
+)
+def test_fail_closed_rejections_are_explicit(changes, reason):
+    assessment = assess_core_trading(_inputs(**changes), LEGACY_RULES)
+    assert assessment.proposal is None
+    assert assessment.rejection is reason
+
+
+def test_strategic_rules_preserve_direct_estimate_and_historic_fee_semantics():
+    assessment = assess_core_trading(
+        _inputs(model_probability=0.405, second_opinion_probability=0.9, fee_rate=0.1),
+        CoreTradingRules(False, False, False, 1.0, False),
+    )
+    assert assessment.proposal is not None
+    assert assessment.proposal.model_probability == pytest.approx(0.405)
+    assert assessment.proposal.edge_percent < 0
+    assert assessment.proposal.quality is None
+
+
+def test_experiment_adapter_is_isolated_from_live_execution():
+    payload = asdict(_inputs())
+    snapshot = MarketSnapshot(
+        observed_at=NOW,
+        sequence=1,
+        market_id="m1",
+        venue="polymarket",
+        prices=(PricePoint(instrument_id="m1:YES", price=0.4),),
+        features=(FeatureValue(
+            name="core_trading_inputs",
+            payload=payload,
+            source="prospective-test",
+            observed_at=NOW,
+            available_at=NOW,
+        ),),
+        data_version="test-v1",
+    )
+    targets = asyncio.run(CoreTradingExperiment(LEGACY_RULES).evaluate(
+        snapshot, PortfolioSnapshot(observed_at=NOW, cash=100, equity=100)
+    ))
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "m1:YES"
+
+    source = Path("auramaur/experiments/strategies/core_trading.py").read_text()
+    imports = {
+        node.module or "" for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = ("auramaur.broker", "auramaur.db", "auramaur.exchange")
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_experiment_econ_indicator.py
+++ b/tests/test_experiment_econ_indicator.py
@@ -1,0 +1,75 @@
+"""Portable economic-indicator decision and runtime contract."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.econ_indicator import (
+    EconIndicatorExperiment,
+    EconIndicatorInputs,
+    EconIndicatorRejection,
+    assess_econ_indicator,
+)
+
+
+def test_assessment_matches_existing_entry_rules():
+    sell = assess_econ_indicator(EconIndicatorInputs(
+        "m1", 0.50, 0.31, 0.07, 0.30, False
+    ))
+    assert sell.proposal is not None
+    assert not sell.proposal.buy_yes
+    assert sell.proposal.instrument_id == "m1:NO"
+    assert sell.proposal.edge_percent == 19.0
+
+    assert assess_econ_indicator(EconIndicatorInputs(
+        "m1", 0.50, 0.44, 0.07, 0.30, False
+    )).rejection == EconIndicatorRejection.INSUFFICIENT_EDGE
+    assert assess_econ_indicator(EconIndicatorInputs(
+        "m1", 0.03, 0.50, 0.07, 0.30, False
+    )).rejection == EconIndicatorRejection.IMPLAUSIBLE_DIVERGENCE
+    assert assess_econ_indicator(EconIndicatorInputs(
+        "m1", 0.50, 0.31, 0.07, 0.30, True
+    )).rejection == EconIndicatorRejection.ALREADY_ENTERED_OR_HELD
+
+
+def test_experiment_emits_target_without_execution_dependencies():
+    async def run():
+        now = datetime.now(timezone.utc)
+        snapshot = MarketSnapshot(
+            market_id="m1",
+            venue="kalshi",
+            observed_at=now,
+            sequence=0,
+            prices=(PricePoint(instrument_id="m1:NO", price=0.50),),
+            features=(FeatureValue(
+                name="econ_indicator_inputs",
+                payload={
+                    "market_probability": 0.50,
+                    "model_probability": 0.31,
+                    "required_edge": 0.07,
+                    "max_divergence": 0.30,
+                    "already_entered_or_held": False,
+                },
+                observed_at=now,
+                available_at=now,
+                source="test",
+            ),),
+            data_version="test-v1",
+        )
+        portfolio = PortfolioSnapshot(
+            observed_at=now, cash=100.0, equity=100.0, positions=()
+        )
+        targets = await EconIndicatorExperiment(10.0).evaluate(snapshot, portfolio)
+        assert len(targets) == 1
+        assert targets[0].instrument_id == "m1:NO"
+        assert targets[0].target_quantity == 20.0
+        assert targets[0].max_notional == 10.0
+
+    asyncio.run(run())

--- a/tests/test_experiment_informed_flow.py
+++ b/tests/test_experiment_informed_flow.py
@@ -1,0 +1,71 @@
+"""Parity and isolation tests for the portable informed-flow proposal."""
+from __future__ import annotations
+import ast
+import asyncio
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+import pytest
+from auramaur.experiments.models import FeatureValue, MarketSnapshot, PortfolioSnapshot, PricePoint
+from auramaur.experiments.strategies.informed_flow import (
+    InformedFlowExperiment, InformedFlowInputs, InformedFlowRejection,
+    InformedFlowRules, assess_informed_flow,
+)
+
+RULES = InformedFlowRules(0.1, 0.9, 100, 2, 7, 0.04, 10)
+
+def _inputs(**changes) -> InformedFlowInputs:
+    values = dict(market_id="KX-1", venue="kalshi", ticker="KXTEST", active=True,
+        market_probability=0.4, liquidity=500, blocked_category=False,
+        hours_to_resolution=24, already_entered_or_held=False, has_signal=True,
+        informed_side="no", abnormal_count=3, baseline_size=10.0,
+        signal_volume=100.0, sample=40)
+    values.update(changes)
+    return InformedFlowInputs(**values)
+
+def test_assessment_matches_production_no_side_signal():
+    proposal = assess_informed_flow(_inputs(), RULES).proposal
+    assert proposal is not None
+    assert proposal.buy_yes is False
+    assert proposal.model_probability == pytest.approx(0.36)
+    assert proposal.edge_percent == pytest.approx(4)
+    assert proposal.reference_price == pytest.approx(0.6)
+    assert proposal.max_notional == 10
+    assert proposal.evidence_summary == (
+        "Informed-flow follow: 3 abnormal trades (100 contracts) on the NO side "
+        "vs a 10-size baseline (n=40).")
+
+@pytest.mark.parametrize(("changes", "reason"), [
+    ({"active": False}, InformedFlowRejection.INACTIVE),
+    ({"venue": "polymarket"}, InformedFlowRejection.WRONG_VENUE),
+    ({"ticker": None}, InformedFlowRejection.MISSING_TICKER),
+    ({"market_probability": 0.95}, InformedFlowRejection.OUTSIDE_PRICE_BAND),
+    ({"liquidity": 10}, InformedFlowRejection.INSUFFICIENT_LIQUIDITY),
+    ({"blocked_category": True}, InformedFlowRejection.BLOCKED_CATEGORY),
+    ({"hours_to_resolution": None}, InformedFlowRejection.MISSING_RESOLUTION_TIME),
+    ({"hours_to_resolution": 1}, InformedFlowRejection.OUTSIDE_RESOLUTION_WINDOW),
+    ({"already_entered_or_held": True}, InformedFlowRejection.ALREADY_ENTERED_OR_HELD),
+    ({"has_signal": False}, InformedFlowRejection.NO_INFORMED_FLOW),
+])
+def test_rejection_parity(changes, reason):
+    result = assess_informed_flow(_inputs(**changes), RULES)
+    assert result.proposal is None
+    assert result.rejection == reason
+
+def test_adapter_emits_target_without_live_dependencies():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    raw = _inputs()
+    snapshot = MarketSnapshot(observed_at=now, sequence=1, market_id=raw.market_id,
+        venue="kalshi", prices=(PricePoint(instrument_id="KX-1:NO", price=0.6),),
+        features=(FeatureValue(name="informed_flow_inputs", payload=asdict(raw),
+        source="test", observed_at=now, available_at=now),), data_version="test-v1")
+    targets = asyncio.run(InformedFlowExperiment(RULES).evaluate(
+        snapshot, PortfolioSnapshot(observed_at=now, cash=100, equity=100)))
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "KX-1:NO"
+    assert targets[0].target_quantity == pytest.approx(10 / 0.6)
+    source = Path("auramaur/experiments/strategies/informed_flow.py").read_text()
+    tree = ast.walk(ast.parse(source))
+    imports = {node.module or "" for node in tree if isinstance(node, ast.ImportFrom)}
+    forbidden = ("auramaur.broker", "auramaur.db", "auramaur.exchange")
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_experiment_long_horizon.py
+++ b/tests/test_experiment_long_horizon.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.experiments.strategies.long_horizon import (
+    LongHorizonInputs,
+    LongHorizonRejection,
+    LongHorizonRules,
+    assess_long_horizon,
+)
+
+
+NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
+
+def _rules(**changes) -> LongHorizonRules:
+    values = dict(
+        venue="polymarket",
+        band_lo=0.58,
+        band_hi=0.85,
+        slope=1.32,
+        min_edge=0.03,
+        stake_usd=8.0,
+        min_liquidity=1000.0,
+        min_days_to_resolution=30,
+        max_days_to_resolution=365,
+        source_tag="long_horizon",
+    )
+    values.update(changes)
+    return LongHorizonRules(**values)
+
+
+def _inputs(**changes) -> LongHorizonInputs:
+    values = dict(
+        market_id="m1",
+        yes_price=0.70,
+        active=True,
+        venue="polymarket",
+        liquidity=5000.0,
+        category_blocked=False,
+        end_at=NOW + timedelta(days=60),
+        as_of=NOW,
+        already_entered_or_held=False,
+    )
+    values.update(changes)
+    return LongHorizonInputs(**values)
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        ({"yes_price": 0.50}, LongHorizonRejection.OUT_OF_BAND),
+        ({"active": False}, LongHorizonRejection.INACTIVE),
+        ({"venue": "kalshi"}, LongHorizonRejection.WRONG_VENUE),
+        ({"liquidity": 100.0}, LongHorizonRejection.INSUFFICIENT_LIQUIDITY),
+        ({"category_blocked": True}, LongHorizonRejection.BLOCKED_CATEGORY),
+        ({"end_at": None}, LongHorizonRejection.MISSING_END),
+        ({"end_at": NOW + timedelta(days=10)}, LongHorizonRejection.TOO_SOON),
+        ({"end_at": NOW + timedelta(days=400)}, LongHorizonRejection.TOO_FAR),
+        (
+            {"already_entered_or_held": True},
+            LongHorizonRejection.ALREADY_ENTERED_OR_HELD,
+        ),
+    ],
+)
+def test_long_horizon_rejections_are_explicit(changes, reason):
+    assessment = assess_long_horizon(_inputs(**changes), _rules())
+    assert assessment.proposal is None
+    assert assessment.rejection is reason
+
+
+@pytest.mark.parametrize(
+    ("yes_price", "buy_yes", "instrument", "fair_side"),
+    [
+        (0.70, True, "m1:YES", "above"),
+        (0.30, False, "m1:NO", "below"),
+    ],
+)
+def test_long_horizon_proposal_preserves_direction_and_fair(
+    yes_price, buy_yes, instrument, fair_side
+):
+    proposal = assess_long_horizon(
+        _inputs(yes_price=yes_price), _rules()
+    ).proposal
+    assert proposal is not None
+    assert proposal.buy_yes is buy_yes
+    assert proposal.instrument_id == instrument
+    assert proposal.max_notional == 8.0
+    assert proposal.target_quantity * proposal.entry_price == pytest.approx(8.0)
+    if fair_side == "above":
+        assert proposal.fair_probability > yes_price
+    else:
+        assert proposal.fair_probability < yes_price
+
+
+def test_long_horizon_pure_module_has_no_live_execution_imports():
+    import auramaur.experiments.strategies.long_horizon as module
+
+    source = module.__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read()
+    assert "ExecutionGateway" not in text
+    assert "TradeIntent" not in text

--- a/tests/test_experiment_news_reactor.py
+++ b/tests/test_experiment_news_reactor.py
@@ -1,0 +1,86 @@
+"""Parity and safety tests for pure news-reactor market proposals."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from auramaur.experiments.strategies.news_reactor import (
+    NewsMarketCandidate,
+    NewsReactorRules,
+    extract_proper_nouns,
+    extract_search_terms,
+    form_news_market_proposal,
+)
+from auramaur.strategy.news_reactor import NewsReactor
+
+
+def _candidate(**changes: object) -> NewsMarketCandidate:
+    values: dict[str, object] = {
+        "market_id": "m1",
+        "question": "Will the Federal Reserve cut rates in September?",
+        "description": "Decision by the Federal Reserve",
+        "category": "economics",
+        "active": True,
+        "liquidity": 2500.0,
+        "volume": 500.0,
+    }
+    values.update(changes)
+    return NewsMarketCandidate(**values)  # type: ignore[arg-type]
+
+
+def test_pure_proposal_matches_production_headline_decisions() -> None:
+    headline = "Federal Reserve signals September interest rate cut"
+    reactor = NewsReactor(MagicMock(), {}, {}, MagicMock())
+    proposal = form_news_market_proposal(headline, _candidate(), NewsReactorRules())
+
+    assert proposal is not None
+    assert proposal.market_id == "m1"
+    assert proposal.matched_proper_nouns == ("Federal", "Reserve", "September")
+    assert reactor._extract_proper_nouns(headline) == extract_proper_nouns(headline)
+    assert reactor._extract_search_terms(headline) == extract_search_terms(headline)
+
+
+def test_volume_fallback_preserves_active_kalshi_style_candidate() -> None:
+    proposal = form_news_market_proposal(
+        "Federal Reserve announces decision",
+        _candidate(liquidity=0.0, volume=9000.0),
+        NewsReactorRules(),
+    )
+    assert proposal is not None
+    assert proposal.activity == 9000.0
+
+
+def test_proposal_fails_closed_for_ineligible_or_invalid_candidates() -> None:
+    headline = "Federal Reserve announces decision"
+    rejected = (
+        _candidate(active=False),
+        _candidate(category="Sports"),
+        _candidate(liquidity=100.0, volume=100.0),
+        _candidate(liquidity=float("nan")),
+        _candidate(question="Unrelated market", description="No relevant entity"),
+    )
+    assert all(
+        form_news_market_proposal(headline, candidate, NewsReactorRules()) is None
+        for candidate in rejected
+    )
+    assert form_news_market_proposal(
+        "Cheap stuff that does not suck", _candidate(), NewsReactorRules()
+    ) is None
+
+
+def test_experiment_strategy_has_no_live_runtime_imports() -> None:
+    path = Path("auramaur/experiments/strategies/news_reactor.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    forbidden = ("auramaur.exchange", "auramaur.strategy", "auramaur.risk", "auramaur.db")
+    assert not any(name.startswith(forbidden) for name in imported)

--- a/tests/test_experiment_platform.py
+++ b/tests/test_experiment_platform.py
@@ -389,4 +389,9 @@ def test_every_production_strategy_is_in_the_migration_inventory():
     }
     assert migrated == {
         "bias_harvest",
+        "core_trading", "news_reactor", "platform_consensus", "long_horizon",
+        "agent_trader", "agent_trader_kalshi", "term_structure", "vol_anchor",
+        "informed_flow", "econ_indicator", "interim_manager", "settlement_arb",
+        "weather_temp", "resolution_lens", "resolution_lens_kalshi",
+        "momentum_coupling",
     }

--- a/tests/test_experiment_platform_consensus.py
+++ b/tests/test_experiment_platform_consensus.py
@@ -1,0 +1,118 @@
+"""Parity and isolation tests for the portable platform-consensus decision."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.platform_consensus import (
+    ConsensusForecast,
+    ConsensusInputs,
+    ConsensusRules,
+    PlatformConsensusExperiment,
+    assess_platform_consensus,
+)
+
+
+RULES = ConsensusRules(100, 2, 30, 0.5, 0.03, 20, 100, 25, 10)
+NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
+
+def _inputs(**changes) -> ConsensusInputs:
+    values = dict(
+        market_id="pm-1",
+        question="Will the mission launch before September?",
+        market_probability=0.4,
+        active=True,
+        liquidity_or_volume=1_000,
+        category_blocked=False,
+        end_at=NOW + timedelta(days=5),
+        as_of=NOW,
+        fee=0.005,
+        forecasts=(ConsensusForecast(
+            "[Manifold: 60%] Will the mission launch before September?",
+            "Unique bettors: 40\nLiquidity: $500",
+            "Manifold",
+        ),),
+    )
+    values.update(changes)
+    return ConsensusInputs(**values)
+
+
+def test_assessment_matches_production_signal_fields():
+    proposal = assess_platform_consensus(_inputs(), RULES)
+    assert proposal is not None
+    assert proposal.buy_yes is True
+    assert proposal.consensus_probability == pytest.approx(0.6)
+    assert proposal.edge_percent == pytest.approx(20)
+    assert proposal.reference_price == pytest.approx(0.4)
+    assert proposal.target_quantity == pytest.approx(25)
+    assert proposal.confidence == "high"
+
+
+@pytest.mark.parametrize("changes", [
+    {"active": False},
+    {"liquidity_or_volume": 10},
+    {"category_blocked": True},
+    {"end_at": None},
+    {"fee": 0.2},
+    {"forecasts": (ConsensusForecast(
+        "[Manifold: 60%] Will the mission launch before September?",
+        "Unique bettors: 2\nLiquidity: $10",
+        "Manifold",
+    ),)},
+])
+def test_assessment_fails_closed(changes):
+    assert assess_platform_consensus(_inputs(**changes), RULES) is None
+
+
+def test_adapter_emits_target_without_live_dependencies():
+    raw = _inputs()
+    payload = asdict(raw)
+    payload["end_at"] = raw.end_at.isoformat() if raw.end_at else None
+    payload["as_of"] = raw.as_of.isoformat()
+    payload["forecasts"] = [asdict(item) for item in raw.forecasts]
+    snapshot = MarketSnapshot(
+        observed_at=NOW,
+        sequence=1,
+        market_id=raw.market_id,
+        venue="polymarket",
+        prices=(PricePoint(instrument_id="pm-1:YES", price=0.4),),
+        features=(FeatureValue(
+            name="platform_consensus_inputs",
+            payload=payload,
+            source="test",
+            observed_at=NOW,
+            available_at=NOW,
+        ),),
+        data_version="test-v1",
+    )
+    targets = asyncio.run(PlatformConsensusExperiment(RULES).evaluate(
+        snapshot, PortfolioSnapshot(observed_at=NOW, cash=100, equity=100)
+    ))
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "pm-1:YES"
+
+    source = Path("auramaur/experiments/strategies/platform_consensus.py").read_text()
+    imports = {
+        node.module or "" for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = (
+        "auramaur.broker",
+        "auramaur.db",
+        "auramaur.exchange",
+        "auramaur.strategy",
+    )
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_experiment_resolution_lens.py
+++ b/tests/test_experiment_resolution_lens.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.resolution_lens import (
+    ResolutionLensCandidate,
+    ResolutionLensExperiment,
+    ResolutionLensRules,
+    form_resolution_lens_proposal,
+)
+
+
+RULES = ResolutionLensRules(
+    min_entry_price=0.55,
+    high_conf_gap_score=0.8,
+    stake_usd=12.0,
+)
+
+
+def test_proposal_preserves_production_signal_semantics():
+    proposal = form_resolution_lens_proposal(
+        ResolutionLensCandidate("market-1", 0.60, 0.82, 0.85, "literal deadline"),
+        RULES,
+    )
+    assert proposal is not None
+    assert proposal.buy_yes
+    assert proposal.high_confidence
+    assert proposal.edge_percent == pytest.approx(22.0)
+    assert proposal.evidence_summary == "Resolution lens (gap 0.85): literal deadline"
+    assert proposal.mispricing_reason == "behavioral: literal deadline"
+    assert proposal.instrument_id == "market-1:YES"
+    assert proposal.target_quantity == pytest.approx(20.0)
+
+    sell = form_resolution_lens_proposal(
+        ResolutionLensCandidate("market-2", 0.30, 0.10, 0.5, "permanence clause"),
+        RULES,
+    )
+    assert sell is not None
+    assert not sell.buy_yes
+    assert not sell.high_confidence
+    assert sell.instrument_id == "market-2:NO"
+    assert sell.reference_price == pytest.approx(0.70)
+
+
+@pytest.mark.parametrize("candidate", [
+    ResolutionLensCandidate("", 0.6, 0.8, 0.9, "deadline"),
+    ResolutionLensCandidate("m", float("nan"), 0.8, 0.9, "deadline"),
+    ResolutionLensCandidate("m", 0.6, 1.2, 0.9, "deadline"),
+    ResolutionLensCandidate("m", 0.6, 0.8, -0.1, "deadline"),
+    ResolutionLensCandidate("m", 0.6, 0.8, 0.9, "  "),
+    ResolutionLensCandidate("m", 0.60, 0.60, 0.9, "deadline"),
+    ResolutionLensCandidate("m", 0.40, 0.80, 0.9, "deadline"),
+])
+def test_proposal_fails_closed(candidate):
+    assert form_resolution_lens_proposal(candidate, RULES) is None
+
+
+@pytest.mark.asyncio
+async def test_portable_experiment_matches_pure_proposal_without_execution_capability():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    snapshot = MarketSnapshot(
+        observed_at=now,
+        sequence=4,
+        market_id="market-1",
+        venue="polymarket",
+        prices=(PricePoint(instrument_id="market-1:YES", price=0.60),),
+        features=(FeatureValue(
+            name="resolution_lens_candidate",
+            payload={
+                "market_probability": 0.60,
+                "fair_probability": 0.82,
+                "gap_score": 0.85,
+                "mechanism": "literal deadline",
+            },
+            source="grounded-lens",
+            observed_at=now,
+            available_at=now,
+        ),),
+        data_version="test-v1",
+    )
+    experiment = ResolutionLensExperiment(RULES)
+    targets = await experiment.evaluate(
+        snapshot,
+        PortfolioSnapshot(observed_at=now, cash=100, equity=100),
+    )
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "market-1:YES"
+    assert targets[0].reference_price == pytest.approx(0.60)
+    assert targets[0].max_notional == 12.0
+    assert not hasattr(experiment, "submit")
+    assert not hasattr(experiment, "execute")

--- a/tests/test_experiment_settlement_arb.py
+++ b/tests/test_experiment_settlement_arb.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.experiments.models import (
+    ExperimentDefinition, FeatureValue, MarketSnapshot, PortfolioSnapshot, PricePoint,
+)
+from auramaur.experiments.registry import ExperimentRegistry
+from auramaur.experiments.runtimes import (
+    InMemoryShadowSink, LinearExecutionModel, ReplayRuntime, ResearchRuntime, ShadowRuntime,
+)
+from auramaur.experiments.strategies.settlement_arb import SettlementArbExperiment
+
+
+@pytest.mark.asyncio
+async def test_settlement_proposal_is_identical_across_non_live_runtimes():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    snapshot = MarketSnapshot(
+        observed_at=now, sequence=0, market_id="cpi", venue="kalshi",
+        prices=(PricePoint(instrument_id="cpi:YES", price=.80),
+                PricePoint(instrument_id="cpi:NO", price=.20)),
+        features=(FeatureValue(
+            name="settlement_predicate",
+            payload={"published_value": 3.0, "indicator": "KXCPIYOY",
+                     "reference_period": "2026-06", "operator": ">=",
+                     "threshold": 3.0},
+            source="fred", observed_at=now, available_at=now,
+        ),), data_version="fred-fixture-v1",
+    )
+    account = PortfolioSnapshot(
+        observed_at=now - timedelta(seconds=1), cash=1000, equity=1000)
+    implementation = SettlementArbExperiment(min_edge=.05, stake_usd=10)
+    definition = ExperimentDefinition(
+        key="settlement-poc", strategy_source="settlement_arb",
+        hypothesis="Published outcomes converge after official release.",
+        mechanism="settlement lag", implementation_version="proposal-v1",
+        parameters={"min_edge": .05, "stake_usd": 10},
+        venues=frozenset({"kalshi", "polymarket"}),
+        primary_metric="net_pnl_after_costs", baseline="no_position",
+        min_observations=30, holdout_days=14, max_drawdown=.15,
+        cost_model="linear-v1", rejection_criteria=("holdout_pnl_lte_zero",),
+    )
+    bound = ExperimentRegistry().register(definition, implementation)
+    research = await ResearchRuntime().run(bound, snapshot, account)
+    sink = InMemoryShadowSink()
+    shadow = await ShadowRuntime(sink).run(bound, snapshot, account)
+    replay = await ReplayRuntime(LinearExecutionModel(version="linear-v1")).run(
+        bound, [snapshot], account)
+    assert research.targets == shadow.targets == replay.results[0].targets
+    assert research.targets[0].instrument_id == "cpi:YES"
+    assert research.targets[0].max_notional == pytest.approx(10)

--- a/tests/test_experiment_weather_temp.py
+++ b/tests/test_experiment_weather_temp.py
@@ -1,0 +1,118 @@
+"""Parity and isolation tests for the portable weather-temperature proposal."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.weather_temp import (
+    WeatherTempInputs,
+    WeatherTempRejection,
+    WeatherTempRules,
+    WeatherTempExperiment,
+    assess_weather_temp,
+)
+
+
+def _inputs(**changes) -> WeatherTempInputs:
+    values = {
+        "market_id": "weather-1",
+        "market_probability": 0.27,
+        "model_probability": 0.03,
+        "member_count": 10,
+        "city": "Tokyo",
+        "temperature_kind": "high",
+        "already_entered_or_held": False,
+    }
+    values.update(changes)
+    return WeatherTempInputs(**values)
+
+
+def test_pure_assessment_matches_production_sell_signal():
+    result = assess_weather_temp(
+        _inputs(),
+        WeatherTempRules(required_edge=0.10, max_divergence=0.40, stake_usd=10),
+    )
+    assert result.rejection is None
+    assert result.proposal is not None
+    assert result.proposal.buy_yes is False
+    assert result.proposal.edge_percent == pytest.approx(24)
+    assert result.proposal.reference_price == pytest.approx(0.73)
+    assert result.proposal.max_notional == 10
+
+
+@pytest.mark.parametrize(
+    ("changes", "rejection"),
+    [
+        ({"model_probability": None}, WeatherTempRejection.NO_MODEL_PRICE),
+        ({"model_probability": 0.30}, WeatherTempRejection.INSUFFICIENT_EDGE),
+        ({"model_probability": 0.90}, WeatherTempRejection.IMPLAUSIBLE_DIVERGENCE),
+        ({"already_entered_or_held": True}, WeatherTempRejection.ALREADY_ENTERED_OR_HELD),
+    ],
+)
+def test_rejection_parity(changes, rejection):
+    result = assess_weather_temp(
+        _inputs(**changes),
+        WeatherTempRules(required_edge=0.10, max_divergence=0.40, stake_usd=10),
+    )
+    assert result.proposal is None
+    assert result.rejection == rejection
+
+
+def test_portable_adapter_emits_same_target_without_live_dependencies():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    payload = {
+        "market_probability": 0.27,
+        "model_probability": 0.03,
+        "member_count": 10,
+        "city": "Tokyo",
+        "temperature_kind": "high",
+        "already_entered_or_held": False,
+    }
+    snapshot = MarketSnapshot(
+        observed_at=now,
+        sequence=1,
+        market_id="weather-1",
+        venue="polymarket",
+        prices=(PricePoint(instrument_id="weather-1:NO", price=0.73),),
+        features=(FeatureValue(
+            name="weather_temp_inputs",
+            payload=payload,
+            source="test",
+            observed_at=now,
+            available_at=now,
+        ),),
+        data_version="test-v1",
+    )
+    portfolio = PortfolioSnapshot(observed_at=now, cash=100, equity=100)
+    targets = asyncio.run(WeatherTempExperiment(
+        WeatherTempRules(required_edge=0.10, max_divergence=0.40, stake_usd=10)
+    ).evaluate(snapshot, portfolio))
+    assert len(targets) == 1
+    assert targets[0].instrument_id == "weather-1:NO"
+    assert targets[0].reference_price == pytest.approx(0.73)
+    assert targets[0].target_quantity == pytest.approx(10 / 0.73)
+
+    source = Path("auramaur/experiments/strategies/weather_temp.py").read_text()
+    imports = {
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module or ""
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = ("auramaur.broker", "auramaur.db", "auramaur.exchange")
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_interim_manager_experiment.py
+++ b/tests/test_interim_manager_experiment.py
@@ -1,0 +1,117 @@
+"""Portable interim-manager proposal assessment and production boundary."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.experiments.strategies.interim_manager import (
+    InterimManagerInputs,
+    InterimManagerRejection,
+    InterimManagerRules,
+    assess_interim_manager,
+)
+
+
+NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+THESIS = (
+    "Resolution fine print prices NO events as YES while the market ignores "
+    "the settlement source's published revision schedule."
+)
+
+
+def _rules(**changes):
+    values = dict(
+        proposal_ttl_hours=24.0,
+        max_open_positions=3,
+        min_robust_edge=0.05,
+        default_uncertainty_buffer=0.02,
+        slippage_buffer=0.005,
+        liquidity_penalty=0.01,
+        thin_liquidity_usd=100.0,
+        correlation_penalty_per_position=0.005,
+        stake_usd=10.0,
+        paper=True,
+    )
+    values.update(changes)
+    return InterimManagerRules(**values)
+
+
+def _inputs(**changes):
+    values = dict(
+        proposal_id=7,
+        market_id="M1",
+        thesis=THESIS,
+        side="BUY",
+        fair_probability=0.72,
+        requested_stake_usd=25.0,
+        market_yes_price=0.40,
+        market_liquidity=500.0,
+        category="economics",
+        created_at=NOW - timedelta(hours=1),
+        sunset_at=NOW + timedelta(hours=6),
+        as_of=NOW,
+        delegated_to=None,
+        open_positions=0,
+        open_positions_in_category=0,
+        fee_rate=0.0,
+        confidence_lo=0.70,
+        confidence_hi=0.74,
+    )
+    values.update(changes)
+    return InterimManagerInputs(**values)
+
+
+def test_valid_candidate_becomes_bounded_paper_proposal():
+    result = assess_interim_manager(_inputs(), _rules())
+
+    assert result.rejection is None
+    assert result.proposal is not None
+    assert result.proposal.buy_yes is True
+    assert result.proposal.entry_price == pytest.approx(0.40)
+    assert result.proposal.requested_stake_usd == 10.0
+    assert result.proposal.force_paper is True
+    assert result.proposal.robust_edge == pytest.approx(0.295)
+
+
+@pytest.mark.parametrize(
+    ("changes", "rejection"),
+    [
+        ({"created_at": NOW - timedelta(hours=25)}, InterimManagerRejection.EXPIRED),
+        ({"thesis": "just vibes"}, InterimManagerRejection.THESIS_TOO_SHORT),
+        ({"delegated_to": "econ_indicator"}, InterimManagerRejection.DELEGATED),
+        ({"sunset_at": NOW}, InterimManagerRejection.SUNSET_REACHED),
+        ({"open_positions": 3}, InterimManagerRejection.POSITION_CAP),
+        ({"max_entry_price": 0.39}, InterimManagerRejection.ENTRY_LIMIT),
+        ({"fair_probability": 0.47}, InterimManagerRejection.INSUFFICIENT_EDGE),
+    ],
+)
+def test_charter_rejections_are_deterministic(changes, rejection):
+    result = assess_interim_manager(_inputs(**changes), _rules())
+    assert result.proposal is None
+    assert result.rejection == rejection
+
+
+def test_sell_uses_no_entry_price_and_directional_edge():
+    result = assess_interim_manager(
+        _inputs(side="SELL", fair_probability=0.15, market_yes_price=0.40),
+        _rules(),
+    )
+    assert result.proposal is not None
+    assert result.proposal.buy_yes is False
+    assert result.proposal.entry_price == pytest.approx(0.60)
+
+
+def test_pure_module_has_no_live_execution_dependencies():
+    import ast
+
+    source = __import__(
+        "auramaur.experiments.strategies.interim_manager", fromlist=["dummy"]
+    ).__file__
+    with open(source, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read())
+    imports = {
+        node.module or "" for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = ("auramaur.broker", "auramaur.db", "auramaur.exchange")
+    assert not any(name.startswith(forbidden) for name in imports)

--- a/tests/test_momentum_coupling_migration.py
+++ b/tests/test_momentum_coupling_migration.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auramaur.experiments.strategies.momentum_coupling import (
+    CouplingCandidate, CouplingInputs, CouplingRejection, CouplingRules,
+    assess_momentum_coupling,
+)
+from auramaur.strategy.momentum_coupling import MomentumCouplingPillar
+
+RULES = CouplingRules(0.5, 0.05, 20.0)
+
+def test_proposal_matches_formula_and_skips_ineligible_candidates():
+    result = assess_momentum_coupling(CouplingInputs("BTC", 50_000, 2.0, (
+        CouplingCandidate("far", "Bitcoin above $60,000?", 0.5),
+        CouplingCandidate("live", "Bitcoin above $50,000?", 0.4),
+    )), RULES)
+    proposal = result.proposal
+    assert proposal is not None
+    assert proposal.market_id == "live"
+    assert proposal.direction == "BUY_YES"
+    assert proposal.fair_probability == pytest.approx(0.5)
+    assert proposal.edge_percent == pytest.approx(10.0)
+    assert proposal.target_quantity == pytest.approx(50.0)
+    assert proposal.confidence == "HIGH"
+
+def test_negative_move_preserves_shift_and_medium_confidence():
+    result = assess_momentum_coupling(CouplingInputs("ETH", 4_000, -0.75, (
+        CouplingCandidate("m", "Ethereum above $4,000?", 0.5),
+    )), RULES)
+    proposal = result.proposal
+    assert proposal is not None
+    assert proposal.direction == "BUY_NO"
+    assert proposal.fair_probability == pytest.approx(0.4625)
+    assert proposal.confidence == "MEDIUM"
+
+def test_small_move_and_pinned_market_are_rejected():
+    small = assess_momentum_coupling(CouplingInputs("BTC", 50_000, 0.1, ()), RULES)
+    assert small.rejection is CouplingRejection.MOVE_TOO_SMALL
+    pinned = assess_momentum_coupling(CouplingInputs("BTC", 50_000, 1.0, (
+        CouplingCandidate("m", "Bitcoin above $50,000?", 0.95),
+    )), RULES)
+    assert pinned.rejection is CouplingRejection.PINNED_MARKET
+
+@pytest.mark.asyncio
+async def test_production_detect_only_has_no_execution_side_effect():
+    cfg = SimpleNamespace(move_threshold_pct=0.5, near_money_pct=0.05,
+                          max_position_usd=20.0, execute=False)
+    market = SimpleNamespace(id="m", question="Will Bitcoin be above $50,000?",
+                             outcome_yes_price=0.4)
+    pillar = MomentumCouplingPillar(SimpleNamespace(momentum_coupling=cfg))
+    pillar._gamma = SimpleNamespace(search_markets=AsyncMock(return_value=[market]))
+    pillar._execute = AsyncMock()
+    await pillar._emit("BTC", 50_000, 1.0)
+    pillar._execute.assert_not_awaited()

--- a/tests/test_term_structure_experiment.py
+++ b/tests/test_term_structure_experiment.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from auramaur.experiments.models import (
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.strategies.term_structure import (
+    TermStructureCandidate,
+    TermStructureExperiment,
+    TermStructureRules,
+    select_term_structure_proposals,
+)
+
+
+RULES = TermStructureRules(8.0, 1_000.0, 2, 10.0)
+
+
+def test_pure_selector_matches_production_ranking_and_direction():
+    proposals = select_term_structure_proposals([
+        TermStructureCandidate("a", 0.10, 0.40, 5_000),
+        TermStructureCandidate("b", 0.30, 0.70, 5_000),
+        TermStructureCandidate("c", 0.50, 0.72, 5_000),
+        TermStructureCandidate("thin", 0.20, 0.90, 100),
+        TermStructureCandidate("claimed", 0.90, 0.10, 5_000, claimed=True),
+    ], RULES)
+    assert [proposal.market_id for proposal in proposals] == ["b", "a"]
+    assert all(proposal.buy_yes for proposal in proposals)
+    assert proposals[0].edge_percent == pytest.approx(40.0)
+    assert proposals[0].target_quantity == pytest.approx(10.0 / 0.30)
+
+
+def test_pure_selector_has_no_live_capability():
+    assert not hasattr(TermStructureExperiment, "submit")
+    assert not hasattr(TermStructureExperiment, "execute")
+    assert select_term_structure_proposals([
+        TermStructureCandidate("small", 0.30, 0.35, 5_000),
+    ], RULES) == []
+
+
+@pytest.mark.asyncio
+async def test_portable_experiment_matches_selector_targets():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    values = [
+        {"market_id": "a", "market_probability": 0.10,
+         "model_probability": 0.40, "liquidity": 5_000},
+        {"market_id": "b", "market_probability": 0.30,
+         "model_probability": 0.70, "liquidity": 5_000},
+        {"market_id": "c", "market_probability": 0.50,
+         "model_probability": 0.72, "liquidity": 5_000},
+    ]
+    snapshot = MarketSnapshot(
+        market_id="family:event", venue="polymarket", observed_at=now,
+        sequence=0,
+        features=(FeatureValue(
+            name="term_structure_candidates", payload=values,
+            observed_at=now, available_at=now, source="curve",
+        ),),
+        prices=(PricePoint(instrument_id="family:event", price=0.5),),
+        data_version="test-v1",
+    )
+    targets = await TermStructureExperiment(RULES).evaluate(
+        snapshot,
+        PortfolioSnapshot(observed_at=now, cash=100.0, equity=100.0, positions=()),
+    )
+    assert [target.instrument_id for target in targets] == ["b:YES", "a:YES"]
+    assert [target.max_notional for target in targets] == [10.0, 10.0]

--- a/tests/test_vol_anchor_experiment.py
+++ b/tests/test_vol_anchor_experiment.py
@@ -1,0 +1,167 @@
+"""Portable vol-anchor proposal parity and non-live runtime coverage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from auramaur.experiments.models import (
+    CapitalEligibility,
+    ExperimentDefinition,
+    FeatureValue,
+    MarketSnapshot,
+    PortfolioSnapshot,
+    PricePoint,
+)
+from auramaur.experiments.registry import ExperimentRegistry
+from auramaur.experiments.runtimes import InMemoryShadowSink, ResearchRuntime, ShadowRuntime
+from auramaur.experiments.strategies.vol_anchor import (
+    VolAnchorExperiment,
+    VolAnchorInputs,
+    VolAnchorRules,
+    assess_vol_anchor,
+    blended_sigma,
+    terminal_above_prob,
+    touch_prob,
+)
+
+NOW = datetime(2026, 7, 9, tzinfo=timezone.utc)
+
+
+def _rules() -> VolAnchorRules:
+    return VolAnchorRules(
+        min_liquidity=1_000.0,
+        min_edge_pts=8.0,
+        stake_usd=10.0,
+        tau_years=0.25,
+        long_run_vol={"ethereum": 0.70},
+    )
+
+
+def _inputs(**changes) -> VolAnchorInputs:
+    values = {
+        "market_id": "eth-touch",
+        "question": "Will Ethereum reach $3,000 by December 31, 2026?",
+        "yes_price": 0.09,
+        "no_price": 0.91,
+        "active": True,
+        "venue": "polymarket",
+        "liquidity": 5_000.0,
+        "category_blocked": False,
+        "as_of": NOW,
+        "spot": 1_734.54,
+        "realized_vol": 0.52,
+        "already_held": False,
+        "term_sigma": None,
+    }
+    values.update(changes)
+    return VolAnchorInputs(**values)
+
+
+def test_pure_assessment_matches_legacy_formula_path():
+    assessment = assess_vol_anchor(_inputs(), _rules())
+    proposal = assessment.proposal
+    assert proposal is not None
+    years = (proposal.deadline - NOW).total_seconds() / (365 * 86400)
+    sigma = blended_sigma(0.52, 0.70, years, 0.25)
+    assert proposal.sigma == pytest.approx(sigma)
+    assert proposal.fair_probability == pytest.approx(
+        touch_prob(1_734.54, 3_000.0, sigma, years)
+    )
+    assert proposal.buy_yes is True
+    assert proposal.edge_percent >= 8.0
+    assert proposal.max_notional == 10.0
+
+
+@pytest.mark.parametrize(
+    ("question", "market_price", "expected"),
+    [
+        (
+            "Will Ethereum be above $1,600 on December 31, 2026?",
+            0.10,
+            lambda sigma, years: terminal_above_prob(1_734.54, 1_600, sigma, years),
+        ),
+        (
+            "Will Ethereum be below $1,600 on December 31, 2026?",
+            0.90,
+            lambda sigma, years: 1.0
+            - terminal_above_prob(1_734.54, 1_600, sigma, years),
+        ),
+    ],
+)
+def test_terminal_kinds_preserve_pricing_parity(question, market_price, expected):
+    assessment = assess_vol_anchor(
+        _inputs(question=question, yes_price=market_price), _rules()
+    )
+    proposal = assessment.proposal
+    assert proposal is not None
+    years = (proposal.deadline - NOW).total_seconds() / (365 * 86400)
+    assert proposal.fair_probability == pytest.approx(expected(proposal.sigma, years))
+
+
+def _registered():
+    rules = _rules()
+    definition = ExperimentDefinition(
+        key="vol_anchor_poc",
+        strategy_source="vol_anchor",
+        hypothesis="Long-horizon threshold prices underweight volatility reversion.",
+        mechanism="Mean-reverting volatility anchor with GBM threshold pricing.",
+        implementation_version="proposal-v1",
+        parameters={
+            "min_liquidity": rules.min_liquidity,
+            "min_edge_pts": rules.min_edge_pts,
+            "stake_usd": rules.stake_usd,
+            "tau_years": rules.tau_years,
+            "long_run_vol": rules.long_run_vol,
+        },
+        venues=frozenset({"polymarket"}),
+        primary_metric="net_pnl",
+        baseline="market_probability",
+        min_observations=30,
+        holdout_days=14,
+        max_drawdown=0.15,
+        cost_model="linear-v1",
+        rejection_criteria=("non_positive_net_pnl",),
+        capital_eligibility=CapitalEligibility.PAPER_ONLY,
+    )
+    return ExperimentRegistry().register(definition, VolAnchorExperiment(rules))
+
+
+def _snapshot() -> MarketSnapshot:
+    details = _inputs().__dict__.copy()
+    for key in ("market_id", "venue", "as_of"):
+        details.pop(key)
+    details["term_sigma"] = None
+    return MarketSnapshot(
+        observed_at=NOW,
+        sequence=1,
+        market_id="eth-touch",
+        venue="polymarket",
+        prices=(PricePoint(instrument_id="eth-touch:YES", price=0.09),),
+        features=(FeatureValue(
+            name="vol_anchor_inputs",
+            payload=details,
+            source="test-fixture",
+            observed_at=NOW,
+            available_at=NOW,
+        ),),
+        data_version="fixture-v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_research_and_shadow_emit_identical_targets_without_live_orders():
+    registered = _registered()
+    snapshot = _snapshot()
+    portfolio = PortfolioSnapshot(
+        observed_at=NOW, cash=100.0, equity=100.0, positions=()
+    )
+    research = await ResearchRuntime().run(registered, snapshot, portfolio)
+    sink = InMemoryShadowSink()
+    shadow = await ShadowRuntime(sink).run(registered, snapshot, portfolio)
+
+    assert research.targets == shadow.targets
+    assert research.targets[0].instrument_id == "eth-touch:YES"
+    assert research.targets[0].max_notional == pytest.approx(10.0)
+    assert sink.results == [shadow]


### PR DESCRIPTION
Stack 2 of 4, based on experiment-platform-core. Migrates portable directional strategies and news routing to pure deterministic proposal contracts while retaining production risk, gateway, persistence, and accounting. Isolated validation: full suite 1711 passed, 5 skipped; Ruff and diff checks passed.