### PR TITLE
Migrate atomic arbitrage and quoting contracts

### DIFF
--- a/auramaur/experiments/migration.py
+++ b/auramaur/experiments/migration.py
@@ -30,7 +30,7 @@ MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
     "core_trading": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "news_reactor": (MigrationTrack.ROUTING, MigrationStatus.MIGRATED),
     "kraken": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
-    "arbitrage": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
+    "arbitrage": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.MIGRATED),
     "bias_harvest": (
         MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED
     ),
@@ -41,8 +41,8 @@ MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
     "term_structure": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "vol_anchor": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "informed_flow": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
-    "entailment_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
-    "cross_venue_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.SPECIALIZED_PLANNED),
+    "entailment_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.MIGRATED),
+    "cross_venue_arb": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.MIGRATED),
     "econ_indicator": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "interim_manager": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "settlement_arb": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
@@ -53,7 +53,7 @@ MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
     ),
     "oddlot_tender": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
     "momentum_coupling": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
-    "market_maker": (MigrationTrack.QUOTING, MigrationStatus.SPECIALIZED_PLANNED),
+    "market_maker": (MigrationTrack.QUOTING, MigrationStatus.MIGRATED),
     "ibkr_etf_paper": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
     "ibkr_multiasset": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
 }

--- a/auramaur/experiments/strategies/arbitrage.py
+++ b/auramaur/experiments/strategies/arbitrage.py
@@ -1,0 +1,108 @@
+"""Pure formation of atomic two-leg arbitrage proposals."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ArbitrageMarket:
+    """The market facts needed to form a pair, detached from venue models."""
+
+    market_id: str
+    question: str
+    yes_price: float
+    exchange: str = "polymarket"
+    yes_token: str = ""
+    no_token: str = ""
+
+
+@dataclass(frozen=True)
+class ArbitrageLeg:
+    market_id: str
+    question: str
+    side: str
+    market_probability: float
+    fair_probability: float
+    edge_percent: float
+
+
+@dataclass(frozen=True)
+class PairedArbitrageProposal:
+    """One indivisible research proposal; its legs are not standalone targets."""
+
+    buy: ArbitrageLeg
+    sell: ArbitrageLeg
+    opportunity_type: str
+    edge: float
+
+
+def form_arbitrage_pair(
+    opportunity: Mapping[str, Any],
+    market_a: ArbitrageMarket,
+    market_b: ArbitrageMarket,
+) -> PairedArbitrageProposal | None:
+    """Deterministically form a pair, failing closed on incomplete candidates."""
+    try:
+        if market_a.market_id != str(opportunity["market_a"]):
+            return None
+        if market_b.market_id != str(opportunity["market_b"]):
+            return None
+        kind = str(opportunity["type"])
+        price_a = float(opportunity["price_a"])
+        price_b = float(opportunity["price_b"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    prices = (price_a, price_b, market_a.yes_price, market_b.yes_price)
+    if any(not math.isfinite(value) or value < 0.0 or value > 1.0 for value in prices):
+        return None
+
+    if kind == "conditional_violation":
+        buy, sell = market_b, market_a
+        edge = price_a - price_b
+    elif kind == "price_divergence":
+        buy, sell = (
+            (market_a, market_b) if price_a < price_b else (market_b, market_a)
+        )
+        try:
+            edge = float(opportunity.get("divergence", abs(price_a - price_b)))
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+
+    if not math.isfinite(edge) or edge <= 0.0:
+        return None
+    if not _has_execution_metadata(buy, "BUY") or not _has_execution_metadata(sell, "SELL"):
+        return None
+
+    half_edge = edge / 2.0
+    return PairedArbitrageProposal(
+        buy=ArbitrageLeg(
+            market_id=buy.market_id,
+            question=buy.question,
+            side="BUY",
+            market_probability=buy.yes_price,
+            fair_probability=buy.yes_price + half_edge,
+            edge_percent=half_edge * 100.0,
+        ),
+        sell=ArbitrageLeg(
+            market_id=sell.market_id,
+            question=sell.question,
+            side="SELL",
+            market_probability=sell.yes_price,
+            fair_probability=sell.yes_price - half_edge,
+            edge_percent=half_edge * 100.0,
+        ),
+        opportunity_type=kind,
+        edge=edge,
+    )
+
+
+def _has_execution_metadata(market: ArbitrageMarket, side: str) -> bool:
+    if (market.exchange or "polymarket") != "polymarket":
+        return True
+    return bool(market.yes_token if side == "BUY" else market.no_token)

--- a/auramaur/experiments/strategies/cross_venue_arb.py
+++ b/auramaur/experiments/strategies/cross_venue_arb.py
@@ -1,0 +1,85 @@
+"""Pure, atomic paired-package proposals for cross-venue arbitrage."""
+from __future__ import annotations
+from dataclasses import dataclass
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot, TargetPosition
+
+@dataclass(frozen=True)
+class PairedLeg:
+    market_id: str
+    venue: str
+    side: str
+    market_probability: float
+    target: TargetPosition
+
+@dataclass(frozen=True)
+class CrossVenuePairProposal:
+    """One indivisible research proposal containing both hedge legs."""
+    package_id: str
+    orientation: str
+    edge: float
+    confidence: float
+    legs: tuple[PairedLeg, PairedLeg]
+
+    @property
+    def targets(self) -> tuple[TargetPosition, TargetPosition]:
+        return self.legs[0].target, self.legs[1].target
+
+def paired_arb_proposal(*, market_a_id: str, venue_a: str, yes_price_a: float,
+                        market_b_id: str, venue_b: str, yes_price_b: float,
+                        orientation: str, confidence: float, min_confidence: float,
+                        required_gap: float, stake_usd: float) -> CrossVenuePairProposal | None:
+    """Form an atomic two-leg proposal, or fail closed."""
+    if (orientation not in {"same", "inverted"} or confidence < min_confidence
+            or stake_usd <= 0 or required_gap < 0
+            or not (0 < yes_price_a < 1) or not (0 < yes_price_b < 1)
+            or not market_a_id or not market_b_id or market_a_id == market_b_id
+            or not venue_a or not venue_b or venue_a == venue_b):
+        return None
+    if orientation == "same":
+        edge = abs(yes_price_a - yes_price_b)
+        sides = ("BUY", "SELL") if yes_price_a < yes_price_b else ("SELL", "BUY")
+    else:
+        total = yes_price_a + yes_price_b
+        edge = abs(1.0 - total)
+        sides = ("BUY", "BUY") if total < 1.0 else ("SELL", "SELL")
+    if edge < required_gap:
+        return None
+    legs = []
+    rationale = f"cross-venue {orientation} package; gap {edge:.3f}"
+    for market_id, venue, yes_price, side in zip(
+            (market_a_id, market_b_id), (venue_a, venue_b),
+            (yes_price_a, yes_price_b), sides, strict=True):
+        contract = "YES" if side == "BUY" else "NO"
+        contract_price = yes_price if side == "BUY" else 1.0 - yes_price
+        legs.append(PairedLeg(market_id=market_id, venue=venue, side=side,
+            market_probability=yes_price, target=TargetPosition(
+                instrument_id=f"{venue}:{market_id}:{contract}",
+                target_quantity=stake_usd / contract_price,
+                reference_price=contract_price, rationale=rationale,
+                max_notional=stake_usd)))
+    return CrossVenuePairProposal(
+        package_id=f"{venue_a}:{market_a_id}|{venue_b}:{market_b_id}",
+        orientation=orientation, edge=edge, confidence=confidence,
+        legs=(legs[0], legs[1]))
+
+@dataclass(frozen=True)
+class CrossVenueArbExperiment:
+    min_confidence: float
+    required_gap: float
+    stake_usd: float
+
+    async def evaluate(self, snapshot: MarketSnapshot,
+                       portfolio: PortfolioSnapshot) -> list[TargetPosition]:
+        del portfolio
+        try:
+            pair = snapshot.feature("cross_venue_pair")
+            proposal = paired_arb_proposal(
+                market_a_id=str(pair["market_a_id"]), venue_a=str(pair["venue_a"]),
+                yes_price_a=float(pair["yes_price_a"]), market_b_id=str(pair["market_b_id"]),
+                venue_b=str(pair["venue_b"]), yes_price_b=float(pair["yes_price_b"]),
+                orientation=str(pair["orientation"]), confidence=float(pair["confidence"]),
+                min_confidence=self.min_confidence, required_gap=self.required_gap,
+                stake_usd=self.stake_usd)
+        except (KeyError, TypeError, ValueError):
+            return []
+        return list(proposal.targets) if proposal is not None else []

--- a/auramaur/experiments/strategies/entailment_arb.py
+++ b/auramaur/experiments/strategies/entailment_arb.py
@@ -1,0 +1,105 @@
+"""Pure formation of atomic entailment-arbitrage pair proposals."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EntailmentMarket:
+    """Point-in-time market facts used by the structural bound."""
+
+    market_id: str
+    question: str
+    yes_probability: float
+
+
+@dataclass(frozen=True)
+class EntailmentLeg:
+    market_id: str
+    question: str
+    side: str
+    market_probability: float
+    fair_probability: float
+    edge_percent: float
+
+
+@dataclass(frozen=True)
+class EntailmentPairProposal:
+    """An indivisible two-leg proposal; neither leg is a standalone target."""
+
+    leg_a: EntailmentLeg
+    leg_b: EntailmentLeg
+    gap: float
+    rationale: str
+    confidence: float
+    negative_implication: bool
+
+
+def form_entailment_pair(
+    implier: EntailmentMarket,
+    implied: EntailmentMarket,
+    *,
+    rationale: str,
+    confidence: float,
+    minimum_gap: float,
+    negative_implication: bool = False,
+) -> EntailmentPairProposal | None:
+    """Apply the implication bound and form both legs, or fail closed."""
+    values = (
+        implier.yes_probability,
+        implied.yes_probability,
+        confidence,
+        minimum_gap,
+    )
+    if (
+        not implier.market_id
+        or not implied.market_id
+        or implier.market_id == implied.market_id
+        or not rationale.strip()
+        or any(not math.isfinite(value) for value in values)
+        or not 0.0 < implier.yes_probability < 1.0
+        or not 0.0 < implied.yes_probability < 1.0
+        or not 0.0 <= confidence <= 1.0
+        or minimum_gap < 0.0
+    ):
+        return None
+
+    if negative_implication:
+        gap = implier.yes_probability + implied.yes_probability - 1.0
+        side_a = side_b = "SELL"
+        fair_a = 1.0 - implied.yes_probability
+        fair_b = 1.0 - implier.yes_probability
+    else:
+        gap = implier.yes_probability - implied.yes_probability
+        side_a, side_b = "SELL", "BUY"
+        fair_a = implied.yes_probability
+        fair_b = implier.yes_probability
+
+    if not math.isfinite(gap) or gap < minimum_gap:
+        return None
+
+    edge_percent = gap * 100.0
+    return EntailmentPairProposal(
+        leg_a=EntailmentLeg(
+            implier.market_id,
+            implier.question,
+            side_a,
+            implier.yes_probability,
+            fair_a,
+            edge_percent,
+        ),
+        leg_b=EntailmentLeg(
+            implied.market_id,
+            implied.question,
+            side_b,
+            implied.yes_probability,
+            fair_b,
+            edge_percent,
+        ),
+        gap=gap,
+        rationale=rationale,
+        confidence=confidence,
+        negative_implication=negative_implication,
+    )

