### PR TITLE
Make two safety gates fail closed instead of open

### DIFF
--- a/auramaur/exchange/kraken.py
+++ b/auramaur/exchange/kraken.py
@@ -269,12 +269,23 @@ class KrakenSpotClient:
         #    any quote (USDC/USDT/EUR/…), not just USD-quoted pairs.
         cap = max_usd if max_usd is not None else self._settings.kraken.max_order_usd
         est_price = price or await self.get_price(pair)
-        if est_price:
-            notional = await self.usd_notional(pair, volume, est_price) or (volume * est_price)
-            if notional > cap:
-                return OrderResult(order_id="BLOCKED", market_id=pair, status="rejected",
-                                   is_paper=True,
-                                   error_message=f"order ${notional:.2f} exceeds cap ${cap:.2f}")
+        # Fail CLOSED when the pair cannot be priced. get_price returns None
+        # whenever _public("Ticker") yields nothing — a 5xx, a rate-limit
+        # response or a Cloudflare blip, since _public logs and returns {}
+        # rather than raising. Gating the cap check behind `if est_price:` meant
+        # a transient ticker failure removed the ceiling entirely and the order
+        # went to AddOrder unbounded. Every autonomous caller passes price=None,
+        # so the probe is the only source of the number this cap needs.
+        if not est_price:
+            return OrderResult(order_id="BLOCKED", market_id=pair, status="rejected",
+                               is_paper=True,
+                               error_message=f"cannot price {pair} to verify the "
+                                             f"${cap:.2f} per-order cap; refusing")
+        notional = await self.usd_notional(pair, volume, est_price) or (volume * est_price)
+        if notional > cap:
+            return OrderResult(order_id="BLOCKED", market_id=pair, status="rejected",
+                               is_paper=True,
+                               error_message=f"order ${notional:.2f} exceeds cap ${cap:.2f}")
 
         # 4. Three-gate live decision.  ``dry_run=False`` opens only the
         # per-order gate; it must never override either global live gate.

--- a/auramaur/risk/manager.py
+++ b/auramaur/risk/manager.py
@@ -213,14 +213,24 @@ class RiskManager:
                 strategy=signal.strategy_source, divergence=extreme_div.value,
                 threshold=rc.extreme_divergence_threshold,
                 model_prob=signal.claude_prob, market_prob=signal.market_prob)
-        is_paper_entry = (
-            not self.settings.is_live
-            or self.live_entries_blocked  # operational preflight BLOCK
+        # Every RESTRICTION that routes this entry to paper, as one value. This
+        # must be a single expression used both to scope the checks below and to
+        # populate RiskDecision.force_paper: when the two diverged, arming a
+        # protective latch (preflight BLOCK, extreme divergence) skipped the
+        # live-only checks while the entry still went out with real money —
+        # turning a guard into a permission.
+        paper_forced = (
+            self.live_entries_blocked  # operational preflight BLOCK
             or self._paper_forced_strategy(signal.strategy_source)
             or cell.force_paper
             or force_paper  # caller-declared, restriction-only
             or extreme_div.force_paper
         )
+        # The global gate is deliberately NOT part of `paper_forced`: it is the
+        # gateway's own precondition (is_live = settings.is_live and not
+        # intent.force_paper), so folding it in would say "this entry was
+        # restricted" about a bot that simply is not live.
+        is_paper_entry = not self.settings.is_live or paper_forced
 
         # Correlation, MODE-SCOPED. A paper entry adds NO real exposure, so it must
         # only correlate against the PAPER book — counting the live book would let
@@ -485,7 +495,7 @@ class RiskManager:
             # Report the effective mode, not just the ladder's view — a
             # caller-declared paper entry must come back marked paper or the
             # pillar would submit it live after the gate judged it as paper.
-            force_paper=cell.force_paper or force_paper,
+            force_paper=paper_forced,
             graduation_status=cell.status,
         )
 

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -823,8 +823,20 @@ class KrakenPillar:
                 assert proposal.action is KrakenAction.SELL
                 vol = proposal.volume
                 notional = await self._k.usd_notional(pair, vol, price) or (vol * price)
+                # Hand the adapter the price THIS cycle already validated. The
+                # per-order cap now fails closed on an unpriceable pair, and
+                # without `price=` the adapter re-probes Ticker — a second,
+                # independent network call moments after the loop's own probe.
+                # Its transient failure (5xx, rate limit, Cloudflare) would
+                # refuse a stop-loss / take-profit / trailing-stop / orphan
+                # liquidation that the loop had just priced successfully. It
+                # also makes the deliberately non-binding exit cap deterministic:
+                # both sides of the comparison come from one number, so a >10%
+                # tick between two probes can no longer block a close. ordertype
+                # is "market", so this price only feeds the cap — AddOrder never
+                # receives it.
                 res = await self._k.place_spot_order(
-                    pair, OrderSide.SELL, volume=vol, ordertype="market",
+                    pair, OrderSide.SELL, volume=vol, ordertype="market", price=price,
                     purpose="directional", max_usd=max(notional, kcfg.max_order_usd) * 1.1,
                     dry_run=True if effective_paper else None,
                     client_order_id=str(uuid.uuid4()))

