### PR TITLE
Fail tests on leaked database connections

### DIFF
--- a/auramaur/web/db.py
+++ b/auramaur/web/db.py
@@ -10,6 +10,8 @@ needs, so ``monitoring.cockpit.gather_state`` runs unchanged on top of it.
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from pathlib import Path
 
 import aiosqlite
@@ -35,14 +37,28 @@ class ReadOnlyDatabase:
         # Linux — both forms SQLite accepts; string-built URIs with
         # backslashes are not portable.
         uri = f"{Path(self.db_path).resolve().as_uri()}?mode=ro"
-        self._db = await aiosqlite.connect(uri, uri=True)
-        self._db.row_factory = aiosqlite.Row
-        # WAL readers can hit a writer's checkpoint lock; wait briefly instead
-        # of erroring (the bot holds busy_timeout=30000 on its side).
-        await self._db.execute("PRAGMA busy_timeout=5000")
-        # Belt on top of mode=ro: even a coding mistake in this process cannot
-        # turn a query into a write.
-        await self._db.execute("PRAGMA query_only=ON")
+        # Keep the handle before awaiting it. Cancellation can land after
+        # aiosqlite starts its worker thread but before __await__ returns; if
+        # assignment happened only after await, shutdown would have no handle
+        # to close and the non-daemon worker would survive pytest/process exit.
+        connection = aiosqlite.connect(uri, uri=True)
+        try:
+            await connection
+            connection.row_factory = aiosqlite.Row
+            # WAL readers can hit a writer's checkpoint lock; wait briefly instead
+            # of erroring (the bot holds busy_timeout=30000 on its side).
+            await connection.execute("PRAGMA busy_timeout=5000")
+            # Belt on top of mode=ro: even a coding mistake in this process cannot
+            # turn a query into a write.
+            await connection.execute("PRAGMA query_only=ON")
+        except (asyncio.CancelledError, Exception):
+            # Preserve the original open/initialization error. Some aiosqlite
+            # releases raise ValueError when close() is called before the
+            # underlying sqlite handle became active.
+            with suppress(Exception):
+                await connection.close()
+            raise
+        self._db = connection
 
     async def close(self) -> None:
         if self._db:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ under >= 0.22 it blocks on an untimed queue get and only exits via the
 sentinel that ``Connection.stop()`` enqueues (sync-safe by design — it is
 what ``__del__`` uses). The old flag-flip alone became a silent no-op the
 day the 0.17 -> 0.22.1 bump landed. This is a backstop, not a license —
