### PR TITLE
Migrate external-asset experiment contracts

### DIFF
--- a/auramaur/experiments/migration.py
+++ b/auramaur/experiments/migration.py
@@ -29,7 +29,7 @@ class MigrationStatus(str, Enum):
 MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
     "core_trading": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "news_reactor": (MigrationTrack.ROUTING, MigrationStatus.MIGRATED),
-    "kraken": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
+    "kraken": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.MIGRATED),
     "arbitrage": (MigrationTrack.PAIRED_PACKAGE, MigrationStatus.MIGRATED),
     "bias_harvest": (
         MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED
@@ -51,9 +51,9 @@ MIGRATION_INVENTORY: dict[str, tuple[MigrationTrack, MigrationStatus]] = {
     "resolution_lens_kalshi": (
         MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED
     ),
-    "oddlot_tender": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
+    "oddlot_tender": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.MIGRATED),
     "momentum_coupling": (MigrationTrack.PORTABLE_DIRECTIONAL, MigrationStatus.MIGRATED),
     "market_maker": (MigrationTrack.QUOTING, MigrationStatus.MIGRATED),
-    "ibkr_etf_paper": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
-    "ibkr_multiasset": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.SPECIALIZED_PLANNED),
+    "ibkr_etf_paper": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.MIGRATED),
+    "ibkr_multiasset": (MigrationTrack.EXTERNAL_ASSET, MigrationStatus.MIGRATED),
 }