--- a/tests/test_kraken_directional.py
+++ b/tests/test_kraken_directional.py
@@ -307,3 +307,77 @@ async def test_mirror_removes_stale_rows_from_prior_sessions():
         "SELECT market_id FROM portfolio")}
     assert rows == {"XBTUSDC", "poly-1"}  # ADAUSDC gone, polymarket untouched
     await db.close()
+
+
+# ---------------------------------------------------------------------------
+# The per-order USD cap is safety layer #3 in this module's own docstring. It
+# sat behind `if est_price:`, and get_price() returns None whenever
+# _public("Ticker") yields nothing — _public logs and returns {} on any error
+# rather than raising. A transient 5xx or rate-limit therefore removed the
+# ceiling entirely and the order went to AddOrder unbounded. Every autonomous
+# caller passes price=None, so the probe is the only source of that number.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unpriceable_pair_is_refused_rather_than_uncapped():
+    settings = MagicMock()
+    settings.is_live = True
+    settings.kraken.directional_enabled = True
+    settings.kraken.max_order_usd = 30.0
+    client = KrakenSpotClient(settings)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
+    client.get_price = AsyncMock(return_value=None)   # ticker blip
+    client._private = AsyncMock(return_value={"error": [], "result": {"txid": ["x"]}})
+
+    with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+        result = await client.place_spot_order(
+            "XBTUSDC", OrderSide.BUY, 10.0, price=None, dry_run=False,
+        )
+
+    assert result.status == "rejected"
+    assert "cannot price" in (result.error_message or "")
+    client._private.assert_not_awaited()   # nothing reached AddOrder
+
+
+@pytest.mark.asyncio
+async def test_priced_pair_still_enforces_the_cap():
+    settings = MagicMock()
+    settings.is_live = True
+    settings.kraken.directional_enabled = True
+    settings.kraken.max_order_usd = 30.0
+    client = KrakenSpotClient(settings)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
+    client.get_price = AsyncMock(return_value=50_000.0)
+    client.usd_notional = AsyncMock(return_value=500.0)
+    client._private = AsyncMock(return_value={"error": [], "result": {"txid": ["x"]}})
+
+    with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+        result = await client.place_spot_order(
+            "XBTUSDC", OrderSide.BUY, 0.01, price=None, dry_run=False,
+        )
+
+    assert result.status == "rejected"
+    assert "exceeds cap" in (result.error_message or "")
+    client._private.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_priced_pair_under_the_cap_still_places():
+    settings = MagicMock()
+    settings.is_live = True
+    settings.kraken.directional_enabled = True
+    settings.kraken.max_order_usd = 100.0
+    client = KrakenSpotClient(settings)
+    client.get_pair_quote = AsyncMock(return_value="USDC")
+    client.get_price = AsyncMock(return_value=50_000.0)
+    client.usd_notional = AsyncMock(return_value=50.0)
+    client._private = AsyncMock(return_value={"error": [], "result": {"txid": ["ok"]}})
+
+    with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+        result = await client.place_spot_order(
+            "XBTUSDC", OrderSide.BUY, 0.001, price=None, dry_run=False,
+        )
+
+    assert result.status != "rejected"
+    client._private.assert_awaited()

--- a/tests/test_kraken_directional_exit.py
+++ b/tests/test_kraken_directional_exit.py
@@ -535,3 +535,101 @@ def test_llm_exit_holds_when_flat_and_view_missing():
         assert await p._llm_exit_reason("X", gain_pct=1.0, kcfg=_llm_kcfg(),
                                         peak_pct=1.0) is None
     asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# The exit prices itself ONCE.