-tests should still close their databases, and the stderr line below names
-the leak count so regressions stay visible.
+tests must still close their databases. A leak now makes the session fail
+after cleanup and reports both its owning test and construction stack.
 """
 
 from __future__ import annotations
@@ -25,13 +25,54 @@ import gc
 import os
 import sys
 import threading
+import traceback
 
 import pytest
+
+_AIOSQLITE_CREATION_STACKS: dict[int, tuple[str, str]] = {}
+_ORIGINAL_AIOSQLITE_CONNECT = None
+_CURRENT_TEST = "<pytest session>"
 
 # Tests exercise order paths while an operator may intentionally have the real
 # repository kill switch armed. Keep configuration and safety-file state local
 # to each test process; dedicated kill-switch tests override the path directly.
 os.environ["AURAMAUR_LOCAL_CONFIG"] = "/tmp/auramaur-test-no-local-config.yaml"
+
+
+def pytest_configure():
+    """Record where every test-owned aiosqlite connection was constructed."""
+    global _ORIGINAL_AIOSQLITE_CONNECT
+    import aiosqlite
+
+    if _ORIGINAL_AIOSQLITE_CONNECT is not None:
+        return
+    _ORIGINAL_AIOSQLITE_CONNECT = aiosqlite.connect
+
+    def tracked_connect(*args, **kwargs):
+        connection = _ORIGINAL_AIOSQLITE_CONNECT(*args, **kwargs)
+        _AIOSQLITE_CREATION_STACKS[id(connection)] = (
+            _CURRENT_TEST,
+            "".join(traceback.format_stack(limit=12)),
+        )
+        return connection
+
+    aiosqlite.connect = tracked_connect
+
+
+def pytest_unconfigure():
+    """Restore the library function for in-process pytest embedders."""
+    global _ORIGINAL_AIOSQLITE_CONNECT
+    if _ORIGINAL_AIOSQLITE_CONNECT is None:
+        return
+    import aiosqlite
+
+    aiosqlite.connect = _ORIGINAL_AIOSQLITE_CONNECT
+    _ORIGINAL_AIOSQLITE_CONNECT = None
+
+
+def pytest_runtest_setup(item):
+    global _CURRENT_TEST
+    _CURRENT_TEST = item.nodeid
 
 
 @pytest.fixture(autouse=True)
@@ -48,12 +89,12 @@ def _isolate_kill_switch(monkeypatch, tmp_path):
             monkeypatch.setattr(module, "kill_switch_present", lambda: False)
 
 
-def pytest_sessionfinish(session, exitstatus):
+def _reap_stranded_connections() -> list[tuple[threading.Thread, str, str]]:
     try:
         import aiosqlite
     except ImportError:  # pragma: no cover
-        return
-    stranded: list = []
+        return []
+    stranded: list[tuple[threading.Thread, str, str]] = []
     for obj in gc.get_objects():
         if type(obj) is not aiosqlite.Connection:
             continue
@@ -64,20 +105,41 @@ def pytest_sessionfinish(session, exitstatus):
             thread = obj  # <= 0.21: Connection IS the thread
         if thread is None or not thread.is_alive():
             continue
+        # close() clears the underlying sqlite handle before the worker exits.
+        # On polling-worker releases (notably 0.17), that thread can remain
+        # alive for one final 100ms tick. It is closing, not leaked.
+        if getattr(obj, "_connection", object()) is None:
+            thread.join(timeout=0.25)
+            continue
         try:
             if hasattr(obj, "stop"):  # >= 0.22: sentinel-based, loop-safe
                 obj.stop()
             else:  # <= 0.21: poll loop honors the flag on its next tick
                 obj._running = False
-            stranded.append(thread)
+            owner, stack = _AIOSQLITE_CREATION_STACKS.get(
+                id(obj),
+                ("<test owner unavailable>",
+                 "<connection creation stack unavailable>"),
+            )
+            stranded.append((thread, owner, stack))
         except Exception:  # pragma: no cover
             pass
-    for thread in stranded:
+    for thread, _, _ in stranded:
         thread.join(timeout=2.0)
+    return stranded
+
+
+def pytest_sessionfinish(session, exitstatus):
+    stranded = _reap_stranded_connections()
     if stranded:
+        details = "\n\n".join(
+            f"unclosed aiosqlite connection #{index} owned by {owner}, "
+            f"created at:\n{stack}"
+            for index, (_, owner, stack) in enumerate(stranded, start=1)
+        )
         print(
             f"\n[conftest] reaped {len(stranded)} unclosed aiosqlite "
-            "connection(s) at session end — tests should close their "
-            "databases",
+            f"connection(s) at session end:\n\n{details}",
             file=sys.stderr,
         )
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED

--- a/tests/test_conftest_backstop.py
+++ b/tests/test_conftest_backstop.py
@@ -13,10 +13,24 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from types import SimpleNamespace
 
 import aiosqlite
+import pytest
 
 from tests import conftest
+
+
+def test_sessionfinish_marks_a_leaking_suite_failed(monkeypatch, capsys):
+    stranded = [(SimpleNamespace(), "tests/test_owner.py::test_leak", "stack")]
+    monkeypatch.setattr(
+        conftest, "_reap_stranded_connections", lambda: stranded)
+    session = SimpleNamespace(exitstatus=pytest.ExitCode.OK)
+
+    conftest.pytest_sessionfinish(session=session, exitstatus=0)
+
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+    assert "tests/test_owner.py::test_leak" in capsys.readouterr().err
 
 
 def test_sessionfinish_backstop_reaps_a_stranded_worker_thread():
@@ -33,9 +47,10 @@ def test_sessionfinish_backstop_reaps_a_stranded_worker_thread():
         thread = conn  # <= 0.21: Connection IS the thread
     assert thread is not None and thread.is_alive()
 
-    conftest.pytest_sessionfinish(session=None, exitstatus=0)
+    stranded = conftest._reap_stranded_connections()
 
     thread.join(timeout=3.0)
+    assert len(stranded) == 1
     assert not thread.is_alive(), (
         "backstop failed to stop a stranded aiosqlite worker — under this "
         "aiosqlite version the suite would hang at interpreter exit"

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -6,6 +6,7 @@ or schemaless database (the service must explain itself and recover on its
 own) — and the dashboard's DB handle is structurally unable to write.
 """
 
+import asyncio
 import time
 
 import aiosqlite
@@ -24,6 +25,40 @@ from auramaur.web.serialize import serialize_state  # noqa: E402
 from config.settings import Settings  # noqa: E402
 
 FAST_REFRESH = 0.1  # keep degraded-recovery tests quick
+
+
+@pytest.mark.asyncio
+async def test_readonly_connect_cancellation_closes_started_worker(monkeypatch):
+    """Cancellation between worker startup and await completion must not
+    orphan an aiosqlite thread with no handle available to shutdown."""
+    started = asyncio.Event()
+
+    class PendingConnection:
+        def __init__(self):
+            self.closed = False
+
+        def __await__(self):
+            return self._wait().__await__()
+
+        async def _wait(self):
+            started.set()
+            await asyncio.Event().wait()
+
+        async def close(self):
+            self.closed = True
+
+    connection = PendingConnection()
+    monkeypatch.setattr(aiosqlite, "connect", lambda *args, **kwargs: connection)
+    db = ReadOnlyDatabase("unused.db")
+
+    task = asyncio.create_task(db.connect())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert connection.closed is True
+    assert db.connected is False
 
 
 async def _seed_bot_db(db_path: str) -> None:


### PR DESCRIPTION
## Summary
- make surviving open aiosqlite workers fail the pytest session after safe cleanup
- record the owning test and connection-creation stack for actionable diagnostics
- distinguish genuinely leaked handles from already-closed workers finishing an older aiosqlite polling tick
- close the dashboard read-only connection if cancellation lands during connection initialization
- preserve original missing/unreadable database errors when cleanup itself cannot run

## Root cause
The dashboard broker could be cancelled after aiosqlite started its worker but before the awaited handle was assigned to ReadOnlyDatabase._db. Shutdown then had no handle to close, leaving a non-daemon worker alive.

## Verification
- focused lifecycle/leak regressions: 5 passed
- python -m pytest -q: 2105 passed, 5 skipped, with no reaper output
- focused Ruff: clean
- git diff --check: clean

The existing FastAPI/httpx deprecation warning is unchanged and out of scope.