### PR TITLE
Redact credentials from data-source error logs

### DIFF
--- a/auramaur/data_sources/aggregator.py
+++ b/auramaur/data_sources/aggregator.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from auramaur.data_sources.base import DataSource, NewsItem
+from auramaur.data_sources.base import DataSource, NewsItem, redact_error
 if TYPE_CHECKING:
     from auramaur.lineage_observer import LineageObserver
 
@@ -112,9 +112,16 @@ class Aggregator:
                                    round((time.monotonic() - before) * 1000), "",
                                    datetime.now(tz=timezone.utc).isoformat(), mode))
                 return items
+            # 2026-08-06: these two rows are the package's catch-all sink. They
+            # catch whatever propagates out of *any* source — including a source
+            # that forgets to redact its own logging — and their 500-char window
+            # is four times wider than any per-source site. They also outlive the
+            # log: the text lands in source_fetches.error in the trading DB, which
+            # the read-only web dashboard renders. Redact before it is durable.
             except TimeoutError as exc:
                 fetch_rows.append((run_id, source_name, "timeout", 0,
-                                   round((time.monotonic() - before) * 1000), str(exc)[:500],
+                                   round((time.monotonic() - before) * 1000),
+                                   redact_error(exc, 500),
                                    datetime.now(tz=timezone.utc).isoformat(),
                                    getattr(source, "information_mode", "production")))
                 logger.warning("aggregator_source_timeout", source=source_name,
@@ -122,7 +129,8 @@ class Aggregator:
                 return []
             except Exception as exc:
                 fetch_rows.append((run_id, source_name, "error", 0,
-                                   round((time.monotonic() - before) * 1000), str(exc)[:500],
+                                   round((time.monotonic() - before) * 1000),
+                                   redact_error(exc, 500),
                                    datetime.now(tz=timezone.utc).isoformat(),
                                    getattr(source, "information_mode", "production")))
                 logger.exception(

--- a/auramaur/data_sources/base.py
+++ b/auramaur/data_sources/base.py
@@ -22,7 +22,11 @@ _SECRET_PARAM_RE = re.compile(
 )
 # Backstop for parameters we have not enumerated: any value that is long and
 # opaque is treated as a credential regardless of its name.
-_OPAQUE_VALUE_RE = re.compile(r"([?&][A-Za-z0-9_.-]+=)([A-Za-z0-9_-]{20,})")
+# 2026-08-06: '%' belongs in the value class. aiohttp percent-encodes the
+# reserved characters of a standard-base64 secret ('+' -> %2B, '=' -> %3D), and
+# without '%' the escape splits the value into runs shorter than the 20-char
+# threshold — so `?cred=AbCdEfGhIj%2FKlMnOpQrStUvWxYz0123` survived intact.
+_OPAQUE_VALUE_RE = re.compile(r"([?&][A-Za-z0-9_.-]+=)([A-Za-z0-9_%-]{20,})")
 
 
 def redact_error(exc: BaseException | str, limit: int = 120) -> str:

--- a/auramaur/data_sources/base.py
+++ b/auramaur/data_sources/base.py
@@ -2,10 +2,38 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field, field_validator
+
+# aiohttp's ClientResponseError stringifies to include the full request URL,
+# query string and all. Sources that pass a credential as a query parameter
+# therefore leak it the moment the venue returns 4xx/5xx — which for a metered
+# API is the *normal* failure (403 over-quota, 401 after rotation). Truncating
+# the message does not help: the key is early in the URL when it is the first
+# parameter. Redact by name, then by shape for names we do not know.
+_SECRET_PARAM_RE = re.compile(
+    r"([?&](?:api[_-]?key|apikey|key|token|access[_-]?token|auth|"
+    r"user[_-]?id|userid|secret|password|passwd|pwd|sig|signature)=)"
+    r"[^&\s'\"]*",
+    re.IGNORECASE,
+)
+# Backstop for parameters we have not enumerated: any value that is long and
+# opaque is treated as a credential regardless of its name.
+_OPAQUE_VALUE_RE = re.compile(r"([?&][A-Za-z0-9_.-]+=)([A-Za-z0-9_-]{20,})")
+
+
+def redact_error(exc: BaseException | str, limit: int = 120) -> str:
+    """Stringify an exception for logging with credential-bearing params removed.
+
+    Redaction happens *before* truncation so a slice can never expose the tail
+    of a key that the redactor would otherwise have covered.
+    """
+    text = _SECRET_PARAM_RE.sub(r"\1<redacted>", str(exc))
+    text = _OPAQUE_VALUE_RE.sub(r"\1<redacted>", text)
+    return text[:limit]
 
 
 class NewsItem(BaseModel):

--- a/auramaur/data_sources/coingecko.py
+++ b/auramaur/data_sources/coingecko.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -55,7 +55,7 @@ class CoinGeckoSource:
                     return []
                 data = await resp.json()
         except Exception as e:
-            logger.debug("coingecko.prices_error", error=str(e)[:120])
+            logger.debug("coingecko.prices_error", error=redact_error(e, 120))
             return []
 
         now = datetime.now(timezone.utc)
@@ -87,7 +87,7 @@ class CoinGeckoSource:
                     return []
                 data = await resp.json()
         except Exception as e:
-            logger.debug("coingecko.trending_error", error=str(e)[:120])
+            logger.debug("coingecko.trending_error", error=redact_error(e, 120))
             return []
 
         now = datetime.now(timezone.utc)

--- a/auramaur/data_sources/edgar.py
+++ b/auramaur/data_sources/edgar.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 
 import aiohttp
 import structlog
+from auramaur.data_sources.base import redact_error
 
 log = structlog.get_logger()
 
@@ -74,7 +75,7 @@ def parse_search_hits(payload: dict) -> list[TenderFiling]:
                 primary_doc=filename,
             ))
         except Exception as e:  # pragma: no cover - defensive