--- a/auramaur/experiments/strategies/market_maker.py
+++ b/auramaur/experiments/strategies/market_maker.py
@@ -1,0 +1,159 @@
+"""Pure contracts and quote formation for two-sided market-making experiments."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class InventoryBounds:
+    """Inventory state and hard capacity carried with a quote proposal."""
+
+    net_yes: float
+    max_abs_yes: float
+    remaining_capacity: float
+
+
+@dataclass(frozen=True)
+class CoupledQuoteProposal:
+    """An indivisible YES/NO maker quote; never a directional target."""
+
+    market_id: str
+    token_yes_id: str
+    token_no_id: str
+    bid_price: float
+    ask_price: float
+    size: float
+    spread_bps: int
+    inventory: InventoryBounds
+    post_only: bool = True
+
+    @property
+    def no_leg_price(self) -> float:
+        return round(1.0 - self.ask_price, 2)
+
+    @property
+    def expected_profit(self) -> float:
+        return (self.ask_price - self.bid_price) * self.size
+
+
+@dataclass(frozen=True)
+class QuoteFormation:
+    proposal: CoupledQuoteProposal | None
+    rejection_reason: str | None = None
+
+
+class QuoteReconciliation(str, Enum):
+    PLACE = "place"
+    KEEP = "keep"
+    CANCEL_REPLACE = "cancel_replace"
+
+
+class QuoteShape(Protocol):
+    bid_price: float
+    ask_price: float
+    size: float
+
+
+def reconcile_quote(
+    proposed: QuoteShape,
+    *,
+    active_bid_price: float | None,
+    active_ask_price: float | None,
+    active_size: float | None,
+    both_legs_pending: bool,
+) -> QuoteReconciliation:
+    """Choose lifecycle intent while leaving cancellation/execution to production."""
+    if active_bid_price is None or active_ask_price is None or active_size is None:
+        return QuoteReconciliation.PLACE
+    unchanged = (
+        abs(active_bid_price - proposed.bid_price) < 1e-9
+        and abs(active_ask_price - proposed.ask_price) < 1e-9
+        and active_size == proposed.size
+    )
+    if unchanged and both_legs_pending:
+        return QuoteReconciliation.KEEP
+    return QuoteReconciliation.CANCEL_REPLACE
+
+
+def form_coupled_quote(
+    *,
+    market_id: str,
+    token_yes_id: str,
+    token_no_id: str,
+    best_bid: float | None,
+    best_ask: float | None,
+    inventory: float,
+    quote_size: float,
+    max_inventory: float,
+    min_spread_bps: int,
+    max_spread_bps: int,
+) -> QuoteFormation:
+    """Form a coupled post-only quote, failing closed on invalid evidence."""
+    if (
+        not market_id
+        or not token_yes_id
+        or not token_no_id
+        or best_bid is None
+        or best_ask is None
+        or not all(math.isfinite(v) for v in (best_bid, best_ask, inventory, quote_size, max_inventory))
+        or not (0 < best_bid < best_ask < 1)
+        or quote_size <= 0
+        or max_inventory <= 0
+        or min_spread_bps < 0
+        or max_spread_bps < min_spread_bps
+    ):
+        return QuoteFormation(None, "no_bbo" if best_bid is None or best_ask is None else "invalid_input")
+
+    book_spread_bps = int((best_ask - best_bid) * 10000)
+    if book_spread_bps > max_spread_bps:
+        return QuoteFormation(None, "dead_book")
+
+    raw_bid, raw_ask = best_bid + 0.01, best_ask - 0.01
+    if int((raw_ask - raw_bid) * 10000) < min_spread_bps:
+        bid, ask = round(best_bid, 2), round(best_ask, 2)
+    else:
+        bid, ask = round(raw_bid, 2), round(raw_ask, 2)
+
+    if abs(inventory) > 0.01:
+        skew = round(inventory / max_inventory * 0.03, 2)
+        bid, ask = round(bid - skew, 2), round(ask - skew, 2)
+    bid, ask = max(0.01, min(0.99, bid)), max(0.01, min(0.99, ask))
+    if bid >= best_ask:
+        bid = round(best_ask - 0.01, 2)
+    if ask <= best_bid:
+        ask = round(best_bid + 0.01, 2)
+    if bid >= ask:
+        return QuoteFormation(None, "bid_gte_ask")
+
+    spread_bps = int((ask - bid) * 10000)
+    if spread_bps < min_spread_bps:
+        return QuoteFormation(None, "spread_too_narrow")
+    no_price = round(1.0 - ask, 2)
+    if not 0.01 <= no_price <= 0.99:
+        return QuoteFormation(None, "invalid_no_price")
+
+    remaining = max_inventory - abs(inventory)
+    size = min(quote_size, remaining)
+    if size < 1.0:
+        return QuoteFormation(None, "inventory_capacity")
+    min_size = max(1.0 / bid, 1.0 / no_price)
+    if size * bid < 1.0 or size * no_price < 1.0:
+        bumped = math.ceil(min_size * 100) / 100
+        if bumped > remaining:
+            return QuoteFormation(None, "min_notional")
+        size = bumped
+
+    proposal = CoupledQuoteProposal(
+        market_id=market_id,
+        token_yes_id=token_yes_id,
+        token_no_id=token_no_id,
+        bid_price=bid,
+        ask_price=ask,
+        size=round(size, 2),
+        spread_bps=spread_bps,
+        inventory=InventoryBounds(inventory, max_inventory, remaining),
+    )
+    return QuoteFormation(proposal)

--- a/auramaur/strategy/arbitrage.py
+++ b/auramaur/strategy/arbitrage.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import structlog
 
 from auramaur.db.database import Database
+from auramaur.experiments.strategies.arbitrage import (
+    ArbitrageMarket,
+    PairedArbitrageProposal,
+    form_arbitrage_pair,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.strategy.correlation import CorrelationDetector
 
@@ -55,31 +60,54 @@ class ArbitrageExecutor:
         if not market_a or not market_b:
             return None
 
-        if opp["type"] == "conditional_violation":
-            # A implies B, but P(A) > P(B) — buy B (underpriced), sell A (overpriced)
-            pair = self._make_signal_pair(
-                buy_market=market_b,
-                sell_market=market_a,
-                edge=opp["price_a"] - opp["price_b"],
-                opp=opp,
-            )
-            return pair if self._pair_is_executable(market_b, market_a, opp) else None
+        proposal = form_arbitrage_pair(
+            opp,
+            self._experiment_market(market_a),
+            self._experiment_market(market_b),
+        )
+        if proposal is None:
+            return None
+        return self._proposal_to_signals(proposal, opp)
 
-        elif opp["type"] == "price_divergence":
-            # Same event priced differently — buy cheap, sell expensive
-            if opp["price_a"] < opp["price_b"]:
-                buy_market, sell_market = market_a, market_b
-            else:
-                buy_market, sell_market = market_b, market_a
-            pair = self._make_signal_pair(
-                buy_market=buy_market,
-                sell_market=sell_market,
-                edge=opp.get("divergence", abs(opp["price_a"] - opp["price_b"])),
-                opp=opp,
-            )
-            return pair if self._pair_is_executable(buy_market, sell_market, opp) else None
+    @staticmethod
+    def _experiment_market(market: Market) -> ArbitrageMarket:
+        return ArbitrageMarket(
+            market_id=market.id,
+            question=market.question,
+            yes_price=market.outcome_yes_price,
+            exchange=market.exchange,
+            yes_token=market.clob_token_yes,
+            no_token=market.clob_token_no,
+        )
 
-        return None
+    @staticmethod
+    def _proposal_to_signals(
+        proposal: PairedArbitrageProposal, opp: dict
+    ) -> tuple[Signal, Signal, dict]:
+        evidence = f"Arbitrage: {proposal.opportunity_type}"
+        buy_signal = Signal(
+            market_id=proposal.buy.market_id,
+            market_question=proposal.buy.question,
+            claude_prob=proposal.buy.fair_probability,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=proposal.buy.market_probability,
+            edge=proposal.buy.edge_percent,
+            evidence_summary=evidence,
+            recommended_side=OrderSide.BUY,
+            strategy_source="arbitrage",
+        )
+        sell_signal = Signal(
+            market_id=proposal.sell.market_id,
+            market_question=proposal.sell.question,
+            claude_prob=proposal.sell.fair_probability,
+            claude_confidence=Confidence.MEDIUM,
+            market_prob=proposal.sell.market_probability,
+            edge=proposal.sell.edge_percent,
+            evidence_summary=evidence,
+            recommended_side=OrderSide.SELL,
+            strategy_source="arbitrage",
+        )
+        return buy_signal, sell_signal, opp
 
     @staticmethod
     def _pair_is_executable(buy: Market, sell: Market, opp: dict) -> bool:

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.experiments.strategies.cross_venue_arb import paired_arb_proposal
 from auramaur.exchange.models import (
     Confidence, Market, Order, OrderSide, OrderType, Signal,
 )
@@ -221,18 +222,17 @@ class CrossVenueArbPillar:
         'same': buy YES where YES is cheaper, NO where dearer (payout always $1).
         'inverted': A,B complementary — if pA+pB<1 buy both YES; if >1 buy both NO.
         """