+#
+# The adapter's per-order USD cap now fails CLOSED: a pair it cannot price is
+# refused rather than sent uncapped. That is right, but the failure it guards
+# against is TRANSIENT — _public logs and returns {} on a 5xx / rate-limit /
+# Cloudflare blip, so get_price returns None — and the exit is the one caller it
+# could hurt. Without price=, place_spot_order re-probes Ticker moments after
+# this loop's own successful probe, so a blip on that SECOND read would refuse a
+# stop-loss / take-profit / trailing-stop / orphan liquidation that the loop had
+# already priced. Passing the validated price also makes the exit cap (which is
+# handed max_usd with headroom precisely so it never binds) deterministic:
+# before, a >10% tick between the two probes could block a close outright.
+# ---------------------------------------------------------------------------
+
+from auramaur.exchange.kraken import KrakenSpotClient  # noqa: E402
+
+
+def test_exit_passes_the_price_the_loop_already_validated():
+    async def run():
+        kcfg = _kcfg()
+        p = _pillar(0.80, kcfg, base_amt=10.0)   # 1.00 -> 0.80 = stop_loss
+        p._momentum = AsyncMock(return_value=-1.0)
+
+        await p._directional()
+
+        _, kwargs = p._k.place_spot_order.call_args
+        # The adapter resolves `price or await get_price(pair)`, so handing it
+        # this number is what stops the redundant second probe.
+        assert kwargs["price"] == 0.80
+
+    asyncio.run(run())
+
+
+def test_exit_survives_a_ticker_blip_once_the_loop_has_priced_it():
+    """End-to-end through the REAL adapter gate: from the moment the loop has
+    priced the exit, every further Ticker read fails. The sell must still reach
+    AddOrder — a transient quote failure cannot veto a stop-loss."""
+    async def run():
+        kcfg = _kcfg()
+        settings = SimpleNamespace(kraken=kcfg, is_live=False,
+                                   kraken_api_key="k", kraken_api_secret="s")
+        k = KrakenSpotClient(settings)          # real place_spot_order, fake transport
+        k.get_free_balance = AsyncMock(return_value={"APE": 10.0, "USDC": 1000.0})
+        k.get_pair_quote = AsyncMock(return_value="USDC")
+        k._public = AsyncMock(return_value={
+            "APEUSDC": {"altname": "APEUSDC", "base": "APE", "ordermin": "1"},
+        })
+        k._private = AsyncMock(return_value={"error": [], "result": {"txid": ["TX1"]}})
+
+        # The blip begins exactly where the loop finishes pricing the exit, so
+        # ANY probe from here on is the redundant one — no call counting needed.
+        blipped = {"on": False}
+
+        async def _usd_notional(pair, vol, px=None):
+            blipped["on"] = True
+            return vol * (px or 0.80)
+
+        async def _get_price(pair):
+            return None if blipped["on"] else 0.80
+
+        k.usd_notional = AsyncMock(side_effect=_usd_notional)
+        k.get_price = AsyncMock(side_effect=_get_price)
+
+        p = KrakenPillar(settings, k, bot=None)
+        p._dir_long = {"APEUSDC": 1.00}
+        p._momentum = AsyncMock(return_value=-1.0)
+
+        with patch("auramaur.exchange.kraken.kill_switch_present", return_value=False):
+            await p._directional()
+
+        assert "AddOrder" in [c.args[0] for c in k._private.await_args_list]
+        assert "APEUSDC" not in p._dir_long   # closed, not vetoed by the blip
+
+    asyncio.run(run())
+
+
+def test_refused_exit_keeps_the_position_and_retries_next_cycle():
+    """A refusal is not a close. The crypto is still held, so the position stays
+    tracked (basis intact) and the sell is attempted again on the next cycle."""
+    async def run():
+        kcfg = _kcfg()
+        p = _pillar(0.80, kcfg, base_amt=10.0)
+        p._momentum = AsyncMock(return_value=-1.0)
+        p._k.place_spot_order = AsyncMock(return_value=SimpleNamespace(
+            order_id="BLOCKED", status="rejected",
+            error_message="cannot price APEUSDC to verify the $25.00 cap; refusing"))
+
+        await p._directional()
+        assert p._dir_long["APEUSDC"] == 1.00   # still held, at its real basis
+
+        await p._directional()
+        assert p._k.place_spot_order.await_count == 2   # retried, not dropped
+        assert p._dir_long["APEUSDC"] == 1.00
+
+    asyncio.run(run())

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -856,3 +856,80 @@ async def test_long_settlement_bucket_disabled_by_zero_knobs():
         two_years, 365, 0.0, 999.0, 30.0, 100.0)).passed
     assert (await check_long_settlement_bucket(
         two_years, 0, 50.0, 999.0, 30.0, 100.0)).passed
