### PR TITLE
Bound concurrent paper experiments

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1147,8 +1147,12 @@ settlement_arb:
   # is ALREADY PUBLISHED and deterministically satisfies/fails the criterion, and
   # the market hasn't repriced (the lag is the edge). No forecasting; the LLM only
   # extracts the predicate (adversarially verified, cached). PAPER-FORCED, own
-  # graduation cell. DEFAULT OFF — flip enabled:true to start the 2-week spike.
-  enabled: true      # spike STARTED 2026-06-26 — 2wk paper measurement
+  # graduation cell. The spike ran 2026-06-26 through its preregistered
+  # 2-week endpoint (2026-07-10). WOUND DOWN 2026-08-05 pending adjudication:
+  # historical evidence remains intact, but an expired clock cannot keep
+  # consuming candidates and operator attention indefinitely. Re-enable only
+  # as a new, dated trial after recording the prior verdict.
+  enabled: false
   paper: true
   stake_usd: 10.0
   min_edge: 0.05
@@ -1235,7 +1239,9 @@ resolution_lens:
   # now (empty descriptions -> rules-text fix; long-dated-only discovery ->
   # close-window merge; 300 floor vs underreporting bulk liquidity field ->
   # 50, matching cross_venue). Don't judge the pre-07-03 silence.
-  kalshi_enabled: true
+  # WOUND DOWN 2026-08-05: the restarted two-week clock ended 2026-07-17.
+  # Keep the Polymarket family running; this only stops the expired Kalshi arm.
+  kalshi_enabled: false
   kalshi_min_liquidity: 50.0
   min_gap_score: 0.4       # lens-judged headline/criteria divergence floor
   high_conf_gap_score: 0.7 # >= this -> HIGH confidence (clears divergence filter)
@@ -1377,3 +1383,12 @@ benchmark:
   # Polymarket $1,180 equity + IBKR ~$795 + Kalshi $221 + Kraken ~$145.
   # Set to 0 to suppress the percentage comparison rather than guess.
   book_capital_usd: 2340.0
+
+# An experiment is not free because its orders are paper: every active family
+# consumes candidate flow, API budget, monitoring surface, and an eventual
+# human adjudication. Families (not model arms) consume one slot because arms
+# share a hypothesis, runtime, and review. Current tracked defaults use 11/12;
+# starting a trial beyond the one free slot fails Settings validation until an
+# existing trial is wound down. See docs/experiment-capacity.md.
+experiment_capacity:
+  max_concurrent_paper_trials: 12

--- a/config/settings.py
+++ b/config/settings.py
@@ -2144,6 +2144,30 @@ class BenchmarkConfig(BaseModel):
     book_capital_usd: float = 0.0
 
 
+class ExperimentCapacityConfig(BaseModel):
+    """Operator-attention budget for concurrent paper strategy families."""
+
+    max_concurrent_paper_trials: int = Field(default=12, ge=1, le=20)
+
+
+_PAPER_TRIAL_SECTIONS = (
+    "entailment_arb",
+    "cross_venue_arb",
+    "econ_indicator",
+    "long_horizon",
+    "agent_trader",
+    "term_structure",
+    "vol_anchor",
+    "informed_flow",
+    "settlement_arb",
+    "weather_temp",
+    "oddlot_tender",
+    "resolution_lens",
+    "bias_harvest",
+    "platform_consensus",
+)
+
+
 class Settings(BaseSettings):
     # API Keys
     anthropic_api_key_primary: str = Field(default="", repr=False, exclude=True)
@@ -2280,6 +2304,28 @@ class Settings(BaseSettings):
     logging: LoggingConfig = Field(default_factory=lambda: LoggingConfig(**_DEFAULTS.get("logging", {})))
     monitoring: MonitoringConfig = Field(default_factory=lambda: MonitoringConfig(**_DEFAULTS.get("monitoring", {})))
     benchmark: BenchmarkConfig = Field(default_factory=lambda: BenchmarkConfig(**_DEFAULTS.get("benchmark", {})))