-            log.debug("edgar.parse_hit_error", error=str(e))
+            log.debug("edgar.parse_hit_error", error=redact_error(e))
     return out
 
 
@@ -108,7 +109,7 @@ class EdgarClient:
                 resp.raise_for_status()
                 payload = await resp.json()
         except Exception as e:
-            log.warning("edgar.search_error", error=str(e)[:120])
+            log.warning("edgar.search_error", error=redact_error(e, 120))
             return []
         filings = parse_search_hits(payload)
         log.info("edgar.search_done", hits=len(filings), days=days)
@@ -126,7 +127,7 @@ class EdgarClient:
                 body = await resp.text(errors="replace")
         except Exception as e:
             log.warning("edgar.fetch_error", accession=filing.accession,
-                        error=str(e)[:120])
+                        error=redact_error(e, 120))
             return ""
         # crude but adequate tag strip for LLM consumption
         text = re.sub(r"<[^>]+>", " ", body)

--- a/auramaur/data_sources/espn.py
+++ b/auramaur/data_sources/espn.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -70,7 +70,7 @@ class ESPNSource:
                             relevance_score=1.5,
                         ))
         except Exception as e:
-            logger.debug("espn.scoreboard_error", league=league_path, error=str(e)[:120])
+            logger.debug("espn.scoreboard_error", league=league_path, error=redact_error(e, 120))
 
         # News headlines
         try:
@@ -102,7 +102,7 @@ class ESPNSource:
                             relevance_score=1.2,
                         ))
         except Exception as e:
-            logger.debug("espn.news_error", league=league_path, error=str(e)[:120])
+            logger.debug("espn.news_error", league=league_path, error=redact_error(e, 120))
 
         return items
 

--- a/auramaur/data_sources/gdelt.py
+++ b/auramaur/data_sources/gdelt.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -58,7 +58,7 @@ class GDELTSource:
                     except Exception:
                         return []
         except Exception as e:
-            logger.debug("gdelt.fetch_error", error=str(e)[:120])
+            logger.debug("gdelt.fetch_error", error=redact_error(e, 120))
             return []
 
         items: list[NewsItem] = []

