### PR TITLE
perf(db): isolate call budget and batch telemetry

### DIFF
--- a/auramaur/data_edge.py
+++ b/auramaur/data_edge.py
@@ -7,6 +7,7 @@ with event time, observation time, coverage, fallbacks, and snapshot identity.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import time
@@ -21,6 +22,7 @@ log = structlog.get_logger()
 
 _HEALTHY_THROTTLE_SECONDS = {"order_book": 15.0}
 _last_healthy_recorded: dict[tuple[int, str, str], float] = {}
+_delivery_batchers: dict[int, "_DeliveryBatcher"] = {}
 
 DeliveryStatus = Literal[
     "ok", "empty", "stale", "partial", "timeout", "error", "unavailable"
@@ -168,6 +170,44 @@ def snapshot_id(*parts: object) -> str:
     return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:24]
 
 
+class _DeliveryBatcher:
+    """Coalesce concurrent telemetry calls into bounded transactions."""
+
+    def __init__(self, db) -> None:
+        self.db = db
+        self.pending: list[tuple[tuple, asyncio.Future]] = []
+        self.task: asyncio.Task | None = None
+
+    async def write(self, params: tuple) -> None:
+        done = asyncio.get_running_loop().create_future()
+        self.pending.append((params, done))
+        if self.task is None or self.task.done():
+            self.task = asyncio.create_task(self._flush())
+        await done
+
+    async def _flush(self) -> None:
+        while self.pending:
+            await asyncio.sleep(0)
+            batch, self.pending = self.pending[:64], self.pending[64:]
+            try:
+                async with self.db.transaction(owner="data_edge"):
+                    await self.db.executemany(
+                        """INSERT INTO strategy_data_deliveries
+                           (delivery_id,strategy,component,status,provider,market_id,snapshot_id,
+                            observed_at,source_at,age_seconds,latency_ms,item_count,
+                            required_fields,missing_fields,fallback_used,detail)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        [params for params, _ in batch],
+                    )
+            except Exception as exc:
+                for _, done in batch:
+                    if not done.done():
+                        done.set_exception(exc)
+            else:
+                for _, done in batch:
+                    if not done.done():
+                        done.set_result(None)
+
 async def record_delivery(db, delivery: DataDelivery) -> None:
     """Persist one delivery without allowing monitoring to kill a strategy."""
     try:
@@ -183,21 +223,19 @@ async def record_delivery(db, delivery: DataDelivery) -> None:
         if source is not None:
             source = (source.replace(tzinfo=timezone.utc) if source.tzinfo is None
                       else source.astimezone(timezone.utc))
-        async with db.transaction(owner="data_edge"):
-            await db.execute(
-                """INSERT INTO strategy_data_deliveries
-               (delivery_id,strategy,component,status,provider,market_id,snapshot_id,
-                observed_at,source_at,age_seconds,latency_ms,item_count,
-                required_fields,missing_fields,fallback_used,detail)
-               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (uuid.uuid4().hex, delivery.strategy, delivery.component,
-                 delivery.status, delivery.provider, delivery.market_id,
-                 delivery.snapshot_id, observed.isoformat(),
-                 source.isoformat() if source else None, delivery.age_seconds,
-                 max(0, delivery.latency_ms), max(0, delivery.item_count),
-                 json.dumps(delivery.required_fields), json.dumps(delivery.missing_fields),
-                delivery.fallback_used, json.dumps(delivery.detail, default=str)[:4000]),
-            )
+        batcher = _delivery_batchers.get(id(db))
+        if batcher is None or batcher.db is not db:
+            batcher = _DeliveryBatcher(db)
+            _delivery_batchers[id(db)] = batcher
+        await batcher.write(
+            (uuid.uuid4().hex, delivery.strategy, delivery.component,
+             delivery.status, delivery.provider, delivery.market_id,
+             delivery.snapshot_id, observed.isoformat(),
+             source.isoformat() if source else None, delivery.age_seconds,
+             max(0, delivery.latency_ms), max(0, delivery.item_count),
+             json.dumps(delivery.required_fields), json.dumps(delivery.missing_fields),
+             delivery.fallback_used, json.dumps(delivery.detail, default=str)[:4000]),
+        )
         if delivery.status == "ok" and throttle > 0:
             _last_healthy_recorded[key] = now_mono
     except Exception as exc:  # noqa: BLE001 - telemetry must be best effort

