### PR TITLE
Make capital decisions benchmark-relative

### DIFF
--- a/auramaur/broker/allocator.py
+++ b/auramaur/broker/allocator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 import structlog
 
@@ -99,6 +100,19 @@ class CapitalAllocator:
             market_id = candidate.market.id
             category = candidate.market.category
 
+            # Capital has a real alternative return. A candidate whose
+            # confidence-discounted EV does not clear that cash hurdle should
+            # receive no allocation, even if it is the best of a weak batch.
+            if candidate.expected_value <= 0:
+                show_order_dropped(
+                    market_id, "expected value does not clear cash benchmark")
+                log.info(
+                    "allocator.below_cash_benchmark",
+                    market_id=market_id,
+                    excess_ev=round(candidate.expected_value, 4),
+                )
+                continue
+
             # Skip if already holding this market (no averaging into an open
             # position). Surface it — this is the single most common reason an
             # APPROVED candidate produces no trade, and it used to be invisible
@@ -194,14 +208,36 @@ class CapitalAllocator:
 
         return allocated
 
-    @staticmethod
-    def compute_expected_value(signal: Signal, kelly_size: float) -> float:
+    def compute_expected_value(
+        self,
+        signal: Signal,
+        kelly_size: float,
+        market: Market | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> float:
         """Compute expected value for ranking.
 
         EV = (edge_pct / 100) * confidence_weight * kelly_size
+             - cash opportunity cost through resolution
 
         Where confidence_weight is HIGH=1.0, MEDIUM=0.75, LOW=0.5.
         """
         confidence_weight = _CONFIDENCE_WEIGHTS.get(signal.claude_confidence, 0.5)
         edge_frac = abs(signal.edge) / 100.0
-        return edge_frac * confidence_weight * kelly_size
+        forecast_ev = edge_frac * confidence_weight * kelly_size
+        if market is None or market.end_date is None:
+            return forecast_ev
+        end = market.end_date
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        as_of = now or datetime.now(timezone.utc)
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=timezone.utc)
+        hold_years = max(0.0, (end - as_of).total_seconds()) / (365.25 * 86400)
+        cash_hurdle = (
+            kelly_size
+            * self._settings.benchmark.risk_free_annual_rate
+            * hold_years
+        )
+        return forecast_ev - cash_hurdle

--- a/auramaur/broker/allocator.py
+++ b/auramaur/broker/allocator.py
@@ -219,14 +219,28 @@ class CapitalAllocator:
         """Compute expected value for ranking.
 
         EV = (edge_pct / 100) * confidence_weight * kelly_size
-             - cash opportunity cost through resolution
+             - cash opportunity cost through resolution (when armed)
 
         Where confidence_weight is HIGH=1.0, MEDIUM=0.75, LOW=0.5.
+
+        The cash-hurdle term is gated by
+        ``benchmark.allocator_cash_hurdle_enabled`` (tracked default OFF,
+        2026-08-05). Two reasons, both pre-registered rather than vibes:
+        (1) the hurdle charges the hold-to-RESOLUTION cost, but this book
+        demonstrably realizes long-dated edges early on repricing (the
+        2026-08-05 Gemini exits: entered 9-12c, exited 21-41c inside a
+        day), so hold-to-end systematically overstates the true cost; and
+        (2) replayed against the prior 14 days of live entries the hurdle
+        would have refused 7 of 13 (~$185 of ~$265) — effectively
+        adjudicating the llm_kalshi long-dated experiment that the
+        2026-10-31 pre-registered cell review exists to decide on
+        evidence. Flip the flag if that review kills the long book.
         """
         confidence_weight = _CONFIDENCE_WEIGHTS.get(signal.claude_confidence, 0.5)
         edge_frac = abs(signal.edge) / 100.0
         forecast_ev = edge_frac * confidence_weight * kelly_size
-        if market is None or market.end_date is None:
+        if (market is None or market.end_date is None
+                or not self._settings.benchmark.allocator_cash_hurdle_enabled):
             return forecast_ev
         end = market.end_date
         if end.tzinfo is None:

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -158,6 +158,7 @@ class GraduationLadder:
                     GROUP BY market_id, is_paper
                 )
                 SELECT d.market_id, d.is_paper, d.observed_at,