-        pa, pb = a.outcome_yes_price, b.outcome_yes_price
-        if orientation == "same":
-            edge = abs(pa - pb)
-            if pa < pb:   # A_YES cheap -> buy A_YES, buy B_NO (sell dear B_YES)
-                return edge, OrderSide.BUY, OrderSide.SELL
-            return edge, OrderSide.SELL, OrderSide.BUY
-        if orientation == "inverted":
-            s = pa + pb
-            if s < 1.0:   # both underpriced -> buy both YES
-                return 1.0 - s, OrderSide.BUY, OrderSide.BUY
-            return s - 1.0, OrderSide.SELL, OrderSide.SELL  # both overpriced -> both NO
-        return None
+        proposal = paired_arb_proposal(
+            market_a_id=a.id, venue_a=a.exchange or "polymarket",
+            yes_price_a=a.outcome_yes_price, market_b_id=b.id,
+            venue_b=b.exchange or "kalshi", yes_price_b=b.outcome_yes_price,
+            orientation=orientation, confidence=1.0, min_confidence=0.0,
+            required_gap=0.0, stake_usd=1.0)
+        if proposal is None:
+            return None
+        side_a = OrderSide.BUY if proposal.legs[0].side == "BUY" else OrderSide.SELL
+        side_b = OrderSide.BUY if proposal.legs[1].side == "BUY" else OrderSide.SELL
+        return proposal.edge, side_a, side_b
 
     # -- execution -------------------------------------------------------
 

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -47,6 +47,11 @@ from auramaur.exchange.models import (
     OrderSide,
     Signal,
 )
