### PR TITLE
Harden database concurrency and transaction isolation

### DIFF
--- a/auramaur/broker/pnl.py
+++ b/auramaur/broker/pnl.py
@@ -65,13 +65,17 @@ class PnLTracker:
                 return
             raise ValueError(f"conflicting fill replay for order {fill.order_id}")
 
-        try:
-            await self._record_fill_once(fill)
-        except Exception:
-            await self._db.rollback()
-            raise
+        async with self._db.transaction(owner="pnl_fill"):
+            ledger_event = await self._record_fill_once(fill)
 
-    async def _record_fill_once(self, fill: Fill) -> None:
+        # Ancillary reporting follows the authoritative fill + cost-basis
+        # commit. It is independently idempotent and must not lengthen the
+        # critical transaction or accidentally commit it halfway through.
+        if ledger_event is not None:
+            from auramaur.broker.ledger import record_ledger_event
+            await record_ledger_event(self._db, **ledger_event)
+
+    async def _record_fill_once(self, fill: Fill) -> dict | None:
         """Write one new fill and its cost basis as a single transaction."""
         # 1. Persist the fill
         cursor = await self._db.execute(
@@ -211,12 +215,6 @@ class PnLTracker:
                 now,
             ),
         )
-        await self._db.commit()
-
-        if ledger_event is not None:
-            from auramaur.broker.ledger import record_ledger_event
-            await record_ledger_event(self._db, **ledger_event)
-
         log.info(
             "pnl.fill_recorded",
             market_id=fill.market_id,
@@ -226,6 +224,7 @@ class PnLTracker:
             new_position_size=new_size,
             avg_cost=round(new_avg_cost, 4),
         )
+        return ledger_event
 
     # ------------------------------------------------------------------
     # Cost basis queries

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -22,6 +22,24 @@ class Database:
         self._txn_lock = asyncio.Lock()
         self._txn_task: asyncio.Task | None = None
         self._txn_owner: str | None = None
