### PR TITLE
Upgrade CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
 
       # Audit the extras the runtime image actually installs (see Dockerfile:
       # kalshi, ibkr, web). --all-extras would drag torch/triton/cuda and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       # Audit the extras the runtime image actually installs (see Dockerfile:
       # kalshi, ibkr, web). --all-extras would drag torch/triton/cuda and
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Dependency security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       # Audit the extras the runtime image actually installs (see Dockerfile:
       # kalshi, ibkr, web). --all-extras would drag torch/triton/cuda and
@@ -34,9 +34,9 @@ jobs:
         continue-on-error: true
         run: uvx pip-audit==2.10.1 -r requirements-audit.txt
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
 
@@ -49,10 +49,10 @@ jobs:
     name: Safety gate tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -85,9 +85,9 @@ jobs:
     # lint is now a required gate — a new violation fails the PR instead of just
     # being surfaced.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -110,10 +110,10 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,7 @@ jobs:
   auramaur:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- upgrade checkout, setup-python, setup-node, and setup-uv to Node 24-backed major versions
- run web dependency audit and dashboard checks on Node.js 24
- update the container workflow checkout action as well

## Why
GitHub now warns when Node 20-backed actions are forced onto Node 24. This removes the deprecated action runtimes at their source instead of suppressing annotations.

## Validation
- git diff --check
- confirmed no deprecated action majors or node-version 20 remain in workflows
- PR CI is the authoritative hosted-runner compatibility gate