+from auramaur.experiments.strategies.entailment_arb import (
+    EntailmentMarket,
+    EntailmentPairProposal,
+    form_entailment_pair,
+)
 
 log = structlog.get_logger()
 
@@ -443,6 +448,14 @@ class EntailmentArbPillar:
     def _exchange_for(self, market: Market):
         return self._exchanges.get(market.exchange or "polymarket")
 
+    @staticmethod
+    def _experiment_market(market: Market) -> EntailmentMarket:
+        return EntailmentMarket(
+            market_id=market.id,
+            question=market.question,
+            yes_probability=market.outcome_yes_price,
+        )
+
     # -- main cycle -------------------------------------------------------
 
     async def run_once(self) -> int:
@@ -489,21 +502,25 @@ class EntailmentArbPillar:
             if placed >= cfg.max_pairs_per_cycle:
                 break
             
-            if is_neg:
-                # Negative implication: P(A) + P(B) > 1.0
-                gap = implier.outcome_yes_price + implied.outcome_yes_price - 1.0
-            else:
-                # Positive implication: P(A) > P(B)
-                gap = implier.outcome_yes_price - implied.outcome_yes_price
-
             # Fee-aware floor: Polymarket uses min_gap; Kalshi must clear both
             # legs' taker fees + buffer, or the "free" arb loses to fees.
-            if gap < self._required_gap(implier, implied):
+            proposal = form_entailment_pair(
+                self._experiment_market(implier),
+                self._experiment_market(implied),
+                rationale=why,
+                confidence=conf,
+                minimum_gap=self._required_gap(implier, implied),
+                negative_implication=is_neg,
+            )
+            if proposal is None:
                 continue
             if await self._already_traded(implier.id, implied.id):
                 continue
             try:
-                if await self._enter_pair(implier, implied, gap, why, conf, is_neg):
+                if await self._enter_pair(
+                    implier, implied, proposal.gap, why, conf, is_neg,
+                    proposal=proposal,
+                ):
                     placed += 1
             except Exception as e:
                 log.error("entailment.entry_error", a=implier.id, b=implied.id,
@@ -537,8 +554,20 @@ class EntailmentArbPillar:
         )
 
     async def _enter_pair(self, implier: Market, implied: Market,
-                          gap: float, why: str, conf: float, is_neg: bool = False) -> bool:
+                          gap: float, why: str, conf: float, is_neg: bool = False,
+                          *, proposal: EntailmentPairProposal | None = None) -> bool:
         cfg = self._settings.entailment_arb
+        proposal = proposal or form_entailment_pair(
+            self._experiment_market(implier),
+            self._experiment_market(implied),
+            rationale=why,
+            confidence=conf,
+            minimum_gap=self._required_gap(implier, implied),
+            negative_implication=is_neg,
+        )
+        if proposal is None:
+            return False
+        gap = proposal.gap
         exchange_a = self._exchange_for(implier)
         exchange_b = self._exchange_for(implied)
         if exchange_a is None or exchange_b is None:
@@ -551,20 +580,16 @@ class EntailmentArbPillar:
             )
             return False
 
-        if is_neg:
-            # Leg 1: NO on implier/A (YES is overpriced vs the bound 1 - pb).
-            sig_a = self._leg_signal(implier, OrderSide.SELL,
-                                     fair=1.0 - implied.outcome_yes_price, gap=gap, why=why, is_neg=True)
-            # Leg 2: NO on implied/B (YES is overpriced vs the bound 1 - pa).
-            sig_b = self._leg_signal(implied, OrderSide.SELL,
-                                     fair=1.0 - implier.outcome_yes_price, gap=gap, why=why, is_neg=True)
-        else:
-            # Leg 1: NO on the implier (its YES is overpriced vs the bound).
-            sig_a = self._leg_signal(implier, OrderSide.SELL,
-                                     fair=implied.outcome_yes_price, gap=gap, why=why)
-            # Leg 2: YES on the implied (its YES is underpriced vs the bound).
-            sig_b = self._leg_signal(implied, OrderSide.BUY,
-                                     fair=implier.outcome_yes_price, gap=gap, why=why)
+        sig_a = self._leg_signal(
+            implier, OrderSide(proposal.leg_a.side),
+            fair=proposal.leg_a.fair_probability, gap=gap, why=why,
+            is_neg=proposal.negative_implication,
+        )
+        sig_b = self._leg_signal(
+            implied, OrderSide(proposal.leg_b.side),
+            fair=proposal.leg_b.fair_probability, gap=gap, why=why,
+            is_neg=proposal.negative_implication,
+        )
 
         dec_a = await self._risk.evaluate(sig_a, implier)
         dec_b = await self._risk.evaluate(sig_b, implied)

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -20,10 +20,14 @@ from __future__ import annotations
 from auramaur.strategy.protocols import ExecutionMode
 
 import asyncio
