### PR TITLE
Block unapproved dependency audit findings

### DIFF
--- a/.github/dependency-audit-policy.json
+++ b/.github/dependency-audit-policy.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "exceptions": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,12 @@ jobs:
           uv export --frozen --extra kalshi --extra ibkr --extra web
           --no-hashes --output-file requirements-audit.txt
 
-      # ADVISORY, never blocking. This verdict depends on an external advisory
-      # feed, so a HIGH published against any locked package would otherwise
-      # turn every open PR red with no code change — the same failure mode as
-      # the unpinned ruff that broke every PR when 0.16.0 shipped. pip-audit
-      # itself is pinned for that same reason.
-      - name: Audit locked Python dependencies
-        continue-on-error: true
-        run: uvx pip-audit==2.10.1 -r requirements-audit.txt
+      - name: Generate Python dependency audit
+        shell: bash
+        run: |
+          uvx pip-audit==2.10.1 -r requirements-audit.txt \
+            --format=json --output=python-audit.json || true
+          test -s python-audit.json
 
       - uses: actions/setup-node@v7
         with:
@@ -42,10 +40,23 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
-      - name: Audit web dependencies
-        continue-on-error: true
+      - name: Generate web dependency audit
         working-directory: web
-        run: npm audit --audit-level=high
+        shell: bash
+        run: |
+          npm audit --json > npm-audit.json || true
+          test -s npm-audit.json
+
+      # Scanner exit code 1 means findings exist, so generation above captures
+      # JSON and this deterministic policy step owns the blocking verdict.
+      # Exceptions require an advisory ID, owner, reason, and future expiry.
+      - name: Enforce dependency audit policy
+        run: >
+          python scripts/check_dependency_audit.py
+          --policy .github/dependency-audit-policy.json
+          --pip-report python-audit.json
+          --npm-report web/npm-audit.json
+          --npm-min-severity high
 
   safety-tests:
     name: Safety gate tests

--- a/docs/dependency-audit-policy.md
+++ b/docs/dependency-audit-policy.md
@@ -1,0 +1,35 @@
+# Dependency audit policy
+
+CI audits the locked Python runtime set and the web lockfile. Findings are
+blocking unless they match an entry in
+`.github/dependency-audit-policy.json`.
+
+Prefer upgrading or removing the dependency. An exception is a temporary
+risk acceptance and must contain:
+
+- `ecosystem`: `pypi` or `npm`
+- `package`: normalized package name
+- `advisory`: the exact advisory identity printed by the policy check
+- `expires`: ISO date after which CI fails until the exception is removed or
+  renewed
+- `owner`: person or team responsible for remediation
+- `reason`: concrete upgrade blocker and compensating control
+
+Example:
+
+```json
+{
+  "ecosystem": "npm",
+  "package": "example-package",
+  "advisory": "GHSA-abcd-1234-5678",
+  "expires": "2026-09-01",
+  "owner": "repository-maintainers",
+  "reason": "Patched release breaks the production bundler; input is not user-controlled."
+}
+```
+
+Expired or malformed exceptions fail CI even when the advisory has
+disappeared. Unused current exceptions produce a warning so they can be
+removed. npm findings below `high` remain visible in the JSON report but do
+not block; all pip-audit findings block because that report does not expose a
+stable severity field.