+        self._write_waiters = 0
+        self._closing = False
+
+    @asynccontextmanager
+    async def _serialized_slot(self):
+        """Acquire the shared connection fairly without leaking waiter state."""
+        self._write_waiters += 1
+        acquired = False
+        try:
+            await self._txn_lock.acquire()
+            acquired = True
+            self._write_waiters -= 1
+            yield
+        finally:
+            if acquired:
+                self._txn_lock.release()
+            else:
+                self._write_waiters -= 1
 
     async def connect(self, ensure_schema: bool = True) -> None:
         """Open the connection.
@@ -105,7 +123,17 @@ class Database:
             yield self
             return
         requested_owner = owner or asyncio.current_task().get_name()
-        async with self._txn_lock:
+        queued_at = time.monotonic()
+        async with self._serialized_slot():
+            queue_wait = time.monotonic() - queued_at
+            if queue_wait > 0.25:
+                log.warning(
+                    "database.transaction_queue_wait",
+                    seconds=round(queue_wait, 3),
+                    requested_owner=requested_owner,
+                    active_owner=self._txn_owner,
+                    waiters=self._write_waiters,
+                )
             # Autocommit legacy writes cannot strand an implicit transaction.
             # Keep this check as a corruption/concurrency tripwire: the only
             # legitimate active transaction is owned by transaction(), which
@@ -139,23 +167,44 @@ class Database:
                         log.error("database.transaction_orphan_rollback_failed",
                                   requested_owner=requested_owner,
                                   error=str(exc))
-            started = time.monotonic()
+            begin_started = time.monotonic()
             try:
                 await self.db.execute("BEGIN IMMEDIATE")
-            except Exception as exc:
-                log.error("database.transaction_begin_failed",
-                          requested_owner=requested_owner,
-                          requested_task=asyncio.current_task().get_name(),
-                          active_owner=self._txn_owner or "legacy/unknown",
-                          in_transaction=self._db._conn.in_transaction,
-                          error=str(exc))
+            except BaseException as exc:
+                # Cancellation cannot retract work already queued on
+                # aiosqlite's worker thread. Queue a rollback behind BEGIN so
+                # a cancelled acquisition can never leave an ownerless txn.
+                cleanup = asyncio.create_task(
+                    self.db.execute("ROLLBACK"),
+                    name=f"db_begin_cleanup_{requested_owner}",
+                )
+                try:
+                    await asyncio.shield(cleanup)
+                except Exception:
+                    pass
+                if not isinstance(exc, asyncio.CancelledError):
+                    log.error(
+                        "database.transaction_begin_failed",
+                        requested_owner=requested_owner,
+                        requested_task=asyncio.current_task().get_name(),
+                        active_owner=self._txn_owner or "legacy/unknown",
+                        in_transaction=self._db._conn.in_transaction,
+                        error=str(exc),
+                    )
                 raise
+            begin_wait = time.monotonic() - begin_started
+            if begin_wait > 0.25:
+                log.warning(
+                    "database.transaction_file_wait",
+                    seconds=round(begin_wait, 3),
+                    owner=requested_owner,
+                )
             self._txn_task = asyncio.current_task()
             self._txn_owner = requested_owner
+            body_started = time.monotonic()
             try:
                 yield self
             except BaseException:
-                await self.db.execute("ROLLBACK")
                 raise
             else:
                 try:
@@ -163,11 +212,6 @@ class Database:
                 except Exception as exc:  # noqa: BLE001 — narrow handling
                     if "no transaction is active" not in str(exc).lower():
                         raise
-                    # A legacy writer's commit() landed mid-transaction and
-                    # ended it early: the batch's rows ARE durable, but its
-                    # atomicity was violated. Log loudly (this is the bleed
-                    # phase 5 exists to retire) without failing the writer —
-                    # failing here reports durable writes as failures.
                     log.warning(
                         "database.transaction_commit_bled",
                         owner=self._txn_owner,
@@ -175,22 +219,36 @@ class Database:
                     )
             finally:
                 finished_owner = self._txn_owner
-                # Never surrender ownership with the transaction still open.
-                # COMMIT/ROLLBACK can raise (SQLITE_BUSY under contention);
-                # unwinding past that point used to leave an ownerless open
-                # transaction that no later writer could clear.
-                if self._db._conn.in_transaction:
-                    try:
-                        await self.db.execute("ROLLBACK")
-                        log.error("database.transaction_forced_rollback",
-                                  owner=finished_owner,
-                                  task=asyncio.current_task().get_name())
-                    except Exception as exc:  # noqa: BLE001 - best effort
-                        log.error("database.transaction_forced_rollback_failed",
-                                  owner=finished_owner, error=str(exc))
+                # Clear ownership synchronously before cancellation-sensitive
+                # cleanup. The serializer lock remains held until this block
+                # exits, so no successor can begin before the queued rollback.
                 self._txn_task = None
                 self._txn_owner = None
-                held = time.monotonic() - started
+                if self._db is not None and self._db._conn.in_transaction:
+                    rollback_task = asyncio.create_task(
+                        self.db.execute("ROLLBACK"),
+                        name=f"db_rollback_{finished_owner or 'unknown'}",
+                    )
+                    try:
+                        await asyncio.shield(rollback_task)
+                        log.warning(
+                            "database.transaction_forced_rollback",
+                            owner=finished_owner,
+                            task=asyncio.current_task().get_name(),
+                        )
+                    except asyncio.CancelledError:
+                        # The aiosqlite worker operation is already queued.
+                        # Shield it from this task's cancellation and keep the
+                        # serializer until cleanup has actually completed.
+                        await asyncio.shield(rollback_task)
+                        raise
+                    except Exception as exc:  # noqa: BLE001 - best effort
+                        log.error(
+                            "database.transaction_forced_rollback_failed",
+                            owner=finished_owner,
+                            error=str(exc),
+                        )
+                held = time.monotonic() - body_started
                 if held > 0.25:
                     log.warning(
                         "database.transaction_held_long",
@@ -198,12 +256,14 @@ class Database:
                         owner=finished_owner,
                         task=asyncio.current_task().get_name(),
                     )
-
     async def close(self) -> None:
-        if self._db:
-            await self._db.close()
-            self._db = None
-
+        if self._db is None:
+            return
+        self._closing = True
+        async with self._serialized_slot():
+            if self._db is not None:
+                await self._db.close()
+                self._db = None
     async def _init_schema(self) -> None:
         await self._db.executescript(TABLES)
         # Check/set schema version
@@ -1299,18 +1359,54 @@ class Database:
         return self._db
 
     async def execute(self, sql: str, params: tuple = ()) -> aiosqlite.Cursor:
-        return await self.db.execute(sql, params)
+        # Autocommit alone is insufficient: without this guard a legacy
+        # statement queued after another task's BEGIN silently joins or reads
+        # that task's uncommitted batch. All statements share the serializer.
+        if self._txn_task is asyncio.current_task():
+            return await self.db.execute(sql, params)
+        queued_at = time.monotonic()
+        async with self._serialized_slot():
+            waited = time.monotonic() - queued_at
+            if waited > 0.25:
+                log.warning(
+                    "database.statement_queue_wait",
+                    seconds=round(waited, 3),
+                    statement=sql.lstrip().split(None, 1)[0].upper(),
+                    waiters=self._write_waiters,
+                )
+            return await self.db.execute(sql, params)
 
     async def executemany(self, sql: str, params_seq: list[tuple]) -> None:
-        await self.db.executemany(sql, params_seq)
+        if self._txn_task is asyncio.current_task():
+            await self.db.executemany(sql, params_seq)
+            return
+        queued_at = time.monotonic()
+        async with self._serialized_slot():
+            waited = time.monotonic() - queued_at
+            if waited > 0.25:
+                log.warning(
+                    "database.statement_queue_wait",
+                    seconds=round(waited, 3),
+                    statement="EXECUTEMANY",
+                    waiters=self._write_waiters,
+                )
+            await self.db.executemany(sql, params_seq)
 
     async def fetchone(self, sql: str, params: tuple = ()) -> aiosqlite.Row | None:
-        cursor = await self.db.execute(sql, params)
-        return await cursor.fetchone()
+        if self._txn_task is asyncio.current_task():
+            cursor = await self.db.execute(sql, params)
+            return await cursor.fetchone()
+        async with self._serialized_slot():
+            cursor = await self.db.execute(sql, params)
+            return await cursor.fetchone()
 
     async def fetchall(self, sql: str, params: tuple = ()) -> list[aiosqlite.Row]:
-        cursor = await self.db.execute(sql, params)
-        return await cursor.fetchall()
+        if self._txn_task is asyncio.current_task():
+            cursor = await self.db.execute(sql, params)
+            return await cursor.fetchall()
+        async with self._serialized_slot():
+            cursor = await self.db.execute(sql, params)
+            return await cursor.fetchall()
 
     async def commit(self) -> None:
         # Deliberate no-op. Under the autocommit connection every legacy
@@ -1327,4 +1423,11 @@ class Database:
                       active_owner=self._txn_owner or "unknown")
 
     async def rollback(self) -> None:
-        await self.db.rollback()
+        # Deliberate no-op, symmetric with commit(). In autocommit mode a
+        # legacy caller owns no transaction; a raw rollback could only discard
+        # another task's explicit transaction. transaction() owns rollback.
+        if self._db is not None and self._db._conn.in_transaction:
+            log.debug(
+                "database.legacy_rollback_skipped_mid_transaction",
+                active_owner=self._txn_owner or "unknown",
+            )

--- a/auramaur/monitoring/candidate_dispositions.py
+++ b/auramaur/monitoring/candidate_dispositions.py
@@ -31,12 +31,17 @@ class CandidateDispositionCycle:
         counts = Counter(row[0] for row in self._rows.values())
         try:
             async with self.db.transaction(owner="candidate_dispositions"):
-                for market_id, (disposition, stage, reason) in self._rows.items():
-                    await self.db.execute("""INSERT INTO candidate_dispositions
+                rows = [
+                    (self.cycle_id, market_id, self.exchange, self.strategy,
+                     disposition, stage, reason)
+                    for market_id, (disposition, stage, reason) in self._rows.items()
+                ]
+                if rows:
+                    await self.db.executemany("""INSERT INTO candidate_dispositions
                         (cycle_id,market_id,exchange,strategy,disposition,stage,reason) VALUES (?,?,?,?,?,?,?)
                         ON CONFLICT(cycle_id,market_id,strategy) DO UPDATE SET
                         disposition=excluded.disposition,stage=excluded.stage,reason=excluded.reason""",
-                        (self.cycle_id,market_id,self.exchange,self.strategy,disposition,stage,reason))
+                        rows)
                 await self.db.execute("""INSERT OR REPLACE INTO candidate_cycle_summaries
                     (cycle_id,exchange,strategy,discovered,executed,risk_blocked,filtered,throttled,malformed,unavailable,failed)
                     VALUES (?,?,?,?,?,?,?,?,?,?,?)""",

--- a/auramaur/strategy/engine.py
+++ b/auramaur/strategy/engine.py
@@ -397,35 +397,43 @@ class TradingEngine(CycleOrchestrationMixin):
             market.category = ensure_category(
                 market.question, market.description, market.category)
 
+        market_rows = [
+            (
+                market.id, market.exchange or self.exchange_name or "polymarket",
+                market.condition_id, market.question,
+                market.description, market.category,
+                market.end_date.isoformat() if market.end_date else None,
+                int(market.active), market.outcome_yes_price, market.outcome_no_price,
+                market.volume, market.liquidity,
+                market.clob_token_yes, market.clob_token_no,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            for market in markets
+        ]
         async with self.db.transaction():
-            for market in markets:
-                await self.db.execute(
+            if market_rows:
+                await self.db.executemany(
                     """INSERT OR REPLACE INTO markets
                        (id, exchange, condition_id, question, description, category, end_date, active,
                         outcome_yes_price, outcome_no_price, volume, liquidity,
                         clob_token_yes, clob_token_no, last_updated)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        market.id, market.exchange or self.exchange_name or "polymarket",
-                        market.condition_id, market.question,
-                        market.description, market.category,
-                        market.end_date.isoformat() if market.end_date else None,
-                        int(market.active), market.outcome_yes_price, market.outcome_no_price,
-                        market.volume, market.liquidity,
-                        market.clob_token_yes, market.clob_token_no,
-                        datetime.now(timezone.utc).isoformat(),
-                    ),
+                    market_rows,
                 )
 
         # Price snapshots + prune as a second short transaction so the
         # markets upsert above commits (and releases the write lock) first.
+        history_rows = [
+            (market.id, market.outcome_yes_price,
+             market.exchange or self.exchange_name or "polymarket")
+            for market in markets
+        ]
         async with self.db.transaction():
-            for market in markets:
-                await self.db.execute(
+            if history_rows:
+                await self.db.executemany(
                     "INSERT INTO price_history (market_id, price, exchange)"
                     " VALUES (?, ?, ?)",
-                    (market.id, market.outcome_yes_price,
-                     market.exchange or self.exchange_name or "polymarket"),
+                    history_rows,
                 )
             # Prune old price history to bound table growth. Extended 7 -> 30
             # days so reversion/intraday research has a multi-week sample; the

--- a/tests/test_database_transaction.py
+++ b/tests/test_database_transaction.py
@@ -250,3 +250,155 @@ async def test_ownerless_open_transaction_is_rolled_back_by_next_writer(tmp_path
     assert row["v"] == 3
     assert not db._db._conn.in_transaction
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_write_waits_out_explicit_transaction(tmp_path):
+    """A one-statement writer may never bleed into another task's batch."""
+    db = await _fresh_db(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    legacy_landed = asyncio.Event()
+
+    async def adopter():
+        async with db.transaction(owner="adopter"):
+            await db.execute("INSERT INTO t (k, v) VALUES ('adopter', 1)")
+            entered.set()
+            await release.wait()
+
+    async def legacy_writer():
+        await entered.wait()
+        await db.execute("INSERT INTO t (k, v) VALUES ('legacy', 2)")
+        legacy_landed.set()
+
+    adopter_task = asyncio.create_task(adopter())
+    legacy_task = asyncio.create_task(legacy_writer())
+    await entered.wait()
+    await asyncio.sleep(0.02)
+    assert not legacy_landed.is_set()
+    release.set()
+    await asyncio.gather(adopter_task, legacy_task)
+    assert legacy_landed.is_set()
+    rows = await db.fetchall("SELECT k FROM t ORDER BY k")
+    assert [row["k"] for row in rows] == ["adopter", "legacy"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_write_survives_concurrent_adopter_rollback(tmp_path):
+    """A rollback cannot discard a queued legacy writer from another task."""
+    db = await _fresh_db(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def adopter():
+        with pytest.raises(RuntimeError):
+            async with db.transaction(owner="adopter"):
+                await db.execute("INSERT INTO t (k, v) VALUES ('rolled-back', 1)")
+                entered.set()
+                await release.wait()
+                raise RuntimeError("rollback")
+
+    async def legacy_writer():
+        await entered.wait()
+        await db.execute("INSERT INTO t (k, v) VALUES ('legacy', 2)")
+
+    adopter_task = asyncio.create_task(adopter())
+    legacy_task = asyncio.create_task(legacy_writer())
+    await entered.wait()
+    release.set()
+    await asyncio.gather(adopter_task, legacy_task)
+    rows = await db.fetchall("SELECT k FROM t ORDER BY k")
+    assert [row["k"] for row in rows] == ["legacy"]
+    await db.close()
+@pytest.mark.asyncio
+async def test_read_waits_out_other_tasks_uncommitted_transaction(tmp_path):
+    """Other tasks cannot observe an adopter's uncommitted rows."""
+    db = await _fresh_db(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    read_finished = asyncio.Event()
+
+    async def adopter():
+        async with db.transaction(owner="adopter"):
+            await db.execute("INSERT INTO t (k, v) VALUES ('private', 1)")
+            entered.set()
+            await release.wait()
+
+    async def reader():
+        await entered.wait()
+        row = await db.fetchone("SELECT v FROM t WHERE k='private'")
+        read_finished.set()
+        return row
+
+    adopter_task = asyncio.create_task(adopter())
+    reader_task = asyncio.create_task(reader())
+    await entered.wait()
+    await asyncio.sleep(0.02)
+    assert not read_finished.is_set()
+    release.set()
+    await adopter_task
+    row = await reader_task
+    assert row["v"] == 1
+    await db.close()
+@pytest.mark.asyncio
+async def test_legacy_rollback_cannot_discard_an_adopters_batch(tmp_path):
+    db = await _fresh_db(tmp_path)
+    async with db.transaction(owner="adopter"):
+        await db.execute("INSERT INTO t (k, v) VALUES ('safe', 1)")
+        await db.rollback()
+        assert db.db.in_transaction is True
+    row = await db.fetchone("SELECT v FROM t WHERE k='safe'")
+    assert row["v"] == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiters_do_not_leak_waiter_count(tmp_path):
+    db = await _fresh_db(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        async with db.transaction(owner="holder"):
+            entered.set()
+            await release.wait()
+
+    holder_task = asyncio.create_task(holder())
+    await entered.wait()
+    waiters = [
+        asyncio.create_task(db.execute("INSERT INTO t (k, v) VALUES ('x', 1)")),
+        asyncio.create_task(db.fetchone("SELECT 1")),
+    ]
+    await asyncio.sleep(0.02)
+    assert db._write_waiters == 2
+    for task in waiters:
+        task.cancel()
+    await asyncio.gather(*waiters, return_exceptions=True)
+    assert db._write_waiters == 0
+    release.set()
+    await holder_task
+    await db.close()
+@pytest.mark.asyncio
+async def test_close_waits_for_active_transaction(tmp_path):
+    db = await _fresh_db(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def writer():
+        async with db.transaction(owner="writer"):
+            await db.execute("INSERT INTO t (k, v) VALUES ('landed', 1)")
+            entered.set()
+            await release.wait()
+
+    writer_task = asyncio.create_task(writer())
+    await entered.wait()
+    close_task = asyncio.create_task(db.close())
+    await asyncio.sleep(0.02)
+    assert not close_task.done()
+    release.set()
+    await writer_task
+    await close_task
+    assert db._db is None
+    assert not db._txn_lock.locked()
+    assert db._txn_owner is None

--- a/tests/test_pnl_ledger.py
+++ b/tests/test_pnl_ledger.py
@@ -219,3 +219,35 @@ def test_kraken_pair_gets_venue_fallback():
         await db.close()
 
     asyncio.run(run())
+
+def test_fill_and_cost_basis_roll_back_atomically_on_mid_batch_failure():
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        tracker = PnLTracker(db, Settings())
+        real_execute = db.execute
+
+        async def fail_cost_basis(sql, params=()):
+            if "INSERT INTO cost_basis" in sql:
+                raise RuntimeError("injected cost-basis failure")
+            return await real_execute(sql, params)
+
+        db.execute = fail_cost_basis
+        try:
+            await tracker.record_fill(_fill("atomic", OrderSide.BUY, 5, 0.4))
+        except RuntimeError as exc:
+            assert "injected" in str(exc)
+        else:
+            raise AssertionError("expected injected failure")
+        finally:
+            db.execute = real_execute
+
+        assert await db.fetchone(
+            "SELECT 1 FROM fills WHERE market_id='atomic'"
+        ) is None
+        assert await db.fetchone(
+            "SELECT 1 FROM cost_basis WHERE market_id='atomic'"
+        ) is None
+        await db.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
Summary:
- serialize shared SQLite access so legacy statements cannot bleed into explicit transactions
- make acquisition, rollback cleanup, waiter accounting, queued-BEGIN cancellation, and shutdown cancellation-safe
- split queue wait, SQLite file-lock wait, and transaction-body telemetry
- restore atomic fill and cost-basis persistence
- batch market, price-history, and candidate-disposition writes

Runtime evidence:
- 749 long-transaction warnings in roughly ten hours
- four failed BEGIN operations with downstream cache, depth, and risk-audit drops
- review found unsafe foreign rollback and non-atomic fill accounting

Verification:
- full suite: 1796 passed, 5 skipped
- focused database/cancellation/PnL suite: 62 passed
- Ruff passed
- diff check passed