--- a/auramaur/lineage_observer.py
+++ b/auramaur/lineage_observer.py
@@ -83,38 +83,47 @@ class LineageObserver:
     async def _run(self) -> None:
         while True:
             event = await self._queue.get()
+            batch = [event]
             try:
                 if event is None:
                     return
-                # Contention retry: transaction()'s in_transaction pre-check
-                # and its BEGIN execute on different sides of the shared
-                # aiosqlite statement queue, so a write racing another task's
-                # implicit transaction can fail in ms with "cannot start a
-                # transaction within a transaction" (or a transient lock).
-                # Both clear as soon as the interleaved writer commits, and a
-                # single dropped event was how forecast_snapshots lost rows
-                # on 2026-07-21. Bounded retries; anything else raises on the
-                # first attempt.
+                while len(batch) < 64:
+                    try:
+                        queued = self._queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+                    if queued is None:
+                        self._queue.task_done()
+                        break
+                    batch.append(queued)
                 for attempt in range(3):
                     try:
-                        await getattr(self, f"_write_{event.kind}")(**event.payload)
+                        async with self.db.transaction(owner="lineage"):
+                            for item in batch:
+                                await getattr(self, f"_write_{item.kind}")(**item.payload)
                         break
                     except Exception as exc:
                         detail = str(exc).lower()
                         transient = ("cannot start a transaction" in detail
                                      or "database is locked" in detail)
                         if not transient or attempt == 2:
-                            raise
+                            if len(batch) == 1:
+                                raise
+                            for item in batch:
+                                try:
+                                    async with self.db.transaction(owner="lineage"):
+                                        await getattr(self, f"_write_{item.kind}")(**item.payload)
+                                except Exception as item_exc:
+                                    log.warning("lineage_observer.write_failed", kind=item.kind,
+                                                batch_size=1, error=str(item_exc)[:200])
+                            break
                         await asyncio.sleep(0.1 * (attempt + 1))
             except Exception as exc:
-                # transaction() already rolled back this batch; a bare
-                # rollback() here would run on the SHARED connection and could
-                # discard another task's uncommitted writes.
                 log.warning("lineage_observer.write_failed", kind=event.kind if event else None,
-                            error=str(exc)[:200])
+                            batch_size=len(batch), error=str(exc)[:200])
             finally:
-                self._queue.task_done()
-
+                for _ in batch:
+                    self._queue.task_done()
     async def _write_ingestion(self, *, run_id: str, query: str, category: str,
                                market_id: str | None, started_at: str,
                                observed_at: str, fetch_rows: list[tuple],
@@ -168,6 +177,7 @@ class LineageObserver:
         # per-event KeyError that silently zeroed the forecast stream for a
         # day (strategic-path emission, found 2026-07-21). The snapshot row
         # is the evidence; config/evidence ids are provenance decoration.
+        p = dict(p)
         fingerprint = hashlib.sha256(json.dumps(
             p.pop("config", {}), sort_keys=True, separators=(",", ":"),
         ).encode()).hexdigest()[:16]

--- a/auramaur/nlp/call_budget.py
+++ b/auramaur/nlp/call_budget.py
@@ -11,7 +11,7 @@ The budget counter used to live in-memory on each analyzer instance
   private counter, so the "daily budget" was really up to 4x the
   configured number.
 
-One row per day in the bot's own sqlite file fixes both. Helpers are
+One row per day in a dedicated sqlite sidecar fixes both. Helpers are
 synchronous on purpose: sub-millisecond statements, callers sit inside
 multi-second LLM calls, and no analyzer constructor has to grow an async
 ``Database`` dependency.
@@ -43,7 +43,8 @@ import structlog
 
 log = structlog.get_logger()
 
-_db_path = "auramaur.db"  # same working-directory convention as Database
+_source_db_path = "auramaur.db"
+_db_path = "auramaur.llm-budget.db"
 _conn_cache: sqlite3.Connection | None = None
 _lock = threading.Lock()  # the connection is shared cross-thread
 _mem_calls = 0
@@ -53,13 +54,17 @@ _PENDING_ALARM = 25  # sustained persistence failure — worth a warning
 
 
 def set_db_path(path: str) -> None:
-    """Point the counter at the instance's sqlite file (bot startup)."""
-    global _db_path, _mem_calls, _mem_day, _pending
-    if path != _db_path:
+    """Derive a dedicated counter sidecar from the instance database path."""
+    global _source_db_path, _db_path, _mem_calls, _mem_day, _pending
+    from pathlib import Path
+
+    source = Path(path)
+    budget_path = str(source.with_name(f"{source.stem}.llm-budget{source.suffix}"))
+    if budget_path != _db_path or path != _source_db_path:
         _reset_conn()
         _mem_calls, _mem_day, _pending = 0, "", 0
-    _db_path = path
-
+    _source_db_path = path
+    _db_path = budget_path
 
 def _conn() -> sqlite3.Connection:
     """One cached connection per process; schema created once.
@@ -76,6 +81,28 @@ def _conn() -> sqlite3.Connection:
                    claude_calls INTEGER NOT NULL DEFAULT 0
                )"""
         )
