### PR TITLE
Size internal arb legs to a common share count, and label the NO leg

### DIFF
--- a/auramaur/bot_arb_execute.py
+++ b/auramaur/bot_arb_execute.py
@@ -268,30 +268,51 @@ class ArbTradeExecutionMixin:
 
         exchange_client = engine.exchange
 
+        yes_px = market.outcome_yes_price
+        no_px = market.outcome_no_price
+        if yes_px <= 0 or no_px <= 0:
+            return
+
+        # Size BOTH legs to a common SHARE quantity, matching
+        # _execute_negrisk_arb above. YES+NO of one market pays exactly $1 per
+        # SHARE held on the winning side, so the hedge exists only at equal
+        # share counts. Sizing each leg to the same DOLLARS bought unequal
+        # shares: at yes=0.60 / no=0.35 with $10 a leg that is 16.67 vs 28.57
+        # shares — $20 out, worst case 16.67 x $1 back, a guaranteed -$3.33 on
+        # a trade booked and alerted as risk-free. Profit existed only when
+        # BOTH legs priced under 0.50; above that the "arb" was a losing bet.
+        qty = min(position_size / yes_px, position_size / no_px)
+        if qty < 1:
+            return
+
         # YES leg
         yes_order = Order(
             market_id=market.id,
             exchange=exchange_name,
             token_id=market.clob_token_yes or market.id,
             side=OrderSide.BUY,
-            size=position_size / market.outcome_yes_price if market.outcome_yes_price > 0 else 0,
-            price=market.outcome_yes_price,
+            token=TokenType.YES,
+            size=qty,
+            price=yes_px,
             dry_run=not self.settings.is_live,
         )
 
-        # NO leg
+        # NO leg. token= is REQUIRED, not decorative: Order.token defaults to
+        # YES, Kalshi derives both the book side and the price inversion from
+        # order.token (not token_id), so omitting it posted two YES bids
+        # instead of a hedge — and the gateway writes token=order.token into
+        # cost_basis/fills, so a NO holding was booked under 'YES' and its cap
+        # accounting attributed to the opposite side.
         no_order = Order(
             market_id=market.id,
             exchange=exchange_name,
             token_id=market.clob_token_no or market.id,
             side=OrderSide.BUY,
-            size=position_size / market.outcome_no_price if market.outcome_no_price > 0 else 0,
-            price=market.outcome_no_price,
+            token=TokenType.NO,
+            size=qty,
+            price=no_px,
             dry_run=not self.settings.is_live,
         )
-
-        if yes_order.size < 1 or no_order.size < 1:
-            return
 
         try:
             (yes_result, _), (no_result, _) = await self._exit_gateway.place_legs(
@@ -312,13 +333,32 @@ class ArbTradeExecutionMixin:
             )
 
             mode = "PAPER" if yes_order.dry_run else "LIVE"