-import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from auramaur.killswitch import kill_switch_present
+from auramaur.experiments.strategies.market_maker import (
+    QuoteReconciliation,
+    form_coupled_quote,
+    reconcile_quote,
+)
 
 import structlog
 
@@ -342,13 +346,17 @@ class MarketMaker:
             # deliberately-kept quote; if the book moves or the market drops
             # out of the candidate set, this guard fails and the normal
             # cancel/stale paths run — the orphaned-GTC leak cannot return.
-            if (
-                abs(prior.bid_price - quote.bid_price) < 1e-9
-                and abs(prior.ask_price - quote.ask_price) < 1e-9
-                and prior.size == quote.size
-                and prior.bid_order_id in self._pending_orders
-                and prior.ask_order_id in self._pending_orders
-            ):
+            reconciliation = reconcile_quote(
+                quote,
+                active_bid_price=prior.bid_price,
+                active_ask_price=prior.ask_price,
+                active_size=prior.size,
+                both_legs_pending=(
+                    prior.bid_order_id in self._pending_orders
+                    and prior.ask_order_id in self._pending_orders
+                ),
+            )
+            if reconciliation is QuoteReconciliation.KEEP:
                 prior.placed_at = datetime.now(timezone.utc)
                 self._active_quotes[market.id] = prior
                 log.debug(
@@ -383,125 +391,29 @@ class MarketMaker:
 
         Polymarket uses 1-cent tick sizes (0.01 increments), prices 0.01-0.99.
         """
-        best_bid = book.best_bid
-        best_ask = book.best_ask
-
-        if best_bid is None or best_ask is None:
-            return None, "no_bbo"
-
-        # Dead-book guard on the LIVE book (selection used market.spread, a summary
-        # field that can be stale or differ from the CLOB BBO). If the actual best
-        # bid/ask are this far apart, there's no genuine two-sided market — quoting
-        # into it just churns and risks one-sided fills at an extreme price.
-        book_spread_bps = int((best_ask - best_bid) * 10000)
-        if book_spread_bps > self._max_spread_bps:
-            log.debug(
-                "market_maker.dead_book",
-                market_id=market.id,
-                best_bid=best_bid,
-                best_ask=best_ask,
-                book_spread_bps=book_spread_bps,
-                max_spread_bps=self._max_spread_bps,
-            )
-            return None, "dead_book"
-
-        # Polymarket has 1-cent ticks. Try to price-improve by one tick on each
-        # side; if the underlying spread is too tight for that (which is the
-        # common case — most liquid markets sit at 2-3 cent spreads), quote at
-        # the BBO instead (join the queue) so we still capture spread as maker.
-        step = 0.01
-        raw_bid = best_bid + step
-        raw_ask = best_ask - step
-        raw_spread_bps = int((raw_ask - raw_bid) * 10000)
-        if raw_spread_bps < self._min_spread_bps:
-            our_bid = round(best_bid, 2)
-            our_ask = round(best_ask, 2)
-        else:
-            our_bid = round(raw_bid, 2)
-            our_ask = round(raw_ask, 2)
-
-        # Inventory skew: adjust quotes based on current inventory
-        inventory = self._inventory.get(market.id, 0)
-        if abs(inventory) > 0.01:
-            # Skew factor: 0.01 per 10 tokens of inventory
-            skew = round(inventory / self._max_inventory * 0.03, 2)
-            # If long YES (inventory > 0): lower bid (less eager to buy YES),
-            # lower ask (more eager to sell YES / buy NO)
-            our_bid = round(our_bid - skew, 2)
-            our_ask = round(our_ask - skew, 2)
-
-        # Clamp to valid Polymarket price range
-        our_bid = max(0.01, min(0.99, our_bid))
-        our_ask = max(0.01, min(0.99, our_ask))
-
-        # Post-only crossing clamp: skew (above) can push a joined/improved
-        # quote onto or through the live BBO on tight books, and the venue
-        # then 400-rejects the leg as 'invalid post-only order: order
-        # crosses book' — one market ground through reject+partial-cancel
-        # every ~34s for hours (2299992, 2026-07-22). A maker order must
-        # rest strictly inside the opposite side of the book.
-        if our_bid >= best_ask:
-            our_bid = round(best_ask - 0.01, 2)
-        if our_ask <= best_bid:
-            our_ask = round(best_bid + 0.01, 2)
-
-        # Sanity: bid must be strictly less than ask
-        if our_bid >= our_ask:
-            log.debug(
-                "market_maker.quote_rejected",
-                market_id=market.id,
-                reason="bid_gte_ask",
-                our_bid=our_bid,
-                our_ask=our_ask,
-                best_bid=best_bid,
-                best_ask=best_ask,
-            )
-            return None, "bid_gte_ask"
-
-        # Check our spread meets minimum
-        our_spread = our_ask - our_bid
-        our_spread_bps = int(our_spread * 10000)
-        if our_spread_bps < self._min_spread_bps:
-            log.debug(
-                "market_maker.quote_rejected",
-                market_id=market.id,
-                reason="spread_too_narrow",
-                our_spread_bps=our_spread_bps,
-                min_spread_bps=self._min_spread_bps,
-            )
-            return None, "spread_too_narrow"
-
-        # Check the NO leg price is valid
-        no_price = round(1.0 - our_ask, 2)
-        if no_price < 0.01 or no_price > 0.99:
-            return None, "invalid_no_price"
-
-        # Determine size — scale down if we're near inventory limit, but bump
-        # above Polymarket's $1 minimum when the configured quote size would
-        # otherwise make both-sided quoting impossible on low-price markets.
-        remaining_capacity = self._max_inventory - abs(inventory)
-        size = min(self._quote_size, remaining_capacity)
-        if size < 1.0:
-            return None, "inventory_capacity"
-
-        min_size = max(1.0 / our_bid, 1.0 / no_price)
-        if size * our_bid < 1.0 or size * no_price < 1.0:
-            bumped = math.ceil(min_size * 100) / 100
-            if bumped > remaining_capacity:
-                return None, "min_notional"
-            size = bumped
-
-        # Round size to Polymarket precision
-        size = round(size, 2)
-
-        return MMQuote(
+        formed = form_coupled_quote(
             market_id=market.id,
             token_yes_id=market.clob_token_yes,
             token_no_id=market.clob_token_no,
-            bid_price=our_bid,
-            ask_price=our_ask,
-            size=size,
-            spread_bps=our_spread_bps,
+            best_bid=book.best_bid,
+            best_ask=book.best_ask,
+            inventory=self._inventory.get(market.id, 0),
+            quote_size=self._quote_size,
+            max_inventory=self._max_inventory,
+            min_spread_bps=self._min_spread_bps,
+            max_spread_bps=self._max_spread_bps,
+        )
+        if formed.proposal is None:
+            return None, formed.rejection_reason
+        proposal = formed.proposal
+        return MMQuote(
+            market_id=proposal.market_id,
+            token_yes_id=proposal.token_yes_id,
+            token_no_id=proposal.token_no_id,
+            bid_price=proposal.bid_price,
+            ask_price=proposal.ask_price,
+            size=proposal.size,
+            spread_bps=proposal.spread_bps,
         ), None
 
     async def _place_two_sided(self, quote: MMQuote, is_live: bool) -> dict:

--- a/docs/plans/experiment-platform-refactor.md
+++ b/docs/plans/experiment-platform-refactor.md
@@ -206,8 +206,9 @@ Bias harvest and every portable directional strategy now delegate deterministic
 proposal formation. News reactor delegates its pure routing decision and hands
 the eventual trade choice to the separately migrated core-trading decision.
 Every live-sensitive risk, gateway, persistence, order-lifecycle, and accounting
-operation remains in production. Paired, quoting, and external-asset entries
-remain explicitly planned on specialized tracks.
+operation remains in production. Arbitrage retains atomic paired-package
+proposals and market making retains coupled quote/reconciliation proposals.
+External-asset entries remain explicitly planned on specialized tracks.
 
 ## Full-set migration sequence
 
@@ -235,6 +236,5 @@ deterministic seam to a pure contract, focused old/new decision coverage passes,
 and its existing execution-contract suite still passes. The status does not
 claim that the contract is supported by the generic replay runtime.
 
-All portable directional and routing entries satisfy that decision-seam gate.
-The following stack layers migrate paired/quoting and external-asset contracts
-in independently reviewable changes.
+Portable, routing, paired-package, and quoting entries satisfy that
+decision-seam gate. The following stack layer migrates external-asset contracts.

--- a/tests/test_experiment_arbitrage.py
+++ b/tests/test_experiment_arbitrage.py
@@ -1,0 +1,82 @@
+"""Contract and production-parity tests for paired arbitrage experiments."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from auramaur.exchange.models import Market, OrderSide
+from auramaur.experiments.strategies.arbitrage import (
+    ArbitrageMarket,
+    form_arbitrage_pair,
+)
+from auramaur.strategy.arbitrage import ArbitrageExecutor
+
+
+def _market(mid: str, price: float) -> ArbitrageMarket:
+    return ArbitrageMarket(mid, f"{mid}?", price, yes_token=f"{mid}-y", no_token=f"{mid}-n")
+
+
+def test_conditional_pair_is_atomic_and_immutable():
+    opp = {"type": "conditional_violation", "market_a": "a", "market_b": "b",
+           "price_a": 0.7, "price_b": 0.6}
+    pair = form_arbitrage_pair(opp, _market("a", 0.7), _market("b", 0.6))
+    assert pair is not None
+    assert (pair.buy.market_id, pair.sell.market_id) == ("b", "a")
+    assert pair.buy.edge_percent == pytest.approx(5.0)
+    with pytest.raises(FrozenInstanceError):
+        pair.edge = 0.2  # type: ignore[misc]
+
+
+def test_divergence_and_production_conversion_have_parity():
+    opp = {"type": "price_divergence", "market_a": "a", "market_b": "b",
+           "price_a": 0.42, "price_b": 0.54, "divergence": 0.12}
+    pair = form_arbitrage_pair(opp, _market("a", 0.42), _market("b", 0.54))
+    assert pair is not None
+    buy, sell, returned = ArbitrageExecutor._proposal_to_signals(pair, opp)
+    assert returned is opp
+    assert (buy.market_id, buy.recommended_side) == ("a", OrderSide.BUY)
+    assert (sell.market_id, sell.recommended_side) == ("b", OrderSide.SELL)
+    assert buy.claude_prob == pytest.approx(pair.buy.fair_probability)
+    assert sell.edge == pytest.approx(pair.sell.edge_percent)
+
+
+@pytest.mark.parametrize("opp", [
+    {},
+    {"type": "unknown", "market_a": "a", "market_b": "b", "price_a": .7, "price_b": .6},
+    {"type": "price_divergence", "market_a": "a", "market_b": "b", "price_a": .5, "price_b": .5},
+    {"type": "price_divergence", "market_a": "a", "market_b": "b", "price_a": float("nan"), "price_b": .5},
+])
+def test_malformed_or_edgeless_candidates_fail_closed(opp):
+    assert form_arbitrage_pair(opp, _market("a", .7), _market("b", .6)) is None
+
+
+def test_missing_required_leg_token_fails_the_whole_pair():
+    a = ArbitrageMarket("a", "a?", .4, yes_token="a-y", no_token="a-n")
+    b = ArbitrageMarket("b", "b?", .6, yes_token="b-y", no_token="")
+    opp = {"type": "price_divergence", "market_a": "a", "market_b": "b",
+           "price_a": .4, "price_b": .6}
+    assert form_arbitrage_pair(opp, a, b) is None
+
+
+def test_production_adapter_delegates_to_pure_pair(monkeypatch):
+    seen = {}
+    def fake(opp, a, b):
+        seen.update(opp=opp, a=a, b=b)
+        return None
+    monkeypatch.setattr("auramaur.strategy.arbitrage.form_arbitrage_pair", fake)
+    executor = ArbitrageExecutor.__new__(ArbitrageExecutor)
+    ma = Market(id="a", question="a?", outcome_yes_price=.6)
+    mb = Market(id="b", question="b?", outcome_yes_price=.4)
+    assert executor._experiment_market(ma).market_id == "a"
+    assert fake({}, executor._experiment_market(ma), executor._experiment_market(mb)) is None
+    assert seen["a"].yes_price == .6
+
+
+def test_pure_module_has_no_live_or_production_imports():
+    source = Path("auramaur/experiments/strategies/arbitrage.py").read_text(encoding="utf-8")
+    assert "auramaur.strategy" not in source
+    assert "auramaur.exchange" not in source
+    assert "place_order" not in source

--- a/tests/test_experiment_cross_venue_arb.py
+++ b/tests/test_experiment_cross_venue_arb.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import pytest
+from auramaur.experiments.models import ExperimentDefinition, FeatureValue, MarketSnapshot, PortfolioSnapshot, PricePoint
+from auramaur.experiments.registry import ExperimentRegistry
+from auramaur.experiments.runtimes import InMemoryShadowSink, LinearExecutionModel, ReplayRuntime, ResearchRuntime, ShadowRuntime
+from auramaur.experiments.strategies.cross_venue_arb import CrossVenueArbExperiment, paired_arb_proposal
+
+BASE = dict(market_a_id="poly-1", venue_a="polymarket", yes_price_a=.35,
+            market_b_id="kalshi-1", venue_b="kalshi", yes_price_b=.60,
+            orientation="same", confidence=.98, min_confidence=.95,
+            required_gap=.04, stake_usd=10)
+
+def test_paired_proposal_is_atomic_and_immutable():
+    proposal = paired_arb_proposal(**BASE)
+    assert proposal is not None
+    assert tuple(leg.side for leg in proposal.legs) == ("BUY", "SELL")
+    assert tuple(t.instrument_id for t in proposal.targets) == (
+        "polymarket:poly-1:YES", "kalshi:kalshi-1:NO")
+    with pytest.raises(AttributeError):
+        proposal.edge = .1
+
+@pytest.mark.parametrize("change", [{"orientation": "none"}, {"confidence": .94},
+    {"required_gap": .26}, {"yes_price_a": 0}, {"venue_b": "polymarket"}])
+def test_paired_proposal_fails_closed(change):
+    values = BASE | change
+    assert paired_arb_proposal(**values) is None
+
+@pytest.mark.asyncio
+async def test_pair_is_identical_across_non_live_runtimes():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    snapshot = MarketSnapshot(observed_at=now, sequence=0,
+        market_id="poly-1|kalshi-1", venue="cross_venue",
+        prices=(PricePoint(instrument_id="polymarket:poly-1:YES", price=.35),
+                PricePoint(instrument_id="kalshi:kalshi-1:NO", price=.40)),
+        features=(FeatureValue(name="cross_venue_pair", payload={
+            "market_a_id": "poly-1", "venue_a": "polymarket", "yes_price_a": .35,
+            "market_b_id": "kalshi-1", "venue_b": "kalshi", "yes_price_b": .60,
+            "orientation": "same", "confidence": .98}, source="fixture",
+            observed_at=now, available_at=now),), data_version="paired-fixture-v1")
+    portfolio = PortfolioSnapshot(observed_at=now - timedelta(seconds=1), cash=1000, equity=1000)
+    implementation = CrossVenueArbExperiment(min_confidence=.95, required_gap=.04, stake_usd=10)
+    definition = ExperimentDefinition(key="cross-venue-poc", strategy_source="cross_venue_arb",
+        hypothesis="Equivalent claims converge across venues.", mechanism="paired semantic arbitrage",
+        implementation_version="paired-v1", parameters={}, venues=frozenset({"polymarket", "kalshi"}),
+        primary_metric="package_net_pnl_after_costs", baseline="no_package", min_observations=30,
+        holdout_days=14, max_drawdown=.15, cost_model="paired-linear-v1",
+        rejection_criteria=("unhedged_leg",))
+    bound = ExperimentRegistry().register(definition, implementation)
+    research = await ResearchRuntime().run(bound, snapshot, portfolio)
+    sink = InMemoryShadowSink()
+    shadow = await ShadowRuntime(sink).run(bound, snapshot, portfolio)
+    replay = await ReplayRuntime(LinearExecutionModel(version="paired-linear-v1")).run(bound, [snapshot], portfolio)
+    assert len(research.targets) == 2
+    assert research.targets == shadow.targets == replay.results[0].targets
+
+def test_pure_module_has_no_live_execution_imports():
+    tree = ast.parse(Path("auramaur/experiments/strategies/cross_venue_arb.py").read_text(encoding="utf-8"))
+    imports = {alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names}
+    imports.update(node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom))
+    assert not any(name.startswith(("auramaur.broker", "auramaur.exchange", "auramaur.risk")) for name in imports)