+                       o.resolved_at, d.requested_size,
                        COALESCE(NULLIF(d.event_family, ''), d.market_id) AS family,
                        ((d.reference_price-o.outcome)*(d.reference_price-o.outcome)
                         -(d.fair_probability-o.outcome)*(d.fair_probability-o.outcome)) AS brier_edge,
@@ -179,7 +180,23 @@ class GraduationLadder:
         z = max(cfg.confidence_z, NormalDist().inv_cdf(1.0-alpha))
 
         def summarize(items: list[dict]) -> dict:
-            pnl = [float(r["net_pnl"] or 0) for r in items]
+            pnl = []
+            for row in items:
+                net_pnl = float(row["net_pnl"] or 0)
+                if cfg.require_cash_benchmark:
+                    opened = datetime.fromisoformat(
+                        str(row["observed_at"]).replace("Z", "+00:00"))
+                    resolved = datetime.fromisoformat(
+                        str(row["resolved_at"]).replace("Z", "+00:00"))
+                    hold_years = max(
+                        0.0, (resolved - opened).total_seconds()
+                    ) / (365.25 * 86400)
+                    net_pnl -= (
+                        max(0.0, float(row["requested_size"] or 0))
+                        * self._settings.benchmark.risk_free_annual_rate
+                        * hold_years
+                    )
+                pnl.append(net_pnl)
             brier = [float(r["brier_edge"] or 0) for r in items]
             def lcb(values: list[float]) -> float:
                 if len(values) < 2:

