### PR TITLE
Add experiment operations, specialized replay, and scoreboard

### DIFF
--- a/auramaur/cli/__init__.py
+++ b/auramaur/cli/__init__.py
@@ -12,7 +12,7 @@ from auramaur.cli._base import console, log, main  # noqa: F401
 
 # Importing these registers their commands onto `main` (side effect).
 from auramaur.cli import (  # noqa: E402,F401
-    diagnostics, intel, kraken, maintenance, manager, redeem, reporting, run,
+    diagnostics, experiments, intel, kraken, maintenance, manager, redeem, reporting, run,
     web,
 )
 

--- a/auramaur/cli/experiments.py
+++ b/auramaur/cli/experiments.py
@@ -1,0 +1,182 @@
+"""Operator commands for registered, reproducible market experiments."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from auramaur.cli._base import console, main
+from auramaur.db.database import Database
+from auramaur.experiments.operations import bind_manifest, load_manifest
+from auramaur.experiments.registry import RegisteredExperiment
+from auramaur.experiments.runtimes import (
+    InMemoryShadowSink,
+    LinearExecutionModel,
+    ReplayRuntime,
+    ShadowRuntime,
+)
+from auramaur.experiments.specialized import (
+    InMemoryPackageSink,
+    SpecializedReplayRuntime,
+    SpecializedShadowRuntime,
+)
+from auramaur.research.experiment_reporting import ExperimentReportBuilder
+from auramaur.research.experiment_repository import ExperimentRepository
+from auramaur.research.experiment_scoreboard import ExperimentScoreboard
+
+
+@main.group("experiment")
+def experiment_group() -> None:
+    """Define, replay, shadow, and compare preregistered experiments."""
+
+
+@experiment_group.command("define")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+def define_experiment(manifest: Path) -> None:
+    """Validate a manifest and print its immutable lineage ID."""
+    loaded = load_manifest(manifest)
+    bind_manifest(loaded)
+    console.print(loaded.definition.lineage_id)
+
+
+@experiment_group.command("register")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--db", "db_path", type=click.Path(dir_okay=False), default=None)
+def register_experiment(manifest: Path, db_path: str | None) -> None:
+    """Persist the manifest's prospective registration before collecting evidence."""
+    async def run() -> None:
+        loaded = load_manifest(manifest)
+        registered = bind_manifest(loaded)
+        database = Database(db_path)
+        await database.connect(ensure_schema=False)
+        try:
+            record = await ExperimentRepository(database).register(registered)
+            console.print(record.lineage_id)
+        finally:
+            await database.close()
+    asyncio.run(run())
+
+
+@experiment_group.command("replay")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--db", "db_path", type=click.Path(dir_okay=False), default=None)
+@click.option("--record/--no-record", default=True)
+def replay_experiment(manifest: Path, db_path: str | None, record: bool) -> None:
+    """Run chronological replay and optionally persist non-graduating evidence."""
+    async def run() -> None:
+        loaded = load_manifest(manifest)
+        registered = bind_manifest(loaded)
+        repository = None
+        database = None
+        if record:
+            database = Database(db_path)
+            await database.connect(ensure_schema=False)
+            repository = ExperimentRepository(database)
+        try:
+            if isinstance(registered, RegisteredExperiment):
+                if loaded.execution_model is None:
+                    raise click.ClickException("portable replay requires execution_model")
+                model = LinearExecutionModel(**loaded.execution_model)
+                report = await ReplayRuntime(model).run(
+                    registered, loaded.snapshots, loaded.initial_portfolio
+                )
+                inserted = await repository.record_replay(registered, report) if repository else 0
+                console.print(
+                    f"{report.lineage_id} equity={report.final_equity:.2f} "
+                    f"events={len(report.results)} recorded={inserted}"
+                )
+            else:
+                report = await SpecializedReplayRuntime().run(
+                    registered, loaded.snapshots, loaded.initial_portfolio
+                )
+                inserted = (
+                    await repository.record_specialized_replay(registered, report)
+                    if repository else 0
+                )
+                proposed = sum(item.proposal is not None for item in report.results)
+                console.print(
+                    f"{report.lineage_id} packages={proposed} "
+                    f"events={len(report.results)} recorded={inserted}"
+                )
+        finally:
+            if database is not None:
+                await database.close()
+    asyncio.run(run())
+
+
+@experiment_group.command("shadow")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+def shadow_experiment(manifest: Path) -> None:
+    """Evaluate every manifest event without orders or database writes."""
+    async def run() -> None:
+        loaded = load_manifest(manifest)
+        registered = bind_manifest(loaded)
+        if isinstance(registered, RegisteredExperiment):
+            sink = InMemoryShadowSink()
+            runtime = ShadowRuntime(sink)
+        else:
+            sink = InMemoryPackageSink()
+            runtime = SpecializedShadowRuntime(sink)
+        for snapshot in loaded.snapshots:
+            result = await runtime.run(registered, snapshot, loaded.initial_portfolio)
+            console.print(result.model_dump_json())
+    asyncio.run(run())
+
+
+@experiment_group.command("report")
+@click.argument("lineage_id")
+@click.option("--db", "db_path", type=click.Path(dir_okay=False), default=None)
+@click.option("--execution-model")
+@click.option("--data-version")
+def report_experiment(
+    lineage_id: str,
+    db_path: str | None,
+    execution_model: str | None,
+    data_version: str | None,
+) -> None:
+    """Print one explicitly selected portable replay cohort report."""
+    async def run() -> None:
+        database = Database(db_path)
+        await database.connect(ensure_schema=False)
+        try:
+            report = await ExperimentReportBuilder(database).build(
+                lineage_id,
+                execution_model_version=execution_model,
+                data_version=data_version,
+            )
+            console.print_json(report.model_dump_json())
+        finally:
+            await database.close()
+    asyncio.run(run())
+
+
+@experiment_group.command("scoreboard")
+@click.option("--db", "db_path", type=click.Path(dir_okay=False), default=None)
+def experiment_scoreboard(db_path: str | None) -> None:
+    """Compare lineages without blending data or execution-model cohorts."""
+    async def run() -> None:
+        database = Database(db_path)
+        await database.connect(ensure_schema=False)
+        try:
+            rows = await ExperimentScoreboard(database).build()
+            table = Table(title="Experiment Scoreboard")
+            for column in ("Strategy", "Lineage", "Model/Data", "Replay", "Prospective", "Net P&L", "DD", "Status"):
+                table.add_column(column)
+            for row in rows:
+                table.add_row(
+                    row.strategy_source,
+                    row.lineage_id[:10],
+                    f"{row.execution_model_version or '-'} / {row.data_version or '-'}",
+                    f"{row.replay_observations} ({row.independent_markets} mkts)",
+                    f"{row.prospective_warmup}/{row.prospective_holdout}",
+                    "-" if row.net_pnl is None else f"{row.net_pnl:+.2f}",
+                    "-" if row.max_drawdown is None else f"{row.max_drawdown:.1%}",
+                    row.status,
+                )
+            console.print(table)
+        finally:
+            await database.close()
+    asyncio.run(run())