--- a/tests/test_experiment_entailment_arb.py
+++ b/tests/test_experiment_entailment_arb.py
@@ -1,0 +1,93 @@
+"""Contract and production-parity tests for entailment pair formation."""
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from auramaur.exchange.models import Market, OrderSide
+from auramaur.experiments.strategies.entailment_arb import (
+    EntailmentMarket,
+    form_entailment_pair,
+)
+from auramaur.strategy.entailment_arb import EntailmentArbPillar
+
+
+def _market(mid: str, probability: float) -> EntailmentMarket:
+    return EntailmentMarket(mid, f"{mid}?", probability)
+
+
+def test_positive_implication_pair_is_atomic_and_immutable():
+    pair = form_entailment_pair(
+        _market("above-70", 0.62), _market("above-60", 0.50),
+        rationale="above 70 => above 60", confidence=1.0, minimum_gap=0.05,
+    )
+    assert pair is not None
+    assert (pair.leg_a.side, pair.leg_b.side) == ("SELL", "BUY")
+    assert pair.gap == pytest.approx(0.12)
+    assert pair.leg_a.fair_probability == pytest.approx(0.50)
+    assert pair.leg_b.fair_probability == pytest.approx(0.62)
+    with pytest.raises(FrozenInstanceError):
+        pair.gap = 0.2  # type: ignore[misc]
+
+
+def test_negative_implication_forms_two_no_legs():
+    pair = form_entailment_pair(
+        _market("a", 0.64), _market("b", 0.48), rationale="mutually exclusive",
+        confidence=0.99, minimum_gap=0.10, negative_implication=True,
+    )
+    assert pair is not None
+    assert (pair.leg_a.side, pair.leg_b.side) == ("SELL", "SELL")
+    assert pair.gap == pytest.approx(0.12)
+    assert pair.leg_a.fair_probability == pytest.approx(0.52)
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "rationale", "confidence", "minimum_gap"),
+    [
+        (_market("a", .5), _market("a", .4), "same", 1.0, .01),
+        (_market("a", float("nan")), _market("b", .4), "bad", 1.0, .01),
+        (_market("a", .51), _market("b", .50), "thin", 1.0, .02),
+        (_market("a", .7), _market("b", .5), "", 1.0, .02),
+        (_market("a", .7), _market("b", .5), "bad confidence", 1.1, .02),
+    ],
+)
+def test_invalid_or_ineligible_pair_fails_closed(a, b, rationale, confidence, minimum_gap):
+    assert form_entailment_pair(
+        a, b, rationale=rationale, confidence=confidence, minimum_gap=minimum_gap,
+    ) is None
+
+
+def test_production_adapter_preserves_pair_signal_semantics():
+    implier = Market(id="a", question="a?", outcome_yes_price=.7)
+    implied = Market(id="b", question="b?", outcome_yes_price=.5)
+    pair = form_entailment_pair(
+        EntailmentArbPillar._experiment_market(implier),
+        EntailmentArbPillar._experiment_market(implied),
+        rationale="a => b", confidence=1.0, minimum_gap=.05,
+    )
+    assert pair is not None
+    pillar = EntailmentArbPillar.__new__(EntailmentArbPillar)
+    sig_a = pillar._leg_signal(
+        implier, OrderSide(pair.leg_a.side), pair.leg_a.fair_probability,
+        pair.gap, pair.rationale,
+    )
+    sig_b = pillar._leg_signal(
+        implied, OrderSide(pair.leg_b.side), pair.leg_b.fair_probability,
+        pair.gap, pair.rationale,
+    )
+    assert (sig_a.recommended_side, sig_b.recommended_side) == (
+        OrderSide.SELL, OrderSide.BUY,
+    )
+    assert sig_a.claude_prob == pytest.approx(pair.leg_a.fair_probability)
+    assert sig_b.edge == pytest.approx(pair.leg_b.edge_percent)
+
+
+def test_pure_pair_module_has_no_live_or_production_imports():
+    source = Path("auramaur/experiments/strategies/entailment_arb.py").read_text(
+        encoding="utf-8"
+    )
+    assert "auramaur.strategy" not in source
+    assert "auramaur.exchange" not in source
+    assert "ExecutionGateway" not in source
+    assert "place_order" not in source