+    experiment_capacity: ExperimentCapacityConfig = Field(
+        default_factory=lambda: ExperimentCapacityConfig(
+            **_DEFAULTS.get("experiment_capacity", {})))
+
+    @property
+    def active_paper_trials(self) -> tuple[str, ...]:
+        """Enabled paper strategy families consuming operator review capacity."""
+        return tuple(
+            name for name in _PAPER_TRIAL_SECTIONS
+            if getattr(self, name).enabled and getattr(self, name).paper
+        )
+
+    @model_validator(mode="after")
+    def enforce_experiment_capacity(self):
+        active = self.active_paper_trials
+        limit = self.experiment_capacity.max_concurrent_paper_trials
+        if len(active) > limit:
+            raise ValueError(
+                f"{len(active)} concurrent paper trials exceed capacity {limit}: "
+                + ", ".join(active)
+            )
+        return self
 
     # Resolve .env to an absolute path anchored at the repo root so Settings
     # loads the same secrets regardless of the caller's CWD. A bare ".env"

--- a/docs/experiment-capacity.md
+++ b/docs/experiment-capacity.md
@@ -1,0 +1,32 @@
+# Experiment capacity and wind-down policy
+
+Paper trading protects capital, not attention. Each enabled paper strategy
+family consumes candidate flow, API or data-source budget, monitoring surface,
+and a future adjudication. Auramaur therefore caps concurrent paper strategy
+families at 12. The tracked configuration currently uses 11 slots.
+
+A family consumes one slot when both `enabled` and `paper` are true. Model or
+venue arms inside one family share its hypothesis, runtime, and review, so they
+do not consume separate slots. Read-only monitors and structurally live services
+are outside this count. `Settings.active_paper_trials` is the canonical
+inventory; startup fails closed if it exceeds
+`experiment_capacity.max_concurrent_paper_trials`.
+
+Every new trial must record, next to its enable flag:
+
+- a start date and a review date or observable sample threshold;
+- success and rejection criteria;
+- the safe wind-down lever; and
+- the condition under which a follow-up trial may be started.
+
+At the review date, stop new observations first. Existing positions continue
+through their normal exit/settlement path and historical registrations and
+ledger rows remain untouched. Record the verdict before re-enabling; a changed
+hypothesis or implementation begins a new dated trial and evidence lineage.
+
+## 2026-08-05 capacity release
+
+Two arms had continued past their preregistered two-week clocks. New collection
+is now disabled for `settlement_arb` (clock ended 2026-07-10) and the Kalshi arm
+of `resolution_lens` (clock ended 2026-07-17). This is a lifecycle action, not
+an inferred performance verdict: their evidence is retained for adjudication.

--- a/tests/test_experiment_capacity.py
+++ b/tests/test_experiment_capacity.py
@@ -1,0 +1,33 @@
+"""Experiment portfolio capacity and time-box retirement guards."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from config.settings import Settings
+
+
+def test_tracked_defaults_leave_one_experiment_slot():
+    settings = Settings()
+
+    assert len(settings.active_paper_trials) == 11
+    assert settings.experiment_capacity.max_concurrent_paper_trials == 12
+    assert "settlement_arb" not in settings.active_paper_trials
+
+
+def test_starting_trials_over_capacity_fails_closed():
+    with pytest.raises(ValidationError, match="concurrent paper trials exceed capacity"):
+        Settings(
+            weather_temp={"enabled": True},
+            econ_indicator={"enabled": True},
+        )
+
+
+def test_expired_spikes_are_explicitly_wound_down():
+    with open("config/defaults.yaml", encoding="utf-8") as stream:
+        defaults = yaml.safe_load(stream)
+
+    assert defaults["settlement_arb"]["enabled"] is False
+    assert defaults["resolution_lens"]["kalshi_enabled"] is False


### PR DESCRIPTION
Winds down settlement_arb and the Kalshi resolution_lens arm after their preregistered two-week clocks expired, while preserving historical evidence and normal position exits. Adds a fail-closed 12-family paper-experiment capacity limit; tracked defaults now use 11 slots. Documents start/review/wind-down requirements and adds regression tests. Verified: 2123 passed, 5 skipped; 35 focused settings tests passed; Ruff and diff checks clean.