--- a/auramaur/experiments/adapters.py
+++ b/auramaur/experiments/adapters.py
@@ -1,0 +1,81 @@
+"""Generic adapters from pure dataclass proposal functions to package runtimes."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any, Callable, get_type_hints
+
+from pydantic import BaseModel
+
+from auramaur.experiments.models import MarketSnapshot, PortfolioSnapshot
+from auramaur.experiments.specialized import PackageSemantics, ProposalPackage
+
+
+class FeatureProposalAdapter:
+    """Call a pure proposal function using one JSON feature as keyword arguments."""
+
+    def __init__(
+        self,
+        *,
+        feature_name: str,
+        evaluator: Callable[..., Any],
+        kind: str,
+        semantics: PackageSemantics,
+        fixed_arguments: dict[str, Any] | None = None,
+        package_id_field: str = "package_id",
+    ) -> None:
+        self.feature_name = feature_name
+        self.evaluator = evaluator
+        self.kind = kind
+        self.semantics = semantics
+        self.fixed_arguments = dict(fixed_arguments or {})
+        self.package_id_field = package_id_field
+
+    async def evaluate_package(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> ProposalPackage | None:
+        del portfolio
+        payload = snapshot.feature(self.feature_name)
+        if not isinstance(payload, dict):
+            raise TypeError(f"{self.feature_name} must contain an object")
+        arguments = {**payload, **self.fixed_arguments}
+        hints = get_type_hints(self.evaluator)
+        for name, value in tuple(arguments.items()):
+            annotation = hints.get(name)
+            if annotation is not None and is_dataclass(annotation) and isinstance(value, dict):
+                arguments[name] = annotation(**value)
+        proposal = self.evaluator(**arguments)
+        if inspect.isawaitable(proposal):
+            proposal = await proposal
+        proposal = getattr(proposal, "proposal", proposal)
+        if proposal is None:
+            return None
+        encoded = _json_value(proposal)
+        package_id = str(
+            encoded.get(self.package_id_field)
+            or encoded.get("market_id")
+            or encoded.get("symbol")
+            or snapshot.market_id
+        )
+        return ProposalPackage(
+            package_id=package_id,
+            kind=self.kind,
+            semantics=self.semantics,
+            payload=encoded,
+        )
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return _json_value(value.model_dump(mode="json"))
+    if is_dataclass(value):
+        return _json_value(asdict(value))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_json_value(item) for item in value]
+    return value

--- a/auramaur/experiments/operations.py
+++ b/auramaur/experiments/operations.py
@@ -1,0 +1,113 @@
+"""Manifest loading and operator-facing experiment orchestration."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from dataclasses import is_dataclass
+from pathlib import Path
+from typing import Any, Literal, get_type_hints
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from auramaur.experiments.adapters import FeatureProposalAdapter
+from auramaur.experiments.models import (
+    ExperimentDefinition,
+    MarketSnapshot,
+    PortfolioSnapshot,
+)
+from auramaur.experiments.registry import ExperimentRegistry, RegisteredExperiment
+from auramaur.experiments.specialized import (
+    PackageSemantics,
+    RegisteredSpecializedExperiment,
+)
+
+
+class ExperimentBinding(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    kind: Literal["portable", "specialized"]
+    implementation: str | None = None
+    evaluator: str | None = None
+    constructor_arguments: dict[str, Any] = Field(default_factory=dict)
+    feature_name: str | None = None
+    proposal_kind: str | None = None
+    semantics: PackageSemantics | None = None
+    fixed_arguments: dict[str, Any] = Field(default_factory=dict)
+    package_id_field: str = "package_id"
+
+    @model_validator(mode="after")
+    def binding_is_complete(self) -> "ExperimentBinding":
+        if self.kind == "portable" and not self.implementation:
+            raise ValueError("portable binding requires implementation")
+        if self.kind == "specialized" and not all((
+            self.evaluator, self.feature_name, self.proposal_kind, self.semantics
+        )):
+            raise ValueError("specialized binding requires evaluator, feature, kind, semantics")
+        return self
+
+
+class ExperimentManifest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    schema_version: Literal[1] = 1
+    definition: ExperimentDefinition
+    binding: ExperimentBinding
+    snapshots: tuple[MarketSnapshot, ...] = Field(min_length=1)
+    initial_portfolio: PortfolioSnapshot
+    execution_model: dict[str, Any] | None = None
+
+
+def load_manifest(path: str | Path) -> ExperimentManifest:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return ExperimentManifest.model_validate(raw)
+
+
+def bind_manifest(
+    manifest: ExperimentManifest,
+) -> RegisteredExperiment | RegisteredSpecializedExperiment:
+    binding = manifest.binding
+    if binding.kind == "portable":
+        implementation_type = _load_symbol(binding.implementation or "")
+        arguments = _coerce_arguments(
+            implementation_type.__init__, binding.constructor_arguments
+        )
+        implementation = implementation_type(**arguments)
+        return ExperimentRegistry().register(manifest.definition, implementation)
+    evaluator = _load_symbol(binding.evaluator or "")
+    adapter = FeatureProposalAdapter(
+        feature_name=binding.feature_name or "",
+        evaluator=evaluator,
+        kind=binding.proposal_kind or "",
+        semantics=binding.semantics or PackageSemantics.ASSET_ORDER,
+        fixed_arguments=binding.fixed_arguments,
+        package_id_field=binding.package_id_field,
+    )
+    return RegisteredSpecializedExperiment(manifest.definition, adapter)
+
+
+def _load_symbol(reference: str):
+    try:
+        module_name, symbol_name = reference.split(":", 1)
+    except ValueError as exc:
+        raise ValueError("binding references must use module:object syntax") from exc
+    if not module_name.startswith("auramaur.experiments.strategies."):
+        raise ValueError("bindings may only load pure experiment strategy modules")
+    module = importlib.import_module(module_name)
+    try:
+        return getattr(module, symbol_name)
+    except AttributeError as exc:
+        raise ValueError(f"unknown binding symbol: {reference}") from exc
+
+
+def _coerce_arguments(callable_object, values: dict[str, Any]) -> dict[str, Any]:
+    hints = get_type_hints(callable_object)
+    result = dict(values)
+    for name, value in tuple(result.items()):
+        annotation = hints.get(name)
+        if annotation is not None and is_dataclass(annotation) and isinstance(value, dict):
+            result[name] = annotation(**value)
+    signature = inspect.signature(callable_object)
+    unknown = set(result) - set(signature.parameters)
+    if unknown:
+        raise ValueError(f"unknown constructor arguments: {sorted(unknown)}")
+    return result

--- a/auramaur/experiments/specialized.py
+++ b/auramaur/experiments/specialized.py
@@ -1,0 +1,134 @@
+"""Semantics-preserving runtimes for non-TargetPosition experiment contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Iterable, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from auramaur.experiments.models import (
+    CanonicalPayload,
+    ExperimentDefinition,
+    MarketSnapshot,
+    PortfolioSnapshot,
+)
+
+
+class PackageSemantics(str, Enum):
+    ALL_OR_NONE = "all_or_none"
+    COUPLED_QUOTES = "coupled_quotes"
+    ROUTING = "routing"
+    MANUAL_ACTION = "manual_action"
+    ASSET_ORDER = "asset_order"
+
+
+class ProposalPackage(BaseModel):
+    """One indivisible specialized proposal, never an execution instruction."""
+
+    model_config = ConfigDict(frozen=True)
+    package_id: str = Field(min_length=1)
+    kind: str = Field(min_length=1)
+    semantics: PackageSemantics
+    payload: CanonicalPayload
+
+
+class SpecializedExperiment(Protocol):
+    async def evaluate_package(
+        self, snapshot: MarketSnapshot, portfolio: PortfolioSnapshot
+    ) -> ProposalPackage | None: ...
+
+
+class SpecializedResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    lineage_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    runtime: str
+    observed_at: datetime
+    event_sequence: int = Field(ge=0)
+    market_id: str
+    data_version: str
+    proposal: ProposalPackage | None = None
+
+
+@dataclass(frozen=True)
+class RegisteredSpecializedExperiment:
+    definition: ExperimentDefinition
+    implementation: SpecializedExperiment
+
+    @property
+    def lineage_id(self) -> str:
+        return self.definition.lineage_id
+
+
+async def _evaluate_package(
+    registered: RegisteredSpecializedExperiment,
+    snapshot: MarketSnapshot,
+    portfolio: PortfolioSnapshot,
+    runtime: str,
+) -> SpecializedResult:
+    if portfolio.observed_at > snapshot.observed_at:
+        raise ValueError("portfolio snapshot cannot come from the future")
+    proposal = await registered.implementation.evaluate_package(snapshot, portfolio)
+    return SpecializedResult(
+        lineage_id=registered.lineage_id,
+        runtime=runtime,
+        observed_at=snapshot.observed_at,
+        event_sequence=snapshot.sequence,
+        market_id=snapshot.market_id,
+        data_version=snapshot.data_version,
+        proposal=proposal,
+    )
+
+
+@dataclass
+class InMemoryPackageSink:
+    results: list[SpecializedResult] = field(default_factory=list)
+
+    async def record(self, result: SpecializedResult) -> None:
+        self.results.append(result)
+
+
+class SpecializedShadowRuntime:
+    def __init__(self, sink: InMemoryPackageSink) -> None:
+        self.sink = sink
+
+    async def run(
+        self,
+        registered: RegisteredSpecializedExperiment,
+        snapshot: MarketSnapshot,
+        portfolio: PortfolioSnapshot,
+    ) -> SpecializedResult:
+        result = await _evaluate_package(registered, snapshot, portfolio, "shadow")
+        await self.sink.record(result)
+        return result
+
+
+@dataclass(frozen=True)
+class SpecializedReplayReport:
+    lineage_id: str
+    results: tuple[SpecializedResult, ...]
+
+
+class SpecializedReplayRuntime:
+    """Chronological proposal replay with deliberately no invented fill model."""
+
+    async def run(
+        self,
+        registered: RegisteredSpecializedExperiment,
+        snapshots: Iterable[MarketSnapshot],
+        portfolio: PortfolioSnapshot,
+    ) -> SpecializedReplayReport:
+        events = list(snapshots)
+        ordered = sorted(events, key=lambda item: (item.observed_at, item.sequence))
+        if events != ordered:
+            raise ValueError("replay snapshots must be in chronological sequence order")
+        identities = [(item.observed_at, item.sequence) for item in events]
+        if len(identities) != len(set(identities)):
+            raise ValueError("replay snapshots contain duplicate event identities")
+        results = tuple([
+            await _evaluate_package(registered, item, portfolio, "specialized_replay")
+            for item in events
+        ])
+        return SpecializedReplayReport(registered.lineage_id, results)

--- a/auramaur/research/experiment_repository.py
+++ b/auramaur/research/experiment_repository.py
@@ -13,6 +13,10 @@ from datetime import datetime, timezone
 
 from auramaur.experiments.registry import RegisteredExperiment
 from auramaur.experiments.runtimes import ReplayReport
+from auramaur.experiments.specialized import (
+    RegisteredSpecializedExperiment,
+    SpecializedReplayReport,
+)
 
 
 @dataclass(frozen=True)
@@ -30,7 +34,7 @@ class ExperimentRepository:
         self.db = db
 
     async def register(
-        self, registered: RegisteredExperiment
+        self, registered: RegisteredExperiment | RegisteredSpecializedExperiment
     ) -> ProspectiveRegistration:
         definition = registered.definition
         async with self.db.transaction(owner="experiment_register"):
@@ -146,6 +150,69 @@ class ExperimentRepository:
                     or int(existing["is_paper"]) != 1
                 ):
                     raise ValueError("replay observation conflicts with an existing row")
+        return inserted
+
+    async def record_specialized_replay(
+        self,
+        registered: RegisteredSpecializedExperiment,
+        report: SpecializedReplayReport,
+    ) -> int:
+        """Persist proposal-only replay without inventing fills, P&L, or targets."""
+        if report.lineage_id != registered.lineage_id:
+            raise ValueError("specialized replay lineage does not match registration")
+        await self.register(registered)  # type: ignore[arg-type]
+        inserted = 0
+        async with self.db.transaction(owner="experiment_specialized_replay"):
+            for result in report.results:
+                proposal = result.proposal
+                mechanism = (
+                    f"experiment_specialized_replay:{registered.lineage_id}:"
+                    f"seq={result.event_sequence}"
+                )
+                payload = json.dumps({
+                    "schema_version": 1,
+                    "lineage_id": registered.lineage_id,
+                    "runtime": "specialized_replay",
+                    "data_version": result.data_version,
+                    "event_sequence": result.event_sequence,
+                    "proposal": proposal.model_dump(mode="json") if proposal else None,
+                }, sort_keys=True, separators=(",", ":"), allow_nan=False)
+                cursor = await self.db.execute(
+                    """INSERT OR IGNORE INTO strategy_evaluations
+                           (strategy_source,market_id,mechanism,score,expected_edge,
+                            payload_json,is_paper,observed_at)
+                       VALUES (?,?,?,0,0,?,1,?)""",
+                    (
+                        registered.definition.strategy_source,
+                        result.market_id,
+                        mechanism,
+                        payload,
+                        _sqlite_timestamp(result.observed_at),
+                    ),
+                )
+                if cursor.rowcount == 1:
+                    inserted += 1
+                    continue
+                existing = await self.db.fetchone(
+                    """SELECT payload_json,score,is_paper FROM strategy_evaluations
+                       WHERE strategy_source=? AND market_id=?
+                         AND mechanism=? AND observed_at=?""",
+                    (
+                        registered.definition.strategy_source,
+                        result.market_id,
+                        mechanism,
+                        _sqlite_timestamp(result.observed_at),
+                    ),
+                )
+                if (
+                    existing is None
+                    or existing["payload_json"] != payload
+                    or float(existing["score"]) != 0.0
+                    or int(existing["is_paper"]) != 1
+                ):
+                    raise ValueError(
+                        "specialized replay conflicts with an existing observation"
+                    )
         return inserted
 
 

--- a/auramaur/research/experiment_scoreboard.py
+++ b/auramaur/research/experiment_scoreboard.py
@@ -1,0 +1,108 @@
+"""Lineage- and cohort-aware experiment scoreboard."""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict
+
+from auramaur.research.experiment_reporting import ExperimentReportBuilder
+
+
+class ScoreboardRow(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    lineage_id: str
+    strategy_source: str
+    registered_at: str
+    execution_model_version: str | None
+    data_version: str | None
+    replay_observations: int
+    independent_markets: int
+    prospective_warmup: int
+    prospective_holdout: int
+    net_pnl: float | None
+    max_drawdown: float | None
+    status: str
+
+
+class ExperimentScoreboard:
+    def __init__(self, db) -> None:
+        self.db = db
+
+    async def build(self) -> tuple[ScoreboardRow, ...]:
+        registrations = await self.db.fetchall(
+            """SELECT strategy_version,strategy_source,registered_at
+               FROM strategy_experiments ORDER BY registered_at,strategy_version"""
+        )
+        rows: list[ScoreboardRow] = []
+        reporter = ExperimentReportBuilder(self.db)
+        for registration in registrations:
+            lineage = str(registration["strategy_version"])
+            evaluations = await self.db.fetchall(
+                """SELECT payload_json FROM strategy_evaluations
+                   WHERE strategy_source=? AND mechanism LIKE ? AND is_paper=1""",
+                (registration["strategy_source"], f"experiment_replay:{lineage}:%"),
+            )
+            cohorts: set[tuple[str, str]] = set()
+            for evaluation in evaluations:
+                payload = json.loads(evaluation["payload_json"])
+                if payload.get("lineage_id") != lineage or payload.get("runtime") != "replay":
+                    continue
+                model = payload.get("execution_model_version")
+                data = payload.get("data_version")
+                if model and data:
+                    cohorts.add((str(model), str(data)))
+            if not cohorts:
+                counts = await self._prospective_counts(lineage, registration["strategy_source"])
+                specialized = await self.db.fetchall(
+                    """SELECT market_id FROM strategy_evaluations
+                       WHERE strategy_source=? AND mechanism LIKE ? AND is_paper=1""",
+                    (
+                        registration["strategy_source"],
+                        f"experiment_specialized_replay:{lineage}:%",
+                    ),
+                )
+                rows.append(ScoreboardRow(
+                    lineage_id=lineage,
+                    strategy_source=str(registration["strategy_source"]),
+                    registered_at=str(registration["registered_at"]),
+                    execution_model_version=None,
+                    data_version=None,
+                    replay_observations=len(specialized),
+                    independent_markets=len({row["market_id"] for row in specialized}),
+                    prospective_warmup=counts[0],
+                    prospective_holdout=counts[1],
+                    net_pnl=None,
+                    max_drawdown=None,
+                    status="proposal_replay" if specialized else "no_replay",
+                ))
+                continue
+            for model, data in sorted(cohorts):
+                report = await reporter.build(
+                    lineage, execution_model_version=model, data_version=data
+                )
+                rows.append(ScoreboardRow(
+                    lineage_id=lineage,
+                    strategy_source=report.strategy_source,
+                    registered_at=report.registered_at,
+                    execution_model_version=model,
+                    data_version=data,
+                    replay_observations=report.replay.observations,
+                    independent_markets=report.replay.independent_markets,
+                    prospective_warmup=report.prospective.warmup_decisions,
+                    prospective_holdout=report.prospective.holdout_decisions,
+                    net_pnl=report.replay.total_net_pnl,
+                    max_drawdown=report.replay.max_drawdown,
+                    status=report.status.value,
+                ))
+        return tuple(rows)
+
+    async def _prospective_counts(self, lineage: str, source: str) -> tuple[int, int]:
+        row = await self.db.fetchone(
+            """SELECT SUM(CASE WHEN is_holdout=0 THEN 1 ELSE 0 END) warmup,
+                      SUM(CASE WHEN is_holdout=1 THEN 1 ELSE 0 END) holdout
+               FROM decision_snapshots
+               WHERE strategy_version=? AND strategy_source=?""",
+            (lineage, source),
+        )
+        return int(row["warmup"] or 0), int(row["holdout"] or 0)

--- a/docs/experiment-operations.md
+++ b/docs/experiment-operations.md
@@ -1,0 +1,75 @@
+# Experiment operations
+
+The experiment CLI turns a JSON manifest into one immutable lineage and keeps
+research evidence separate from capital-graduation evidence.
+
+```text
+auramaur experiment define manifest.json
+auramaur experiment register manifest.json --db research.db
+auramaur experiment replay manifest.json --db research.db
+auramaur experiment shadow manifest.json
+auramaur experiment report LINEAGE --db research.db \
+  --execution-model linear-v1 --data-version dataset-2026-07
+auramaur experiment scoreboard --db research.db
+```
+
+`define` validates the complete definition, implementation binding, immutable
+snapshots, and initial portfolio before printing the content-derived lineage.
+`register` must run before prospective evidence collection. Replay persistence
+uses only paper `strategy_evaluations`; it never writes graduation decisions,
+fills, outcomes, or P&L ledger rows.
+
+## Manifest shape
+
+Every manifest contains:
+
+- `schema_version` (currently `1`);
+- a complete `ExperimentDefinition` under `definition`;
+- a pure implementation `binding`;
+- chronological, point-in-time `snapshots`;
+- `initial_portfolio`;
+- an `execution_model` for portable target replay.
+
+Portable bindings name an experiment class and constructor arguments:
+
+```json
+{
+  "kind": "portable",
+  "implementation": "auramaur.experiments.strategies.bias_harvest:BiasHarvestExperiment",
+  "constructor_arguments": {"rules": {"band_lo": 0.1, "band_hi": 0.9}}
+}
+```
+
+The complete rule object is required; abbreviated arguments above are only an
+illustration. Bindings are restricted to `auramaur.experiments.strategies` and
+cannot dynamically load broker, database, exchange, or production modules.
+
+Specialized bindings call an existing pure proposal function against one named
+feature and declare the semantics that must survive replay:
+
+```json
+{
+  "kind": "specialized",
+  "evaluator": "auramaur.experiments.strategies.cross_venue_arb:paired_arb_proposal",
+  "feature_name": "cross_venue_pair",
+  "proposal_kind": "cross_venue_pair",
+  "semantics": "all_or_none",
+  "fixed_arguments": {
+    "min_confidence": 0.8,
+    "required_gap": 0.05,
+    "stake_usd": 10
+  }
+}
+```
+
+Supported semantic labels are `all_or_none`, `coupled_quotes`, `routing`,
+`manual_action`, and `asset_order`. Specialized replay records immutable
+proposal packages but deliberately reports no fill, cost, or P&L metric until
+a package-specific execution model exists.
+
+## Scoreboard semantics
+
+The scoreboard emits one row per lineage and portable data/execution-model
+cohort. It never pools incompatible cohorts. Specialized proposal replays are
+shown as `proposal_replay` with no P&L, while untested registrations are
+`no_replay`. Prospective warmup and holdout counts remain separate columns.

--- a/tests/test_experiment_operations.py
+++ b/tests/test_experiment_operations.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from click.testing import CliRunner
+
+from auramaur.db.database import Database
+from auramaur.cli._base import main
+from auramaur.experiments.operations import ExperimentManifest, bind_manifest
+from auramaur.experiments.registry import RegisteredExperiment
+from auramaur.experiments.specialized import (
+    PackageSemantics,
+    RegisteredSpecializedExperiment,
+    SpecializedReplayRuntime,
+)
+from auramaur.research.experiment_repository import ExperimentRepository
+from auramaur.research.experiment_scoreboard import ExperimentScoreboard
+
+
+NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
+
+def _definition(source: str = "bias_harvest") -> dict:
+    return {
+        "key": f"ops-{source}", "strategy_source": source,
+        "hypothesis": "A deterministic proposal is testable.",
+        "mechanism": "fixture", "implementation_version": "v1",
+        "parameters": {}, "venues": ["polymarket"],
+        "primary_metric": "net_pnl", "baseline": "no_position",
+        "min_observations": 1, "holdout_days": 1, "max_drawdown": 0.2,
+        "cost_model": "linear-v1",
+        "rejection_criteria": ["max_drawdown_exceeds_limit"],
+    }
+
+
+def _portfolio() -> dict:
+    return {"observed_at": NOW.isoformat(), "cash": 100, "equity": 100}
+
+
+def _feature(name: str, payload: dict) -> dict:
+    return {
+        "name": name, "payload": payload, "source": "fixture",
+        "observed_at": NOW.isoformat(), "available_at": NOW.isoformat(),
+    }
+
+
+def test_portable_manifest_binds_dataclass_rules():
+    manifest = ExperimentManifest.model_validate({
+        "definition": _definition(),
+        "binding": {
+            "kind": "portable",
+            "implementation": (
+                "auramaur.experiments.strategies.bias_harvest:BiasHarvestExperiment"
+            ),
+            "constructor_arguments": {"rules": {
+                "band_lo": 0.05, "band_hi": 0.95, "edge_uplift": 0.05,
+                "min_liquidity": 10,
+                "min_hours_to_resolution": 1, "max_days_to_resolution": 30,
+                "stake_usd": 10, "skip_disputed": True, "maker_entry": False,
+                "maker_min_spread": 0.01, "paper": True,
+            }},
+        },
+        "snapshots": [{
+            "observed_at": NOW.isoformat(), "sequence": 1, "market_id": "m1",
+            "venue": "polymarket",
+            "prices": [{"instrument_id": "m1:YES", "price": 0.5}],
+            "features": [_feature("bias_harvest_candidate", {
+                "market_id": "m1", "venue": "polymarket", "question": "Will X?",
+                "description": "", "category": "other", "active": True,
+                "accepting_orders": True, "liquidity": 100, "volume": 100,
+                "yes_price": 0.5, "no_price": 0.5,
+                "end_at": (NOW + timedelta(days=2)).isoformat(),
+                "already_entered_or_held": False, "maker_book_available": True,
+            })], "data_version": "fixture-v1",
+        }],
+        "initial_portfolio": _portfolio(),
+        "execution_model": {"version": "linear-v1"},
+    })
+    assert isinstance(bind_manifest(manifest), RegisteredExperiment)
+
+
+def _specialized_manifest() -> ExperimentManifest:
+    return ExperimentManifest.model_validate({
+        "definition": _definition("cross_venue_arb"),
+        "binding": {
+            "kind": "specialized",
+            "evaluator": (
+                "auramaur.experiments.strategies.cross_venue_arb:paired_arb_proposal"
+            ),
+            "feature_name": "cross_venue_pair", "proposal_kind": "cross_venue_pair",
+            "semantics": "all_or_none",
+            "fixed_arguments": {
+                "min_confidence": 0.8, "required_gap": 0.05, "stake_usd": 10,
+            },
+        },
+        "snapshots": [{
+            "observed_at": NOW.isoformat(), "sequence": 1, "market_id": "pair-1",
+            "venue": "multi", "prices": [{"instrument_id": "marker", "price": 1}],
+            "features": [_feature("cross_venue_pair", {
+                "market_a_id": "a", "venue_a": "polymarket", "yes_price_a": 0.3,
+                "market_b_id": "b", "venue_b": "kalshi", "yes_price_b": 0.5,
+                "orientation": "same", "confidence": 0.9,
+            })], "data_version": "fixture-v1",
+        }],
+        "initial_portfolio": _portfolio(),
+    })
+
+
+def test_specialized_replay_preserves_atomic_package():
+    manifest = _specialized_manifest()
+    registered = bind_manifest(manifest)
+    assert isinstance(registered, RegisteredSpecializedExperiment)
+    report = asyncio.run(SpecializedReplayRuntime().run(
+        registered, manifest.snapshots, manifest.initial_portfolio
+    ))
+    proposal = report.results[0].proposal
+    assert proposal is not None
+    assert proposal.semantics is PackageSemantics.ALL_OR_NONE
+    assert len(proposal.payload.decoded()["legs"]) == 2
+
+
+def test_specialized_adapter_coerces_nested_external_asset_contracts():
+    raw = {
+        "definition": _definition("kraken"),
+        "binding": {
+            "kind": "specialized",
+            "evaluator": "auramaur.experiments.strategies.kraken:assess_kraken_spot",
+            "feature_name": "kraken_order", "proposal_kind": "kraken_spot_order",
+            "semantics": "asset_order", "package_id_field": "pair",
+        },
+        "snapshots": [{
+            "observed_at": NOW.isoformat(), "sequence": 1, "market_id": "BTCUSD",
+            "venue": "kraken", "prices": [{"instrument_id": "BTCUSD", "price": 50000}],
+            "features": [_feature("kraken_order", {
+                "inputs": {
+                    "pair": "BTCUSD", "price": 50000, "holding": False,
+                    "orphaned": False, "signal_accepted": True,
+                    "sized_entry_volume": 0.001, "allocated_usd": 0,
+                    "budget_usd": 100, "paper": True,
+                },
+                "rules": {"max_order_usd": 50, "lot_decimals": 6},
+            })], "data_version": "fixture-v1",
+        }],
+        "initial_portfolio": _portfolio(),
+    }
+    manifest = ExperimentManifest.model_validate(raw)
+    registered = bind_manifest(manifest)
+    assert isinstance(registered, RegisteredSpecializedExperiment)
+    report = asyncio.run(SpecializedReplayRuntime().run(
+        registered, manifest.snapshots, manifest.initial_portfolio
+    ))
+    proposal = report.results[0].proposal
+    assert proposal is not None
+    assert proposal.package_id == "BTCUSD"
+    assert proposal.semantics is PackageSemantics.ASSET_ORDER
+    assert proposal.payload.decoded()["action"] == "buy"
+
+
+@pytest.mark.asyncio
+async def test_specialized_replay_persists_without_pnl_and_scores_separately(tmp_path):
+    manifest = _specialized_manifest()
+    registered = bind_manifest(manifest)
+    assert isinstance(registered, RegisteredSpecializedExperiment)
+    report = await SpecializedReplayRuntime().run(
+        registered, manifest.snapshots, manifest.initial_portfolio
+    )
+    db = Database(str(tmp_path / "ops.db"))
+    await db.connect()
+    try:
+        inserted = await ExperimentRepository(db).record_specialized_replay(
+            registered, report
+        )
+        assert inserted == 1
+        assert await ExperimentRepository(db).record_specialized_replay(
+            registered, report
+        ) == 0
+        row = await db.fetchone("SELECT score,payload_json FROM strategy_evaluations")
+        payload = json.loads(row["payload_json"])
+        assert row["score"] == 0
+        assert "net_pnl" not in payload
+        board = await ExperimentScoreboard(db).build()
+        assert board[0].status == "proposal_replay"
+        assert board[0].replay_observations == 1
+        assert board[0].net_pnl is None
+    finally:
+        await db.close()
+
+
+def test_experiment_commands_are_registered():
+    from auramaur.cli import experiments  # noqa: F401
+
+    result = CliRunner().invoke(main, ["experiment", "--help"])
+    assert result.exit_code == 0
+    for command in ("define", "register", "replay", "shadow", "report", "scoreboard"):
+        assert command in result.output


### PR DESCRIPTION
Adds the operator workflow for define/register/replay/shadow/report/scoreboard, semantics-preserving proposal-only replay for atomic, coupled, routing, manual-action, and external-asset contracts, and lineage/cohort-aware scoreboards. Specialized replay deliberately records no fabricated fills or P&L and remains outside graduation evidence. Validation: 1794 passed, 5 skipped; Ruff and diff checks passed.