### PR TITLE
Align the documented minimum-edge contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,10 @@ When making git commits, use `Assisted-by: Claude (Anthropic)` in the commit mes
   two always applies — check the effective value, not this line.
 - Daily loss limit: $200
 - Max open positions: 500
-- Minimum edge: 5% after fees
+- Minimum edge (neutral tracked baseline): 2.5% after fees. The risk-tolerance
+  lever scales this gateway floor at runtime; individual strategies may impose
+  higher entry bars. `RiskConfig` retains a conservative 5% class fallback for
+  callers that construct it without the tracked YAML.
 - Kelly fraction: 30%
 - Confidence floor: LOW
 - Category exposure cap: 60%

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,10 +57,27 @@ def test_default_risk_params():
     assert s.risk.max_stake_per_market == 0.02
     assert s.risk.daily_loss_limit == 200.0
     assert s.risk.max_open_positions == 500
+    assert s.risk.min_edge_pct == 2.5
     # Kalshi gets a lower candidate liquidity floor than Polymarket (thinner book)
     assert s.risk.min_liquidity == 1000.0
     assert s.risk.kalshi_min_liquidity == 300.0
     assert s.kelly.fraction == 0.30
+
+
+def test_documented_minimum_edge_matches_tracked_baseline():
+    """The operator safety contract must describe the effective tracked YAML,
+    not RiskConfig's conservative no-YAML fallback."""
+    from pathlib import Path
+
+    settings = Settings()
+    safety_contract = (
+        Path(__file__).resolve().parent.parent / "CLAUDE.md"
+    ).read_text(encoding="utf-8")
+    documented = (
+        f"Minimum edge (neutral tracked baseline): "
+        f"{settings.risk.min_edge_pct:g}% after fees"
+    )
+    assert documented in safety_contract
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- document the effective tracked neutral minimum edge as 2.5% after fees
- explain that risk tolerance scales the gateway floor and strategies may impose higher bars
- preserve and document RiskConfig's conservative 5% no-YAML fallback
- add a regression test that keeps CLAUDE.md synchronized with loaded tracked settings

## Verification
- python -m pytest tests/test_settings.py tests/test_risk_manager.py tests/test_router_crossing.py -q (76 passed)
- python -m pytest -q (2095 passed, 5 skipped)
- python -m ruff check tests/test_settings.py (clean)
- git diff --check (clean)

## Scope
Documentation and contract test only; runtime thresholds are unchanged.