+        # Preserve today's spend when upgrading from the historical row.
+        # MAX makes this restart-safe: legacy state can never roll us back.
+        from pathlib import Path
+        if Path(_source_db_path).exists() and _source_db_path != _db_path:
+            try:
+                legacy = sqlite3.connect(_source_db_path, timeout=0.0)
+                try:
+                    row = legacy.execute(
+                        "SELECT claude_calls FROM llm_call_counter WHERE day = ?",
+                        (date.today().isoformat(),),
+                    ).fetchone()
+                finally:
+                    legacy.close()
+                if row:
+                    conn.execute(
+                        """INSERT INTO llm_call_counter(day, claude_calls) VALUES (?, ?)
+                           ON CONFLICT(day) DO UPDATE SET claude_calls =
+                           MAX(claude_calls, excluded.claude_calls)""",
+                        (date.today().isoformat(), int(row[0])),
+                    )
+            except sqlite3.Error:
+                pass
         conn.commit()
         _conn_cache = conn
     return _conn_cache

--- a/tests/test_call_budget.py
+++ b/tests/test_call_budget.py
@@ -60,39 +60,34 @@ def test_sqlite_failure_degrades_to_memory(tmp_path):
     assert call_budget._mem_day == date.today().isoformat()
 
 
-def test_locked_writer_fails_fast_and_folds_count_back(tmp_path):
-    """The 2026-07-19 event-loop freeze: a held write lock used to busy-wait
-    ~31s ON the loop (a potential self-deadlock — the holder's commit only
-    advances when the loop does). A miss must return in a beat, and the
-    missed increment must land in the row on the next successful write."""
+def test_trading_db_writer_does_not_block_call_budget(tmp_path):
     import sqlite3
     import time
 
     _use_tmp_db(tmp_path)
     assert call_budget.record_call() == 1
-
     blocker = sqlite3.connect(str(tmp_path / "test.db"))
-    blocker.execute("BEGIN IMMEDIATE")  # hold the write lock
+    blocker.execute("BEGIN IMMEDIATE")
     t0 = time.monotonic()
-    n = call_budget.record_call()  # cannot persist
+    assert call_budget.record_call() == 2
     elapsed = time.monotonic() - t0
-    blocker.rollback()
-    blocker.close()
-
-    assert n == 2  # in-memory total is still right
-    assert elapsed < 2.0, f"blocked {elapsed:.1f}s — busy-wait is back"
-    assert call_budget._pending == 1
-
-    # Budget checks between the miss and the flush must still see the call.
-    assert call_budget.calls_today() == 2
-
-    assert call_budget.record_call() == 3  # 1 stored + 1 pending + 1 new
+    blocker.rollback(); blocker.close()
+    assert elapsed < 0.1
     assert call_budget._pending == 0
 