--- a/auramaur/experiments/strategies/ibkr_etf_paper.py
+++ b/auramaur/experiments/strategies/ibkr_etf_paper.py
@@ -1,0 +1,94 @@
+"""Pure proposal contract for the structurally paper-only IBKR ETF book."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from auramaur.risk.ibkr_math import adverse_fill, risk_quantity, stop_distance
+
+
+@dataclass(frozen=True)
+class ETFExitProposal:
+    symbol: str
+    quantity: float
+    price: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ETFEntryProposal:
+    symbol: str
+    quantity: float
+    price: float
+    stop_price: float
+    initial_risk_usd: float
+    probability: float
+    confidence: str
+
+
+def exit_proposal(*, symbol: str, quantity: float, entry_price: float,
+                  bid: float, ask: float, stored_stop: float, peak_gain_pct: float,
+                  probability: float | None, stop_loss_pct: float,
+                  take_profit_pct: float, trailing_stop_pct: float,
+                  exit_probability: float, slippage_bps: float) -> ETFExitProposal | None:
+    """Return a deterministic liquidation proposal, using production precedence."""
+    values = (quantity, entry_price, bid, ask, stored_stop, peak_gain_pct,
+              stop_loss_pct, take_profit_pct, trailing_stop_pct,
+              exit_probability, slippage_bps)
+    if (not symbol or any(not math.isfinite(v) for v in values)
+            or quantity <= 0 or entry_price <= 0 or bid <= 0 or ask < bid):
+        return None
+    gain = (bid - entry_price) / entry_price * 100
+    reason = None
+    if (stored_stop > 0 and bid <= stored_stop) or gain <= -stop_loss_pct:
+        reason = "stop_loss"
+    elif gain >= take_profit_pct:
+        reason = "take_profit"
+    elif peak_gain_pct > 0 and peak_gain_pct - gain >= trailing_stop_pct:
+        reason = "trailing_stop"
+    elif (probability is not None and math.isfinite(probability)
+          and probability < exit_probability):
+        reason = "llm_bearish"
+    if reason is None:
+        return None
+    return ETFExitProposal(symbol, quantity,
+                           adverse_fill(bid, ask, "SELL", slippage_bps), reason)
+
+
+def entry_proposal(*, symbol: str, bid: float, ask: float, probability: float | None,
+                   confidence: str, confidence_rank: int, min_confidence_rank: int,
+                   min_probability: float, annual_volatility: float | None,
+                   momentum: float | None, remaining_deployment_usd: float,
+                   remaining_class_usd: float, max_entry_usd: float,
+                   fee_usd: float, slippage_bps: float, stop_vol_multiple: float,
+                   min_stop_pct: float, risk_budget_usd: float,
+                   open_risk_usd: float, max_portfolio_risk_usd: float,
+                   controls_allow_entry: bool) -> ETFEntryProposal | None:
+    """Propose paper exposure only after every upstream control has passed."""
+    numeric = (bid, ask, min_probability, remaining_deployment_usd,
+               remaining_class_usd, max_entry_usd, fee_usd, slippage_bps,
+               stop_vol_multiple, min_stop_pct, risk_budget_usd,
+               open_risk_usd, max_portfolio_risk_usd)
+    if (not controls_allow_entry or not symbol or probability is None
+            or annual_volatility is None or momentum is None
+            or any(not math.isfinite(v) for v in numeric)
+            or not math.isfinite(probability) or not math.isfinite(annual_volatility)
+            or not math.isfinite(momentum) or bid <= 0 or ask < bid
+            or confidence_rank < min_confidence_rank or probability < min_probability
+            or annual_volatility < 0 or momentum <= 0):
+        return None
+    notional = min(max_entry_usd, remaining_deployment_usd, remaining_class_usd)
+    if notional <= fee_usd:
+        return None
+    price = adverse_fill(bid, ask, "BUY", slippage_bps)
+    distance = stop_distance(price, annual_volatility, stop_vol_multiple, min_stop_pct)
+    quantity = min((notional - fee_usd) / price,
+                   risk_quantity(risk_budget_usd, distance, 1, 1, fractional=True))
+    if quantity <= 0:
+        return None
+    initial_risk = quantity * distance
+    if open_risk_usd + initial_risk > max_portfolio_risk_usd:
+        return None
+    return ETFEntryProposal(symbol, quantity, price, price - distance,
+                            initial_risk, probability, confidence)

--- a/auramaur/experiments/strategies/ibkr_multiasset.py
+++ b/auramaur/experiments/strategies/ibkr_multiasset.py
@@ -1,0 +1,89 @@
+"""Pure order proposals for the specialized IBKR multi-asset experiment."""
+from __future__ import annotations
+from dataclasses import dataclass
+import math
+from auramaur.risk.ibkr_math import adverse_fill, risk_quantity, stop_distance
+
+@dataclass(frozen=True)
+class MultiAssetEntryRules:
+    budget_usd: float
+    max_position_pct: float
+    max_deployment_pct: float
+    risk_per_position_pct: float
+    max_asset_class_risk_pct: float
+    stop_vol_multiple: float
+    min_stop_pct: float
+    slippage_bps: float
+
+@dataclass(frozen=True)
+class MultiAssetEntryInputs:
+    instrument_key: str
+    asset_class: str
+    ask: float
+    bid: float
+    fx_to_usd: float
+    multiplier: float
+    annual_volatility: float
+    deployed_usd: float
+    asset_class_risk_usd: float
+    capital_per_unit_usd: float
+    fractional: bool
+
+@dataclass(frozen=True)
+class MultiAssetOrderProposal:
+    """An execution-independent, long-only IBKR order instruction."""
+    instrument_key: str
+    asset_class: str
+    side: str
+    quantity: float
+    reference_price: float
+    stop_price: float
+    initial_risk_usd: float
+    target_notional_usd: float
+    paper_by_default: bool = True
+
+def propose_multiasset_entry(inputs: MultiAssetEntryInputs,
+                             rules: MultiAssetEntryRules) -> MultiAssetOrderProposal | None:
+    """Size one candidate, failing closed on invalid or exhausted budgets."""
+    values = (inputs.ask, inputs.bid, inputs.fx_to_usd, inputs.multiplier,
+              inputs.annual_volatility, inputs.deployed_usd,
+              inputs.asset_class_risk_usd, inputs.capital_per_unit_usd,
+              rules.budget_usd, rules.max_position_pct,
+              rules.max_deployment_pct, rules.risk_per_position_pct,
+              rules.max_asset_class_risk_pct, rules.stop_vol_multiple,
+              rules.min_stop_pct, rules.slippage_bps)
+    if (not inputs.instrument_key or not inputs.asset_class
+            or not all(math.isfinite(value) for value in values)
+            or inputs.ask <= 0 or inputs.bid <= 0 or inputs.ask < inputs.bid
+            or inputs.fx_to_usd <= 0 or inputs.multiplier <= 0
+            or inputs.annual_volatility <= 0 or inputs.deployed_usd < 0
+            or inputs.asset_class_risk_usd < 0
+            or inputs.capital_per_unit_usd <= 0 or rules.budget_usd <= 0):
+        return None
+    deployment_cap = rules.budget_usd * rules.max_deployment_pct / 100
+    target = min(rules.budget_usd * rules.max_position_pct / 100,
+                 deployment_cap - inputs.deployed_usd)
+    entry_price = adverse_fill(inputs.bid, inputs.ask, "BUY", rules.slippage_bps)
+    distance = stop_distance(entry_price, inputs.annual_volatility,
+                             rules.stop_vol_multiple, rules.min_stop_pct)
+    risk_budget = min(
+        rules.budget_usd * rules.risk_per_position_pct / 100,
+        rules.budget_usd * rules.max_asset_class_risk_pct / 100
+        - inputs.asset_class_risk_usd,
+    )
+    if target <= 0 or risk_budget <= 0 or distance <= 0:
+        return None
+    raw_quantity = target / inputs.capital_per_unit_usd
+    capital_quantity = (math.floor(raw_quantity * 10_000) / 10_000
+                        if inputs.fractional else float(math.floor(raw_quantity)))
+    quantity = min(capital_quantity, risk_quantity(
+        risk_budget, distance, inputs.multiplier, inputs.fx_to_usd,
+        fractional=inputs.fractional))
+    if not math.isfinite(quantity) or quantity <= 0:
+        return None
+    initial_risk = quantity * distance * inputs.multiplier * inputs.fx_to_usd
+    return MultiAssetOrderProposal(
+        instrument_key=inputs.instrument_key, asset_class=inputs.asset_class,
+        side="BUY", quantity=quantity, reference_price=entry_price,
+        stop_price=entry_price - distance, initial_risk_usd=initial_risk,
+        target_notional_usd=quantity * inputs.capital_per_unit_usd)

--- a/auramaur/experiments/strategies/kraken.py
+++ b/auramaur/experiments/strategies/kraken.py
@@ -1,0 +1,143 @@
+"""Pure proposal contract for Kraken long-only spot experiments.
+
+The contract deliberately describes a spot order candidate, not a binary-market
+``TargetPosition``.  Market-data acquisition, balances, persistence, risk
+scaling, paper/live gates, and order submission remain production concerns.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+
+class KrakenAction(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class KrakenRejection(str, Enum):
+    INVALID_INPUT = "invalid_input"
+    ORPHAN_REENTRY = "orphan_reentry"
+    COOLDOWN = "cooldown"
+    SIGNAL_GATE = "signal_gate"
+    NO_EXIT = "no_exit"
+    BUDGET_FULL = "budget_full"
+    INVALID_VOLUME = "invalid_volume"
+    BELOW_ORDER_MINIMUM = "below_order_minimum"
+    MINIMUM_TOO_EXPENSIVE = "minimum_too_expensive"
+    UNFUNDED = "unfunded"
+
+
+@dataclass(frozen=True)
+class KrakenSpotRules:
+    max_order_usd: float
+    lot_decimals: int
+    order_minimum: float = 0.0
+    funding_fee_buffer: float = 0.005
+    minimum_notional_multiplier: float = 1.5
+
+
+@dataclass(frozen=True)
+class KrakenSpotInputs:
+    pair: str
+    price: float
+    holding: bool
+    orphaned: bool
+    in_cooldown: bool = False
+    signal_accepted: bool = False
+    exit_reason: str | None = None
+    held_quantity: float = 0.0
+    sized_entry_volume: float = 0.0
+    allocated_usd: float = 0.0
+    budget_usd: float = 0.0
+    free_quote: float | None = None
+    minimum_notional_usd: float | None = None
+    paper: bool = True
+
+
+@dataclass(frozen=True)
+class KrakenSpotOrderProposal:
+    pair: str
+    action: KrakenAction
+    volume: float
+    reference_price: float
+    estimated_quote_notional: float
+    rationale: str
+
+
+@dataclass(frozen=True)
+class KrakenSpotAssessment:
+    proposal: KrakenSpotOrderProposal | None
+    rejection: KrakenRejection | None = None
+
+
+def _floor_lot(quantity: float, decimals: int) -> float:
+    scale = 10 ** decimals
+    return math.floor(quantity * scale) / scale
+
+
+def assess_kraken_spot(
+    inputs: KrakenSpotInputs, rules: KrakenSpotRules
+) -> KrakenSpotAssessment:
+    """Return one deterministic order candidate, failing closed on bad data."""
+    numbers = (
+        inputs.price, inputs.held_quantity, inputs.sized_entry_volume,
+        inputs.allocated_usd, inputs.budget_usd, rules.max_order_usd,
+        rules.order_minimum, rules.funding_fee_buffer,
+    )
+    if (
+        not inputs.pair or inputs.price <= 0 or rules.max_order_usd <= 0
+        or rules.lot_decimals < 0 or any(not math.isfinite(value) for value in numbers)
+        or any(value < 0 for value in numbers[1:])
+    ):
+        return KrakenSpotAssessment(None, KrakenRejection.INVALID_INPUT)
+
+    if inputs.holding:
+        if not inputs.exit_reason:
+            return KrakenSpotAssessment(None, KrakenRejection.NO_EXIT)
+        volume = _floor_lot(inputs.held_quantity, rules.lot_decimals)
+        if volume <= 0:
+            return KrakenSpotAssessment(None, KrakenRejection.INVALID_VOLUME)
+        if rules.order_minimum and volume < rules.order_minimum:
+            return KrakenSpotAssessment(None, KrakenRejection.BELOW_ORDER_MINIMUM)
+        return KrakenSpotAssessment(KrakenSpotOrderProposal(
+            pair=inputs.pair, action=KrakenAction.SELL, volume=volume,
+            reference_price=inputs.price,
+            estimated_quote_notional=volume * inputs.price,
+            rationale=inputs.exit_reason,
+        ))
+
+    if inputs.orphaned:
+        return KrakenSpotAssessment(None, KrakenRejection.ORPHAN_REENTRY)
+    if inputs.in_cooldown:
+        return KrakenSpotAssessment(None, KrakenRejection.COOLDOWN)
+    if not inputs.signal_accepted:
+        return KrakenSpotAssessment(None, KrakenRejection.SIGNAL_GATE)
+    if inputs.allocated_usd + rules.max_order_usd > inputs.budget_usd:
+        return KrakenSpotAssessment(None, KrakenRejection.BUDGET_FULL)
+
+    volume = _floor_lot(inputs.sized_entry_volume, rules.lot_decimals)
+    if rules.order_minimum and volume < rules.order_minimum:
+        minimum_notional = (inputs.minimum_notional_usd
+                            if inputs.minimum_notional_usd is not None
+                            else rules.order_minimum * inputs.price)
+        if not math.isfinite(minimum_notional) or minimum_notional < 0:
+            return KrakenSpotAssessment(None, KrakenRejection.INVALID_INPUT)
+        if minimum_notional > rules.max_order_usd * rules.minimum_notional_multiplier:
+            return KrakenSpotAssessment(None, KrakenRejection.MINIMUM_TOO_EXPENSIVE)
+        volume = rules.order_minimum
+    if volume <= 0:
+        return KrakenSpotAssessment(None, KrakenRejection.INVALID_VOLUME)
+    notional = volume * inputs.price
+    if not inputs.paper:
+        if inputs.free_quote is None or not math.isfinite(inputs.free_quote):
+            return KrakenSpotAssessment(None, KrakenRejection.INVALID_INPUT)
+        if inputs.free_quote < notional * (1.0 + rules.funding_fee_buffer):
+            return KrakenSpotAssessment(None, KrakenRejection.UNFUNDED)
+    return KrakenSpotAssessment(KrakenSpotOrderProposal(
+        pair=inputs.pair, action=KrakenAction.BUY, volume=volume,
+        reference_price=inputs.price, estimated_quote_notional=notional,
+        rationale="directional_signal",
+    ))

--- a/auramaur/experiments/strategies/oddlot_tender.py
+++ b/auramaur/experiments/strategies/oddlot_tender.py
@@ -1,0 +1,153 @@
+"""Pure proposal formation for manually submitted odd-lot tenders."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+
+class OddLotTenderRejection(str, Enum):
+    INVALID_INPUT = "invalid_input"
+    NO_PRIORITY = "no_priority"
+    RECORD_DATE_REQUIRED = "record_date_required"
+    LOW_CONFIDENCE = "low_confidence"
+
+
+class OddLotTenderDisposition(str, Enum):
+    ALERT_ONLY = "alerted"
+    NO_MARKET_PRICE = "alerted_no_price"
+    PREMIUM_TOO_THIN = "premium_too_thin"
+    TOO_EXPENSIVE = "too_expensive"
+    ENTER = "enter"
+
+
+@dataclass(frozen=True)
+class OddLotTenderRules:
+    min_confidence: float
+    min_premium_pct: float
+    max_position_usd: float
+
+
+@dataclass(frozen=True)
+class OddLotTenderInputs:
+    accession: str
+    company: str
+    ticker: str
+    form: str
+    filed_at: str
+    odd_lot_priority: bool
+    requires_record_date_holding: bool
+    tender_price: float
+    tender_price_high: float
+    expiration: str
+    conditions: str
+    confidence: float
+    entry_enabled: bool = False
+    market_price: float | None = None
+
+
+@dataclass(frozen=True)
+class TenderEntryProposal:
+    ticker: str
+    quantity: int
+    limit_price: float
+    conservative_payout: float
+    premium_pct: float
+
+
+@dataclass(frozen=True)
+class OddLotTenderProposal:
+    accession: str
+    ticker: str
+    alert_message: str
+    expiration: str
+    manual_submission_required: bool
+    disposition: OddLotTenderDisposition
+    entry: TenderEntryProposal | None = None
+
+
+@dataclass(frozen=True)
+class OddLotTenderAssessment:
+    proposal: OddLotTenderProposal | None
+    rejection: OddLotTenderRejection | None = None
+
+
+def assess_oddlot_tender(
+    inputs: OddLotTenderInputs,
+    rules: OddLotTenderRules,
+) -> OddLotTenderAssessment:
+    """Form an alert/manual-tender proposal and optional equity entry."""
+    values = (
+        inputs.tender_price,
+        inputs.tender_price_high,
+        inputs.confidence,
+        rules.min_confidence,
+        rules.min_premium_pct,
+        rules.max_position_usd,
+    )
+    if (
+        not inputs.accession
+        or not inputs.company
+        or any(not math.isfinite(value) for value in values)
+        or inputs.tender_price < 0.0
+        or inputs.tender_price_high < 0.0
+        or not 0.0 <= inputs.confidence <= 1.0
+        or not 0.0 <= rules.min_confidence <= 1.0
+        or rules.max_position_usd < 0.0
+    ):
+        return OddLotTenderAssessment(None, OddLotTenderRejection.INVALID_INPUT)
+    if not inputs.odd_lot_priority:
+        return OddLotTenderAssessment(None, OddLotTenderRejection.NO_PRIORITY)
+    if inputs.requires_record_date_holding:
+        return OddLotTenderAssessment(None, OddLotTenderRejection.RECORD_DATE_REQUIRED)
+    if inputs.confidence < rules.min_confidence:
+        return OddLotTenderAssessment(None, OddLotTenderRejection.LOW_CONFIDENCE)
+
+    ticker = inputs.ticker or "?"
+    message = (
+        f"ODD-LOT TENDER: {inputs.company} [{ticker}] {inputs.form} filed "
+        f"{inputs.filed_at} — price ${inputs.tender_price:.2f}"
+        + (
+            f"-${inputs.tender_price_high:.2f}"
+            if inputs.tender_price_high > inputs.tender_price
+            else ""
+        )
+        + f", expires {inputs.expiration or '?'}. "
+        f"Conditions: {inputs.conditions or 'none noted'}. "
+        "TENDERING IS MANUAL — submit in TWS before expiration."
+    )
+
+    disposition = OddLotTenderDisposition.ALERT_ONLY
+    entry = None
+    if inputs.entry_enabled and ticker != "?":
+        price = inputs.market_price
+        if price is None or not math.isfinite(price) or price <= 0.0:
+            disposition = OddLotTenderDisposition.NO_MARKET_PRICE
+        else:
+            premium_pct = (inputs.tender_price - price) / price * 100.0
+            if premium_pct < rules.min_premium_pct:
+                disposition = OddLotTenderDisposition.PREMIUM_TOO_THIN
+            else:
+                quantity = min(99, int(rules.max_position_usd // price))
+                if quantity < 1:
+                    disposition = OddLotTenderDisposition.TOO_EXPENSIVE
+                else:
+                    disposition = OddLotTenderDisposition.ENTER
+                    entry = TenderEntryProposal(
+                        ticker=ticker,
+                        quantity=quantity,
+                        limit_price=price,
+                        conservative_payout=inputs.tender_price,
+                        premium_pct=premium_pct,
+                    )
+
+    return OddLotTenderAssessment(OddLotTenderProposal(
+        accession=inputs.accession,
+        ticker=ticker,
+        alert_message=message,
+        expiration=inputs.expiration,
+        manual_submission_required=True,
+        disposition=disposition,
+        entry=entry,
+    ))

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -11,10 +11,12 @@ from zoneinfo import ZoneInfo
 import structlog
 
 from auramaur.exchange.models import Market, OrderSide
+from auramaur.experiments.strategies.ibkr_etf_paper import (
+    entry_proposal, exit_proposal,
+)
 from auramaur.strategy.protocols import ExecutionMode
 from auramaur.risk.ibkr_math import (
-    adverse_fill, annualized_volatility, normalized_momentum,
-    risk_quantity, stop_distance,
+    annualized_volatility, normalized_momentum,
 )
 
 log = structlog.get_logger()
@@ -395,22 +397,22 @@ class IBKRETFPaperPillar:
                 qty, entry = held
                 gain = (quote.bid - entry) / entry * 100
                 peak = await self._peak(symbol, gain)
-                reason = None
                 risk_row = await self._db.fetchone(
                     """SELECT stop_price FROM ibkr_etf_positions
                          WHERE model_alias=? AND symbol=?""", (self._alias, symbol))
                 stored_stop = float(risk_row["stop_price"] or 0) if risk_row else 0
-                if (stored_stop > 0 and quote.bid <= stored_stop) or gain <= -cfg.etf_stop_loss_pct:
-                    reason = "stop_loss"
-                elif gain >= cfg.etf_take_profit_pct:
-                    reason = "take_profit"
-                elif peak > 0 and peak - gain >= cfg.etf_trailing_stop_pct:
-                    reason = "trailing_stop"
-                elif prob is not None and prob < cfg.etf_exit_prob:
-                    reason = "llm_bearish"
-                if reason:
-                    exit_price = adverse_fill(quote.bid, quote.ask, "SELL", cfg.etf_slippage_bps)
-                    await self._fill(symbol, OrderSide.SELL, qty, exit_price)
+                proposal = exit_proposal(
+                    symbol=symbol, quantity=qty, entry_price=entry,
+                    bid=quote.bid, ask=quote.ask, stored_stop=stored_stop,
+                    peak_gain_pct=peak, probability=prob,
+                    stop_loss_pct=cfg.etf_stop_loss_pct,
+                    take_profit_pct=cfg.etf_take_profit_pct,
+                    trailing_stop_pct=cfg.etf_trailing_stop_pct,
+                    exit_probability=cfg.etf_exit_prob,
+                    slippage_bps=cfg.etf_slippage_bps)
+                if proposal:
+                    await self._fill(symbol, OrderSide.SELL, proposal.quantity,
+                                     proposal.price)
                     self._cooldown[symbol] = time.time() + (
                         cfg.etf_reentry_cooldown_hours * 3600)
                     await self._db.execute(
@@ -426,7 +428,8 @@ class IBKRETFPaperPillar:
                         0.0, class_allocated.get(asset_class, 0.0) - cost)
                     position_count -= 1
                     unmarked_positions.discard(symbol)
-                    log.info("ibkr_etf.paper.exit", symbol=symbol, reason=reason,
+                    log.info("ibkr_etf.paper.exit", symbol=symbol,
+                             reason=proposal.reason,
                              model_alias=self._alias,
                              gain_pct=round(gain, 2),
                              probability=(round(prob, 3) if prob is not None else None))
@@ -442,41 +445,42 @@ class IBKRETFPaperPillar:
                 deployment_cap = cfg.etf_paper_budget_usd * cfg.etf_max_deployment_pct / 100.0
                 asset_class = self._asset_class(symbol)
                 class_cap = cfg.etf_paper_budget_usd * cfg.etf_max_asset_class_pct / 100.0
-                remaining = min(
-                    deployment_cap - allocated,
-                    class_cap - class_allocated.get(asset_class, 0.0),
-                )
                 closes_raw = await self._client.get_adjusted_daily_closes(symbol)
                 closes = [float(close) for _, close in closes_raw if close and close > 0]
                 annual_vol = annualized_volatility(closes)
                 momentum = normalized_momentum(closes)
                 if annual_vol is None or momentum is None or momentum <= 0:
                     continue
-                notional = min(cfg.etf_max_entry_usd, remaining)
-                if notional <= cfg.etf_fee_per_order_usd:
-                    continue
-                entry = adverse_fill(quote.bid, quote.ask, "BUY", cfg.etf_slippage_bps)
-                distance = stop_distance(entry, annual_vol, cfg.etf_stop_vol_multiple,
-                                         cfg.etf_min_stop_pct)
                 risk_budget = cfg.etf_paper_budget_usd * cfg.etf_risk_per_position_pct / 100
-                qty = min(
-                    (notional - cfg.etf_fee_per_order_usd) / entry,
-                    risk_quantity(risk_budget, distance, 1, 1, fractional=True),
-                )
-                if qty <= 0:
-                    continue
-                initial_risk = qty * distance
                 open_risk = await self._db.fetchone(
                     """SELECT COALESCE(SUM(initial_risk_usd), 0) AS risk
                          FROM ibkr_etf_positions WHERE model_alias=?""", (self._alias,))
                 max_risk = cfg.etf_paper_budget_usd * cfg.etf_max_portfolio_risk_pct / 100
-                if float(open_risk["risk"] or 0) + initial_risk > max_risk:
+                proposal = entry_proposal(
+                    symbol=symbol, bid=quote.bid, ask=quote.ask,
+                    probability=prob, confidence=confidence,
+                    confidence_rank=self._CONF.get(confidence.upper(), 0),
+                    min_confidence_rank=self._CONF.get(cfg.etf_min_confidence.upper(), 2),
+                    min_probability=cfg.etf_min_prob,
+                    annual_volatility=annual_vol, momentum=momentum,
+                    remaining_deployment_usd=deployment_cap - allocated,
+                    remaining_class_usd=class_cap - class_allocated.get(asset_class, 0.0),
+                    max_entry_usd=cfg.etf_max_entry_usd,
+                    fee_usd=cfg.etf_fee_per_order_usd,
+                    slippage_bps=cfg.etf_slippage_bps,
+                    stop_vol_multiple=cfg.etf_stop_vol_multiple,
+                    min_stop_pct=cfg.etf_min_stop_pct,
+                    risk_budget_usd=risk_budget,
+                    open_risk_usd=float(open_risk["risk"] or 0),
+                    max_portfolio_risk_usd=max_risk,
+                    controls_allow_entry=True)
+                if proposal is None:
                     continue
-                await self._fill(symbol, OrderSide.BUY, qty, entry,
-                                 stop_price=entry - distance,
-                                 initial_risk_usd=initial_risk)
-                await self._mirror(symbol, qty, entry, quote.bid)
-                actual_cost = qty * entry + cfg.etf_fee_per_order_usd
+                await self._fill(symbol, OrderSide.BUY, proposal.quantity,
+                                 proposal.price, stop_price=proposal.stop_price,
+                                 initial_risk_usd=proposal.initial_risk_usd)
+                await self._mirror(symbol, proposal.quantity, proposal.price, quote.bid)
+                actual_cost = proposal.quantity * proposal.price + cfg.etf_fee_per_order_usd
                 allocated += actual_cost
                 class_allocated[asset_class] = (
                     class_allocated.get(asset_class, 0.0) + actual_cost)

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -11,13 +11,17 @@ from zoneinfo import ZoneInfo
 
 import structlog
 
+from auramaur.experiments.strategies.ibkr_multiasset import (
+    MultiAssetEntryInputs, MultiAssetEntryRules, propose_multiasset_entry,
+)
+
 from auramaur.exchange.ibkr_instruments import (
     BY_BOOK, BY_KEY, ContractKind, IBKRBook, InstrumentSpec,
 )
 from auramaur.strategy.protocols import ExecutionMode
 from auramaur.risk.ibkr_math import (
     adverse_fill, annualized_volatility, closes_from_bars,
-    normalized_momentum, risk_quantity, stop_distance,
+    normalized_momentum,
 )
 
 log = structlog.get_logger()
@@ -413,33 +417,35 @@ class IBKRMultiAssetPaperBook:
                         held_specs.get(key) or BY_KEY[key],
                         float(row["avg_cost"]), float(row["fx_to_usd"]))
                     for key, row in positions.items())
-                deployment_cap = cfg.budget_usd * cfg.max_deployment_pct / 100
-                target = min(cfg.budget_usd * cfg.max_position_pct / 100,
-                             deployment_cap - deployed)
                 unit_capital = self._capital_per_unit(spec, quote.ask, fx)
-                entry_price = adverse_fill(
-                    quote.bid, quote.ask, "BUY", cfg.slippage_bps)
-                distance = stop_distance(entry_price, annual_vol,
-                                         cfg.stop_vol_multiple, cfg.min_stop_pct)
-                risk_budget = cfg.budget_usd * cfg.risk_per_position_pct / 100
                 class_risk = sum(
                     float(row["initial_risk_usd"] or 0)
                     for key, row in positions.items()
                     if (held_specs.get(key) or BY_KEY[key]).asset_class == spec.asset_class
                 )
-                class_risk_cap = cfg.budget_usd * cfg.max_asset_class_risk_pct / 100
-                risk_budget = min(risk_budget, class_risk_cap - class_risk)
-                quantity = min(
-                    self._quantity(spec, target, unit_capital),
-                    risk_quantity(risk_budget, distance, quote.multiplier, fx,
-                                  fractional=spec.kind is ContractKind.STOCK),
-                )
-                if quantity <= 0:
+                proposal = propose_multiasset_entry(
+                    MultiAssetEntryInputs(
+                        instrument_key=spec.key, asset_class=spec.asset_class,
+                        ask=quote.ask, bid=quote.bid, fx_to_usd=fx,
+                        multiplier=quote.multiplier, annual_volatility=annual_vol,
+                        deployed_usd=deployed, asset_class_risk_usd=class_risk,
+                        capital_per_unit_usd=unit_capital,
+                        fractional=spec.kind is ContractKind.STOCK),
+                    MultiAssetEntryRules(
+                        budget_usd=cfg.budget_usd,
+                        max_position_pct=cfg.max_position_pct,
+                        max_deployment_pct=cfg.max_deployment_pct,
+                        risk_per_position_pct=cfg.risk_per_position_pct,
+                        max_asset_class_risk_pct=cfg.max_asset_class_risk_pct,
+                        stop_vol_multiple=cfg.stop_vol_multiple,
+                        min_stop_pct=cfg.min_stop_pct,
+                        slippage_bps=cfg.slippage_bps))
+                if proposal is None:
                     continue
-                initial_risk = quantity * distance * quote.multiplier * fx
-                await self._fill(spec, quote, "BUY", quantity, fx,
-                                 stop_price=entry_price - distance,
-                                 initial_risk_usd=initial_risk)
+                await self._fill(
+                    spec, quote, proposal.side, proposal.quantity, fx,
+                    stop_price=proposal.stop_price,
+                    initial_risk_usd=proposal.initial_risk_usd)
                 positions = await self._positions()
                 entries += 1
             except Exception as exc:  # noqa: BLE001

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -36,6 +36,13 @@ from datetime import datetime, timezone
 
 import structlog
 
+from auramaur.experiments.strategies.oddlot_tender import (
+    OddLotTenderDisposition,
+    OddLotTenderInputs,
+    OddLotTenderProposal,
+    OddLotTenderRules,
+    assess_oddlot_tender,
+)
 from auramaur.exchange.models import Fill, OrderSide
 
 log = structlog.get_logger()
@@ -112,11 +119,11 @@ class OddLotTenderPillar:
             verdict = await self._audit_filing(f)
             if verdict is None:
                 continue
-            if (verdict["odd_lot_priority"]
-                    and not verdict["requires_record_date_holding"]
-                    and verdict["confidence"] >= cfg.llm_min_confidence):
+            assessment = assess_oddlot_tender(
+                self._proposal_inputs(f, verdict), self._proposal_rules())
+            if assessment.proposal is not None:
                 found += 1
-                await self._on_opportunity(f, verdict)
+                await self._on_opportunity(f, verdict, assessment.proposal)
         log.info("oddlot.cycle", analyzed=analyzed, opportunities=found)
         return found
 
@@ -171,21 +178,41 @@ class OddLotTenderPillar:
 
     # ------------------------------------------------------------------
 
-    async def _on_opportunity(self, f, verdict: dict) -> None:
+    def _proposal_rules(self) -> OddLotTenderRules:
         cfg = self._settings.oddlot_tender
-        ticker = f.ticker or "?"
-        msg = (f"ODD-LOT TENDER: {f.company} [{ticker}] {f.form} filed {f.filed_at} — "
-               f"price ${verdict['tender_price']:.2f}"
-               + (f"-${verdict['tender_price_high']:.2f}"
-                  if verdict["tender_price_high"] > verdict["tender_price"] else "")
-               + f", expires {verdict['expiration'] or '?'}. "
-               f"Conditions: {verdict['conditions'] or 'none noted'}. "
-               f"TENDERING IS MANUAL — submit in TWS before expiration.")
+        return OddLotTenderRules(
+            min_confidence=cfg.llm_min_confidence,
+            min_premium_pct=cfg.min_premium_pct,
+            max_position_usd=cfg.max_position_usd,
+        )
+
+    @staticmethod
+    def _proposal_inputs(
+        f, verdict: dict, *, entry_enabled: bool = False,
+        market_price: float | None = None,
+    ) -> OddLotTenderInputs:
+        return OddLotTenderInputs(
+            accession=f.accession, company=f.company, ticker=f.ticker or "?",
+            form=f.form, filed_at=f.filed_at,
+            odd_lot_priority=verdict["odd_lot_priority"],
+            requires_record_date_holding=verdict["requires_record_date_holding"],
+            tender_price=verdict["tender_price"],
+            tender_price_high=verdict["tender_price_high"],
+            expiration=verdict["expiration"], conditions=verdict["conditions"],
+            confidence=verdict["confidence"], entry_enabled=entry_enabled,
+            market_price=market_price,
+        )
+
+    async def _on_opportunity(
+        self, f, verdict: dict, proposal: OddLotTenderProposal,
+    ) -> None:
+        cfg = self._settings.oddlot_tender
+        ticker = proposal.ticker
         log.info("oddlot.opportunity", accession=f.accession, ticker=ticker,
                  price=verdict["tender_price"], expiration=verdict["expiration"])
         if self._alerts is not None:
             try:
-                await self._alerts.send(msg, level="warning")
+                await self._alerts.send(proposal.alert_message, level="warning")
             except Exception as e:
                 log.debug("oddlot.alert_error", error=str(e))
 
@@ -197,20 +224,33 @@ class OddLotTenderPillar:
         # that preserves the minimum premium vs the LOW tender price (Dutch
         # offers fill at >= low, so low is the conservative payout).
         price = await self._equity.get_price(ticker)
-        if not price or price <= 0:
+        assessment = assess_oddlot_tender(
+            self._proposal_inputs(
+                f, verdict, entry_enabled=True, market_price=price,
+            ),
+            self._proposal_rules(),
+        )
+        proposal = assessment.proposal
+        if proposal is None:
             await self._set_status(f.accession, "alerted_no_price")
             return
-        payout = verdict["tender_price"]
-        premium_pct = (payout - price) / price * 100.0 if price else 0.0
-        if premium_pct < cfg.min_premium_pct:
+        if proposal.disposition is OddLotTenderDisposition.NO_MARKET_PRICE:
+            await self._set_status(f.accession, "alerted_no_price")
+            return
+        if proposal.disposition is OddLotTenderDisposition.PREMIUM_TOO_THIN:
+            premium_pct = (verdict["tender_price"] - price) / price * 100.0
             log.info("oddlot.premium_too_thin", ticker=ticker,
-                     price=price, payout=payout, premium_pct=round(premium_pct, 2))
+                     price=price, payout=verdict["tender_price"],
+                     premium_pct=round(premium_pct, 2))
             await self._set_status(f.accession, "premium_too_thin")
             return
-        qty = min(99, int(cfg.max_position_usd // price))
-        if qty < 1:
+        if proposal.disposition is OddLotTenderDisposition.TOO_EXPENSIVE:
             await self._set_status(f.accession, "too_expensive")
             return
+        if proposal.entry is None:
+            await self._set_status(f.accession, "alerted")
+            return
+        qty = proposal.entry.quantity
         dry_run = cfg.paper or not self._settings.is_live
         result = await self._equity.place_share_order(
             ticker, OrderSide.BUY, qty, limit_price=price, dry_run=dry_run)

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -28,6 +28,13 @@ import structlog
 from auramaur.strategy.protocols import ExecutionMode
 
 from auramaur.exchange.models import Fill, OrderSide, TokenType
+from auramaur.experiments.strategies.kraken import (
+    KrakenAction,
+    KrakenRejection,
+    KrakenSpotInputs,
+    KrakenSpotRules,
+    assess_kraken_spot,
+)
 
 log = structlog.get_logger()
 
@@ -793,13 +800,28 @@ class KrakenPillar:
                 # balance by a rounding sliver. If the held amount is below the
                 # pair's ordermin, a single market sell can't close it — log once
                 # and skip rather than spamming rejected orders forever.
-                vol = self._floor_lot(pair, qty)
                 ordermin = self._pair_min.get(pair, 0.0)
-                if vol <= 0 or (ordermin and vol < ordermin):
+                assessment = assess_kraken_spot(
+                    KrakenSpotInputs(
+                        pair=pair, price=price, holding=True, orphaned=orphaned,
+                        exit_reason=reason, held_quantity=qty,
+                    ),
+                    KrakenSpotRules(
+                        max_order_usd=kcfg.max_order_usd,
+                        lot_decimals=self._pair_lot_dec.get(pair, 8),
+                        order_minimum=ordermin,
+                    ),
+                )
+                if assessment.proposal is None:
                     log.warning("kraken.directional.exit_below_ordermin", pair=pair,
                                 reason=reason, held=round(qty, 8), ordermin=ordermin,
+                                rejection=(assessment.rejection.value
+                                           if assessment.rejection else None),
                                 note="position too small to close with one market sell")
                     continue
+                proposal = assessment.proposal
+                assert proposal.action is KrakenAction.SELL
+                vol = proposal.volume
                 notional = await self._k.usd_notional(pair, vol, price) or (vol * price)
                 res = await self._k.place_spot_order(
                     pair, OrderSide.SELL, volume=vol, ordertype="market",
@@ -888,17 +910,11 @@ class KrakenPillar:
                 # over-precise volume), then respect the minimum lot — bump up to
                 # ordermin only if it still fits ~1.5x the per-order cap in USD;
                 # else the pair is too expensive per lot to trade within budget.
-                vol = self._floor_lot(pair, vol)
                 ordermin = self._pair_min.get(pair, 0.0)
-                if ordermin and vol < ordermin:
-                    min_usd = await self._k.usd_notional(pair, ordermin, price)
-                    if min_usd and min_usd > kcfg.max_order_usd * 1.5:
-                        log.info("kraken.directional.min_lot_too_large", pair=pair,
-                                 ordermin=ordermin, min_usd=round(min_usd, 2))
-                        continue
-                    vol = ordermin  # ordermin is already a valid lot size
-                if vol <= 0:
-                    continue
+                minimum_notional_usd = (
+                    await self._k.usd_notional(pair, ordermin, price)
+                    if ordermin and vol < ordermin else None
+                )
                 # Funding gate: only fire if we actually hold enough FREE quote
                 # currency to pay for it. The notional budget ceiling above is far
                 # larger than available cash, so without this the loop spams orders
@@ -906,14 +922,35 @@ class KrakenPillar:
                 # Paper validation simulates entries, so it needs no real quote
                 # balance — skip the funding gate (else a fully-deployed wallet
                 # would block the paper book from ever opening a position).
-                if not effective_paper:
-                    quote = await self._k.get_pair_quote(pair) or "ZUSD"
-                    free_quote = bal.get(quote, 0.0)
-                    need_quote = vol * price * 1.005   # +0.5% for taker fee headroom
-                    if free_quote < need_quote:
+                quote = await self._k.get_pair_quote(pair) or "ZUSD"
+                free_quote = bal.get(quote, 0.0)
+                assessment = assess_kraken_spot(
+                    KrakenSpotInputs(
+                        pair=pair, price=price, holding=False, orphaned=False,
+                        signal_accepted=True, sized_entry_volume=vol,
+                        allocated_usd=allocated, budget_usd=budget,
+                        free_quote=free_quote, paper=effective_paper,
+                        minimum_notional_usd=minimum_notional_usd,
+                    ),
+                    KrakenSpotRules(
+                        max_order_usd=kcfg.max_order_usd,
+                        lot_decimals=self._pair_lot_dec.get(pair, 8),
+                        order_minimum=ordermin,
+                    ),
+                )
+                if assessment.proposal is None:
+                    if assessment.rejection is KrakenRejection.MINIMUM_TOO_EXPENSIVE:
+                        log.info("kraken.directional.min_lot_too_large", pair=pair,
+                                 ordermin=ordermin,
+                                 min_usd=round(minimum_notional_usd or 0.0, 2))
+                    elif assessment.rejection is KrakenRejection.UNFUNDED:
+                        need_quote = vol * price * 1.005
                         log.info("kraken.directional.skip_unfunded", pair=pair, quote=quote,
                                  free=round(free_quote, 2), need=round(need_quote, 2))
-                        continue
+                    continue
+                proposal = assessment.proposal
+                assert proposal.action is KrakenAction.BUY
+                vol = proposal.volume
                 res = await self._k.place_spot_order(
                     pair, OrderSide.BUY, volume=vol, ordertype="market", purpose="directional",
                     dry_run=True if effective_paper else None,

--- a/docs/plans/experiment-platform-refactor.md
+++ b/docs/plans/experiment-platform-refactor.md
@@ -207,8 +207,8 @@ proposal formation. News reactor delegates its pure routing decision and hands
 the eventual trade choice to the separately migrated core-trading decision.
 Every live-sensitive risk, gateway, persistence, order-lifecycle, and accounting
 operation remains in production. Arbitrage retains atomic paired-package
-proposals and market making retains coupled quote/reconciliation proposals.
-External-asset entries remain explicitly planned on specialized tracks.
+proposals, market making retains coupled quote/reconciliation proposals, and
+Kraken, IBKR, and tender strategies retain asset-specific contracts.
 
 ## Full-set migration sequence
 
@@ -236,5 +236,10 @@ deterministic seam to a pure contract, focused old/new decision coverage passes,
 and its existing execution-contract suite still passes. The status does not
 claim that the contract is supported by the generic replay runtime.
 
-Portable, routing, paired-package, and quoting entries satisfy that
-decision-seam gate. The following stack layer migrates external-asset contracts.
+All entries in the authoritative inventory satisfy that decision-seam gate.
+Specialized contracts deliberately remain outside the generic
+`list[TargetPosition]` runtime where using it would discard atomic pair,
+coupled-quote, routing, manual-action, or external-asset semantics. Generic
+replay/shadow adapters, provenance fixtures, and compatibility-path retirement
+remain explicit follow-on work for those contracts. This completes the
+production delegation refactor without overstating runtime portability.

--- a/tests/test_experiment_ibkr_etf_paper.py
+++ b/tests/test_experiment_ibkr_etf_paper.py
@@ -1,0 +1,90 @@
+"""Contract tests for the paper-only ETF experiment boundary."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from auramaur.experiments.strategies.ibkr_etf_paper import (
+    ETFEntryProposal, entry_proposal, exit_proposal,
+)
+from auramaur.risk.ibkr_math import adverse_fill, risk_quantity, stop_distance
+
+
+def _entry(**overrides):
+    values = dict(
+        symbol="SPY", bid=499.9, ask=500.1, probability=0.67,
+        confidence="HIGH", confidence_rank=4, min_confidence_rank=2,
+        min_probability=0.6, annual_volatility=0.2, momentum=0.03,
+        remaining_deployment_usd=1_000, remaining_class_usd=800,
+        max_entry_usd=500, fee_usd=1, slippage_bps=5,
+        stop_vol_multiple=1.5, min_stop_pct=1.0, risk_budget_usd=50,
+        open_risk_usd=10, max_portfolio_risk_usd=100,
+        controls_allow_entry=True)
+    values.update(overrides)
+    return entry_proposal(**values)
+
+
+def test_entry_matches_legacy_sizing_and_cost_controls():
+    proposal = _entry()
+    assert proposal is not None
+    expected_price = adverse_fill(499.9, 500.1, "BUY", 5)
+    distance = stop_distance(expected_price, 0.2, 1.5, 1.0)
+    expected_qty = min(499 / expected_price,
+                       risk_quantity(50, distance, 1, 1, fractional=True))
+    assert proposal.price == pytest.approx(expected_price)
+    assert proposal.quantity == pytest.approx(expected_qty)
+    assert proposal.stop_price == pytest.approx(expected_price - distance)
+    assert proposal.initial_risk_usd == pytest.approx(expected_qty * distance)
+
+
+@pytest.mark.parametrize("override", [
+    {"controls_allow_entry": False}, {"probability": None},
+    {"confidence_rank": 1}, {"momentum": 0},
+    {"remaining_class_usd": 1}, {"annual_volatility": None},
+    {"open_risk_usd": 100},
+])
+def test_entry_fails_closed(override):
+    assert _entry(**override) is None
+
+
+@pytest.mark.parametrize(("kwargs", "reason"), [
+    ({"bid": 94.0, "ask": 94.1}, "stop_loss"),
+    ({"bid": 108.0, "ask": 108.1}, "take_profit"),
+    ({"bid": 102.0, "ask": 102.1, "peak_gain_pct": 7.0}, "trailing_stop"),
+    ({"bid": 101.0, "ask": 101.1, "probability": 0.3}, "llm_bearish"),
+])
+def test_exit_precedence_and_reasons(kwargs, reason):
+    values = dict(symbol="SPY", quantity=2, entry_price=100, bid=101, ask=101.1,
+                  stored_stop=0, peak_gain_pct=1, probability=0.7,
+                  stop_loss_pct=5, take_profit_pct=7,
+                  trailing_stop_pct=4, exit_probability=0.4,
+                  slippage_bps=5)
+    values.update(kwargs)
+    proposal = exit_proposal(**values)
+    assert proposal is not None
+    assert proposal.reason == reason
+    assert proposal.price == pytest.approx(
+        adverse_fill(values["bid"], values["ask"], "SELL", 5))
+
+
+def test_hold_has_no_order_proposal():
+    assert exit_proposal(
+        symbol="SPY", quantity=2, entry_price=100, bid=101, ask=101.1,
+        stored_stop=0, peak_gain_pct=1, probability=0.7,
+        stop_loss_pct=5, take_profit_pct=7, trailing_stop_pct=4,
+        exit_probability=0.4, slippage_bps=5) is None
+
+
+def test_proposals_are_immutable():
+    proposal = _entry()
+    assert isinstance(proposal, ETFEntryProposal)
+    with pytest.raises(FrozenInstanceError):
+        proposal.quantity = 99
+
+
+def test_experiment_module_has_no_broker_or_live_execution_imports():
+    import auramaur.experiments.strategies.ibkr_etf_paper as module
+    source = module.__loader__.get_source(module.__name__)
+    assert "auramaur.exchange" not in source
+    assert "auramaur.strategy" not in source
+    assert "place_order" not in source