-            await alerts.send(
-                f"[{mode}] Internal arb executed: {market.question[:50]} | "
-                f"YES@{opp.price_a:.2f} + NO@{opp.price_b:.2f} = "
-                f"{opp.price_a + opp.price_b:.3f} | "
-                f"profit: {opp.expected_profit_pct:.1f}%",
-                level="warning",
-            )
+            # Inspect the legs before claiming success. place_legs runs these
+            # sequentially and each leg can independently come back
+            # INSUFFICIENT_BALANCE / POST_ONLY_REJECTED / SKIP_DUP — leaving a
+            # one-sided directional position on a market nobody analysed while
+            # the operator is told the arb executed. Both sibling paths
+            # (_execute_negrisk_arb, _execute_cross_exchange_arb) already raise
+            # critical on a half-leg; this one reported unconditionally.
+            ok = ("filled", "paper", "partial", "pending")
+            legs_ok = sum(1 for r in (yes_result, no_result) if r.status in ok)
+            if legs_ok < 2:
+                await alerts.send(
+                    f"[{mode}] INTERNAL ARB PARTIAL FILL: {legs_ok}/2 legs for "
+                    f"{market.question[:40]}. Hedge is incomplete — the filled "
+                    f"leg is an unhedged directional position. Manual review "
+                    f"required. (YES: {yes_result.status}, NO: {no_result.status})",
+                    level="critical",
+                )
+            else:
+                await alerts.send(
+                    f"[{mode}] Internal arb executed: {market.question[:50]} | "
+                    f"YES@{opp.price_a:.2f} + NO@{opp.price_b:.2f} = "
+                    f"{opp.price_a + opp.price_b:.3f} | "
+                    f"{qty:.1f} shares/leg | "
+                    f"profit: {opp.expected_profit_pct:.1f}%",
+                    level="warning",
+                )
         except Exception as e:
             log.error(
                 "arb_scanner.internal_execution_error",

--- a/tests/test_internal_arb_hedge.py
+++ b/tests/test_internal_arb_hedge.py
@@ -1,0 +1,64 @@
+"""An internal (YES+NO) arb is only a hedge at EQUAL SHARE COUNTS.
+
+YES+NO of one market pays exactly $1 per SHARE held on the winning side.
+Sizing both legs to the same DOLLARS buys unequal shares, so the "risk-free"
+package has a losing branch whenever either leg prices above 0.50 — and it was
+booked and alerted as risk-free. _execute_negrisk_arb got this right and says
+so ("Size all legs to a common SHARE quantity"); this path did not.
+"""
+
+import pytest
+
+
+def _qty(position_size: float, yes_px: float, no_px: float) -> float:
+    """The sizing rule as implemented in _execute_internal_arb."""
+    return min(position_size / yes_px, position_size / no_px)
+
+
+def _worst_case_pnl(qty_yes: float, qty_no: float, yes_px: float, no_px: float) -> float:
+    """A binary market pays $1 per share on exactly one side."""
+    outlay = qty_yes * yes_px + qty_no * no_px
+    return min(qty_yes, qty_no) * 1.0 - outlay
+
+
+@pytest.mark.parametrize("yes_px,no_px", [
+    (0.60, 0.35),   # the reported case: sum 0.95, one leg above 0.50
+    (0.70, 0.25),
+    (0.55, 0.40),
+    (0.45, 0.45),   # both under 0.50 — the only region equal-notional survived
+])
+def test_equal_share_sizing_is_never_a_guaranteed_loss(yes_px, no_px):
+    stake = 10.0
+    q = _qty(stake, yes_px, no_px)
+    assert _worst_case_pnl(q, q, yes_px, no_px) > 0, "a real arb cannot lose"
+
+
+def test_equal_notional_sizing_would_have_lost_on_the_reported_case():
+    """Pin the defect this fixes: same stake, dollar-sized legs, guaranteed loss."""
+    stake, yes_px, no_px = 10.0, 0.60, 0.35
+    q_yes, q_no = stake / yes_px, stake / no_px      # the old behaviour
+    assert q_yes != q_no
+    assert _worst_case_pnl(q_yes, q_no, yes_px, no_px) < 0
+
+    q = _qty(stake, yes_px, no_px)                    # the new behaviour
+    assert _worst_case_pnl(q, q, yes_px, no_px) > 0
+
+
+def test_common_quantity_never_exceeds_the_approved_stake_on_either_leg():
+    stake, yes_px, no_px = 10.0, 0.60, 0.35
+    q = _qty(stake, yes_px, no_px)
+    assert q * yes_px <= stake + 1e-9
+    assert q * no_px <= stake + 1e-9
+
+
+def test_no_leg_carries_the_no_token():
+    """Order.token defaults to YES. Kalshi derives the book side and the price
+    inversion from order.token, not token_id, so an unset token posted two YES
+    bids instead of a hedge; the gateway also writes token=order.token into
+    cost_basis/fills, booking a NO holding under 'YES'."""
+    import inspect
+    from auramaur import bot_arb_execute
+
+    src = inspect.getsource(bot_arb_execute.ArbTradeExecutionMixin._execute_internal_arb)
+    no_leg = src.split("# NO leg", 1)[1]
+    assert "token=TokenType.NO" in no_leg


### PR DESCRIPTION
`_execute_internal_arb` had three defects that made a "risk-free" package a guaranteed loss. It **auto-executes with no separate enable flag** (unlike `cross_exchange_auto_execute` / `negrisk_auto_execute`) and `arbitrage.enabled` defaults true.

## 1. Equal dollars, not equal shares

YES+NO of one market pays exactly **$1 per share** on the winning side, so the hedge exists only at equal share counts. Both legs were sized `position_size / price`:

| | yes 0.60 | no 0.35 |
|---|---|---|
| shares bought with $10 | 16.67 | 28.57 |

$20 out, worst case `16.67 × $1` back → **guaranteed −$3.33**, logged and alerted as an executed arb. Profit existed only when *both* legs priced under 0.50.

`_execute_negrisk_arb`, 150 lines above, already states the rule:

> Size all legs to a common **SHARE** quantity so each losing leg pays an identical $1.

Now applied here: `qty = min(position_size / yes_px, position_size / no_px)`, which also guarantees neither leg exceeds the risk-approved stake.

## 2. The NO leg had no `token`

`Order.token` defaults to `TokenType.YES` (`exchange/models.py:162`).

- **Kalshi** derives both the book side and the price inversion from `order.token`, *not* `token_id` — so this posted **two YES bids** instead of a hedge. The second usually tripped Kalshi's own resting-order dup guard and returned `SKIP_DUP`, leaving a single unhedged directional position reported as an executed arb.
- **Polymarket** routes purely on `token_id`, so the venue trade was correct — but `_record_result` writes `token=order.token` into `cost_basis`/`fills`. A NO holding landed under `'YES'`, which is the exact key `_exceeds_market_cap` reads, so cap accounting and marks were attributed to the opposite side.

## 3. Success reported unconditionally

`place_legs` runs these sequentially (`concurrent=False`) and either leg can independently return `INSUFFICIENT_BALANCE`, `POST_ONLY_REJECTED` or `SKIP_DUP`. The code logged `internal_executed` and sent "Internal arb executed" without inspecting either status — a half-leg read as success. Both sibling paths already raise `critical` on a partial fill; this one now does too.

## Deliberately NOT fixed here

The same equal-dollar sizing exists at `entailment_arb:602` and `cross_venue_arb:334`. Those route through `submit_paired(size_dollars=...)`, and the gateway picks each leg's execution price inside `router.route` / `prepare_executable_order` — Kalshi crosses the spread with an aggression term, Polymarket applies a min-order bump. **A pillar cannot predict the share count its dollars will buy**, so computing dollars from a quoted price would substitute one wrong answer for another.

Fixing those properly means giving `submit_paired` a common-share-quantity contract — a gateway *interface* decision rather than a pillar edit, and yours to make. Both consumers are paper/disabled today (`entailment_arb.paper: true`, `cross_venue_arb.enabled: false`), so this is latent.

## Tests

`tests/test_internal_arb_hedge.py` — 7 tests, including one that pins the *old* behaviour as a guaranteed loss on the reported case, a parametrized sweep showing equal-share sizing is never negative, a check that neither leg exceeds the approved stake, and a source assertion that the NO leg carries `TokenType.NO`.

- Full suite: **2113 passed, 5 skipped, 0 failed**
- `ruff==0.15.22 check .` — clean

Assisted-by: Claude (Anthropic)