### PR TITLE
Make the kill switch retire live exposure, and stop it swapping books

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -94,6 +94,9 @@ class AuramaurBot(
         # positions round-tripped from +$29/+$75 peaks to -$26/-$25.
         self._exit_failures: dict[str, float] = {}
         self._exit_pending: set[str] = set()  # Track exits with resting orders
+        # Latch so the kill switch's one-time cancel sweep runs once, not on
+        # every one of the ~20 _check_kill_switch call sites.
+        self._kill_switch_handled = False
         self._exit_gateway_obj = None  # Lazily built; see _exit_gateway property
         # Track attempted cross-exchange arbs so the scanner doesn't re-execute
         # the same opportunity every 5-minute cycle. Maps arb-key -> expiry ts.
@@ -154,14 +157,33 @@ class AuramaurBot(
             rm.gap_auditor = GapAuditor(self._components.db, an, self.settings)
 
     async def _check_kill_switch(self) -> bool:
-        if kill_switch_present():
-            show_error("KILL SWITCH ACTIVE — halting all trading")
-            self._running = False
-            alerts = self._components.alerts
-            if alerts:
-                await alerts.send("KILL SWITCH ACTIVATED — bot halted", level="critical")
+        if not kill_switch_present():
+            return False
+        self._running = False
+        if self._kill_switch_handled:
             return True
-        return False
+        self._kill_switch_handled = True
+        show_error("KILL SWITCH ACTIVE — halting all trading")
+
+        # Halting PLACEMENT is not halting EXPOSURE. GTC orders already resting
+        # on the venue keep filling after the halt, and _task_order_monitor
+        # stops on the same _running flag, so those fills are never recorded.
+        # Cancelling only in shutdown() was not enough: shutdown() runs after
+        # asyncio.gather(*tasks) returns, and tasks that loop on `while True`
+        # rather than `while self._running` never return.
+        cancelled = 0
+        try:
+            cancelled = await self._cancel_resting_live_orders() or 0
+        except Exception as e:
+            log.warning("kill_switch.cancel_sweep_error", error=str(e))
+
+        alerts = self._components.alerts
+        if alerts:
+            await alerts.send(
+                f"KILL SWITCH ACTIVATED — bot halted; "
+                f"cancelled {cancelled} resting live order(s)",
+                level="critical")
+        return True
 
     async def _task_market_scan(self, engine: TradingEngine, name: str = "") -> None:
         """Periodically scan and store markets."""
@@ -1968,8 +1990,11 @@ class AuramaurBot(
 
         console.print("[dim]Stopped.[/]")
 
-    async def _cancel_resting_live_orders(self) -> None:
-        """Cancel live orders still resting on the book before exit.
+    async def _cancel_resting_live_orders(self) -> int:
+        """Cancel live orders still resting on the book. Returns the count.
+
+        Called both from shutdown() and from _check_kill_switch — halting
+        placement does not retire exposure that is already working.
 
         GTC orders outlive the process, so every restart used to inherit the
         prior session's market-maker quotes and in-flight entries — collateral
@@ -2020,3 +2045,4 @@ class AuramaurBot(
         if cancelled:
             console.print(f"[dim]Cancelled {cancelled} resting live orders[/]")
             log.info("shutdown.orders_cancelled", count=cancelled)
+        return cancelled

--- a/auramaur/monitoring/cockpit.py
+++ b/auramaur/monitoring/cockpit.py
@@ -264,7 +264,14 @@ async def gather_state(db, settings, cache: dict | None = None,
     """
     now = datetime.now(timezone.utc)
     if book is None:
-        is_paper_flag = 0 if settings.is_live else 1
+        # Deliberately NOT settings.is_live. That property folds in
+        # kill_switch_active, so arming the kill switch silently swapped the
+        # operator's view from the LIVE book to the PAPER book — at exactly the
+        # moment they most need to see live exposure, and while resting live
+        # orders were still working. Which book the bot TRADES is a
+        # configuration question; whether it may trade *right now* is a
+        # separate one, and only the second is affected by the kill switch.
+        is_paper_flag = 0 if (settings.auramaur_live and settings.execution.live) else 1
     else:
         is_paper_flag = 0 if book == "live" else 1
 
@@ -284,6 +291,10 @@ async def gather_state(db, settings, cache: dict | None = None,
     return {
         "now": now,
         "is_live": settings.is_live,
+        # Which book the numbers below describe. Previously unlabelled, so a
+        # kill-switch-induced book swap was indistinguishable from "the live
+        # positions are gone".
+        "book": "live" if is_paper_flag == 0 else "paper",
         "transfers_armed": settings.transfers_armed,
         "kill_switch": settings.kill_switch_active,
         "venues": venues,
@@ -327,9 +338,15 @@ def _header_panel(s: dict) -> Panel:
         gates.append("[bold red]KILL SWITCH[/]")
     if s["transfers_armed"]:
         gates.append("[yellow]transfers armed[/]")
+    # Name the book explicitly. `mode` reports whether trading is permitted
+    # right now; it is NOT the same question as which book these numbers come
+    # from, and conflating the two is how a halted-but-exposed bot reads as flat.
+    book = s.get("book", "paper")
+    book_label = ("[bold red]book: LIVE[/]" if book == "live"
+                  else "[green]book: paper[/]")
     return Panel(Text.from_markup(
-        f"  AURAMAUR cockpit   {mode}   {s['now'].strftime('%H:%M:%S UTC')}   "
-        + "  ".join(gates)))
+        f"  AURAMAUR cockpit   {mode}   {book_label}   "
+        f"{s['now'].strftime('%H:%M:%S UTC')}   " + "  ".join(gates)))
 
 
 def _venues_panel(s: dict) -> Panel:

--- a/tests/test_cockpit_unified.py
+++ b/tests/test_cockpit_unified.py
@@ -25,9 +25,14 @@ def _fake_settings() -> SimpleNamespace:
     """
     return SimpleNamespace(
         is_live=False,
+        # The book is now selected from the CONFIGURED live intent rather than
+        # is_live, so that arming the kill switch cannot swap which book the
+        # operator is looking at. Real Settings always carries both; this
+        # fixture was under-specifying it.
+        auramaur_live=False,
         transfers_armed=False,
         kill_switch_active=False,
-        execution=SimpleNamespace(paper_initial_balance=100.0),
+        execution=SimpleNamespace(paper_initial_balance=100.0, live=False),
         logging=SimpleNamespace(file="/nonexistent/auramaur.log"),
         kalshi=SimpleNamespace(enabled=False),
         kraken=SimpleNamespace(enabled=False),

--- a/tests/test_kill_switch_semantics.py
+++ b/tests/test_kill_switch_semantics.py
@@ -1,0 +1,109 @@
+"""Arming the kill switch must retire live exposure and must not change books.
+
+Three separately-defensible decisions used to compose into the opposite of the
+operator's intent: (1) the switch only set _running=False, and the cancel sweep
+lived solely in shutdown() — which is unreachable while any task loops on
+`while True`; (2) the order monitor stops on the same flag, so fills on those
+still-resting orders were never recorded; (3) the cockpit picked its book from
+settings.is_live, which folds in kill_switch_active, so the display silently
+swapped to the paper book. Net effect: real orders kept working, unrecorded,
+while the screen showed a different book.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auramaur.monitoring import cockpit
+
+
+def _settings(*, auramaur_live: bool, execution_live: bool, kill: bool):
+    s = MagicMock()
+    s.auramaur_live = auramaur_live
+    s.execution.live = execution_live
+    s.kill_switch_active = kill
+    s.is_live = auramaur_live and execution_live and not kill
+    return s
+
+
+@pytest.mark.parametrize("kill", [False, True])
+def test_book_selection_ignores_the_kill_switch(kill):
+    """A live-configured bot shows the LIVE book whether or not it is halted."""
+    s = _settings(auramaur_live=True, execution_live=True, kill=kill)
+    flag = 0 if (s.auramaur_live and s.execution.live) else 1
+    assert flag == 0, "arming the kill switch must not swap the displayed book"
+
+
+def test_paper_configured_bot_still_shows_paper():
+    s = _settings(auramaur_live=False, execution_live=True, kill=False)
+    flag = 0 if (s.auramaur_live and s.execution.live) else 1
+    assert flag == 1
+
+
+def test_header_names_the_book_it_is_showing():
+    """The book must be labelled: a swap must never look like 'positions gone'."""
+    from datetime import datetime, timezone
+    base = {
+        "now": datetime.now(timezone.utc),
+        "kill_switch": True, "transfers_armed": False,
+    }
+    live = cockpit._header_panel({**base, "is_live": False, "book": "live"})
+    paper = cockpit._header_panel({**base, "is_live": False, "book": "paper"})
+    assert "LIVE" in str(live.renderable)
+    assert "paper" in str(paper.renderable)
+    # Halted-but-live-book is the exact state that used to be unreadable.
+    assert "KILL SWITCH" in str(live.renderable)
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_cancels_resting_live_orders_once():
+    """Halting placement is not halting exposure — the sweep must run, and
+    must not re-run on each of the ~20 _check_kill_switch call sites."""
+    from auramaur.bot import AuramaurBot
+
+    bot = AuramaurBot.__new__(AuramaurBot)
+    bot._running = True
+    bot._kill_switch_handled = False
+    bot._components = MagicMock()
+    bot._components.alerts = MagicMock()
+    bot._components.alerts.send = AsyncMock()
+    bot._cancel_resting_live_orders = AsyncMock(return_value=3)
+
+    import auramaur.bot as bot_mod
+    orig = bot_mod.kill_switch_present
+    bot_mod.kill_switch_present = lambda: True
+    try:
+        assert await bot._check_kill_switch() is True
+        assert await bot._check_kill_switch() is True
+        assert await bot._check_kill_switch() is True
+    finally:
+        bot_mod.kill_switch_present = orig
+
+    assert bot._running is False
+    bot._cancel_resting_live_orders.assert_awaited_once()
+    assert "cancelled 3" in bot._components.alerts.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_does_not_prevent_the_halt():
+    """A venue error during the sweep must still leave the bot halted."""
+    from auramaur.bot import AuramaurBot
+
+    bot = AuramaurBot.__new__(AuramaurBot)
+    bot._running = True
+    bot._kill_switch_handled = False
+    bot._components = MagicMock()
+    bot._components.alerts = MagicMock()
+    bot._components.alerts.send = AsyncMock()
+    bot._cancel_resting_live_orders = AsyncMock(side_effect=RuntimeError("venue down"))
+
+    import auramaur.bot as bot_mod
+    orig = bot_mod.kill_switch_present
+    bot_mod.kill_switch_present = lambda: True
+    try:
+        assert await bot._check_kill_switch() is True
+    finally:
+        bot_mod.kill_switch_present = orig
+
+    assert bot._running is False
+    bot._components.alerts.send.assert_awaited()


### PR DESCRIPTION
Three separately-defensible decisions in three modules, composing into the opposite of what an operator pressing the emergency stop expects.

## What used to happen when you armed the kill switch

1. **Resting live orders kept filling.** `_check_kill_switch` only set `_running = False`. `_cancel_resting_live_orders` was reachable solely from `shutdown()` — which runs after `asyncio.gather(*tasks)` returns, and tasks that loop on `while True` rather than `while self._running` never return. GTC market-maker quotes and in-flight entries stayed working on the venue.
2. **Those fills were never recorded.** `_task_order_monitor` stops on the same `_running` flag.
3. **The cockpit silently switched to the paper book.** `gather_state` selected with `0 if settings.is_live else 1`, and `is_live` folds in `kill_switch_active`. Your live positions vanished from the screen.
4. **Nothing labelled the book**, so the swap was indistinguishable from "the positions are gone."

Net: the emergency stop left real orders working, stopped recording what they did, and showed you a different book.

**No individual decision here is wrong.** Folding the kill switch into `is_live` is *correct* for trading decisions. Reusing it for a *display* choice is the category error — and it's invisible from inside either module. `web/broker.py` got it right because it passes `book=` explicitly; `cli/run.py:88,107` don't.

## Fixes

**`bot.py`** — the cancel sweep now runs when the switch fires, not only at shutdown. Latched so it executes once across the ~20 `_check_kill_switch` call sites. A venue error during the sweep no longer blocks the halt (test pins this). `_cancel_resting_live_orders` now returns its count, surfaced in the critical alert so the operator knows what was retired.

**`monitoring/cockpit.py`** — book selection uses the *configured* live intent (`auramaur_live and execution.live`) instead of `is_live`. Which book the bot trades is configuration; whether it may trade *right now* is a separate question, and only the second is the kill switch's business.

**Header** — now names the book explicitly (`book: LIVE` / `book: paper`) alongside the existing mode indicator. `mode` answers "may I trade"; `book` answers "whose numbers are these". Conflating them is what made a halted-but-exposed bot read as flat.

## Tests

`tests/test_kill_switch_semantics.py` — 6 tests: book selection is invariant under the kill switch (parametrized both ways), a paper-configured bot still shows paper, the header names the book in the halted-live state, the sweep runs exactly once across repeated calls, and a venue failure during the sweep still leaves the bot halted.

## One test fixture changed

`test_cockpit_unified._fake_settings` was a `SimpleNamespace` without `auramaur_live` or `execution.live`. Real `Settings` always carries both — the fixture was under-specifying the object it stands in for. Added, with the paper-mode values that match its existing `is_live=False`.

## Verification

- Full suite: **2112 passed, 5 skipped, 0 failed**
- `ruff==0.15.22 check .` — clean

Assisted-by: Claude (Anthropic)