--- a/tests/test_experiment_ibkr_multiasset.py
+++ b/tests/test_experiment_ibkr_multiasset.py
@@ -1,0 +1,78 @@
+"""Portable IBKR multi-asset proposal coverage."""
+from __future__ import annotations
+from dataclasses import FrozenInstanceError
+import importlib
+import sys
+import pytest
+from auramaur.experiments.strategies.ibkr_multiasset import (
+    MultiAssetEntryInputs, MultiAssetEntryRules, propose_multiasset_entry,
+)
+from auramaur.risk.ibkr_math import adverse_fill, risk_quantity, stop_distance
+
+def _rules(**changes):
+    values = dict(budget_usd=10_000, max_position_pct=20,
+                  max_deployment_pct=80, risk_per_position_pct=1,
+                  max_asset_class_risk_pct=3, stop_vol_multiple=2,
+                  min_stop_pct=2, slippage_bps=5)
+    values.update(changes)
+    return MultiAssetEntryRules(**values)
+
+def _inputs(**changes):
+    values = dict(instrument_key="SPY", asset_class="equity", bid=499.8,
+                  ask=500.0, fx_to_usd=1.0, multiplier=1.0,
+                  annual_volatility=.20, deployed_usd=1_000,
+                  asset_class_risk_usd=25, capital_per_unit_usd=500,
+                  fractional=True)
+    values.update(changes)
+    return MultiAssetEntryInputs(**values)
+
+def test_proposal_preserves_legacy_sizing_and_stop_formula():
+    inputs, rules = _inputs(), _rules()
+    proposal = propose_multiasset_entry(inputs, rules)
+    assert proposal is not None
+    entry = adverse_fill(inputs.bid, inputs.ask, "BUY", rules.slippage_bps)
+    distance = stop_distance(entry, inputs.annual_volatility,
+                             rules.stop_vol_multiple, rules.min_stop_pct)
+    expected = min(4.0, risk_quantity(100, distance, 1, 1, fractional=True))
+    assert proposal.quantity == pytest.approx(expected)
+    assert proposal.reference_price == pytest.approx(entry)
+    assert proposal.stop_price == pytest.approx(entry - distance)
+    assert proposal.initial_risk_usd == pytest.approx(expected * distance)
+    assert proposal.paper_by_default is True
+
+def test_whole_contract_assets_do_not_propose_fractional_orders():
+    proposal = propose_multiasset_entry(
+        _inputs(instrument_key="ES", asset_class="future", multiplier=1,
+                capital_per_unit_usd=1_200, fractional=False),
+        _rules(max_position_pct=50))
+    assert proposal is not None
+    assert proposal.quantity == float(int(proposal.quantity))
+
+@pytest.mark.parametrize("changes", [
+    {"fx_to_usd": 0}, {"ask": float("nan")}, {"ask": 499, "bid": 500},
+    {"annual_volatility": 0}, {"deployed_usd": -1},
+    {"capital_per_unit_usd": 0},
+])
+def test_invalid_market_or_portfolio_inputs_fail_closed(changes):
+    assert propose_multiasset_entry(_inputs(**changes), _rules()) is None
+
+def test_exhausted_budgets_fail_closed():
+    assert propose_multiasset_entry(_inputs(deployed_usd=8_000), _rules()) is None
+    assert propose_multiasset_entry(
+        _inputs(asset_class_risk_usd=300), _rules()) is None
+
+def test_contracts_are_immutable():
+    proposal = propose_multiasset_entry(_inputs(), _rules())
+    assert proposal is not None
+    with pytest.raises(FrozenInstanceError):
+        proposal.quantity = 1
+
+def test_experiment_module_has_no_broker_or_strategy_imports():
+    name = "auramaur.experiments.strategies.ibkr_multiasset"
+    sys.modules.pop(name, None)
+    before = set(sys.modules)
+    importlib.import_module(name)
+    loaded = set(sys.modules) - before
+    assert not any(module.startswith(
+        ("auramaur.exchange.ibkr_multiasset_execution",
+         "auramaur.strategy.ibkr_multiasset_paper")) for module in loaded)