--- a/auramaur/strategy/engine_cycle.py
+++ b/auramaur/strategy/engine_cycle.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
+from auramaur.broker.allocator import CandidateTrade
 from auramaur.killswitch import kill_switch_present
 from auramaur.exchange.models import Market, OrderSide, Signal
 from auramaur.experiments.strategies.core_trading import (
@@ -566,7 +566,8 @@ class CycleOrchestrationMixin:
             results.append(result)
 
             if decision.approved and decision.position_size > 0 and self.allocator:
-                ev = CapitalAllocator.compute_expected_value(tc.signal, decision.position_size)
+                ev = self.allocator.compute_expected_value(
+                    tc.signal, decision.position_size, tc.market)
                 alloc_candidates.append(CandidateTrade(
                     market=tc.market, signal=tc.signal, risk_decision=decision,
                     kelly_size=decision.position_size, expected_value=ev,
@@ -908,7 +909,8 @@ class CycleOrchestrationMixin:
             results.append(result)
 
             if decision.approved and decision.position_size > 0 and self.allocator:
-                ev = CapitalAllocator.compute_expected_value(signal, decision.position_size)
+                ev = self.allocator.compute_expected_value(
+                    signal, decision.position_size, market)
                 candidates.append(CandidateTrade(
                     market=market, signal=signal, risk_decision=decision,
                     kelly_size=decision.position_size, expected_value=ev,
@@ -961,7 +963,8 @@ class CycleOrchestrationMixin:
             decision = r["decision"]
             if decision.approved and decision.position_size > 0:
                 signal = r["signal"]
-                ev = CapitalAllocator.compute_expected_value(signal, decision.position_size)
+                ev = self.allocator.compute_expected_value(
+                    signal, decision.position_size, r["market"])
                 candidates.append(CandidateTrade(
                     market=r["market"],
                     signal=signal,

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1359,6 +1359,14 @@ cross_venue_arb:
 # judgement in the system was scored against zero.
 benchmark:
   risk_free_annual_rate: 0.045
+  # Allocator ENTRY veto stays disarmed (2026-08-05): the hurdle prices a
+  # hold-to-resolution the book does not practice (long-dated edges get
+  # exited on repricing), and a 14-day live replay showed it refusing 7 of
+  # 13 real entries — the llm_kalshi long-dated cells the 2026-10-31
+  # pre-registered review adjudicates. Flip AFTER that review, on its
+  # evidence. Graduation measurement (require_cash_benchmark) is on
+  # regardless of this flag.
+  allocator_cash_hurdle_enabled: false
   # Total deployable capital across ALL venues, USD. Operator-maintained:
   # only Polymarket reports capital numerically, and the venues are
   # mixed-currency, so this cannot be derived. Measured 2026-08-01:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -190,6 +190,9 @@ graduation:
   # Prospective proof contract: old/backfilled rows remain reportable but cannot
   # graduate a strategy whose parameters and execution provenance were not frozen.
   prospective_only: true
+  # Positive dollars are not enough: charge the committed stake the return it
+  # could have earned at benchmark.risk_free_annual_rate over the actual hold.
+  require_cash_benchmark: true
   require_market_brier_edge: true
   require_executable_fills: true
   min_calendar_days: 30

--- a/config/settings.py
+++ b/config/settings.py
@@ -1339,6 +1339,10 @@ class GraduationConfig(BaseModel):
     window_days: int = 90
     confidence_z: float = 1.645
     min_mean_pnl_lower_bound: float = 0.0
+    # Require realized returns to clear the configured cash benchmark after
+    # charging opportunity cost for the capital and time committed. Applied to
+    # prospective evidence, where stake and holding-period provenance exist.
+    require_cash_benchmark: bool = False
     probation_multiplier: float = 0.5
     cache_seconds: int = 300
     exempt_strategies: list[str] = ["arbitrage", "market_maker", "order_monitor"]

--- a/config/settings.py
+++ b/config/settings.py
@@ -2118,6 +2118,16 @@ class BenchmarkConfig(BaseModel):
     # Annualised risk-free rate the book is measured against. Roughly the
     # T-bill / money-market rate available on idle balances.
     risk_free_annual_rate: float = 0.045
+    # Arm the allocator's per-candidate cash hurdle (EV minus
+    # stake x rate x years-to-END-DATE, refusing non-positive excess).
+    # Default OFF: the charge models hold-to-resolution, which overstates
+    # cost for a book that exits long-dated positions on repricing, and a
+    # 14-day live replay showed it refusing 7 of 13 real entries — the
+    # llm_kalshi long-dated cells whose worth the 2026-10-31 pre-registered
+    # review adjudicates on evidence. Measurement (graduation's
+    # require_cash_benchmark) stays on regardless; this flag only gates the
+    # ENTRY veto. Outside every strategy_version hash — clock-safe to flip.
+    allocator_cash_hurdle_enabled: bool = False
     # Total deployable capital across ALL venues, in USD. Operator-maintained:
     # only Polymarket reports capital numerically in venue_balances, and the
     # rest are mixed-currency, so this cannot be derived reliably. 0 disables

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -7,10 +7,17 @@ from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
 from tests.test_risk_manager import _make_market, _make_signal
 
 
-def test_expected_value_is_ranked_after_cash_hurdle():
-    settings = SimpleNamespace(
-        benchmark=SimpleNamespace(risk_free_annual_rate=0.05))
-    allocator = CapitalAllocator(settings)
+def _settings(hurdle: bool, **risk):
+    return SimpleNamespace(
+        benchmark=SimpleNamespace(
+            risk_free_annual_rate=0.05,
+            allocator_cash_hurdle_enabled=hurdle),
+        **({"risk": SimpleNamespace(**risk)} if risk else {}),
+    )
+
+
+def test_expected_value_is_ranked_after_cash_hurdle_when_armed():
+    allocator = CapitalAllocator(_settings(hurdle=True))
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     market = _make_market()
     market.end_date = now + timedelta(days=365)
@@ -21,10 +28,23 @@ def test_expected_value_is_ranked_after_cash_hurdle():
         signal, 100.0, market, now=now) == pytest.approx(5.0, abs=0.02)
 
 
+def test_expected_value_ignores_hurdle_while_disarmed():
+    """Tracked default: the ENTRY veto stays off until the 2026-10-31
+    pre-registered cell review adjudicates the long-dated book — the same
+    market that costs $5 of hurdle when armed ranks at its full forecast
+    EV while disarmed."""
+    allocator = CapitalAllocator(_settings(hurdle=False))
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    market = _make_market()
+    market.end_date = now + timedelta(days=365)
+    signal = _make_signal(edge=10.0)
+
+    assert allocator.compute_expected_value(
+        signal, 100.0, market, now=now) == 10.0
+
+
 def test_expected_value_preserves_legacy_result_without_resolution_date():
-    settings = SimpleNamespace(
-        benchmark=SimpleNamespace(risk_free_annual_rate=0.05))
-    allocator = CapitalAllocator(settings)
+    allocator = CapitalAllocator(_settings(hurdle=True))
     market = _make_market()
     market.end_date = None
     signal = _make_signal(edge=10.0)
@@ -33,11 +53,8 @@ def test_expected_value_preserves_legacy_result_without_resolution_date():
 
 
 def test_allocator_does_not_fund_nonpositive_excess_value():
-    settings = SimpleNamespace(
-        benchmark=SimpleNamespace(risk_free_annual_rate=0.05),
-        risk=SimpleNamespace(
-            max_open_positions=10, category_exposure_cap_pct=100))
-    allocator = CapitalAllocator(settings)
+    allocator = CapitalAllocator(_settings(
+        hurdle=True, max_open_positions=10, category_exposure_cap_pct=100))
     market = _make_market(category="tech")
     signal = _make_signal()
     candidate = CandidateTrade(
@@ -50,3 +67,11 @@ def test_allocator_does_not_fund_nonpositive_excess_value():
 
     assert allocator.allocate([candidate], 100.0, []) == []
     assert candidate.allocated_size == 0.0
+
+
+def test_tracked_default_keeps_the_entry_veto_disarmed():
+    """The committed YAML must not arm the hurdle silently — arming is the
+    2026-10-31 review's decision, not a config drift."""
+    from config.settings import Settings
+
+    assert Settings().benchmark.allocator_cash_hurdle_enabled is False

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.broker.allocator import CandidateTrade, CapitalAllocator
+from tests.test_risk_manager import _make_market, _make_signal
+
+
+def test_expected_value_is_ranked_after_cash_hurdle():
+    settings = SimpleNamespace(
+        benchmark=SimpleNamespace(risk_free_annual_rate=0.05))
+    allocator = CapitalAllocator(settings)
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    market = _make_market()
+    market.end_date = now + timedelta(days=365)
+    signal = _make_signal(edge=10.0)
+
+    # High-confidence forecast EV is $10; a one-year 5% cash hurdle costs $5.
+    assert allocator.compute_expected_value(
+        signal, 100.0, market, now=now) == pytest.approx(5.0, abs=0.02)
+
+
+def test_expected_value_preserves_legacy_result_without_resolution_date():
+    settings = SimpleNamespace(
+        benchmark=SimpleNamespace(risk_free_annual_rate=0.05))
+    allocator = CapitalAllocator(settings)
+    market = _make_market()
+    market.end_date = None
+    signal = _make_signal(edge=10.0)
+
+    assert allocator.compute_expected_value(signal, 100.0, market) == 10.0
+
+
+def test_allocator_does_not_fund_nonpositive_excess_value():
+    settings = SimpleNamespace(
+        benchmark=SimpleNamespace(risk_free_annual_rate=0.05),
+        risk=SimpleNamespace(
+            max_open_positions=10, category_exposure_cap_pct=100))
+    allocator = CapitalAllocator(settings)
+    market = _make_market(category="tech")
+    signal = _make_signal()
+    candidate = CandidateTrade(
+        market=market,
+        signal=signal,
+        risk_decision=SimpleNamespace(),
+        kelly_size=10.0,
+        expected_value=0.0,
+    )
+
+    assert allocator.allocate([candidate], 100.0, []) == []
+    assert candidate.allocated_size == 0.0

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -17,12 +17,13 @@ from unittest.mock import MagicMock, patch
 
 from auramaur.db.database import Database
 from auramaur.risk.graduation import GraduationLadder
-from config.settings import GraduationConfig
+from config.settings import BenchmarkConfig, GraduationConfig
 
 
 def _settings(mode="enforce", min_markets=5, **kw):
     s = MagicMock()
     s.graduation = GraduationConfig(mode=mode, min_markets=min_markets, **kw)
+    s.benchmark = BenchmarkConfig(risk_free_annual_rate=0.045)
     return s
 
 
@@ -379,6 +380,72 @@ def test_graduation_uses_pnl_net_of_fees():
             )
         ladder = GraduationLadder(db, _settings(min_markets=5))
         decision = await ladder.decide("fee_test", "crypto")
+        assert decision.status == "paper_negative"
+        assert decision.force_paper is True
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_prospective_graduation_charges_cash_opportunity_cost():
+    """A nominally profitable strategy must not graduate when its committed
+    capital would have earned more at the configured cash benchmark."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        await db.execute(
+            """INSERT INTO strategy_experiments
+               (strategy_version, strategy_source, config_json, holdout_starts_at)
+               VALUES ('cash-v1', 'cash_test', '{}', datetime('now', '-60 days'))"""
+        )
+        for i in range(2):
+            market_id = f"cash-{i}"
+            await db.execute(
+                """INSERT INTO markets
+                   (id, question, category, last_updated)
+                   VALUES (?, 'Cash hurdle?', 'tech', datetime('now'))""",
+                (market_id,),
+            )
+            await db.execute(
+                """INSERT INTO decision_snapshots
+                   (market_id, strategy_source, side, fair_probability,
+                    reference_price, requested_size, venue, event_family,
+                    strategy_version, is_holdout, fill_evidence, is_paper,
+                    filled, observed_at)
+                   VALUES (?, 'cash_test', 'BUY', 0.7, 0.5, 100,
+                           'polymarket', ?, 'cash-v1', 1, 'venue_fill', 1, 1,
+                           datetime('now', '-40 days'))""",
+                (market_id, f"family-{i}"),
+            )
+            await db.execute(
+                """INSERT INTO market_outcomes
+                   (event_key, venue, market_id, outcome, resolved_at, source)
+                   VALUES (?, 'polymarket', ?, 1, datetime('now'), 'test')""",
+                (f"polymarket:{market_id}", market_id),
+            )
+            await db.execute(
+                """INSERT INTO pnl_ledger
+                   (market_id, venue, category, strategy_source, kind, token,
+                    qty, pnl, fees, is_paper, source_ref)
+                   VALUES (?, 'polymarket', 'tech', 'cash_test', 'sell', 'YES',
+                           1, 0.20, 0, 1, ?)""",
+                (market_id, f"cash-ref-{i}"),
+            )
+        await db.commit()
+
+        base = dict(
+            prospective_only=True,
+            min_markets=2,
+            confidence_z=0,
+            require_executable_fills=True,
+        )
+        nominal = GraduationLadder(
+            db, _settings(require_cash_benchmark=False, **base))
+        assert (await nominal.decide("cash_test", "tech")).status == "probation"
+
+        benchmarked = GraduationLadder(
+            db, _settings(require_cash_benchmark=True, **base))
+        decision = await benchmarked.decide("cash_test", "tech")
         assert decision.status == "paper_negative"
         assert decision.force_paper is True
         await db.close()


### PR DESCRIPTION
## Summary
- subtract cash-rate opportunity cost from prospective graduation P&L using committed stake and actual holding time
- rank allocation candidates by excess expected value through resolution
- refuse capital allocation when benchmark-relative expected value is non-positive
- keep the stronger behavior tracked-on while preserving permissive class defaults for isolated callers

## Verification
- python -m pytest tests/test_allocator.py tests/test_graduation.py tests/test_engine_cycle.py -q (27 passed)
- python -m pytest -q (2098 passed, 5 skipped)
- python -m ruff check ... on all touched Python files (clean)
- git diff --check (clean)

## Follow-up
The existing test-session aiosqlite leak remains visible and is intentionally scoped to PR 3 of the audit sequence.