--- a/scripts/check_dependency_audit.py
+++ b/scripts/check_dependency_audit.py
@@ -1,0 +1,166 @@
+"""Enforce dependency-audit findings against explicit, expiring exceptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+_SEVERITY = {"info": 0, "low": 1, "moderate": 2, "medium": 2, "high": 3, "critical": 4}
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    ecosystem: str
+    package: str
+    advisory: str
+    severity: str = ""
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: unreadable audit JSON: {exc}") from exc
+
+
+def pip_findings(report: object) -> set[Finding]:
+    if isinstance(report, dict):
+        dependencies = report.get("dependencies")
+    else:
+        dependencies = report
+    if not isinstance(dependencies, list):
+        raise ValueError("pip-audit report must contain a dependencies list")
+    findings: set[Finding] = set()
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            raise ValueError("pip-audit dependency entries must be objects")
+        package = str(dependency.get("name", "")).lower()
+        vulns = dependency.get("vulns", [])
+        if not package or not isinstance(vulns, list):
+            raise ValueError("pip-audit dependency is missing name/vulns")
+        for vulnerability in vulns:
+            if not isinstance(vulnerability, dict) or not vulnerability.get("id"):
+                raise ValueError(f"pip-audit vulnerability for {package} has no id")
+            findings.add(Finding("pypi", package, str(vulnerability["id"])))
+    return findings
+
+
+def _npm_advisory(via: object, package: str) -> str:
+    if isinstance(via, str):
+        return f"dependency:{via}"
+    if not isinstance(via, dict):
+        raise ValueError(f"npm vulnerability for {package} has malformed via entry")
+    url = str(via.get("url", "")).rstrip("/")
+    if url:
+        return url.rsplit("/", 1)[-1]
+    if via.get("source") is not None:
+        return f"source:{via['source']}"
+    raise ValueError(f"npm vulnerability for {package} has no advisory identity")
+
+
+def npm_findings(report: object, min_severity: str = "high") -> set[Finding]:
+    if not isinstance(report, dict) or not isinstance(report.get("vulnerabilities"), dict):
+        raise ValueError("npm audit report must contain a vulnerabilities object")
+    if min_severity not in _SEVERITY:
+        raise ValueError(f"unknown npm severity threshold: {min_severity}")
+    findings: set[Finding] = set()
+    for key, vulnerability in report["vulnerabilities"].items():
+        if not isinstance(vulnerability, dict):
+            raise ValueError(f"npm vulnerability {key} must be an object")
+        package = str(vulnerability.get("name") or key).lower()
+        severity = str(vulnerability.get("severity", "")).lower()
+        if severity not in _SEVERITY:
+            raise ValueError(f"npm vulnerability for {package} has unknown severity {severity!r}")
+        if _SEVERITY[severity] < _SEVERITY[min_severity]:
+            continue
+        via = vulnerability.get("via", [])
+        if not isinstance(via, list):
+            raise ValueError(f"npm vulnerability for {package} has malformed via")
+        for advisory in via or [f"package:{package}"]:
+            findings.add(Finding(
+                "npm", package, _npm_advisory(advisory, package), severity))
+    return findings
+
+
+def policy_exceptions(policy: object, today: date) -> dict[tuple[str, str, str], dict]:
+    if not isinstance(policy, dict) or policy.get("version") != 1:
+        raise ValueError("policy must be an object with version 1")
+    exceptions = policy.get("exceptions")
+    if not isinstance(exceptions, list):
+        raise ValueError("policy exceptions must be a list")
+    approved: dict[tuple[str, str, str], dict] = {}
+    required = {"ecosystem", "package", "advisory", "expires", "owner", "reason"}
+    for item in exceptions:
+        if not isinstance(item, dict) or not required.issubset(item):
+            raise ValueError(f"policy exception must contain {sorted(required)}")
+        key = (
+            str(item["ecosystem"]).lower(),
+            str(item["package"]).lower(),
+            str(item["advisory"]),
+        )
+        if key in approved:
+            raise ValueError(f"duplicate policy exception: {key}")
+        try:
+            expires = date.fromisoformat(str(item["expires"]))
+        except ValueError as exc:
+            raise ValueError(f"invalid expiry for {key}: {item['expires']}") from exc
+        if expires < today:
+            raise ValueError(f"expired policy exception: {key} expired {expires}")
+        if not str(item["owner"]).strip() or not str(item["reason"]).strip():
+            raise ValueError(f"policy exception lacks owner/reason: {key}")
+        approved[key] = item
+    return approved
+
+
+def evaluate(
+    policy: object,
+    findings: set[Finding],
+    *,
+    today: date | None = None,
+) -> tuple[list[Finding], list[tuple[str, str, str]]]:
+    approved = policy_exceptions(policy, today or date.today())
+    finding_keys = {(f.ecosystem, f.package, f.advisory) for f in findings}
+    unapproved = sorted(f for f in findings if (
+        f.ecosystem, f.package, f.advisory) not in approved)
+    unused = sorted(key for key in approved if key not in finding_keys)
+    return unapproved, unused
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--pip-report", type=Path, required=True)
+    parser.add_argument("--npm-report", type=Path, required=True)
+    parser.add_argument("--npm-min-severity", default="high")
+    args = parser.parse_args(argv)
+    try:
+        policy = _load_json(args.policy)
+        findings = pip_findings(_load_json(args.pip_report))
+        findings |= npm_findings(
+            _load_json(args.npm_report), args.npm_min_severity)
+        unapproved, unused = evaluate(policy, findings)
+    except ValueError as exc:
+        print(f"dependency audit policy error: {exc}", file=sys.stderr)
+        return 2
+    for key in unused:
+        print(f"warning: unused dependency exception: {key}", file=sys.stderr)
+    if unapproved:
+        print("unapproved dependency vulnerabilities:", file=sys.stderr)
+        for finding in unapproved:
+            suffix = f" ({finding.severity})" if finding.severity else ""
+            print(
+                f"  {finding.ecosystem}:{finding.package}:"
+                f"{finding.advisory}{suffix}",
+                file=sys.stderr,
+            )
+        return 1
+    print(f"dependency audit policy passed ({len(findings)} finding(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dependency_audit_policy.py
+++ b/tests/test_dependency_audit_policy.py
@@ -1,0 +1,83 @@
+from datetime import date
+
+import pytest
+
+from scripts.check_dependency_audit import (
+    Finding,
+    evaluate,
+    npm_findings,
+    pip_findings,
+    policy_exceptions,
+)
+
+
+def _policy(*exceptions):
+    return {"version": 1, "exceptions": list(exceptions)}
+
+
+def _exception(**overrides):
+    item = {
+        "ecosystem": "pypi",
+        "package": "demo",
+        "advisory": "GHSA-demo",
+        "expires": "2026-09-01",
+        "owner": "repository-maintainers",
+        "reason": "Upgrade is blocked by an upstream compatibility issue.",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_pip_report_extracts_advisory_identity():
+    report = {"dependencies": [
+        {"name": "Demo", "version": "1", "vulns": [{"id": "GHSA-demo"}]},
+        {"name": "clean", "version": "2", "vulns": []},
+    ]}
+    assert pip_findings(report) == {Finding("pypi", "demo", "GHSA-demo")}
+
+
+def test_npm_report_filters_below_threshold_and_extracts_url_id():
+    report = {"vulnerabilities": {
+        "direct": {
+            "name": "Direct", "severity": "high",
+            "via": [{"url": "https://github.com/advisories/GHSA-node"}],
+        },
+        "low": {"name": "low", "severity": "low", "via": ["transitive"]},
+    }}
+    assert npm_findings(report) == {
+        Finding("npm", "direct", "GHSA-node", "high")}
+
+
+def test_unapproved_finding_fails_policy():
+    finding = Finding("pypi", "demo", "GHSA-demo")
+    unapproved, unused = evaluate(_policy(), {finding}, today=date(2026, 8, 5))
+    assert unapproved == [finding]
+    assert unused == []
+
+
+def test_current_owned_exception_approves_exact_finding():
+    finding = Finding("pypi", "demo", "GHSA-demo")
+    unapproved, unused = evaluate(
+        _policy(_exception()), {finding}, today=date(2026, 8, 5))
+    assert unapproved == []
+    assert unused == []
+
+
+def test_expired_exception_is_configuration_error():
+    with pytest.raises(ValueError, match="expired policy exception"):
+        policy_exceptions(
+            _policy(_exception(expires="2026-08-04")), date(2026, 8, 5))
+
+
+@pytest.mark.parametrize("field", ["owner", "reason"])
+def test_exception_requires_accountability_fields(field):
+    with pytest.raises(ValueError, match="lacks owner/reason"):
+        policy_exceptions(
+            _policy(_exception(**{field: ""})), date(2026, 8, 5))
+
+
+def test_unused_exception_is_reported_for_cleanup():
+    unapproved, unused = evaluate(
+        _policy(_exception()), set(), today=date(2026, 8, 5))
+    assert unapproved == []
+    assert unused == [("pypi", "demo", "GHSA-demo")]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- replace advisory-only pip/npm audit steps with JSON report generation plus a blocking policy verdict
- require exact advisory identity, owner, reason, and future expiry for every exception
- fail on malformed reports/policies, unapproved findings, and expired exceptions
- keep npm's blocking threshold at high while treating all pip-audit findings as blocking
- document the exception workflow and cover both report formats/policy states
- upgrade brace-expansion 5.0.8 -> 5.0.9 to fix the current high-severity GHSA-rgw5-rvv9-x895 finding rather than excepting it

## Verification
- real pip-audit 2.10.1: no known vulnerabilities
- real npm audit after lock update: 0 vulnerabilities
- policy tests: 8 passed
- full Python suite: 2118 passed, 5 skipped
- web: 14 tests passed, build passed, ESLint passed
- Ruff, workflow YAML, policy JSON, and diff checks: clean

## Policy posture
The initial exception list is empty. New findings fail CI unless remediated or explicitly accepted with accountable, expiring metadata.