--- a/tests/test_experiment_kraken.py
+++ b/tests/test_experiment_kraken.py
@@ -1,0 +1,91 @@
+"""Specialized Kraken spot experiment contract and production parity."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from auramaur.experiments.strategies.kraken import (
+    KrakenAction,
+    KrakenRejection,
+    KrakenSpotInputs,
+    KrakenSpotRules,
+    assess_kraken_spot,
+)
+
+
+RULES = KrakenSpotRules(max_order_usd=30.0, lot_decimals=4, order_minimum=0.001)
+
+
+def test_entry_proposal_is_immutable_spot_order_candidate():
+    result = assess_kraken_spot(KrakenSpotInputs(
+        pair="XBTUSDC", price=60_000.0, holding=False, orphaned=False,
+        signal_accepted=True, sized_entry_volume=0.00049,
+        allocated_usd=0.0, budget_usd=600.0, paper=True,
+        minimum_notional_usd=40.0,
+    ), RULES)
+
+    assert result.proposal is not None
+    assert result.proposal.action is KrakenAction.BUY
+    assert result.proposal.volume == 0.001
+    with pytest.raises(Exception):
+        result.proposal.volume = 2.0  # type: ignore[misc]
+
+
+def test_live_entry_fails_closed_without_quote_funding():
+    result = assess_kraken_spot(KrakenSpotInputs(
+        pair="ETHUSDC", price=3_000.0, holding=False, orphaned=False,
+        signal_accepted=True, sized_entry_volume=0.01,
+        allocated_usd=0.0, budget_usd=100.0, free_quote=29.0, paper=False,
+    ), KrakenSpotRules(max_order_usd=30.0, lot_decimals=6))
+    assert result.proposal is None
+    assert result.rejection is KrakenRejection.UNFUNDED
+
+
+@pytest.mark.parametrize("change, rejection", [
+    ({"orphaned": True}, KrakenRejection.ORPHAN_REENTRY),
+    ({"in_cooldown": True}, KrakenRejection.COOLDOWN),
+    ({"signal_accepted": False}, KrakenRejection.SIGNAL_GATE),
+    ({"allocated_usd": 90.0}, KrakenRejection.BUDGET_FULL),
+])
+def test_entry_gates_fail_closed(change, rejection):
+    values = dict(
+        pair="XBTUSDC", price=100.0, holding=False, orphaned=False,
+        signal_accepted=True, sized_entry_volume=0.3,
+        allocated_usd=0.0, budget_usd=100.0, paper=True,
+    )
+    values.update(change)
+    result = assess_kraken_spot(KrakenSpotInputs(**values), RULES)
+    assert result.proposal is None
+    assert result.rejection is rejection
+
+
+def test_exit_floors_actual_held_quantity_and_preserves_reason():
+    result = assess_kraken_spot(KrakenSpotInputs(
+        pair="XBTUSDC", price=100.0, holding=True, orphaned=False,
+        exit_reason="trailing_stop", held_quantity=0.123456,
+    ), RULES)
+    assert result.proposal is not None
+    assert result.proposal.action is KrakenAction.SELL
+    assert result.proposal.volume == 0.1234
+    assert result.proposal.rationale == "trailing_stop"
+
+
+def test_pure_module_has_no_live_execution_imports():
+    path = Path("auramaur/experiments/strategies/kraken.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    assert not any(name.startswith((
+        "auramaur.exchange", "auramaur.broker", "auramaur.gateway",
+        "auramaur.treasury", "auramaur.db",
+    )) for name in imported)

--- a/tests/test_experiment_oddlot_tender.py
+++ b/tests/test_experiment_oddlot_tender.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from auramaur.experiments.strategies.oddlot_tender import (
+    OddLotTenderDisposition,
+    OddLotTenderInputs,
+    OddLotTenderRejection,
+    OddLotTenderRules,
+    assess_oddlot_tender,
+)
+
+
+def _inputs(**changes) -> OddLotTenderInputs:
+    values = dict(
+        accession="0001", company="Acme Corp", ticker="ACME", form="SC TO-I",
+        filed_at="2026-06-09", odd_lot_priority=True,
+        requires_record_date_holding=False, tender_price=20.0,
+        tender_price_high=22.0, expiration="2026-07-15",
+        conditions="none material", confidence=0.95,
+    )
+    values.update(changes)
+    return OddLotTenderInputs(**values)
+
+
+def _rules(**changes) -> OddLotTenderRules:
+    values = dict(min_confidence=0.8, min_premium_pct=2.0,
+                  max_position_usd=2500.0)
+    values.update(changes)
+    return OddLotTenderRules(**values)
+
+
+def test_alert_contract_preserves_manual_submission_and_expiration():
+    proposal = assess_oddlot_tender(_inputs(), _rules()).proposal
+    assert proposal is not None
+    assert proposal.disposition is OddLotTenderDisposition.ALERT_ONLY
+    assert proposal.manual_submission_required is True
+    assert proposal.expiration == "2026-07-15"
+    assert "submit in TWS before expiration" in proposal.alert_message
+    assert "$20.00-$22.00" in proposal.alert_message
+    with pytest.raises(FrozenInstanceError):
+        proposal.expiration = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        ({"odd_lot_priority": False}, OddLotTenderRejection.NO_PRIORITY),
+        ({"requires_record_date_holding": True},
+         OddLotTenderRejection.RECORD_DATE_REQUIRED),
+        ({"confidence": 0.79}, OddLotTenderRejection.LOW_CONFIDENCE),
+        ({"tender_price": float("nan")}, OddLotTenderRejection.INVALID_INPUT),
+    ],
+)
+def test_candidate_gates_fail_closed(changes, reason):
+    assessment = assess_oddlot_tender(_inputs(**changes), _rules())
+    assert assessment.proposal is None
+    assert assessment.rejection is reason
+
+
+def test_entry_proposal_matches_production_limits():
+    proposal = assess_oddlot_tender(
+        _inputs(entry_enabled=True, market_price=19.0), _rules(),
+    ).proposal
+    assert proposal is not None and proposal.entry is not None
+    assert proposal.disposition is OddLotTenderDisposition.ENTER
+    assert proposal.entry.quantity == 99
+    assert proposal.entry.limit_price == 19.0
+    assert proposal.entry.conservative_payout == 20.0
+
+
+def test_entry_dispositions_match_legacy_path():
+    thin = assess_oddlot_tender(
+        _inputs(entry_enabled=True, market_price=19.9), _rules(),
+    ).proposal
+    missing = assess_oddlot_tender(
+        _inputs(entry_enabled=True, market_price=None), _rules(),
+    ).proposal
+    expensive = assess_oddlot_tender(
+        _inputs(entry_enabled=True, market_price=30.0, tender_price=40.0),
+        _rules(max_position_usd=25.0),
+    ).proposal
+    assert thin and thin.disposition is OddLotTenderDisposition.PREMIUM_TOO_THIN
+    assert missing and missing.disposition is OddLotTenderDisposition.NO_MARKET_PRICE
+    assert expensive and expensive.disposition is OddLotTenderDisposition.TOO_EXPENSIVE
+
+
+def test_pure_module_has_no_live_execution_imports():
+    path = Path("auramaur/experiments/strategies/oddlot_tender.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not any(
+        name.startswith(("auramaur.exchange", "auramaur.broker", "auramaur.strategy"))
+        for name in imports
+    )

--- a/tests/test_experiment_platform.py
+++ b/tests/test_experiment_platform.py
@@ -395,4 +395,5 @@ def test_every_production_strategy_is_in_the_migration_inventory():
         "weather_temp", "resolution_lens", "resolution_lens_kalshi",
         "momentum_coupling",
         "arbitrage", "entailment_arb", "cross_venue_arb", "market_maker",
+        "kraken", "oddlot_tender", "ibkr_etf_paper", "ibkr_multiasset",
     }


### PR DESCRIPTION
Stack 4 of 4, based on experiment-market-structure-contracts. Adds specialized immutable contracts for Kraken, odd-lot tender, IBKR ETF paper, and IBKR multiasset while preserving their safety and execution boundaries. Final isolated validation: 1789 passed, 5 skipped; Ruff and diff checks passed; 25 of 25 registrations migrated.