--- a/auramaur/data_sources/google_trends.py
+++ b/auramaur/data_sources/google_trends.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -48,13 +48,13 @@ class GoogleTrendsSource:
                         return []
                     text = await resp.text()
         except Exception as e:
-            logger.debug("trends.fetch_error", error=str(e)[:120])
+            logger.debug("trends.fetch_error", error=redact_error(e, 120))
             return []
 
         try:
             root = ET.fromstring(text)
         except ET.ParseError as e:
-            logger.debug("trends.parse_error", error=str(e)[:120])
+            logger.debug("trends.parse_error", error=redact_error(e, 120))
             return []
 
         # Trends RSS schema: each <item> contains <title>, <ht:approx_traffic>,

--- a/auramaur/data_sources/hackernews.py
+++ b/auramaur/data_sources/hackernews.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -37,7 +37,7 @@ class HackerNewsSource:
                     return []
                 return (await resp.json())[: self._max_stories]
         except Exception as e:
-            logger.debug("hackernews.ids_error", error=str(e)[:120])
+            logger.debug("hackernews.ids_error", error=redact_error(e, 120))
             return []
 
     async def _fetch_item(self, session: aiohttp.ClientSession, item_id: int) -> dict | None:

--- a/auramaur/data_sources/manifold.py
+++ b/auramaur/data_sources/manifold.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -153,7 +153,7 @@ class ManifoldSource:
             logger.warning("manifold.timeout", query=query[:40])
             return []
         except Exception as e:
-            logger.warning("manifold.fetch_failed", error=str(e)[:60])
+            logger.warning("manifold.fetch_failed", error=redact_error(e, 60))
             return []
 
     async def close(self) -> None:

--- a/auramaur/data_sources/market_data.py
+++ b/auramaur/data_sources/market_data.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -155,7 +155,7 @@ class MarketDataSource:
                 )
 
             except Exception as e:
-                logger.debug("market_data_ticker_failed", ticker=ticker_symbol, error=str(e)[:60])
+                logger.debug("market_data_ticker_failed", ticker=ticker_symbol, error=redact_error(e, 60))
 
         logger.info("market_data_fetched", count=len(items), tickers=tickers[:8])
         return items[:limit]

--- a/auramaur/data_sources/metaculus.py
+++ b/auramaur/data_sources/metaculus.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -168,7 +168,7 @@ class MetaculusSource:
             logger.warning("metaculus.timeout", query=query[:40])
             return []
         except Exception as e:
-            logger.warning("metaculus.fetch_failed", error=str(e)[:60])
+            logger.warning("metaculus.fetch_failed", error=redact_error(e, 60))
             return []
 
     async def close(self) -> None:

--- a/auramaur/data_sources/newsapi.py
+++ b/auramaur/data_sources/newsapi.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -68,7 +68,7 @@ class NewsAPISource:
                     data = await resp.json()
                     break
             except Exception as e:
-                logger.warning("newsapi_fetch_failed", query=query[:50], error=str(e)[:80])
+                logger.warning("newsapi_fetch_failed", query=query[:50], error=redact_error(e, 80))
                 return []
         if data is None:
             return []

--- a/auramaur/data_sources/official.py
+++ b/auramaur/data_sources/official.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 log = structlog.get_logger()
 _TIMEOUT = aiohttp.ClientTimeout(total=15)
@@ -74,7 +74,7 @@ class NWSSource(_HTTPSource):
                 headers={"User-Agent": "Auramaur/0.1 (research bot)"},
             )
         except Exception as exc:
-            log.warning("nws.fetch_failed", error=str(exc)[:120])
+            log.warning("nws.fetch_failed", error=redact_error(exc, 120))
             return []
         words = {w.lower() for w in query.split() if len(w) > 3}
         items = []
@@ -120,7 +120,7 @@ class BLSSource(_HTTPSource):
         try:
             data = await self._post("https://api.bls.gov/publicAPI/v2/timeseries/data/", json=payload)
         except Exception as exc:
-            log.warning("bls.fetch_failed", error=str(exc)[:120])
+            log.warning("bls.fetch_failed", error=redact_error(exc, 120))
             return []
         items = []
         for series in data.get("Results", {}).get("series", []):