+
+
+# ---------------------------------------------------------------------------
+# force_paper must report EVERY restriction, not a subset.
+#
+# is_paper_entry is built from six sources and is what disables the live-only
+# checks. RiskDecision.force_paper previously carried only two of them, so a
+# preflight BLOCK or an extreme-divergence route-to-paper skipped the live
+# checks and still reached the venue with real money: arming a guard made the
+# system MORE permissive.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_preflight_block_is_reported_as_force_paper(mock_kill):
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(is_live=True)
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+    manager.live_entries_blocked = True  # what bot._run_live_gate sets on BLOCK
+
+    decision = await manager.evaluate(
+        _make_signal(), _make_market(), available_cash=500.0)
+
+    # The gateway computes is_live = settings.is_live and not intent.force_paper,
+    # so a False here sends a preflight-blocked entry out with real money.
+    assert decision.force_paper is True
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_extreme_divergence_is_reported_as_force_paper(mock_kill):
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(is_live=True)
+    settings.risk.extreme_divergence_enabled = True
+    settings.risk.extreme_divergence_threshold = 0.40
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    # The documented adverse bucket: model far below a confident market.
+    decision = await manager.evaluate(
+        _make_signal(claude_prob=0.10, market_prob=0.89, edge=10.0),
+        _make_market(yes_price=0.89), available_cash=500.0)
+
+    assert decision.force_paper is True
+
+
+@pytest.mark.asyncio
+@patch("auramaur.risk.manager.check_kill_switch")
+async def test_unrestricted_live_entry_is_not_marked_force_paper(mock_kill):
+    """The global live gate is not a restriction — a paper-mode bot must not
+    report force_paper, or the flag stops meaning 'this entry was restricted'."""
+    from auramaur.risk.checks import CheckResult
+    mock_kill.return_value = CheckResult(name="kill_switch", passed=True, reason="", value=False)
+
+    settings = _make_settings(is_live=False)  # simply not live
+    db = MagicMock()
+    db.fetchone = AsyncMock(return_value=None)
+
+    manager = RiskManager(settings, db)
+    manager.portfolio = _mock_portfolio()
+
+    decision = await manager.evaluate(
+        _make_signal(), _make_market(), available_cash=500.0)
+
+    assert decision.force_paper is False


### PR DESCRIPTION
Two guards that became **permissions** under the exact condition they exist to handle.

## 1. `risk/manager.py` — `force_paper` reported 2 of 6 restrictions

`is_paper_entry` is built from six sources and is what disables the live-only checks:

```python
is_paper_entry = (
    not self.settings.is_live
    or self.live_entries_blocked        # operational preflight BLOCK
    or self._paper_forced_strategy(signal.strategy_source)
    or cell.force_paper
    or force_paper                       # caller-declared
    or extreme_div.force_paper
)
```

The decision reported:

```python
force_paper=cell.force_paper or force_paper,   # two of six
```

`execution_gateway.py:112` computes `is_live = settings.is_live and not intent.force_paper`. So an entry could skip `check_category_allowlist`, `check_dispute_risk` and `check_divergence_band` **because** it was restricted, and still go to the venue with real money.

Concretely: preflight fails → `bot._run_live_gate` sets `live_entries_blocked` → the allowlist check is never appended → a non-allowlisted category is approved at full size, live. **Arming the guard made the system more permissive.**

The comment directly above that line already stated the correct invariant:

> Report the effective mode, not just the ladder's view — a caller-declared paper entry must come back marked paper or the pillar would submit it live after the gate judged it as paper.

It was implemented for two of the six inputs. There is now a single `paper_forced` expression used both to scope the checks and to populate the decision, so the two cannot drift again.

The global live gate is deliberately **excluded** from `paper_forced` — it is the gateway's own precondition, and folding it in would report "this entry was restricted" about a bot that simply isn't live. There's a test pinning that.

## 2. `exchange/kraken.py` — per-order USD cap skipped when the price probe failed

Safety layer #3 in that module's own docstring sat behind `if est_price:`:

```python
est_price = price or await self.get_price(pair)
if est_price:
    if notional > cap: return BLOCKED
```

`get_price` returns `None` whenever `_public("Ticker")` yields nothing, and `_public` **logs and returns `{}`** on any error rather than raising (`kraken.py:74-76`). A 5xx, a rate-limit response, or a Cloudflare blip removed the ceiling entirely and the order proceeded to `AddOrder` unbounded. Every autonomous caller passes `price=None`, so that probe is the sole source of the number the cap needs.

Now an unpriceable pair is refused — matching `transfers.py`, which fails closed at every equivalent point and is the model the rest of the codebase should follow here.

## Verification

Every new test was run against the **unfixed** code first:

```
--- against UNFIXED manager.py ---
FAILED test_preflight_block_is_reported_as_force_paper
FAILED test_extreme_divergence_is_reported_as_force_paper

--- against UNFIXED kraken.py ---
FAILED test_unpriceable_pair_is_refused_rather_than_uncapped
```

All pass after. Six tests added total, including one pinning that a paper-mode bot does *not* report `force_paper` (so the flag keeps meaning "restricted").

- Full suite: **2118 passed, 5 skipped, 0 failed**
- `ruff==0.15.22 check .` — clean

Assisted-by: Claude (Anthropic)