--- a/tests/test_experiment_market_maker.py
+++ b/tests/test_experiment_market_maker.py
@@ -1,0 +1,135 @@
+"""Parity and safety tests for the specialized market-making experiment."""
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.exchange.models import Market, OrderBook, OrderBookLevel
+from auramaur.experiments.strategies.market_maker import (
+    QuoteReconciliation,
+    form_coupled_quote,
+    reconcile_quote,
+)
+from auramaur.strategy.market_maker import MarketMaker
+
+
+def _maker() -> MarketMaker:
+    settings = SimpleNamespace(
+        is_live=False,
+        market_maker=SimpleNamespace(
+            min_spread_bps=40,
+            max_spread_bps=1500,
+            quote_size=10.0,
+            max_inventory=50.0,
+            max_markets=5,
+            refresh_seconds=30,
+            op_timeout_seconds=15.0,
+            paper=True,
+        ),
+        risk=SimpleNamespace(blocked_categories=[], allowed_categories_live=[]),
+    )
+    return MarketMaker(settings, SimpleNamespace(), SimpleNamespace())
+
+
+def _pure(**overrides):
+    values = dict(
+        market_id="m1",
+        token_yes_id="yes",
+        token_no_id="no",
+        best_bid=0.40,
+        best_ask=0.46,
+        inventory=0.0,
+        quote_size=10.0,
+        max_inventory=50.0,
+        min_spread_bps=40,
+        max_spread_bps=1500,
+    )
+    values.update(overrides)
+    return form_coupled_quote(**values)
+
+
+def test_production_quote_formation_matches_pure_contract():
+    maker = _maker()
+    maker._inventory["m1"] = 20.0
+    market = Market(id="m1", question="Will it happen?", clob_token_yes="yes", clob_token_no="no")
+    book = OrderBook(
+        bids=[OrderBookLevel(price=0.40, size=100)],
+        asks=[OrderBookLevel(price=0.46, size=100)],
+    )
+
+    production, reason = maker._compute_quotes(market, book)
+    pure = _pure(inventory=20.0)
+
+    assert reason is None
+    assert production is not None and pure.proposal is not None
+    assert (production.bid_price, production.ask_price, production.size, production.spread_bps) == (
+        pure.proposal.bid_price,
+        pure.proposal.ask_price,
+        pure.proposal.size,
+        pure.proposal.spread_bps,
+    )
+    assert pure.proposal.inventory.net_yes == 20.0
+    assert pure.proposal.inventory.remaining_capacity == 30.0
+    assert pure.proposal.post_only is True
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        ({"best_bid": None}, "no_bbo"),
+        ({"best_bid": 0.02, "best_ask": 0.98}, "dead_book"),
+        ({"inventory": 50.0}, "inventory_capacity"),
+        ({"token_no_id": ""}, "invalid_input"),
+        ({"max_inventory": 0.0}, "invalid_input"),
+        ({"best_bid": float("nan")}, "invalid_input"),
+    ],
+)
+def test_quote_formation_fails_closed(changes, reason):
+    formed = _pure(**changes)
+    assert formed.proposal is None
+    assert formed.rejection_reason == reason
+
+
+def test_coupled_quote_retains_both_legs_and_notional_floor():
+    formed = _pure(best_bid=0.04, best_ask=0.10)
+    assert formed.proposal is not None
+    quote = formed.proposal
+    assert quote.token_yes_id == "yes"
+    assert quote.token_no_id == "no"
+    assert quote.size * quote.bid_price >= 1.0
+    assert quote.size * quote.no_leg_price >= 1.0
+
+
+def test_reconciliation_preserves_keep_and_cancel_replace_semantics():
+    proposal = _pure().proposal
+    assert proposal is not None
+    assert reconcile_quote(
+        proposal,
+        active_bid_price=None,
+        active_ask_price=None,
+        active_size=None,
+        both_legs_pending=False,
+    ) is QuoteReconciliation.PLACE
+    assert reconcile_quote(
+        proposal,
+        active_bid_price=proposal.bid_price,
+        active_ask_price=proposal.ask_price,
+        active_size=proposal.size,
+        both_legs_pending=True,
+    ) is QuoteReconciliation.KEEP
+    assert reconcile_quote(
+        proposal,
+        active_bid_price=proposal.bid_price,
+        active_ask_price=proposal.ask_price,
+        active_size=proposal.size,
+        both_legs_pending=False,
+    ) is QuoteReconciliation.CANCEL_REPLACE
+
+
+def test_experiment_module_has_no_live_execution_imports():
+    import auramaur.experiments.strategies.market_maker as module
+
+    source = open(module.__file__, encoding="utf-8").read()
+    assert "auramaur.exchange" not in source
+    assert "ExecutionGateway" not in source
+    assert "PolymarketClient" not in source
+    assert "place_order" not in source

--- a/tests/test_experiment_platform.py
+++ b/tests/test_experiment_platform.py
@@ -394,4 +394,5 @@ def test_every_production_strategy_is_in_the_migration_inventory():
         "informed_flow", "econ_indicator", "interim_manager", "settlement_arb",
         "weather_temp", "resolution_lens", "resolution_lens_kalshi",
         "momentum_coupling",
+        "arbitrage", "entailment_arb", "cross_venue_arb", "market_maker",
     }


### PR DESCRIPTION
Stack 3 of 4, based on experiment-portable-strategies. Adds atomic paired proposals for arbitrage families and coupled quote/reconciliation contracts for market making without weakening all-or-none or order-lifecycle semantics. Isolated validation: 120 focused tests passed; Ruff and diff checks passed.