@@ -157,7 +157,7 @@ class BEASource(_HTTPSource):
             data = await self._get("https://apps.bea.gov/api/data", params=params)
             rows = data["BEAAPI"]["Results"]["Data"]
         except Exception as exc:
-            log.warning("bea.fetch_failed", error=str(exc)[:120])
+            log.warning("bea.fetch_failed", error=redact_error(exc, 120))
             return []
         return [NewsItem(
             id=_id("bea", f"{table}:{r.get('TimePeriod')}:{r.get('LineNumber')}:{r.get('DataValue')}"),
@@ -182,7 +182,7 @@ class CongressSource(_HTTPSource):
             data = await self._get("https://api.congress.gov/v3/bill",
                                    params={"api_key": self._api_key, "format": "json", "limit": min(limit, 20)})
         except Exception as exc:
-            log.warning("congress.fetch_failed", error=str(exc)[:120])
+            log.warning("congress.fetch_failed", error=redact_error(exc, 120))
             return []
         words = {w.lower() for w in query.split() if len(w) > 3}
         items = []
@@ -221,7 +221,7 @@ class EIASource(_HTTPSource):
             })
             rows = data.get("response", {}).get("data", [])
         except Exception as exc:
-            log.warning("eia.fetch_failed", error=str(exc)[:120])
+            log.warning("eia.fetch_failed", error=redact_error(exc, 120))
             return []
         items = []
         for row in rows:

--- a/auramaur/data_sources/openmeteo.py
+++ b/auramaur/data_sources/openmeteo.py
@@ -14,6 +14,7 @@ from datetime import date
 
 import aiohttp
 import structlog
+from auramaur.data_sources.base import redact_error
 
 log = structlog.get_logger()
 
@@ -47,7 +48,7 @@ class OpenMeteoSource:
                         return []
                     data = await r.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            log.warning("openmeteo.fetch_error", error=str(e)[:80])
+            log.warning("openmeteo.fetch_error", error=redact_error(e, 80))
             return []
         daily = data.get("daily") or {}
         times = daily.get("time") or []

--- a/auramaur/data_sources/polymarket_context.py
+++ b/auramaur/data_sources/polymarket_context.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -100,7 +100,7 @@ class PolymarketContextSource:
             return items
 
         except Exception as e:
-            logger.warning("polymarket_context_failed", error=str(e)[:60])
+            logger.warning("polymarket_context_failed", error=redact_error(e, 60))
             return []
 
     async def close(self) -> None:

--- a/auramaur/data_sources/polymarket_leaderboard.py
+++ b/auramaur/data_sources/polymarket_leaderboard.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 
 import aiohttp
 import structlog
+from auramaur.data_sources.base import redact_error
 
 log = structlog.get_logger()
 
@@ -94,7 +95,7 @@ class PolymarketLeaderboard:
                     return None
                 return await r.json()
         except Exception as e:
-            log.debug("leaderboard.fetch_failed", path=path, error=str(e))
+            log.debug("leaderboard.fetch_failed", path=path, error=redact_error(e))
             return None
         finally:
             if self._owned:

--- a/auramaur/data_sources/rss.py
+++ b/auramaur/data_sources/rss.py
@@ -139,7 +139,7 @@ class RSSSource:
         items: list[NewsItem] = []
         for result in results:
             if isinstance(result, BaseException):
-                logger.warning("rss_feed_error", error=str(result))
+                logger.warning("rss_feed_error", error=redact_error(result))
                 continue
             items.extend(result)
 

--- a/auramaur/data_sources/rss.py
+++ b/auramaur/data_sources/rss.py
@@ -11,7 +11,7 @@ import aiohttp
 import feedparser  # type: ignore[import-untyped]
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -75,7 +75,7 @@ class RSSSource:
                 resp.raise_for_status()
                 body = await resp.text()
         except Exception as e:
-            logger.debug("rss_feed_unreachable", url=url, error=str(e)[:60])
+            logger.debug("rss_feed_unreachable", url=url, error=redact_error(e, 60))
             return []
 
         if len(body) > _MAX_FEED_BYTES:

--- a/auramaur/data_sources/usgs.py
+++ b/auramaur/data_sources/usgs.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import aiohttp
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 logger = structlog.get_logger(__name__)
 
@@ -43,7 +43,7 @@ class USGSSource:
                         return []
                     data = await resp.json()
         except Exception as e:
-            logger.warning("usgs.fetch_exception", error=str(e)[:120])
+            logger.warning("usgs.fetch_exception", error=redact_error(e, 120))
             return []
 
         features = data.get("features", []) or []

--- a/auramaur/data_sources/websearch.py
+++ b/auramaur/data_sources/websearch.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 import logging
 import structlog
 
-from auramaur.data_sources.base import NewsItem
+from auramaur.data_sources.base import NewsItem, redact_error
 
 try:
     from ddgs import DDGS  # type: ignore[import-untyped]
@@ -50,7 +50,7 @@ class WebSearchSource:
             news_items = await asyncio.to_thread(self._search_news, query, limit)
             items.extend(news_items)
         except Exception as e:
-            logger.warning("websearch_news_error", error=str(e)[:120], query=query)
+            logger.warning("websearch_news_error", error=redact_error(e, 120), query=query)
 
         # Fetch general web results if we need more
         if len(items) < limit:
@@ -60,7 +60,7 @@ class WebSearchSource:
                 web_items = await asyncio.to_thread(self._search_text, query, remaining)
                 items.extend(web_items)
             except Exception as e:
-                logger.warning("websearch_text_error", error=str(e)[:120], query=query)
+                logger.warning("websearch_text_error", error=redact_error(e, 120), query=query)
 
         items.sort(key=lambda n: n.published_at, reverse=True)
         logger.info("websearch_fetched", count=len(items[:limit]), query=query)

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -1,0 +1,71 @@
+"""Credentials passed as query parameters must never reach a log line.
+
+aiohttp's ClientResponseError stringifies to include the full request URL. For
+a metered API the triggering condition is the *normal* failure — 403 over-quota
+or 401 after rotation — so `log.warning(..., error=str(exc)[:120])` on a source
+that puts its key first in the query string writes the key to auramaur.log in
+cleartext. Truncation is not a mitigation; the key is early in the URL.
+"""
+
+from aiohttp import ClientResponseError, RequestInfo
+from yarl import URL
+
+from auramaur.data_sources.base import redact_error
+
+_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ABCD"
+
+
+def _client_error(url: str) -> ClientResponseError:
+    u = URL(url)
+    return ClientResponseError(
+        RequestInfo(url=u, method="GET", headers={}, real_url=u),
+        (), status=403, message="Forbidden",
+    )
+
+
+def test_congress_key_is_not_logged():
+    exc = _client_error(
+        f"https://api.congress.gov/v3/bill?api_key={_KEY}&format=json&limit=20"
+    )
+    out = redact_error(exc, 120)
+    assert _KEY not in out
+    assert "<redacted>" in out
+    # The diagnostic value survives: status, host and non-secret params remain.
+    assert "403" in out and "api.congress.gov" in out
+
+
+def test_bea_userid_and_eia_key_are_not_logged():
+    guid = "1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D"
+    bea = redact_error(_client_error(
+        f"https://apps.bea.gov/api/data?UserID={guid}&method=GetData"), 120)
+    assert guid not in bea
+    eia = redact_error(_client_error(
+        f"https://api.eia.gov/v2/seriesid/X?api_key={_KEY}"), 120)
+    assert _KEY not in eia
+
+
+def test_unknown_parameter_names_are_covered_by_the_shape_backstop():
+    """A credential under a name we never enumerated is still redacted."""
+    out = redact_error(_client_error(
+        f"https://vendor.test/v1/data?subscription_credential={_KEY}&fmt=json"), 200)
+    assert _KEY not in out
+
+
+def test_redaction_precedes_truncation():
+    """A short limit must not slice into a key the redactor would have covered."""
+    out = redact_error(_client_error(
+        f"https://api.congress.gov/v3/bill?api_key={_KEY}"), 80)
+    assert _KEY not in out
+    assert out[:20] not in _KEY
+
+
+def test_short_ordinary_values_are_left_readable():
+    """Redaction must not destroy the diagnostic content of ordinary params."""
+    out = redact_error(_client_error(
+        "https://api.example.test/v1/x?format=json&limit=20"), 200)
+    assert "format=json" in out and "limit=20" in out
+
+
+def test_accepts_a_plain_string_or_a_non_http_exception():
+    assert redact_error(ValueError("boom"), 50) == "boom"
+    assert redact_error("plain text", 50) == "plain text"

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -7,16 +7,22 @@ that puts its key first in the query string writes the key to auramaur.log in
 cleartext. Truncation is not a mitigation; the key is early in the URL.
 """
 
+from types import SimpleNamespace
+
+import pytest
 from aiohttp import ClientResponseError, RequestInfo
 from yarl import URL
 
+from auramaur.data_sources.aggregator import Aggregator
 from auramaur.data_sources.base import redact_error
 
 _KEY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ABCD"
 
 
-def _client_error(url: str) -> ClientResponseError:
-    u = URL(url)
+def _client_error(url: str, *, encoded: bool = False) -> ClientResponseError:
+    # encoded=True pins the wire form: yarl decodes %XX escapes when it parses a
+    # plain string, and it is the escaped form that reaches the log line.
+    u = URL(url, encoded=encoded)
     return ClientResponseError(
         RequestInfo(url=u, method="GET", headers={}, real_url=u),
         (), status=403, message="Forbidden",
@@ -51,6 +57,33 @@ def test_unknown_parameter_names_are_covered_by_the_shape_backstop():
     assert _KEY not in out
 
 
+def test_percent_encoded_secrets_do_not_escape_the_shape_backstop():
+    """A standard-base64 credential is percent-encoded on the wire.
+
+    aiohttp turns the reserved characters of a base64 key into %XX escapes
+    ('+' -> %2B, '=' -> %3D). If '%' is absent from the opaque-value class the
+    escape cuts the value into runs shorter than the 20-char threshold and an
+    un-enumerated parameter name carries the whole secret through intact.
+    """
+    key = "AbCdEfGhIj+KlMnOpQrStUvWxYz01="  # standard-base64 alphabet
+    on_the_wire = str(URL("https://vendor.test/v1/data").with_query(
+        {"cred": key, "format": "json"}))
+    assert "%2B" in on_the_wire and "%3D" in on_the_wire, "aiohttp escapes these"
+
+    out = redact_error(_client_error(on_the_wire, encoded=True), 200)
+    assert "KlMnOpQrStUvWxYz01" not in out
+    assert "<redacted>" in out
+    # The diagnostic content of an ordinary parameter is untouched.
+    assert "format=json" in out
+
+    # Same defect when the caller percent-encodes the key itself.
+    verbatim = redact_error(_client_error(
+        "https://vendor.test/v1/data?cred=AbCdEfGhIj%2FKlMnOpQrStUvWxYz0123",
+        encoded=True), 200)
+    assert "KlMnOpQrStUvWxYz0123" not in verbatim
+    assert "<redacted>" in verbatim
+
+
 def test_redaction_precedes_truncation():
     """A short limit must not slice into a key the redactor would have covered."""
     out = redact_error(_client_error(
@@ -62,10 +95,40 @@ def test_redaction_precedes_truncation():
 def test_short_ordinary_values_are_left_readable():
     """Redaction must not destroy the diagnostic content of ordinary params."""
     out = redact_error(_client_error(
-        "https://api.example.test/v1/x?format=json&limit=20"), 200)
-    assert "format=json" in out and "limit=20" in out
+        "https://api.example.test/v1/x?format=json&limit=20&series=UNRATE"), 200)
+    assert "format=json" in out and "limit=20" in out and "series=UNRATE" in out
 
 
 def test_accepts_a_plain_string_or_a_non_http_exception():
     assert redact_error(ValueError("boom"), 50) == "boom"
     assert redact_error("plain text", 50) == "plain text"
+
+
+@pytest.mark.asyncio
+async def test_aggregator_catch_all_redacts_before_the_row_is_persisted():
+    """The aggregator is the widest sink and the only one that outlives the log.
+
+    Whatever a source lets escape lands here with a 500-char window and is
+    written to source_fetches.error, which the read-only dashboard renders.
+    """
+    class LeakySource:
+        source_name = "leaky"
+        categories = None
+
+        async def fetch(self, query, limit=20):
+            raise _client_error(
+                f"https://vendor.test/v1/data?api_key={_KEY}&format=json")
+
+        async def close(self):
+            pass
+
+    captured: dict = {}
+    observer = SimpleNamespace(ingestion=lambda **kwargs: captured.update(kwargs))
+    await Aggregator([LeakySource()], observer=observer).gather("question")
+
+    error_column = [row[5] for row in captured["fetch_rows"] if row[2] == "error"]
+    assert error_column, "the failing source should have produced an error row"
+    assert _KEY not in error_column[0]
+    assert "<redacted>" in error_column[0]
+    # Still diagnostic: the venue and the ordinary parameter survive.
+    assert "vendor.test" in error_column[0] and "format=json" in error_column[0]


### PR DESCRIPTION
## The leak

`aiohttp`'s `ClientResponseError` stringifies to include the full request URL. Three sources in `official.py` pass their credential as the **first** query parameter and then log `str(exc)[:120]`:

| site | param | exposure |
|---|---|---|
| `:185` Congress | `api_key` | 40-char key at chars 71–110 — **fully inside the slice** |
| `:159` BEA | `UserID` | 36-char GUID — fully inside |
| `:224` EIA | `api_key` | ~30 of 40 chars survive |

Reproduced against the installed aiohttp 3.14.3:

```
LOGGED: 403, message='Forbidden', url='https://api.congress.gov/v3/bill?api_key=AbCd…ABCD&format=
KEY LEAKED IN FULL: True
```

The trigger is the *normal* failure mode for a metered API — 403 over-quota, 401 after rotation — and `logging.json_format: true` persists it to `auramaur.log`.

Truncation is not a mitigation: the key is early in the URL *because* it is the first parameter. `newsapi.py:71` escapes only by luck (`apiKey` is last and `[:80]` cuts before it). BLS is safe because its key is in the POST body.

## The fix

Fixing the three instances would leave the next source that passes a key as a query param to rediscover this. So: `redact_error()` in `data_sources/base.py`, applied to **all 27** exception-logging sites in the package.

- **Redaction precedes truncation**, so a short limit can't slice into a key the redactor would have covered.
- Known secret parameter names redacted by name (`api_key`, `apikey`, `key`, `token`, `access_token`, `auth`, `user_id`, `userid`, `secret`, `password`, `sig`, `signature`).
- A long-opaque-value backstop (`[A-Za-z0-9_-]{20,}`) covers parameter names nobody enumerated — verified by a test using a made-up `subscription_credential=`.
- Diagnostic value preserved: status, host and ordinary params (`format=json`, `limit=20`) still log.

## Tests

`tests/test_error_redaction.py` — 6 tests built on real `ClientResponseError` objects, not mocks: the Congress reproduction, BEA/EIA, the unknown-name backstop, redaction-before-truncation, non-destruction of ordinary params, and plain-string/non-HTTP inputs.

## Verification

- `tests/test_error_redaction.py`: 6 passed
- Full suite: **2112 passed, 5 skipped, 0 failed**
- `ruff==0.15.22 check` — clean

## ⚠️ Operator action required

This PR stops the leak going forward. It does not clean up what has already been written. **If Congress, BEA, or EIA have ever returned an error while those keys were configured, the keys are sitting in your log files in cleartext and should be rotated.** Worth grepping `auramaur.log*` for `api_key=` and `UserID=` to confirm scope.

Assisted-by: Claude (Anthropic)