-    # The ROW carries all three: a fresh reader (restart) agrees.
-    call_budget.set_db_path(str(tmp_path / "test.db"))
-    assert call_budget.calls_today() == 3
 
+def test_legacy_today_count_migrates_without_budget_reset(tmp_path):
+    import sqlite3
+
+    source = tmp_path / "legacy.db"
+    conn = sqlite3.connect(source)
+    conn.execute("CREATE TABLE llm_call_counter (day TEXT PRIMARY KEY, claude_calls INTEGER NOT NULL)")
+    conn.execute("INSERT INTO llm_call_counter VALUES (?, 17)", (date.today().isoformat(),))
+    conn.commit(); conn.close()
+    call_budget.set_db_path(str(source))
+    assert call_budget.calls_today() == 17
+    assert call_budget.record_call() == 18
+    assert (tmp_path / "legacy.llm-budget.db").exists()
 
 # ---------------------------------------------------------------------------
 # Pacing envelope — the non-reserved pool is time-shaped toward the peak

--- a/tests/test_data_edge.py
+++ b/tests/test_data_edge.py
@@ -229,3 +229,14 @@ async def test_market_snapshot_partial_only_when_nothing_priced(db):
     assert [(r["provider"], r["status"]) for r in rows] == [
         ("t1", "ok"), ("t2", "partial")]
     assert '"missing_market_count": 1' in rows[0]["detail"]
+
+@pytest.mark.asyncio
+async def test_concurrent_deliveries_share_one_transaction(db):
+    statements = []
+    await db._db.set_trace_callback(statements.append)
+    await asyncio.gather(*(record_delivery(db, DataDelivery(
+        strategy=f"batch-{i}", component="market_snapshot", status="ok",
+        source_at=datetime.now(timezone.utc), item_count=1)) for i in range(12)))
+    assert len([sql for sql in statements if sql.startswith("BEGIN IMMEDIATE")]) == 1
+    row = await db.fetchone("SELECT COUNT(*) n FROM strategy_data_deliveries WHERE strategy LIKE 'batch-%'")
+    assert row["n"] == 12

--- a/tests/test_transaction_adoption.py
+++ b/tests/test_transaction_adoption.py
@@ -120,3 +120,20 @@ async def test_close_is_idempotent_and_leaves_shared_db_open(tmp_path):
     row = await db.fetchone("SELECT COUNT(*) AS n FROM forecast_snapshots")
     assert row["n"] == 1
     await db.close()
+
+@pytest.mark.asyncio
+async def test_ready_lineage_events_share_one_outer_transaction(tmp_path):
+    db = Database(str(tmp_path / "batched.db"))
+    await db.connect()
+    statements = []
+    await db._db.set_trace_callback(statements.append)
+    observer = await LineageObserver.create(db)
+    try:
+        for index in range(12):
+            payload = _forecast_payload(); payload["market_id"] = f"m-{index}"
+            observer.forecast(**payload)
+        await observer.flush()
+        assert len([sql for sql in statements if sql.startswith("BEGIN IMMEDIATE")]) == 1
+        assert (await db.fetchone("SELECT COUNT(*) n FROM forecast_snapshots"))["n"] == 12
+    finally:
+        await observer.close(); await db.close()


### PR DESCRIPTION
## Summary
- move the synchronous Claude call-budget counter to a dedicated SQLite sidecar, seeding today's count from the legacy trading-DB row without allowing rollback
- batch up to 64 ready lineage events under one outer transaction, with per-event fallback so poison records do not drop healthy siblings
- coalesce concurrent data-edge deliveries into bounded executemany transactions while preserving await-time durability and readiness freshness

## Contention impact
- a trading-database BEGIN IMMEDIATE no longer blocks or defers call-budget writes
- regression benchmarks prove 12 concurrent data-edge writes use one transaction
- regression benchmarks prove 12 queued lineage events use one outer transaction

## Verification
- python -m ruff check (focused files): passed
- targeted contention/regression suite: 31 passed
- full suite: 1804 passed, 5 skipped
- git diff --check: clean