### PR TITLE
Add prospective maker observatory

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -1279,6 +1279,43 @@ class AuramaurBot(
                 show_error(f"Market maker cycle failed: {e}")
             await asyncio.sleep(interval)
 
+    async def _task_maker_observatory(self) -> None:
+        """Resolve due maker fill markouts on their own timer.
+
+        Deliberately NOT folded into `_task_market_maker`. The scan grows with
+        retained history and used to run inside `_quote_market`, inside the
+        per-market `op_timeout` window, holding the process-wide Database
+        serializer — 4.6 s per 5-market cycle at 45-day retention. Slow quotes
+        get picked off, so leaving it there meant the instrument would cause
+        the adverse selection it exists to measure. Its own task also keeps
+        resolution running when the maker has nothing to quote, so the
+        measurement record does not silently develop holes.
+
+        This task deliberately does NOT `beat()`. `check_strategy_data_delivery`
+        fails a readiness criterion for any heartbeat whose strategy has no
+        registered data contract, and this task consumes no market data — it
+        reads rows the maker already wrote. Its liveness surface is the
+        observatory's own valid-mark completeness, which is the honest one.
+
+        No kill-switch gate, on purpose: this places no orders and moves no
+        cash. Halting it would only corrupt the measurement record (marks would
+        go permanently late) for a reason unrelated to trading safety.
+        """
+        mm: MarketMaker | None = self._components.market_maker
+        observatory = getattr(self.settings, "maker_observatory", None)
+        if mm is None or observatory is None or not observatory.enabled:
+            return
+        interval = observatory.resolve_interval_seconds
+        while self._running:
+            try:
+                resolved = await mm.resolve_markouts()
+                if resolved:
+                    log.info("maker_observatory.markouts_resolved", marks=resolved)
+            except Exception as e:
+                # Measurement must never take the process down.
+                log.warning("maker_observatory.resolve_error", error=str(e))
+            await asyncio.sleep(interval)
+
     async def _task_price_monitor(self) -> None:
         """Monitor real-time price changes via WebSocket."""
         ws = self._components.websocket
@@ -1936,6 +1973,12 @@ class AuramaurBot(
         # Market maker (if enabled)
         if self._components.market_maker:
             tasks.append(asyncio.create_task(self._task_market_maker(), name="market_maker"))
+            # Shadow measurement, on its own timer so markout resolution never
+            # sits on the quoting path.
+            if getattr(self.settings, "maker_observatory", None) is not None \
+                    and self.settings.maker_observatory.enabled:
+                tasks.append(asyncio.create_task(
+                    self._task_maker_observatory(), name="maker_observatory"))
 
         # Hybrid strategy report (hourly per-pillar P&L)
         if self._hybrid and self._components.attributor:

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -61,21 +61,40 @@ def maker_observatory_report(days: int):
                       "holdout marks. Synthetic paper fills never count.[/]")
         scorecard = Table(title="Frozen-threshold holdout scorecard")
         for column in ("Horizon", "Feature", "Warmup", "Holdout", "Markets",
-                       "High-low markout"):
+                       "Measured", "High-low markout"):
             scorecard.add_column(column)
         for row in features:
+            # "Measured" is the share of this horizon's marks for which the
+            # feature was recorded at all. A blank effect over low coverage is
+            # an absent result, not a negative one.
+            covered = row["coverage"]
             scorecard.add_row(
                 f"{row['horizon_seconds']}s", row["feature"],
                 str(row["warmup_n"]), str(row["holdout_n"]), str(row["markets"]),
+                ("—" if covered is None
+                 else f"{row['covered_n']}/{row['marks_n']} ({covered:.0%})"),
                 "—" if row["effect"] is None else f"{row['effect']:+.4f}",
             )
         console.print(scorecard)
         sampled = coverage["sampled_quote_coverage"]
+        flow = coverage["flow_coverage"]
         console.print(
             f"[dim]Cadence samples={coverage['samples']}; active quote present="
             f"{'—' if sampled is None else f'{sampled:.1%}'}; "
             f"holdout samples={coverage['holdout_samples']}. This is sampled "
             "coverage, not venue-certified uptime.[/]")
+        console.print(
+            f"[dim]Trade-feed coverage: {coverage['flow_samples']}/"
+            f"{coverage['samples']} observations had signed_flow data"
+            f"{'' if flow is None else f' ({flow:.1%})'}. The rest are NULL — "
+            "no feed reached the market, which is NOT balanced flow and is "
+            "excluded from every flow statistic.[/]")
+        if flow is not None and flow < 1.0:
+            console.print(
+                "[yellow]signed_flow is not fully covered.[/] The websocket "
+                "feed subscribes to the first 20 discovered markets; the maker "
+                "picks its five by spread. Read any signed_flow effect as "
+                "conditional on the covered subset.")
         settings = Settings()
         blockers = maker_promotion_blockers(
             rows,

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -15,6 +15,84 @@ from config.settings import Settings
 from auramaur.cli._base import console, main
 
 
+@main.command("maker-observatory")
+@click.option("--days", default=21, type=click.IntRange(1, 365), show_default=True)
+def maker_observatory_report(days: int):
+    """Show shadow maker fill toxicity at each configured markout horizon."""
+    async def _run():
+        from auramaur.monitoring.maker_observatory import (
+            maker_observatory_feature_report,
+            maker_promotion_blockers,
+            maker_observatory_summary,
+            maker_quote_coverage,
+        )
+        from auramaur.web.db import ReadOnlyDatabase
+
+        db = ReadOnlyDatabase()
+        await db.connect()
+        try:
+            rows = await maker_observatory_summary(db, days=days)
+            features = await maker_observatory_feature_report(db, days=days)
+            coverage = await maker_quote_coverage(db, days=days)
+        finally:
+            await db.close()
+        table = Table(title=f"Maker observatory — last {days}d")
+        for column in ("Mode", "Horizon", "Fills", "Due", "Valid", "Credible holdout",
+                       "Markets", "Mean", "Size-wtd", "95% CI", "Toxic"):
+            table.add_column(column)
+        for row in rows:
+            mean = row["mean_markout"]
+            weighted = row["size_weighted_markout"]
+            toxic = row["toxic_rate"]
+            table.add_row(
+                "paper" if row["is_paper"] else "live",
+                f"{row['horizon_seconds']}s", str(row["fills"]),
+                str(row["due_marks"]),
+                f"{row['valid_marks']} ({row['completeness']:.0%})",
+                str(row["credible_holdout_marks"]), str(row["markets"]),
+                "—" if mean is None else f"{mean:+.4f}",
+                "—" if weighted is None else f"{weighted:+.4f}",
+                ("—" if row["ci_low"] is None else
+                 f"[{row['ci_low']:+.4f}, {row['ci_high']:+.4f}]"),
+                "—" if toxic is None else f"{toxic:.1%}",
+            )
+        console.print(table)
+        console.print("[dim]Promotion evidence = valid, credible, post-warmup "
+                      "holdout marks. Synthetic paper fills never count.[/]")
+        scorecard = Table(title="Frozen-threshold holdout scorecard")
+        for column in ("Horizon", "Feature", "Warmup", "Holdout", "Markets",
+                       "High-low markout"):
+            scorecard.add_column(column)
+        for row in features:
+            scorecard.add_row(
+                f"{row['horizon_seconds']}s", row["feature"],
+                str(row["warmup_n"]), str(row["holdout_n"]), str(row["markets"]),
+                "—" if row["effect"] is None else f"{row['effect']:+.4f}",
+            )
+        console.print(scorecard)
+        sampled = coverage["sampled_quote_coverage"]
+        console.print(
+            f"[dim]Cadence samples={coverage['samples']}; active quote present="
+            f"{'—' if sampled is None else f'{sampled:.1%}'}; "
+            f"holdout samples={coverage['holdout_samples']}. This is sampled "
+            "coverage, not venue-certified uptime.[/]")
+        settings = Settings()
+        blockers = maker_promotion_blockers(
+            rows,
+            min_fills=settings.market_maker.observatory_min_fills,
+            min_markets=settings.market_maker.observatory_min_markets,
+            min_completeness=settings.market_maker.observatory_min_completeness,
+        )
+        if blockers:
+            console.print("[yellow]Not promotable:[/]")
+            for blocker in blockers:
+                console.print(f"  [dim]• {blocker}[/]")
+        else:
+            console.print("[green]Evidence gate passed.[/] Any quote-policy "
+                          "change still requires a separately versioned experiment.")
+    asyncio.run(_run())
+
+
 @main.command("intelligence-eval")
 @click.option("--all-streams", is_flag=True,
               help="Compare production, intelligence, and information-trial streams.")

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -79,9 +79,9 @@ def maker_observatory_report(days: int):
         settings = Settings()
         blockers = maker_promotion_blockers(
             rows,
-            min_fills=settings.market_maker.observatory_min_fills,
-            min_markets=settings.market_maker.observatory_min_markets,
-            min_completeness=settings.market_maker.observatory_min_completeness,
+            min_fills=settings.maker_observatory.min_fills,
+            min_markets=settings.maker_observatory.min_markets,
+            min_completeness=settings.maker_observatory.min_completeness,
         )
         if blockers:
             console.print("[yellow]Not promotable:[/]")

--- a/auramaur/composition.py
+++ b/auramaur/composition.py
@@ -552,7 +552,8 @@ async def assemble_components(
     # rebate tier is introduced.
     market_maker = None
     if s.market_maker.enabled and exchange is not None:
-        market_maker = MarketMaker(settings=s, exchange=exchange, db=db)
+        market_maker = MarketMaker(
+            settings=s, exchange=exchange, db=db, flow_tracker=flow_tracker)
 
     # Alerts
     alerts = AlertManager(

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -398,7 +398,10 @@ class Database:
                 observed_at TEXT NOT NULL, best_bid REAL NOT NULL, best_ask REAL NOT NULL,
                 midpoint REAL NOT NULL, microprice REAL NOT NULL, spread REAL NOT NULL,
                 bid_depth REAL NOT NULL, ask_depth REAL NOT NULL,
-                depth_imbalance REAL NOT NULL, signed_flow REAL NOT NULL DEFAULT 0,
+                depth_imbalance REAL NOT NULL,
+                -- Nullable: NULL is "no trade feed reached this market", which
+                -- is a different fact from balanced flow. See models.py.
+                signed_flow REAL,
                 short_vol REAL NOT NULL DEFAULT 0, long_vol REAL NOT NULL DEFAULT 0,
                 quote_bid REAL, quote_ask REAL, quote_changed INTEGER,
                 quote_age_seconds REAL, quote_active INTEGER NOT NULL DEFAULT 0,
@@ -414,9 +417,12 @@ class Database:
                 side TEXT NOT NULL CHECK(side IN ('bid','ask')),
                 fill_price REAL NOT NULL, fill_size REAL NOT NULL,
                 is_paper INTEGER NOT NULL, fill_evidence TEXT NOT NULL,
-                filled_at TEXT NOT NULL);
+                filled_at TEXT NOT NULL,
+                marks_pending INTEGER NOT NULL DEFAULT 1);
             CREATE INDEX IF NOT EXISTS idx_maker_fills_market_time
                 ON maker_observatory_fills(market_id, filled_at);
+            CREATE INDEX IF NOT EXISTS idx_maker_fills_pending
+                ON maker_observatory_fills(filled_at) WHERE marks_pending=1;
             CREATE TABLE IF NOT EXISTS maker_observatory_markouts (
                 fill_id INTEGER NOT NULL, horizon_seconds INTEGER NOT NULL,
                 target_at TEXT NOT NULL, midpoint REAL NOT NULL, markout REAL NOT NULL,

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -384,6 +384,49 @@ class Database:
             await self._migrate_v47_to_v48()
         if from_version < 49:
             await self._migrate_v48_to_v49()
+        if from_version < 50:
+            await self._migrate_v49_to_v50()
+
+    async def _migrate_v49_to_v50(self) -> None:
+        """Shadow-only maker microstructure observations and fill markouts."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS maker_observations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                market_id TEXT NOT NULL, condition_id TEXT NOT NULL DEFAULT '',
+                token_id TEXT NOT NULL, strategy_version TEXT NOT NULL,
+                is_holdout INTEGER NOT NULL DEFAULT 0,
+                observed_at TEXT NOT NULL, best_bid REAL NOT NULL, best_ask REAL NOT NULL,
+                midpoint REAL NOT NULL, microprice REAL NOT NULL, spread REAL NOT NULL,
+                bid_depth REAL NOT NULL, ask_depth REAL NOT NULL,
+                depth_imbalance REAL NOT NULL, signed_flow REAL NOT NULL DEFAULT 0,
+                short_vol REAL NOT NULL DEFAULT 0, long_vol REAL NOT NULL DEFAULT 0,
+                quote_bid REAL, quote_ask REAL, quote_changed INTEGER,
+                quote_age_seconds REAL, quote_active INTEGER NOT NULL DEFAULT 0,
+                reward_eligible INTEGER);
+            CREATE INDEX IF NOT EXISTS idx_maker_obs_market_time
+                ON maker_observations(market_id, observed_at);
+            CREATE TABLE IF NOT EXISTS maker_observatory_horizons (
+                strategy_version TEXT NOT NULL, horizon_seconds INTEGER NOT NULL,
+                PRIMARY KEY (strategy_version, horizon_seconds));
+            CREATE TABLE IF NOT EXISTS maker_observatory_fills (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, order_id TEXT NOT NULL UNIQUE,
+                observation_id INTEGER, market_id TEXT NOT NULL,
+                side TEXT NOT NULL CHECK(side IN ('bid','ask')),
+                fill_price REAL NOT NULL, fill_size REAL NOT NULL,
+                is_paper INTEGER NOT NULL, fill_evidence TEXT NOT NULL,
+                filled_at TEXT NOT NULL);
+            CREATE INDEX IF NOT EXISTS idx_maker_fills_market_time
+                ON maker_observatory_fills(market_id, filled_at);
+            CREATE TABLE IF NOT EXISTS maker_observatory_markouts (
+                fill_id INTEGER NOT NULL, horizon_seconds INTEGER NOT NULL,
+                target_at TEXT NOT NULL, midpoint REAL NOT NULL, markout REAL NOT NULL,
+                marked_at TEXT NOT NULL, lateness_seconds REAL NOT NULL,
+                is_valid INTEGER NOT NULL,
+                PRIMARY KEY (fill_id, horizon_seconds));
+            UPDATE schema_version SET version = 50;
+        """)
+        await self._db.commit()
+        log.info("database.migrated", from_version=49, to_version=50)
 
     async def _migrate_v48_to_v49(self) -> None:
         """Record the deterministic pair post-check on entailment verdicts (#405).

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -458,7 +458,11 @@ CREATE TABLE IF NOT EXISTS maker_observations (
     observed_at TEXT NOT NULL, best_bid REAL NOT NULL, best_ask REAL NOT NULL,
     midpoint REAL NOT NULL, microprice REAL NOT NULL, spread REAL NOT NULL,
     bid_depth REAL NOT NULL, ask_depth REAL NOT NULL,
-    depth_imbalance REAL NOT NULL, signed_flow REAL NOT NULL DEFAULT 0,
+    depth_imbalance REAL NOT NULL,
+    -- Nullable ON PURPOSE. NULL means no trade feed ever reached this market,
+    -- which is not the same fact as balanced flow; a NOT NULL DEFAULT 0 column
+    -- could not tell the two apart and would read as healthy forever.
+    signed_flow REAL,
     short_vol REAL NOT NULL DEFAULT 0, long_vol REAL NOT NULL DEFAULT 0,
     quote_bid REAL, quote_ask REAL, quote_changed INTEGER,
     quote_age_seconds REAL, quote_active INTEGER NOT NULL DEFAULT 0,
@@ -476,10 +480,17 @@ CREATE TABLE IF NOT EXISTS maker_observatory_fills (
     side TEXT NOT NULL CHECK(side IN ('bid','ask')),
     fill_price REAL NOT NULL, fill_size REAL NOT NULL,
     is_paper INTEGER NOT NULL, fill_evidence TEXT NOT NULL,
-    filled_at TEXT NOT NULL
+    filled_at TEXT NOT NULL,
+    marks_pending INTEGER NOT NULL DEFAULT 1
 );
 CREATE INDEX IF NOT EXISTS idx_maker_fills_market_time
     ON maker_observatory_fills(market_id, filled_at);
+-- Partial: the markout resolver only ever asks for fills that still owe a
+-- mark, so the index holds the backlog rather than every retained fill. This
+-- is what keeps the offline pass proportional to work outstanding instead of
+-- to 45 days of history.
+CREATE INDEX IF NOT EXISTS idx_maker_fills_pending
+    ON maker_observatory_fills(filled_at) WHERE marks_pending=1;
 CREATE TABLE IF NOT EXISTS maker_observatory_markouts (
     fill_id INTEGER NOT NULL, horizon_seconds INTEGER NOT NULL,
     target_at TEXT NOT NULL, midpoint REAL NOT NULL, markout REAL NOT NULL,

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 49
+SCHEMA_VERSION = 50
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -449,6 +449,44 @@ CREATE TABLE IF NOT EXISTS orderbook_snapshots (
     recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_orderbook_market_time ON orderbook_snapshots(market_id, recorded_at);
+
+CREATE TABLE IF NOT EXISTS maker_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    market_id TEXT NOT NULL, condition_id TEXT NOT NULL DEFAULT '',
+    token_id TEXT NOT NULL, strategy_version TEXT NOT NULL,
+    is_holdout INTEGER NOT NULL DEFAULT 0,
+    observed_at TEXT NOT NULL, best_bid REAL NOT NULL, best_ask REAL NOT NULL,
+    midpoint REAL NOT NULL, microprice REAL NOT NULL, spread REAL NOT NULL,
+    bid_depth REAL NOT NULL, ask_depth REAL NOT NULL,
+    depth_imbalance REAL NOT NULL, signed_flow REAL NOT NULL DEFAULT 0,
+    short_vol REAL NOT NULL DEFAULT 0, long_vol REAL NOT NULL DEFAULT 0,
+    quote_bid REAL, quote_ask REAL, quote_changed INTEGER,
+    quote_age_seconds REAL, quote_active INTEGER NOT NULL DEFAULT 0,
+    reward_eligible INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_maker_obs_market_time
+    ON maker_observations(market_id, observed_at);
+CREATE TABLE IF NOT EXISTS maker_observatory_horizons (
+    strategy_version TEXT NOT NULL, horizon_seconds INTEGER NOT NULL,
+    PRIMARY KEY (strategy_version, horizon_seconds)
+);
+CREATE TABLE IF NOT EXISTS maker_observatory_fills (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, order_id TEXT NOT NULL UNIQUE,
+    observation_id INTEGER, market_id TEXT NOT NULL,
+    side TEXT NOT NULL CHECK(side IN ('bid','ask')),
+    fill_price REAL NOT NULL, fill_size REAL NOT NULL,
+    is_paper INTEGER NOT NULL, fill_evidence TEXT NOT NULL,
+    filled_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_maker_fills_market_time
+    ON maker_observatory_fills(market_id, filled_at);
+CREATE TABLE IF NOT EXISTS maker_observatory_markouts (
+    fill_id INTEGER NOT NULL, horizon_seconds INTEGER NOT NULL,
+    target_at TEXT NOT NULL, midpoint REAL NOT NULL, markout REAL NOT NULL,
+    marked_at TEXT NOT NULL, lateness_seconds REAL NOT NULL,
+    is_valid INTEGER NOT NULL,
+    PRIMARY KEY (fill_id, horizon_seconds)
+);
 
 -- Immutable decision-time observations used for executable-price and
 -- closing-line-value evaluation.  These are separate from mutable signals so

--- a/auramaur/monitoring/maker_observatory.py
+++ b/auramaur/monitoring/maker_observatory.py
@@ -72,8 +72,17 @@ class MakerObservatory:
         }, sort_keys=True, separators=(",", ":"))
         self.config_json = frozen
         self.strategy_version = hashlib.sha256(frozen.encode()).hexdigest()
+        self._registered = False
 
     async def _register(self) -> None:
+        # Registration is idempotent and constant for this instance's frozen
+        # config, but observe() runs on the market maker's quoting path, where
+        # every statement takes the process-wide Database serializer. Re-issuing
+        # 1 + len(horizons) INSERT OR IGNOREs on every refresh spends four
+        # shared-lock acquisitions per observation to re-learn a fact that
+        # cannot change. Do it once per process.
+        if self._registered:
+            return
         await self.db.execute(
             """INSERT OR IGNORE INTO strategy_experiments
                    (strategy_version,strategy_source,config_json,holdout_starts_at)
@@ -86,6 +95,7 @@ class MakerObservatory:
                        (strategy_version,horizon_seconds) VALUES (?,?)""",
                 (self.strategy_version, horizon),
             )
+        self._registered = True
 
     async def observe(self, market, book: OrderBook, *, quote=None, active_quote=None,
                       observed_at: datetime | None = None) -> int:
@@ -149,10 +159,18 @@ class MakerObservatory:
                    for index in range(1, len(prices))]
         return statistics.pstdev(changes) if len(changes) >= 2 else 0.0
 
-    async def record_fill(self, *, observation_id: int | None, order_id: str,
-                          market_id: str, side: str, price: float, size: float,
-                          is_paper: bool, fill_evidence: str,
-                          filled_at: datetime | None = None) -> None:
+    async def record_observed_fill(self, *, observation_id: int | None, order_id: str,
+                                   market_id: str, side: str, price: float, size: float,
+                                   is_paper: bool, fill_evidence: str,
+                                   filled_at: datetime | None = None) -> None:
+        """Note that a fill happened. NOT ``record_fill``, deliberately.
+
+        ``record_fill`` is in exposure_registry.SENSITIVE_METHODS, and that
+        registry is scanned by attribute name — so calling this method
+        ``record_fill`` forced a pure measurement write to be declared as a
+        ``prediction_quoting`` exposure-mutation callsite, which it is not.
+        This class books no position, moves no cash and touches no venue.
+        """
         if not order_id or price <= 0 or size <= 0:
             return
         stamp = (filled_at or datetime.now(timezone.utc)).astimezone(timezone.utc)

--- a/auramaur/monitoring/maker_observatory.py
+++ b/auramaur/monitoring/maker_observatory.py
@@ -1,0 +1,383 @@
+"""Shadow-only market-maker microstructure observations and fill markouts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import statistics
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from auramaur.exchange.models import OrderBook
+
+FEATURE_SCHEMA = "maker-observatory-v2"
+CREDIBLE_FILL_EVIDENCE = frozenset({"venue_fill", "book_cross", "trade_through"})
+
+
+@dataclass(frozen=True)
+class MakerFeatures:
+    best_bid: float
+    best_ask: float
+    midpoint: float
+    microprice: float
+    spread: float
+    bid_depth: float
+    ask_depth: float
+    imbalance: float
+
+
+def compute_maker_features(book: OrderBook, *, levels: int = 5) -> MakerFeatures:
+    """Compute ordering-agnostic top-of-book microstructure features."""
+    bids = sorted(book.bids, key=lambda level: level.price, reverse=True)[:levels]
+    asks = sorted(book.asks, key=lambda level: level.price)[:levels]
+    if not bids or not asks:
+        raise ValueError("maker observatory requires a two-sided book")
+    best_bid, best_ask = bids[0].price, asks[0].price
+    if best_ask <= best_bid:
+        raise ValueError("maker observatory requires a positive spread")
+    bid_depth = sum(level.size for level in bids)
+    ask_depth = sum(level.size for level in asks)
+    total_depth = bid_depth + ask_depth
+    imbalance = (bid_depth - ask_depth) / total_depth if total_depth else 0.0
+    top_total = bids[0].size + asks[0].size
+    midpoint = (best_bid + best_ask) / 2.0
+    microprice = (
+        (best_ask * bids[0].size + best_bid * asks[0].size) / top_total
+        if top_total else midpoint
+    )
+    return MakerFeatures(
+        best_bid=best_bid, best_ask=best_ask, midpoint=midpoint,
+        microprice=microprice, spread=best_ask - best_bid,
+        bid_depth=bid_depth, ask_depth=ask_depth, imbalance=imbalance,
+    )
+
+
+class MakerObservatory:
+    """Persist measurements only; this class has no order-placement capability."""
+
+    def __init__(self, db, *, flow_tracker=None, horizons=(30, 60, 300),
+                 retention_days: int = 45, max_mark_lateness_seconds: int = 45,
+                 holdout_days: int = 7) -> None:
+        self.db = db
+        self.flow_tracker = flow_tracker
+        self.horizons = tuple(sorted(set(int(value) for value in horizons)))
+        self.retention_days = retention_days
+        self.max_mark_lateness_seconds = max_mark_lateness_seconds
+        self.holdout_days = holdout_days
+        frozen = json.dumps({
+            "feature_schema": FEATURE_SCHEMA,
+            "horizons": self.horizons,
+            "max_mark_lateness_seconds": max_mark_lateness_seconds,
+        }, sort_keys=True, separators=(",", ":"))
+        self.config_json = frozen
+        self.strategy_version = hashlib.sha256(frozen.encode()).hexdigest()
+
+    async def _register(self) -> None:
+        await self.db.execute(
+            """INSERT OR IGNORE INTO strategy_experiments
+                   (strategy_version,strategy_source,config_json,holdout_starts_at)
+               VALUES (?,'maker_observatory',?,datetime('now', ?))""",
+            (self.strategy_version, self.config_json, f"+{self.holdout_days} days"),
+        )
+        for horizon in self.horizons:
+            await self.db.execute(
+                """INSERT OR IGNORE INTO maker_observatory_horizons
+                       (strategy_version,horizon_seconds) VALUES (?,?)""",
+                (self.strategy_version, horizon),
+            )
+
+    async def observe(self, market, book: OrderBook, *, quote=None, active_quote=None,
+                      observed_at: datetime | None = None) -> int:
+        now = (observed_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        await self._register()
+        features = compute_maker_features(book)
+        signed_flow = 0.0
+        if self.flow_tracker is not None:
+            signed_flow = self.flow_tracker.signed_flow(
+                (market.id, market.condition_id, market.clob_token_yes), now=now)
+        quote_age = (
+            max(0.0, (now - active_quote.placed_at).total_seconds())
+            if active_quote is not None else None
+        )
+        quote_changed = None
+        if quote is not None and active_quote is not None:
+            quote_changed = int(
+                quote.bid_price != active_quote.bid_price
+                or quote.ask_price != active_quote.ask_price
+                or quote.size != active_quote.size
+            )
+        short_vol = await self._realized_vol(market.id, features.midpoint, now, 300)
+        long_vol = await self._realized_vol(market.id, features.midpoint, now, 1800)
+        cursor = await self.db.execute(
+            """INSERT INTO maker_observations
+                   (market_id,condition_id,token_id,strategy_version,is_holdout,
+                    observed_at,best_bid,best_ask,midpoint,
+                    microprice,spread,bid_depth,ask_depth,depth_imbalance,
+                    signed_flow,short_vol,long_vol,quote_bid,quote_ask,
+                    quote_changed,quote_age_seconds,quote_active)
+               VALUES (?,?,?,?,CASE WHEN datetime(?) >=
+                    (SELECT holdout_starts_at FROM strategy_experiments
+                     WHERE strategy_version=?) THEN 1 ELSE 0 END,
+                    ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (market.id, getattr(market, "condition_id", "") or "",
+             market.clob_token_yes, self.strategy_version,
+             now.isoformat(timespec="microseconds"), self.strategy_version,
+             now.isoformat(timespec="microseconds"),
+             features.best_bid, features.best_ask, features.midpoint,
+             features.microprice, features.spread, features.bid_depth,
+             features.ask_depth, features.imbalance, signed_flow, short_vol, long_vol,
+             getattr(quote, "bid_price", None), getattr(quote, "ask_price", None),
+             quote_changed, quote_age, int(active_quote is not None)),
+        )
+        await self._mark_due(market.id, features.midpoint, now)
+        return int(cursor.lastrowid)
+
+    async def _realized_vol(self, market_id: str, midpoint: float,
+                            now: datetime, window_seconds: int) -> float:
+        cutoff = datetime.fromtimestamp(
+            now.timestamp() - window_seconds, tz=timezone.utc
+        ).isoformat(timespec="microseconds")
+        rows = await self.db.fetchall(
+            """SELECT midpoint FROM maker_observations
+               WHERE market_id=? AND observed_at>=? AND observed_at<?
+               ORDER BY observed_at""",
+            (market_id, cutoff, now.isoformat(timespec="microseconds")),
+        )
+        prices = [float(row["midpoint"]) for row in rows] + [midpoint]
+        changes = [prices[index] - prices[index - 1]
+                   for index in range(1, len(prices))]
+        return statistics.pstdev(changes) if len(changes) >= 2 else 0.0
+
+    async def record_fill(self, *, observation_id: int | None, order_id: str,
+                          market_id: str, side: str, price: float, size: float,
+                          is_paper: bool, fill_evidence: str,
+                          filled_at: datetime | None = None) -> None:
+        if not order_id or price <= 0 or size <= 0:
+            return
+        stamp = (filled_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        await self.db.execute(
+            """INSERT OR IGNORE INTO maker_observatory_fills
+                   (order_id,observation_id,market_id,side,fill_price,fill_size,
+                    is_paper,fill_evidence,filled_at) VALUES (?,?,?,?,?,?,?,?,?)""",
+            (order_id, observation_id, market_id, side, price, size, int(is_paper),
+             fill_evidence, stamp.isoformat(timespec="microseconds")),
+        )
+
+    async def _mark_due(self, market_id: str, midpoint: float, now: datetime) -> None:
+        for horizon in self.horizons:
+            rows = await self.db.fetchall(
+                """SELECT f.id,f.side,f.fill_price,f.filled_at
+                   FROM maker_observatory_fills f
+                   WHERE f.market_id=?
+                     AND unixepoch(?) - unixepoch(f.filled_at) >= ?
+                     AND NOT EXISTS (SELECT 1 FROM maker_observatory_markouts m
+                         WHERE m.fill_id=f.id AND m.horizon_seconds=?)
+                   """,
+                (market_id, now.isoformat(timespec="microseconds"), horizon, horizon),
+            )
+            for row in rows:
+                filled_at = datetime.fromisoformat(str(row["filled_at"]))
+                target_at = datetime.fromtimestamp(
+                    filled_at.timestamp() + horizon, tz=timezone.utc)
+                lateness = max(0.0, (now - target_at).total_seconds())
+                # Positive means price moved in the maker fill's favour.
+                markout = (midpoint - row["fill_price"] if row["side"] == "bid"
+                           else row["fill_price"] - midpoint)
+                await self.db.execute(
+                    """INSERT OR IGNORE INTO maker_observatory_markouts
+                           (fill_id,horizon_seconds,target_at,midpoint,markout,
+                            marked_at,lateness_seconds,is_valid)
+                       VALUES (?,?,?,?,?,?,?,?)""",
+                    (row["id"], horizon, target_at.isoformat(timespec="microseconds"),
+                     midpoint, markout, now.isoformat(timespec="microseconds"),
+                     lateness, int(lateness <= self.max_mark_lateness_seconds)),
+                )
+
+    async def prune(self) -> None:
+        """Bound raw storage while retaining rows needed by surviving fills."""
+        modifier = f"-{self.retention_days} days"
+        await self.db.execute(
+            "DELETE FROM maker_observatory_markouts WHERE fill_id IN "
+            "(SELECT id FROM maker_observatory_fills "
+            "WHERE datetime(filled_at) < datetime('now', ?))",
+            (modifier,),
+        )
+        await self.db.execute(
+            "DELETE FROM maker_observatory_fills "
+            "WHERE datetime(filled_at) < datetime('now', ?)",
+            (modifier,),
+        )
+        await self.db.execute(
+            "DELETE FROM maker_observations "
+            "WHERE datetime(observed_at) < datetime('now', ?)",
+            (modifier,),
+        )
+
+
+async def maker_observatory_summary(db, *, days: int = 21) -> list[dict]:
+    """Return honest markout evidence, including invalid/missing mark diagnostics."""
+    rows = await db.fetchall(
+        """SELECT h.horizon_seconds,f.is_paper,f.market_id,f.fill_size,
+                  f.fill_evidence,m.markout,m.is_valid,m.lateness_seconds,
+                  o.is_holdout,
+                  CASE WHEN unixepoch('now')-unixepoch(f.filled_at)
+                         >= h.horizon_seconds THEN 1 ELSE 0 END AS is_due
+           FROM maker_observatory_fills f
+           JOIN maker_observations o ON o.id=f.observation_id
+           JOIN maker_observatory_horizons h
+             ON h.strategy_version=o.strategy_version
+           LEFT JOIN maker_observatory_markouts m
+             ON m.fill_id=f.id AND m.horizon_seconds=h.horizon_seconds
+           WHERE datetime(f.filled_at) >= datetime('now', ?)
+           ORDER BY f.is_paper,h.horizon_seconds,f.market_id""",
+        (f"-{days} days",),
+    )
+    grouped: dict[tuple[int, int], list] = {}
+    for row in rows:
+        grouped.setdefault((row["horizon_seconds"], row["is_paper"]), []).append(row)
+    output = []
+    for (horizon, is_paper), values in grouped.items():
+        due = [row for row in values if row["is_due"] == 1]
+        valid = [row for row in due if row["is_valid"] == 1]
+        credible = [row for row in valid
+                    if row["fill_evidence"] in CREDIBLE_FILL_EVIDENCE
+                    and row["is_holdout"] == 1]
+        cluster_values = [(str(row["market_id"]), float(row["markout"]))
+                          for row in credible]
+        marks = [value for _, value in cluster_values]
+        low, high = _clustered_mean_ci(cluster_values)
+        weighted_denominator = sum(float(row["fill_size"]) for row in credible)
+        output.append({
+            "horizon_seconds": horizon, "is_paper": is_paper,
+            "fills": len(values), "due_marks": len(due),
+            "pending_marks": len(values) - len(due),
+            "valid_marks": len(valid),
+            "credible_holdout_marks": len(credible),
+            "markets": len({key for key, _ in cluster_values}),
+            "mean_markout": statistics.fmean(marks) if marks else None,
+            "size_weighted_markout": (
+                sum(float(row["markout"]) * float(row["fill_size"])
+                    for row in credible) / weighted_denominator
+                if weighted_denominator else None),
+            "ci_low": low, "ci_high": high,
+            "toxic_rate": (sum(value < 0 for value in marks) / len(marks)
+                           if marks else None),
+            "completeness": len(valid) / len(due) if due else 0.0,
+            "late_marks": sum(row["is_valid"] == 0 and row["markout"] is not None
+                              for row in values),
+        })
+    return output
+
+
+async def maker_observatory_feature_report(db, *, days: int = 21) -> list[dict]:
+    """Score frozen warmup thresholds only on credible holdout fill markouts."""
+    rows = await db.fetchall(
+        """SELECT m.horizon_seconds,f.market_id,f.fill_evidence,f.filled_at,
+                  o.is_holdout,o.microprice-o.midpoint AS microprice_skew,
+                  o.depth_imbalance,o.signed_flow,o.short_vol,o.long_vol,
+                  o.quote_age_seconds,m.markout
+             FROM maker_observatory_fills f
+             JOIN maker_observations o ON o.id=f.observation_id
+             JOIN maker_observatory_markouts m ON m.fill_id=f.id
+            WHERE datetime(f.filled_at) >= datetime('now', ?)
+              AND f.is_paper=0 AND m.is_valid=1
+            ORDER BY m.horizon_seconds,f.market_id""",
+        (f"-{days} days",),
+    )
+    features = ("microprice_skew", "depth_imbalance", "signed_flow",
+                "short_vol", "long_vol", "quote_age_seconds")
+    output = []
+    horizons = sorted({int(row["horizon_seconds"]) for row in rows})
+    for horizon in horizons:
+        horizon_rows = [row for row in rows if row["horizon_seconds"] == horizon]
+        for feature in features:
+            warmup = [float(row[feature]) for row in horizon_rows
+                      if row["is_holdout"] == 0 and row[feature] is not None]
+            holdout = [row for row in horizon_rows
+                       if row["is_holdout"] == 1
+                       and row["fill_evidence"] in CREDIBLE_FILL_EVIDENCE
+                       and row[feature] is not None]
+            threshold = statistics.median(warmup) if warmup else None
+            high = [] if threshold is None else [
+                (str(row["market_id"]), float(row["markout"]))
+                for row in holdout if float(row[feature]) >= threshold]
+            low = [] if threshold is None else [
+                (str(row["market_id"]), float(row["markout"]))
+                for row in holdout if float(row[feature]) < threshold]
+            effect = (statistics.fmean(value for _, value in high)
+                      - statistics.fmean(value for _, value in low)
+                      if high and low else None)
+            output.append({
+                "horizon_seconds": horizon, "feature": feature,
+                "warmup_n": len(warmup), "holdout_n": len(holdout),
+                "threshold": threshold, "high_n": len(high), "low_n": len(low),
+                "effect": effect,
+                "markets": len({key for key, _ in high + low}),
+            })
+    return output
+
+
+async def maker_quote_coverage(db, *, days: int = 21) -> dict:
+    """Report cadence-weighted quote presence without pretending it is uptime."""
+    row = await db.fetchone(
+        """SELECT COUNT(*) AS samples,
+                  SUM(quote_active=1) AS active,
+                  SUM(quote_changed=1) AS changed,
+                  SUM(is_holdout=1) AS holdout
+             FROM maker_observations
+            WHERE datetime(observed_at) >= datetime('now', ?)""",
+        (f"-{days} days",),
+    )
+    samples = int(row["samples"] or 0)
+    return {
+        "samples": samples,
+        "active_samples": int(row["active"] or 0),
+        "changed_samples": int(row["changed"] or 0),
+        "holdout_samples": int(row["holdout"] or 0),
+        "sampled_quote_coverage": (
+            int(row["active"] or 0) / samples if samples else None),
+    }
+
+
+def maker_promotion_blockers(rows: list[dict], *, min_fills: int = 100,
+                             min_markets: int = 5,
+                             min_completeness: float = .95) -> list[str]:
+    """Return explicit reasons the live observatory evidence cannot be promoted."""
+    blockers = []
+    live = [row for row in rows if not row["is_paper"]]
+    if not live:
+        return ["no live fills"]
+    for row in live:
+        label = f"{row['horizon_seconds']}s"
+        if row["credible_holdout_marks"] < min_fills:
+            blockers.append(
+                f"{label}: {row['credible_holdout_marks']}/{min_fills} "
+                "credible holdout marks")
+        if row["markets"] < min_markets:
+            blockers.append(f"{label}: {row['markets']}/{min_markets} markets")
+        if row["completeness"] < min_completeness:
+            blockers.append(
+                f"{label}: {row['completeness']:.1%}/{min_completeness:.1%} "
+                "valid-mark completeness")
+        if row["ci_low"] is None or row["ci_low"] <= 0:
+            blockers.append(f"{label}: mean markout lower CI is not positive")
+    return blockers
+
+
+def _clustered_mean_ci(values: list[tuple[str, float]], *, samples: int = 2000,
+                       seed: int = 20260805) -> tuple[float | None, float | None]:
+    clusters: dict[str, list[float]] = {}
+    for market_id, value in values:
+        clusters.setdefault(market_id, []).append(value)
+    keys = sorted(clusters)
+    if len(keys) < 2:
+        return None, None
+    rng = random.Random(seed)
+    draws = []
+    for _ in range(samples):
+        chosen = [rng.choice(keys) for _ in keys]
+        draw = [value for key in chosen for value in clusters[key]]
+        draws.append(statistics.fmean(draw))
+    draws.sort()
+    return draws[int(samples * .025)], draws[int(samples * .975)]

--- a/auramaur/monitoring/maker_observatory.py
+++ b/auramaur/monitoring/maker_observatory.py
@@ -15,6 +15,51 @@ FEATURE_SCHEMA = "maker-observatory-v2"
 CREDIBLE_FILL_EVIDENCE = frozenset({"venue_fill", "book_cross", "trade_through"})
 
 
+# The resolver's two hot statements, named so tests can EXPLAIN QUERY PLAN the
+# exact SQL that ships. Both compare a timestamp column against a bound
+# computed in Python.
+#
+# The MAX(observed_at) term is a liveness guard, not a filter on the evidence.
+# A mark can only ever come from an observation, so a fill whose market has not
+# been observed until at least its EARLIEST horizon cannot be marked at all
+# yet — and because the batch below is oldest-first, fills stranded by a market
+# that left the maker's five would otherwise hold the head of the queue until
+# retention pruned them 45 days later, starving every newer mark behind them.
+# Excluding them changes nothing about what gets concluded: the moment that
+# market is observed again the fill re-enters the scan and takes its (late,
+# is_valid=0) mark exactly as before. It is a per-candidate-row filter, not the
+# driving predicate — `filled_at<=?` still seeks the index — and the subquery
+# is an index-max lookup on (market_id, observed_at).
+#
+# The predicate this replaced,
+# ``unixepoch(?) - unixepoch(f.filled_at) >= ?``, wrapped the column in a
+# function: SQLite could seek to the market but then had to walk EVERY retained
+# fill in it and probe the markouts index once per row
+# (``SEARCH f USING INDEX idx_maker_fills_market_time (market_id=?)`` +
+# ``CORRELATED SCALAR SUBQUERY``), which is where the 4.6 s went.
+DUE_FILL_SCAN_SQL = """SELECT f.id,f.market_id,f.side,f.fill_price,f.filled_at
+     FROM maker_observatory_fills f
+    WHERE f.marks_pending=1 AND f.filled_at<=?
+      AND unixepoch((SELECT MAX(o.observed_at) FROM maker_observations o
+                      WHERE o.market_id=f.market_id))
+          - unixepoch(f.filled_at) >= ?
+    ORDER BY f.filled_at LIMIT ?"""
+MARK_BOOK_SQL = """SELECT observed_at,midpoint FROM maker_observations
+    WHERE market_id=? AND observed_at>=?
+    ORDER BY observed_at LIMIT 1"""
+
+
+def _stamp(moment: datetime) -> str:
+    """The one timestamp spelling this module writes and compares.
+
+    Every ``observed_at``/``filled_at`` is written through here, so the columns
+    are fixed-width UTC ISO-8601 and lexicographic order IS chronological
+    order. That is what lets the resolver's range predicates use an index
+    instead of wrapping the column in ``unixepoch()``.
+    """
+    return moment.astimezone(timezone.utc).isoformat(timespec="microseconds")
+
+
 @dataclass(frozen=True)
 class MakerFeatures:
     best_bid: float
@@ -54,17 +99,29 @@ def compute_maker_features(book: OrderBook, *, levels: int = 5) -> MakerFeatures
 
 
 class MakerObservatory:
-    """Persist measurements only; this class has no order-placement capability."""
+    """Persist measurements only; this class has no order-placement capability.
+
+    The two halves run on different paths on purpose. ``observe()`` is on the
+    market maker's quoting path and stays cheap and constant-cost:
+    ``compute_maker_features`` plus a bounded, indexed volatility window plus
+    one INSERT. ``resolve_markouts()`` — deciding whether a fill from four
+    minutes ago moved against us — is on its own timer and touches nothing the
+    current quote depends on. See docs/maker-observatory.md.
+    """
 
     def __init__(self, db, *, flow_tracker=None, horizons=(30, 60, 300),
                  retention_days: int = 45, max_mark_lateness_seconds: int = 45,
-                 holdout_days: int = 7) -> None:
+                 holdout_days: int = 7, resolve_batch_fills: int = 500) -> None:
         self.db = db
         self.flow_tracker = flow_tracker
         self.horizons = tuple(sorted(set(int(value) for value in horizons)))
         self.retention_days = retention_days
         self.max_mark_lateness_seconds = max_mark_lateness_seconds
         self.holdout_days = holdout_days
+        # Bounds one resolver pass. A backlog (long outage, clock jump) must not
+        # let a single pass hold the shared Database serializer for minutes;
+        # the remainder stays pending and the next pass takes it.
+        self.resolve_batch_fills = max(1, int(resolve_batch_fills))
         frozen = json.dumps({
             "feature_schema": FEATURE_SCHEMA,
             "horizons": self.horizons,
@@ -99,13 +156,24 @@ class MakerObservatory:
 
     async def observe(self, market, book: OrderBook, *, quote=None, active_quote=None,
                       observed_at: datetime | None = None) -> int:
+        """Record one microstructure sample. Runs on the quoting path.
+
+        Everything here is O(1) in retained history. Markout resolution is
+        deliberately absent: it belongs to ``resolve_markouts()``, because an
+        instrument that added seconds to the quote path would cause the adverse
+        selection it exists to measure.
+        """
         now = (observed_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
         await self._register()
         features = compute_maker_features(book)
-        signed_flow = 0.0
+        # NULL, not 0.0, when no feed ever reached this market. See
+        # OrderFlowTracker.signed_flow: the two are different facts and the
+        # column has to be able to say which.
+        signed_flow = None
         if self.flow_tracker is not None:
             signed_flow = self.flow_tracker.signed_flow(
-                (market.id, market.condition_id, market.clob_token_yes), now=now)
+                (market.id, getattr(market, "condition_id", "") or "",
+                 market.clob_token_yes), now=now)
         quote_age = (
             max(0.0, (now - active_quote.placed_at).total_seconds())
             if active_quote is not None else None
@@ -132,27 +200,24 @@ class MakerObservatory:
                     ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (market.id, getattr(market, "condition_id", "") or "",
              market.clob_token_yes, self.strategy_version,
-             now.isoformat(timespec="microseconds"), self.strategy_version,
-             now.isoformat(timespec="microseconds"),
+             _stamp(now), self.strategy_version, _stamp(now),
              features.best_bid, features.best_ask, features.midpoint,
              features.microprice, features.spread, features.bid_depth,
              features.ask_depth, features.imbalance, signed_flow, short_vol, long_vol,
              getattr(quote, "bid_price", None), getattr(quote, "ask_price", None),
              quote_changed, quote_age, int(active_quote is not None)),
         )
-        await self._mark_due(market.id, features.midpoint, now)
         return int(cursor.lastrowid)
 
     async def _realized_vol(self, market_id: str, midpoint: float,
                             now: datetime, window_seconds: int) -> float:
-        cutoff = datetime.fromtimestamp(
-            now.timestamp() - window_seconds, tz=timezone.utc
-        ).isoformat(timespec="microseconds")
+        cutoff = _stamp(datetime.fromtimestamp(
+            now.timestamp() - window_seconds, tz=timezone.utc))
         rows = await self.db.fetchall(
             """SELECT midpoint FROM maker_observations
                WHERE market_id=? AND observed_at>=? AND observed_at<?
                ORDER BY observed_at""",
-            (market_id, cutoff, now.isoformat(timespec="microseconds")),
+            (market_id, cutoff, _stamp(now)),
         )
         prices = [float(row["midpoint"]) for row in rows] + [midpoint]
         changes = [prices[index] - prices[index - 1]
@@ -179,38 +244,99 @@ class MakerObservatory:
                    (order_id,observation_id,market_id,side,fill_price,fill_size,
                     is_paper,fill_evidence,filled_at) VALUES (?,?,?,?,?,?,?,?,?)""",
             (order_id, observation_id, market_id, side, price, size, int(is_paper),
-             fill_evidence, stamp.isoformat(timespec="microseconds")),
+             fill_evidence, _stamp(stamp)),
         )
 
-    async def _mark_due(self, market_id: str, midpoint: float, now: datetime) -> None:
+    async def resolve_markouts(self, *, now: datetime | None = None) -> int:
+        """Mark out every fill whose horizon has come due. Runs OFF the quote path.
+
+        This used to run inline in ``observe()``, inside the market maker's
+        per-market ``op_timeout`` window, holding the process-wide
+        ``Database`` serializer that ~30 pillar tasks share. It was 93% of
+        ``observe()``'s cost and it grew with retained history (4.6 s per
+        5-market cycle at 45-day retention), so the instrument would have
+        slowed the quotes it measures into exactly the adverse selection it
+        exists to detect.
+
+        Two properties make the move safe:
+
+        * **The mark is a pure function of the record, not of when this runs.**
+          A fill's mark is taken from the FIRST observation at or after
+          ``filled_at + horizon`` — which is precisely the book the inline scan
+          used, because the inline scan ran on the observation that first found
+          the fill due. Horizons, lateness and the validity rule are unchanged,
+          and a mark taken from a late book is still stored with
+          ``is_valid=0``. Running once an hour and running every cycle
+          therefore produce identical rows; only the wall-clock moment of the
+          INSERT differs.
+        * **An interrupted pass leaves due marks unresolved, never fabricated.**
+          ``marks_pending`` is only cleared in the same transaction that writes
+          a fill's last mark, and every insert is ``INSERT OR IGNORE`` against
+          the ``(fill_id,horizon_seconds)`` primary key, so a re-run resumes
+          rather than double-counting. A fill whose market has not been
+          observed since its horizon simply stays pending.
+
+        ``marks_pending`` is also what keeps this cheap: the partial index
+        ``idx_maker_fills_pending`` contains only unresolved fills, so the scan
+        is proportional to the backlog, not to the 259k retained fills per
+        market that the old ``unixepoch()`` predicate had to re-read.
+        """
+        instant = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        due_bound = _stamp(datetime.fromtimestamp(
+            instant.timestamp() - min(self.horizons), tz=timezone.utc))
+        pending = await self.db.fetchall(
+            DUE_FILL_SCAN_SQL,
+            (due_bound, min(self.horizons), self.resolve_batch_fills))
+        resolved = 0
+        for fill in pending:
+            resolved += await self._resolve_one(fill, instant)
+        return resolved
+
+    async def _resolve_one(self, fill, instant: datetime) -> int:
+        filled_at = datetime.fromisoformat(str(fill["filled_at"]))
+        marked = {int(row["horizon_seconds"]) for row in await self.db.fetchall(
+            "SELECT horizon_seconds FROM maker_observatory_markouts WHERE fill_id=?",
+            (fill["id"],))}
+        # Reads first, writes second: the transaction below must not span the
+        # per-horizon lookups, or the resolver would hold the write lock for
+        # the whole fill instead of for its inserts.
+        rows: list[tuple] = []
         for horizon in self.horizons:
-            rows = await self.db.fetchall(
-                """SELECT f.id,f.side,f.fill_price,f.filled_at
-                   FROM maker_observatory_fills f
-                   WHERE f.market_id=?
-                     AND unixepoch(?) - unixepoch(f.filled_at) >= ?
-                     AND NOT EXISTS (SELECT 1 FROM maker_observatory_markouts m
-                         WHERE m.fill_id=f.id AND m.horizon_seconds=?)
-                   """,
-                (market_id, now.isoformat(timespec="microseconds"), horizon, horizon),
-            )
+            if horizon in marked:
+                continue
+            target_at = datetime.fromtimestamp(
+                filled_at.timestamp() + horizon, tz=timezone.utc)
+            if target_at > instant:
+                continue
+            mark = await self.db.fetchone(
+                MARK_BOOK_SQL, (fill["market_id"], _stamp(target_at)))
+            if mark is None:
+                continue  # no book at or after the horizon yet: stay pending
+            marked_at = datetime.fromisoformat(str(mark["observed_at"]))
+            midpoint = float(mark["midpoint"])
+            lateness = max(0.0, (marked_at - target_at).total_seconds())
+            # Positive means price moved in the maker fill's favour.
+            markout = (midpoint - fill["fill_price"] if fill["side"] == "bid"
+                       else fill["fill_price"] - midpoint)
+            rows.append((fill["id"], horizon, _stamp(target_at), midpoint, markout,
+                         _stamp(marked_at), lateness,
+                         int(lateness <= self.max_mark_lateness_seconds)))
+            marked.add(horizon)
+        if not rows:
+            return 0
+        complete = marked.issuperset(self.horizons)
+        async with self.db.transaction(owner="maker_observatory.resolve_markouts"):
             for row in rows:
-                filled_at = datetime.fromisoformat(str(row["filled_at"]))
-                target_at = datetime.fromtimestamp(
-                    filled_at.timestamp() + horizon, tz=timezone.utc)
-                lateness = max(0.0, (now - target_at).total_seconds())
-                # Positive means price moved in the maker fill's favour.
-                markout = (midpoint - row["fill_price"] if row["side"] == "bid"
-                           else row["fill_price"] - midpoint)
                 await self.db.execute(
                     """INSERT OR IGNORE INTO maker_observatory_markouts
                            (fill_id,horizon_seconds,target_at,midpoint,markout,
                             marked_at,lateness_seconds,is_valid)
-                       VALUES (?,?,?,?,?,?,?,?)""",
-                    (row["id"], horizon, target_at.isoformat(timespec="microseconds"),
-                     midpoint, markout, now.isoformat(timespec="microseconds"),
-                     lateness, int(lateness <= self.max_mark_lateness_seconds)),
-                )
+                       VALUES (?,?,?,?,?,?,?,?)""", row)
+            if complete:
+                await self.db.execute(
+                    "UPDATE maker_observatory_fills SET marks_pending=0 WHERE id=?",
+                    (fill["id"],))
+        return len(rows)
 
     async def prune(self) -> None:
         """Bound raw storage while retaining rows needed by surviving fills."""
@@ -289,7 +415,17 @@ async def maker_observatory_summary(db, *, days: int = 21) -> list[dict]:
 
 
 async def maker_observatory_feature_report(db, *, days: int = 21) -> list[dict]:
-    """Score frozen warmup thresholds only on credible holdout fill markouts."""
+    """Score frozen warmup thresholds only on credible holdout fill markouts.
+
+    Every row carries its own ``covered_n``/``coverage``: the share of the
+    horizon's marks for which this feature was actually recorded. A feature
+    can be NULL for reasons that have nothing to do with the market —
+    ``signed_flow`` is NULL whenever no trade feed reached the market — and a
+    "no effect" verdict computed over a feature that was never measured is not
+    a negative result, it is an absent one. NULLs are excluded from the warmup
+    median and from both holdout buckets; the coverage number is what stops a
+    future reader from reading that exclusion as balance.
+    """
     rows = await db.fetchall(
         """SELECT m.horizon_seconds,f.market_id,f.fill_evidence,f.filled_at,
                   o.is_holdout,o.microprice-o.midpoint AS microprice_skew,
@@ -326,23 +462,33 @@ async def maker_observatory_feature_report(db, *, days: int = 21) -> list[dict]:
             effect = (statistics.fmean(value for _, value in high)
                       - statistics.fmean(value for _, value in low)
                       if high and low else None)
+            covered = sum(row[feature] is not None for row in horizon_rows)
             output.append({
                 "horizon_seconds": horizon, "feature": feature,
                 "warmup_n": len(warmup), "holdout_n": len(holdout),
                 "threshold": threshold, "high_n": len(high), "low_n": len(low),
                 "effect": effect,
                 "markets": len({key for key, _ in high + low}),
+                "marks_n": len(horizon_rows), "covered_n": covered,
+                "coverage": covered / len(horizon_rows) if horizon_rows else None,
             })
     return output
 
 
 async def maker_quote_coverage(db, *, days: int = 21) -> dict:
-    """Report cadence-weighted quote presence without pretending it is uptime."""
+    """Report cadence-weighted quote presence without pretending it is uptime.
+
+    Also reports trade-feed coverage. ``COUNT(signed_flow)`` skips NULLs by
+    definition, so ``flow_samples`` is literally "how many observations had
+    flow data at all" — the number that separates a market whose flow was
+    balanced from one no feed ever reached.
+    """
     row = await db.fetchone(
         """SELECT COUNT(*) AS samples,
                   SUM(quote_active=1) AS active,
                   SUM(quote_changed=1) AS changed,
-                  SUM(is_holdout=1) AS holdout
+                  SUM(is_holdout=1) AS holdout,
+                  COUNT(signed_flow) AS flow
              FROM maker_observations
             WHERE datetime(observed_at) >= datetime('now', ?)""",
         (f"-{days} days",),
@@ -355,6 +501,8 @@ async def maker_quote_coverage(db, *, days: int = 21) -> dict:
         "holdout_samples": int(row["holdout"] or 0),
         "sampled_quote_coverage": (
             int(row["active"] or 0) / samples if samples else None),
+        "flow_samples": int(row["flow"] or 0),
+        "flow_coverage": int(row["flow"] or 0) / samples if samples else None,
     }
 
 

--- a/auramaur/strategy/exposure_registry.py
+++ b/auramaur/strategy/exposure_registry.py
@@ -496,12 +496,6 @@ REGISTERED_CALLSITES = Counter(
             "prediction_quoting",
         ): 1,
         (
-            "auramaur/strategy/market_maker.py",
-            "_record_observatory_fill",
-            "record_fill",
-            "prediction_quoting",
-        ): 1,
-        (
             "auramaur/strategy/momentum_coupling.py",
             "_execute",
             "submit",

--- a/auramaur/strategy/exposure_registry.py
+++ b/auramaur/strategy/exposure_registry.py
@@ -496,6 +496,12 @@ REGISTERED_CALLSITES = Counter(
             "prediction_quoting",
         ): 1,
         (
+            "auramaur/strategy/market_maker.py",
+            "_record_observatory_fill",
+            "record_fill",
+            "prediction_quoting",
+        ): 1,
+        (
             "auramaur/strategy/momentum_coupling.py",
             "_execute",
             "submit",

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -119,6 +119,7 @@ class MarketMaker:
                 retention_days=observatory_cfg.retention_days,
                 max_mark_lateness_seconds=observatory_cfg.max_mark_lateness_seconds,
                 holdout_days=observatory_cfg.holdout_days,
+                resolve_batch_fills=observatory_cfg.resolve_batch_fills,
             )
         self._last_observation: dict[str, int] = {}
         # Wall-clock, not a cycle counter. A counter starting at 0 every
@@ -719,6 +720,24 @@ class MarketMaker:
             size=size,
             net_inventory=self._inventory[market_id],
         )
+
+    async def resolve_markouts(self) -> int:
+        """Mark out fills whose horizon has come due. NOT on the quoting path.
+
+        The bot drives this from its own timer (`_task_maker_observatory`)
+        rather than from `run_cycle`, because the scan grows with retained
+        history — 4.6 s per 5-market cycle at 45-day retention, 93% of
+        `observe()`'s cost — and a market maker that takes seconds to requote
+        gets picked off. An observatory that caused the adverse selection it
+        measures would be worse than no observatory. Nothing about "did a fill
+        from four minutes ago move against us" is an input to the current
+        quote, so nothing is lost by resolving it elsewhere.
+
+        Returns the number of marks written, 0 when the observatory is off.
+        """
+        if self._observatory is None:
+            return 0
+        return await self._observatory.resolve_markouts()
 
     async def _record_observatory_fill(self, order_id: str, market_id: str,
                                        side: str, price: float, size: float,

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from auramaur.strategy.protocols import ExecutionMode
 
 import asyncio
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from auramaur.killswitch import kill_switch_present
@@ -104,23 +105,28 @@ class MarketMaker:
         # Placement runs through the ExecutionGateway (the single choke point);
         # lazily built if not injected so existing callers/tests keep working.
         self._gateway = gateway
+        # Shadow-only instrument. Its config is settings.maker_observatory, a
+        # section deliberately OUTSIDE settings.market_maker: the latter is
+        # hashed into market_maker's strategy_version, so an observatory knob
+        # living there would restart the observed strategy's holdout clock.
         self._observatory = None
-        if getattr(settings.market_maker, "observatory_enabled", False) and db is not None:
+        observatory_cfg = getattr(settings, "maker_observatory", None)
+        if observatory_cfg is not None and observatory_cfg.enabled and db is not None:
             from auramaur.monitoring.maker_observatory import MakerObservatory
             self._observatory = MakerObservatory(
                 db, flow_tracker=flow_tracker,
-                horizons=getattr(settings.market_maker,
-                                 "observatory_horizons_seconds", (30, 60, 300)),
-                retention_days=getattr(settings.market_maker,
-                                       "observatory_retention_days", 45),
-                max_mark_lateness_seconds=getattr(
-                    settings.market_maker,
-                    "observatory_max_mark_lateness_seconds", 45),
-                holdout_days=getattr(
-                    settings.market_maker, "observatory_holdout_days", 7),
+                horizons=observatory_cfg.horizons_seconds,
+                retention_days=observatory_cfg.retention_days,
+                max_mark_lateness_seconds=observatory_cfg.max_mark_lateness_seconds,
+                holdout_days=observatory_cfg.holdout_days,
             )
         self._last_observation: dict[str, int] = {}
-        self._observatory_cycles = 0
+        # Wall-clock, not a cycle counter. A counter starting at 0 every
+        # process start means retention NEVER runs on a stack that restarts
+        # more often than its 24h period — the table then grows without bound
+        # and _mark_due's per-refresh scan grows with it. None = "never pruned
+        # in this process", so the first cycle after startup prunes.
+        self._observatory_pruned_at: float | None = None
 
         # MM configuration from settings
         mm_cfg = settings.market_maker
@@ -154,13 +160,18 @@ class MarketMaker:
             return []
 
         results: list[dict] = []
-        self._observatory_cycles += 1
-        prune_every = max(1, int(86400 / max(self._refresh_seconds, 1)))
-        if self._observatory and self._observatory_cycles % prune_every == 0:
-            try:
-                await self._observatory.prune()
-            except Exception as exc:
-                log.warning("market_maker.observatory_prune_error", error=str(exc))
+        if self._observatory is not None:
+            elapsed = (None if self._observatory_pruned_at is None
+                       else time.monotonic() - self._observatory_pruned_at)
+            if elapsed is None or elapsed >= 86400:
+                try:
+                    await self._observatory.prune()
+                except Exception as exc:
+                    log.warning("market_maker.observatory_prune_error", error=str(exc))
+                finally:
+                    # Stamp on failure too: a prune that raises every cycle
+                    # would otherwise retry on the quoting path forever.
+                    self._observatory_pruned_at = time.monotonic()
 
         # Step 1: Select suitable markets
         candidates = self._select_mm_markets(markets)
@@ -717,7 +728,7 @@ class MarketMaker:
         if self._observatory is None:
             return
         try:
-            await self._observatory.record_fill(
+            await self._observatory.record_observed_fill(
                 observation_id=observation_id,
                 order_id=order_id, market_id=market_id, side=side,
                 price=price, size=size, is_paper=is_paper,

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -96,6 +96,7 @@ class MarketMaker:
         exchange: PolymarketClient,
         db,
         gateway=None,
+        flow_tracker=None,
     ):
         self._settings = settings
         self._exchange = exchange
@@ -103,6 +104,23 @@ class MarketMaker:
         # Placement runs through the ExecutionGateway (the single choke point);
         # lazily built if not injected so existing callers/tests keep working.
         self._gateway = gateway
+        self._observatory = None
+        if getattr(settings.market_maker, "observatory_enabled", False) and db is not None:
+            from auramaur.monitoring.maker_observatory import MakerObservatory
+            self._observatory = MakerObservatory(
+                db, flow_tracker=flow_tracker,
+                horizons=getattr(settings.market_maker,
+                                 "observatory_horizons_seconds", (30, 60, 300)),
+                retention_days=getattr(settings.market_maker,
+                                       "observatory_retention_days", 45),
+                max_mark_lateness_seconds=getattr(
+                    settings.market_maker,
+                    "observatory_max_mark_lateness_seconds", 45),
+                holdout_days=getattr(
+                    settings.market_maker, "observatory_holdout_days", 7),
+            )
+        self._last_observation: dict[str, int] = {}
+        self._observatory_cycles = 0
 
         # MM configuration from settings
         mm_cfg = settings.market_maker
@@ -136,6 +154,13 @@ class MarketMaker:
             return []
 
         results: list[dict] = []
+        self._observatory_cycles += 1
+        prune_every = max(1, int(86400 / max(self._refresh_seconds, 1)))
+        if self._observatory and self._observatory_cycles % prune_every == 0:
+            try:
+                await self._observatory.prune()
+            except Exception as exc:
+                log.warning("market_maker.observatory_prune_error", error=str(exc))
 
         # Step 1: Select suitable markets
         candidates = self._select_mm_markets(markets)
@@ -324,6 +349,17 @@ class MarketMaker:
 
         # Compute our quote
         quote, skip_reason = self._compute_quotes(market, book)
+        if self._observatory is not None:
+            try:
+                observation_id = await self._observatory.observe(
+                    market, book, quote=quote,
+                    active_quote=self._active_quotes.get(market.id),
+                )
+                self._last_observation[market.id] = observation_id
+            except Exception as exc:
+                # Measurement must never interrupt quoting.
+                log.warning("market_maker.observatory_error",
+                            market_id=market.id, error=str(exc))
         if quote is None:
             return None, skip_reason
 
@@ -495,19 +531,38 @@ class MarketMaker:
                 "market_id": quote.market_id,
                 "side": "bid",
                 "size": quote.size,
+                "price": quote.bid_price,
+                "observation_id": self._last_observation.get(quote.market_id),
             }
         if ask_result.status in ("pending", "paper", "filled"):
             self._pending_orders[ask_result.order_id] = {
                 "market_id": quote.market_id,
                 "side": "ask",
                 "size": quote.size,
+                "price": quote.ask_price,
+                "observation_id": self._last_observation.get(quote.market_id),
             }
 
         # If paper trading, fills are instant — update inventory
         if bid_result.status in ("paper", "filled"):
             self._update_inventory(quote.market_id, "bid", bid_result.filled_size)
+            await self._record_observatory_fill(
+                bid_result.order_id, quote.market_id, "bid",
+                bid_result.filled_price or quote.bid_price,
+                bid_result.filled_size, bid_result.status == "paper",
+                fill_evidence=("synthetic" if bid_result.status == "paper"
+                               else "venue_fill"),
+                observation_id=self._last_observation.get(quote.market_id))
         if ask_result.status in ("paper", "filled"):
             self._update_inventory(quote.market_id, "ask", ask_result.filled_size)
+            await self._record_observatory_fill(
+                ask_result.order_id, quote.market_id, "ask",
+                (1.0 - ask_result.filled_price
+                if ask_result.filled_price else quote.ask_price),
+                ask_result.filled_size, ask_result.status == "paper",
+                fill_evidence=("synthetic" if ask_result.status == "paper"
+                               else "venue_fill"),
+                observation_id=self._last_observation.get(quote.market_id))
 
         bid_live = bid_result.status not in ("rejected",)
         ask_live = ask_result.status not in ("rejected",)
@@ -654,6 +709,24 @@ class MarketMaker:
             net_inventory=self._inventory[market_id],
         )
 
+    async def _record_observatory_fill(self, order_id: str, market_id: str,
+                                       side: str, price: float, size: float,
+                                       is_paper: bool, *,
+                                       fill_evidence: str,
+                                       observation_id: int | None = None) -> None:
+        if self._observatory is None:
+            return
+        try:
+            await self._observatory.record_fill(
+                observation_id=observation_id,
+                order_id=order_id, market_id=market_id, side=side,
+                price=price, size=size, is_paper=is_paper,
+                fill_evidence=fill_evidence,
+            )
+        except Exception as exc:
+            log.warning("market_maker.observatory_fill_error",
+                        market_id=market_id, order_id=order_id, error=str(exc))
+
     async def check_fills(self) -> list[dict]:
         """Check pending live orders for fills and update inventory.
 
@@ -672,6 +745,14 @@ class MarketMaker:
                 result = await self._exchange.get_order_status(order_id)
                 if result.status == "filled":
                     self._update_inventory(info["market_id"], info["side"], result.filled_size)
+                    await self._record_observatory_fill(
+                        order_id, info["market_id"], info["side"],
+                        ((1.0 - result.filled_price) if (
+                            info["side"] == "ask" and result.filled_price)
+                        else (result.filled_price or info["price"])),
+                        result.filled_size, False,
+                        fill_evidence="venue_fill",
+                        observation_id=info.get("observation_id"))
                     completed_ids.append(order_id)
                     filled.append({
                         "order_id": order_id,

--- a/auramaur/strategy/order_flow.py
+++ b/auramaur/strategy/order_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import datetime, timezone
+import math
 
 import structlog
 
@@ -39,6 +40,20 @@ class OrderFlowTracker:
     def record_book_snapshot(self, market_id: str, book: OrderBook) -> None:
         """Record an order book snapshot for imbalance analysis."""
         self._last_books[market_id] = book
+
+    def signed_flow(self, market_ids, *, now: datetime | None = None,
+                    half_life_seconds: float = 60.0,
+                    window_seconds: float = 300.0) -> float:
+        """Time-decayed signed aggressor volume across equivalent feed keys."""
+        instant = now or datetime.now(timezone.utc)
+        total = 0.0
+        for market_id in market_ids:
+            for timestamp, side, size in self._recent_trades.get(market_id, ()):
+                age = max(0.0, (instant - timestamp).total_seconds())
+                if age <= window_seconds:
+                    sign = 1.0 if side is OrderSide.BUY else -1.0
+                    total += sign * size * math.exp(-math.log(2) * age / half_life_seconds)
+        return total
 
     def get_flow_signal(self, market_id: str) -> FlowSignal:
         """Compute order flow signals for a market.

--- a/auramaur/strategy/order_flow.py
+++ b/auramaur/strategy/order_flow.py
@@ -43,17 +43,37 @@ class OrderFlowTracker:
 
     def signed_flow(self, market_ids, *, now: datetime | None = None,
                     half_life_seconds: float = 60.0,
-                    window_seconds: float = 300.0) -> float:
-        """Time-decayed signed aggressor volume across equivalent feed keys."""
+                    window_seconds: float = 300.0) -> float | None:
+        """Time-decayed signed aggressor volume, or None when there is no feed.
+
+        Returns None — never 0.0 — when this tracker has never seen a trade
+        under ANY of ``market_ids``. This tracker is fed only by the websocket
+        price monitor's ``on_trade``, which subscribes to the first 20
+        discovered markets; the market maker picks its five by spread and
+        usually is not in that set. A 0.0 in that case would say "flow was
+        balanced" about a market no feed ever reached — the 2026-07-29
+        qwen3 failure mode, where a metric that could not move looked healthy
+        for a week. Callers must keep None distinguishable all the way to the
+        report.
+
+        A market the feed HAS reached but which saw no aggressive trade inside
+        ``window_seconds`` genuinely scores 0.0: that is a measurement, not a
+        gap.
+        """
         instant = now or datetime.now(timezone.utc)
         total = 0.0
+        observed = False
         for market_id in market_ids:
-            for timestamp, side, size in self._recent_trades.get(market_id, ()):
+            trades = self._recent_trades.get(market_id)
+            if not trades:
+                continue
+            observed = True
+            for timestamp, side, size in trades:
                 age = max(0.0, (instant - timestamp).total_seconds())
                 if age <= window_seconds:
                     sign = 1.0 if side is OrderSide.BUY else -1.0
                     total += sign * size * math.exp(-math.log(2) * age / half_life_seconds)
-        return total
+        return total if observed else None
 
     def get_flow_signal(self, market_id: str) -> FlowSignal:
         """Compute order flow signals for a market.

--- a/auramaur/strategy/registry.py
+++ b/auramaur/strategy/registry.py
@@ -358,6 +358,11 @@ NON_STRATEGY_TASKS = frozenset(
         "_task_ibkr_registry_refresh",
         "_task_kill_switch_monitor",
         "_task_live_gate_monitor",
+        # Shadow measurement of market_maker: resolves due fill markouts from
+        # rows the maker already wrote. It reaches no venue, opens no risk and
+        # places no order — it exists precisely so that work is NOT on the
+        # quoting path.
+        "_task_maker_observatory",
         "_task_market_scan",
         "_task_order_monitor",
         "_task_resolution_checker",

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -751,17 +751,25 @@ market_maker:
   # twice on 2026-06-30 (silent 12-24 min). Bound each quote op so a stuck call is
   # abandoned and the cycle continues.
   op_timeout_seconds: 15.0
-  # Shadow-only 21-day measurement contract. No feature below changes quotes.
-  # Review after 100 marked fills; retain 45d so the review is reproducible.
-  observatory_enabled: true
-  observatory_horizons_seconds: [30, 60, 300]
-  observatory_retention_days: 45
-  observatory_review_days: 21
-  observatory_min_fills: 100
-  observatory_min_markets: 5
-  observatory_min_completeness: 0.95
-  observatory_max_mark_lateness_seconds: 45
-  observatory_holdout_days: 7
+
+# Shadow-only 21-day measurement contract for the market maker. No key below
+# changes quotes. It is a TOP-LEVEL section, not nine fields under
+# `market_maker:`, on purpose: ExecutionGateway._capture_decision hashes
+# `settings.market_maker` into market_maker's strategy_version, so a knob
+# parked in that section would restart the strategy's holdout clock every time
+# the instrument was retuned. An observatory must not be able to re-version the
+# thing it observes. Review after 100 marked fills; retain 45d so the review is
+# reproducible.
+maker_observatory:
+  enabled: true
+  horizons_seconds: [30, 60, 300]
+  retention_days: 45
+  review_days: 21
+  min_fills: 100
+  min_markets: 5
+  min_completeness: 0.95
+  max_mark_lateness_seconds: 45
+  holdout_days: 7
 
 arbitrage:
   enabled: true

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -753,7 +753,7 @@ market_maker:
   op_timeout_seconds: 15.0
 
 # Shadow-only 21-day measurement contract for the market maker. No key below
-# changes quotes. It is a TOP-LEVEL section, not nine fields under
+# changes quotes. It is a TOP-LEVEL section, not a set of fields under
 # `market_maker:`, on purpose: ExecutionGateway._capture_decision hashes
 # `settings.market_maker` into market_maker's strategy_version, so a knob
 # parked in that section would restart the strategy's holdout clock every time
@@ -770,6 +770,12 @@ maker_observatory:
   min_completeness: 0.95
   max_mark_lateness_seconds: 45
   holdout_days: 7
+  # Markout resolution runs on its own task at this cadence, never on the
+  # quoting path. It cannot change what a mark concludes (the mark comes from
+  # the first observation at or after the horizon), only how fresh the report
+  # is and how often the resolver competes for the DB serializer.
+  resolve_interval_seconds: 60.0
+  resolve_batch_fills: 500
 
 arbitrage:
   enabled: true

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -751,6 +751,17 @@ market_maker:
   # twice on 2026-06-30 (silent 12-24 min). Bound each quote op so a stuck call is
   # abandoned and the cycle continues.
   op_timeout_seconds: 15.0
+  # Shadow-only 21-day measurement contract. No feature below changes quotes.
+  # Review after 100 marked fills; retain 45d so the review is reproducible.
+  observatory_enabled: true
+  observatory_horizons_seconds: [30, 60, 300]
+  observatory_retention_days: 45
+  observatory_review_days: 21
+  observatory_min_fills: 100
+  observatory_min_markets: 5
+  observatory_min_completeness: 0.95
+  observatory_max_mark_lateness_seconds: 45
+  observatory_holdout_days: 7
 
 arbitrage:
   enabled: true

--- a/config/settings.py
+++ b/config/settings.py
@@ -566,7 +566,7 @@ class MakerObservatoryConfig(BaseModel):
     _prospective_stats joins on the LATEST version — so a knob living inside
     that section discards every decision captured under the previous hash and
     restarts the holdout clock. A purely observational instrument must never
-    be able to do that to the strategy it observes; keeping these nine fields
+    be able to do that to the strategy it observes; keeping these fields
     outside the hashed section is what makes "no feature below changes quotes"
     true of the graduation clock as well as of the quotes.
     """
@@ -580,6 +580,14 @@ class MakerObservatoryConfig(BaseModel):
     min_completeness: float = Field(default=0.95, ge=0.8, le=1.0)
     max_mark_lateness_seconds: int = Field(default=45, ge=1, le=600)
     holdout_days: int = Field(default=7, ge=1, le=30)
+    # Cadence of the offline markout resolver task. It does NOT affect what a
+    # mark concludes — a mark is taken from the first observation at or after
+    # its horizon, whenever the resolver gets round to it — so this is a
+    # report-freshness and DB-contention knob only.
+    resolve_interval_seconds: float = Field(default=60.0, ge=1.0, le=3600.0)
+    # Ceiling on fills examined per resolver pass, so a backlog cannot hold the
+    # shared Database serializer for minutes. The remainder stays pending.
+    resolve_batch_fills: int = Field(default=500, ge=1, le=20000)
 
     @model_validator(mode="after")
     def validate_observatory(self):

--- a/config/settings.py
+++ b/config/settings.py
@@ -555,6 +555,26 @@ class MarketMakerConfig(BaseModel):
     # min on a stuck request). Bound each per-market quote op and the stale-cancel
     # with this timeout so a stuck call is abandoned and the cycle continues.
     op_timeout_seconds: float = 15.0
+    # Shadow-only observatory. These fields may record and report; they are
+    # never read by quote formation or execution.
+    observatory_enabled: bool = True
+    observatory_horizons_seconds: tuple[int, ...] = (30, 60, 300)
+    observatory_retention_days: int = Field(default=45, ge=7, le=365)
+    observatory_review_days: int = Field(default=21, ge=7, le=90)
+    observatory_min_fills: int = Field(default=100, ge=20)
+    observatory_min_markets: int = Field(default=5, ge=2)
+    observatory_min_completeness: float = Field(default=0.95, ge=0.8, le=1.0)
+    observatory_max_mark_lateness_seconds: int = Field(default=45, ge=1, le=600)
+    observatory_holdout_days: int = Field(default=7, ge=1, le=30)
+
+    @model_validator(mode="after")
+    def validate_observatory(self):
+        horizons = self.observatory_horizons_seconds
+        if not horizons or any(value <= 0 for value in horizons):
+            raise ValueError("maker observatory horizons must be positive")
+        if len(set(horizons)) != len(horizons):
+            raise ValueError("maker observatory horizons must be unique")
+        return self
 
 
 class TechnicalConfig(BaseModel):

--- a/config/settings.py
+++ b/config/settings.py
@@ -555,21 +555,35 @@ class MarketMakerConfig(BaseModel):
     # min on a stuck request). Bound each per-market quote op and the stale-cancel
     # with this timeout so a stuck call is abandoned and the cycle continues.
     op_timeout_seconds: float = 15.0
-    # Shadow-only observatory. These fields may record and report; they are
-    # never read by quote formation or execution.
-    observatory_enabled: bool = True
-    observatory_horizons_seconds: tuple[int, ...] = (30, 60, 300)
-    observatory_retention_days: int = Field(default=45, ge=7, le=365)
-    observatory_review_days: int = Field(default=21, ge=7, le=90)
-    observatory_min_fills: int = Field(default=100, ge=20)
-    observatory_min_markets: int = Field(default=5, ge=2)
-    observatory_min_completeness: float = Field(default=0.95, ge=0.8, le=1.0)
-    observatory_max_mark_lateness_seconds: int = Field(default=45, ge=1, le=600)
-    observatory_holdout_days: int = Field(default=7, ge=1, le=30)
+
+
+class MakerObservatoryConfig(BaseModel):
+    """Shadow-only measurement of the market maker. Reads nothing, changes nothing.
+
+    Deliberately its OWN top-level section rather than fields under
+    ``market_maker:``. ExecutionGateway._capture_decision freezes
+    ``settings.market_maker.model_dump()`` into the strategy_version hash, and
+    _prospective_stats joins on the LATEST version — so a knob living inside
+    that section discards every decision captured under the previous hash and
+    restarts the holdout clock. A purely observational instrument must never
+    be able to do that to the strategy it observes; keeping these nine fields
+    outside the hashed section is what makes "no feature below changes quotes"
+    true of the graduation clock as well as of the quotes.
+    """
+
+    enabled: bool = True
+    horizons_seconds: tuple[int, ...] = (30, 60, 300)
+    retention_days: int = Field(default=45, ge=7, le=365)
+    review_days: int = Field(default=21, ge=7, le=90)
+    min_fills: int = Field(default=100, ge=20)
+    min_markets: int = Field(default=5, ge=2)
+    min_completeness: float = Field(default=0.95, ge=0.8, le=1.0)
+    max_mark_lateness_seconds: int = Field(default=45, ge=1, le=600)
+    holdout_days: int = Field(default=7, ge=1, le=30)
 
     @model_validator(mode="after")
     def validate_observatory(self):
-        horizons = self.observatory_horizons_seconds
+        horizons = self.horizons_seconds
         if not horizons or any(value <= 0 for value in horizons):
             raise ValueError("maker observatory horizons must be positive")
         if len(set(horizons)) != len(horizons):
@@ -2296,6 +2310,9 @@ class Settings(BaseSettings):
             **_DEFAULTS.get("intelligence_eval", {})))
     momentum_coupling: MomentumCouplingConfig = Field(default_factory=lambda: MomentumCouplingConfig(**_DEFAULTS.get("momentum_coupling", {})))
     market_maker: MarketMakerConfig = Field(default_factory=lambda: MarketMakerConfig(**_DEFAULTS.get("market_maker", {})))
+    maker_observatory: MakerObservatoryConfig = Field(
+        default_factory=lambda: MakerObservatoryConfig(
+            **_DEFAULTS.get("maker_observatory", {})))
     technical: TechnicalConfig = Field(default_factory=lambda: TechnicalConfig(**_DEFAULTS.get("technical", {})))
     bias_harvest: BiasHarvestConfig = Field(default_factory=lambda: BiasHarvestConfig(**_DEFAULTS.get("bias_harvest", {})))
     platform_consensus: PlatformConsensusConfig = Field(default_factory=lambda: PlatformConsensusConfig(**_DEFAULTS.get("platform_consensus", {})))

--- a/docs/maker-observatory.md
+++ b/docs/maker-observatory.md
@@ -4,6 +4,39 @@ Status: shadow-only prospective experiment. It has no order-placement interface,
 and no observatory field is read by quote formation, selection, sizing, or
 execution.
 
+## Configuration lives outside the strategy it observes
+
+The knobs are the top-level `maker_observatory:` section, NOT fields under
+`market_maker:`. `ExecutionGateway._capture_decision` hashes
+`settings.market_maker` into market_maker's `strategy_version`, and
+`_prospective_stats` joins on the LATEST version — so an observatory knob
+parked in that section would discard the observed strategy's accrued
+prospective evidence and restart its holdout clock every time the instrument
+was retuned. An instrument must not be able to re-version its subject.
+`tests/test_maker_observatory.py::test_observatory_config_cannot_reversion_the_strategy_it_observes`
+pins this.
+
+## Cost on the quoting path
+
+"Shadow-only" is a claim about what the observatory READS, not about what it
+costs. `observe()` runs inline in `_quote_market`, inside the
+`op_timeout_seconds` watchdog, and every statement takes the process-wide
+`Database` serializer that ~30 pillar tasks share. Measured on an idle SSD, one
+`observe()` is 6 serialized round-trips and:
+
+| retained fills / market | observe() | 5-market cycle |
+|-------------------------|-----------|----------------|
+| 0 (day 0)               | ~7 ms     | ~38 ms         |
+| 40k (day 7)             | ~236 ms   | ~1.2 s         |
+| 259k (day 45)           | ~917 ms   | ~4.6 s         |
+
+93% of that is `_mark_due`, which rescans every retained fill for the market on
+every refresh. The growth is driven by synthetic paper fills (two per market per
+30 s cycle = ~1.3M rows at 45-day retention), which by this document's own
+evidence contract can never be promoted. Before this instrument runs on a
+latency-sensitive live book, the operator should decide between a per-horizon
+mark watermark, a shorter retention, and not persisting every synthetic fill.
+
 ## Research question
 
 Can L1 microprice skew, top-five depth imbalance, time-decayed signed aggressor
@@ -66,4 +99,19 @@ stable holdout effect and acceptable quote-coverage and fill-rate trade-offs.
 
 Passing this gate does not authorize a quote change. Any quote policy informed
 by these findings is a separate, frozen, prospectively evaluated experiment.
-Raw observations are retained for 45 days.
+Raw observations are retained for 45 days, pruned on the first cycle after
+startup and every 24 hours thereafter (wall-clock, so a stack that restarts
+more often than daily still prunes).
+
+## Known measurement gaps
+
+- `signed_flow` is read from `OrderFlowTracker`, which is fed only by the
+  websocket price-monitor's `on_trade` for the first 20 discovered markets, and
+  keeps at most 50 trades per market. The maker's own five markets are selected
+  by spread and frequently are not in that set, so this feature can be
+  identically 0.0 for reasons that have nothing to do with flow. The column
+  cannot currently distinguish "balanced flow" from "no feed", so a null result
+  on it is uninterpretable rather than negative.
+- A fill whose `observation_id` is NULL (its `observe()` raised) is dropped by
+  the summary's inner join, so it is invisible rather than counted as an
+  incomplete mark.

--- a/docs/maker-observatory.md
+++ b/docs/maker-observatory.md
@@ -21,21 +21,72 @@ pins this.
 "Shadow-only" is a claim about what the observatory READS, not about what it
 costs. `observe()` runs inline in `_quote_market`, inside the
 `op_timeout_seconds` watchdog, and every statement takes the process-wide
-`Database` serializer that ~30 pillar tasks share. Measured on an idle SSD, one
-`observe()` is 6 serialized round-trips and:
+`Database` serializer that ~30 pillar tasks share.
 
-| retained fills / market | observe() | 5-market cycle |
-|-------------------------|-----------|----------------|
-| 0 (day 0)               | ~7 ms     | ~38 ms         |
-| 40k (day 7)             | ~236 ms   | ~1.2 s         |
-| 259k (day 45)           | ~917 ms   | ~4.6 s         |
+Markout resolution used to run there too, and 93% of `observe()`'s cost was
+that scan: its predicate `unixepoch(?) - unixepoch(filled_at) >= ?` wrapped the
+column in a function, so every refresh walked every retained fill for the
+market and probed the markouts index once per row. This matters beyond ordinary
+latency — slow quotes get picked off, so an observatory that added seconds to
+the quote path would have CAUSED the adverse selection it exists to measure.
 
-93% of that is `_mark_due`, which rescans every retained fill for the market on
-every refresh. The growth is driven by synthetic paper fills (two per market per
-30 s cycle = ~1.3M rows at 45-day retention), which by this document's own
-evidence contract can never be promoted. Before this instrument runs on a
-latency-sensitive live book, the operator should decide between a per-horizon
-mark watermark, a shorter retention, and not persisting every synthetic fill.
+Resolution now runs on its own bot task, `maker_observatory`, at
+`resolve_interval_seconds`. Measured on the same harness and the same
+synthetic volumes, per 5-market quoting cycle:
+
+| retained fills / market | before   | after   | offline resolver pass |
+|-------------------------|----------|---------|-----------------------|
+| 0 (day 0)               | 21.4 ms  | 13.1 ms | 20.6 ms               |
+| 40k (day 7)             | 744.6 ms | 13.9 ms | 24.0 ms               |
+| 121k (day 21)           | 2.21 s   | 13.6 ms | 21.2 ms               |
+| 259k (day 45)           | 4.49 s   | 13.1 ms | 27.3 ms               |
+
+(Three runs; the before column varied 21–35 ms / 0.74–1.03 s / 2.21–2.61 s /
+4.49–6.10 s with machine load, the after column never left 13–24 ms at any
+volume. The resolver pass is measured against a realistic backlog: one
+60 s interval at two fills per 30 s cycle, i.e. four newly due fills.)
+
+The quoting cycle is now flat in retained history — what is left of
+`observe()` is `compute_maker_features` (0.14 ms), two indexed volatility
+windows and one INSERT, three serialized round-trips in steady state instead
+of six. The resolver pass is flat too, and is bounded by outstanding work
+rather than by history: `maker_observatory_fills.marks_pending` drives a
+partial index (`idx_maker_fills_pending`) holding only fills that still owe a
+mark, and the range predicate compares `filled_at` against a precomputed
+timestamp instead of wrapping it in `unixepoch()`. `EXPLAIN QUERY PLAN`:
+
+```
+SEARCH f USING INDEX idx_maker_fills_pending (filled_at<?)
+CORRELATED SCALAR SUBQUERY 1
+SEARCH o USING COVERING INDEX idx_maker_obs_market_time (market_id=?)
+```
+
+against what it replaced, which could seek to the market and then had to walk
+every retained fill in it:
+
+```
+SEARCH f USING INDEX idx_maker_fills_market_time (market_id=?)
+CORRELATED SCALAR SUBQUERY 1
+SEARCH m USING COVERING INDEX sqlite_autoindex_maker_observatory_markouts_1
+       (fill_id=? AND horizon_seconds=?)
+```
+
+`test_the_due_fill_scan_seeks_an_index_instead_of_scanning_history` asserts
+the plan against the shipped SQL.
+
+Moving the scan cannot change what it concludes. A mark is taken from the
+first observation at or after `filled_at + horizon` — exactly the book the
+inline scan used, because the inline scan ran on the observation that first
+found the fill due. Resolving every cycle and resolving once an hour therefore
+write identical rows; only the wall-clock moment of the INSERT differs.
+`tests/test_maker_observatory.py::test_offline_resolution_reproduces_the_inline_marks`
+pins that equivalence, including the late/invalid case.
+
+Storage growth is unchanged and still driven by synthetic paper fills (two per
+market per 30 s cycle, ~1.3M rows at 45-day retention), which by this
+document's own evidence contract can never be promoted. Shorter retention and
+not persisting synthetic fills remain open operator decisions; they are no
+longer latency-critical.
 
 ## Research question
 
@@ -72,8 +123,19 @@ as alpha evidence.
 - Ask/NO: effective YES sale price minus future midpoint.
 - Positive is favourable to the maker; negative is toxic.
 - Target time, actual mark time, lateness, and validity are immutable.
-- The first observed book after a horizon is used. A late post-restart book is
-  retained and visibly invalid instead of masquerading as a timely mark.
+- The first observed book at or after a horizon is used. A late post-restart
+  book is retained and visibly invalid instead of masquerading as a timely
+  mark.
+- An interrupted resolver pass leaves due marks unresolved for the next pass;
+  it never fabricates one. `marks_pending` is cleared only in the same
+  transaction that writes a fill's last mark, and every mark is
+  `INSERT OR IGNORE` against `(fill_id, horizon_seconds)`.
+- Each pass takes at most `resolve_batch_fills` fills, oldest first, and skips
+  fills whose market has not been observed as far as their earliest horizon —
+  those cannot be marked yet at any horizon, and without that guard a market
+  that left the maker's five would strand fills at the head of an oldest-first
+  queue and starve every newer mark until retention pruned them. They stay
+  pending and are marked (late, `is_valid=0`) if the market returns.
 - Paper and live fills are never pooled.
 - Report windows are based on fill time, not the later mark time.
 
@@ -103,15 +165,34 @@ Raw observations are retained for 45 days, pruned on the first cycle after
 startup and every 24 hours thereafter (wall-clock, so a stack that restarts
 more often than daily still prunes).
 
+## Flow coverage
+
+`signed_flow` is read from `OrderFlowTracker`, which is fed only by the
+websocket price-monitor's `on_trade` for the first 20 discovered markets and
+keeps at most 50 trades per market. The maker's own five markets are selected
+by spread and frequently are not in that set.
+
+The column is therefore **nullable**, and `NULL` means "no trade feed ever
+reached this market" — a different fact from "flow was balanced", which is a
+genuine 0.0. Coercing the first to the second is the 2026-07-29 qwen3 failure
+mode, where a metric incapable of moving looked healthy for a week.
+
+- `OrderFlowTracker.signed_flow` returns `None`, never 0.0, when it has seen no
+  trade under any of the market's feed keys (market id, condition id, YES token
+  id). A market the feed HAS reached but which saw no aggressive trade inside
+  the 300 s window still scores 0.0: that is a measurement.
+- `maker_observatory_feature_report` excludes NULLs from the warmup median and
+  from both holdout buckets, and every row reports `covered_n` / `marks_n` /
+  `coverage` so an absent result cannot be read as a negative one.
+- `maker_quote_coverage` reports `flow_samples` (`COUNT(signed_flow)`, which
+  skips NULLs by definition) and `flow_coverage`.
+- `auramaur maker-observatory` prints a Measured column per feature, the
+  trade-feed coverage line, and a warning whenever coverage is below 100%.
+
 ## Known measurement gaps
 
-- `signed_flow` is read from `OrderFlowTracker`, which is fed only by the
-  websocket price-monitor's `on_trade` for the first 20 discovered markets, and
-  keeps at most 50 trades per market. The maker's own five markets are selected
-  by spread and frequently are not in that set, so this feature can be
-  identically 0.0 for reasons that have nothing to do with flow. The column
-  cannot currently distinguish "balanced flow" from "no feed", so a null result
-  on it is uninterpretable rather than negative.
 - A fill whose `observation_id` is NULL (its `observe()` raised) is dropped by
   the summary's inner join, so it is invisible rather than counted as an
   incomplete mark.
+- Flow coverage is reported, not fixed. Subscribing the websocket to the
+  maker's own selected markets is a separate change to the price-monitor task.

--- a/docs/maker-observatory.md
+++ b/docs/maker-observatory.md
@@ -1,0 +1,69 @@
+# Maker observatory
+
+Status: shadow-only prospective experiment. It has no order-placement interface,
+and no observatory field is read by quote formation, selection, sizing, or
+execution.
+
+## Research question
+
+Can L1 microprice skew, top-five depth imbalance, time-decayed signed aggressor
+flow, midpoint-change volatility, and quote persistence identify maker fills
+with adverse post-fill markouts?
+
+The observatory records hypotheses; it does not assume those features are
+signals. In particular, L1 microprice is kept distinct from top-five depth
+imbalance, and reward eligibility remains NULL until trustworthy per-market
+reward parameters are available.
+
+## Prospective contract
+
+The feature schema, horizons, and permitted mark lateness are serialized and
+hashed into a strategy version. A new definition creates a new version and a
+new seven-day warmup. Warmup data fixes each feature's median threshold; only
+later holdout fills score the high-versus-low markout effect.
+
+A fill can count toward promotion only when all of these are true:
+
+- it is live and has credible evidence (venue_fill, book_cross, or
+  trade_through);
+- it belongs to the prospective holdout;
+- its mark is taken no more than 45 seconds after the requested horizon;
+- the configured horizon has a valid mark.
+
+Synthetic resting paper fills are retained to test plumbing but can never count
+as alpha evidence.
+
+## Mark semantics
+
+- Bid: future midpoint minus effective YES fill price.
+- Ask/NO: effective YES sale price minus future midpoint.
+- Positive is favourable to the maker; negative is toxic.
+- Target time, actual mark time, lateness, and validity are immutable.
+- The first observed book after a horizon is used. A late post-restart book is
+  retained and visibly invalid instead of masquerading as a timely mark.
+- Paper and live fills are never pooled.
+- Report windows are based on fill time, not the later mark time.
+
+## Reporting
+
+Run: auramaur maker-observatory --days 21
+
+The report shows total fills, valid-mark completeness, credible holdout marks,
+independent markets, unweighted and size-weighted markouts, market-clustered
+bootstrap intervals, toxicity, frozen-threshold feature effects, sampled quote
+coverage, and explicit promotion blockers.
+
+Sampled quote coverage means an active quote was present at an observatory
+sampling instant. It is deliberately not described as exchange-certified
+uptime or reward-qualified time.
+
+## Promotion gate
+
+Every configured horizon must have at least 100 credible holdout marks across
+at least five markets, at least 95% timely-mark completeness, and a positive
+lower clustered-confidence bound. A candidate feature must additionally show a
+stable holdout effect and acceptable quote-coverage and fill-rate trade-offs.
+
+Passing this gate does not authorize a quote change. Any quote policy informed
+by these findings is a separate, frozen, prospectively evaluated experiment.
+Raw observations are retained for 45 days.

--- a/tests/test_maker_observatory.py
+++ b/tests/test_maker_observatory.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Market, OrderBook, OrderBookLevel, OrderSide
+from auramaur.monitoring.maker_observatory import (
+    MakerObservatory,
+    compute_maker_features,
+    maker_observatory_feature_report,
+    maker_observatory_summary,
+)
+from auramaur.strategy.order_flow import OrderFlowTracker
+
+
+def _book(bid=.40, ask=.44):
+    # Deliberately worst-first, matching the CLOB response shape.
+    return OrderBook(
+        bids=[OrderBookLevel(price=.10, size=100),
+              OrderBookLevel(price=bid, size=30)],
+        asks=[OrderBookLevel(price=.90, size=100),
+              OrderBookLevel(price=ask, size=10)],
+    )
+
+
+def _market():
+    return Market(id="m1", question="fixture", clob_token_yes="yes-1",
+                  clob_token_no="no-1")
+
+
+def test_features_are_ordering_agnostic_and_depth_weighted():
+    features = compute_maker_features(_book())
+
+    assert features.best_bid == .40
+    assert features.best_ask == .44
+    assert features.midpoint == pytest.approx(.42)
+    assert features.microprice == pytest.approx(.43)
+    assert features.bid_depth == 130
+    assert features.ask_depth == 110
+
+
+def test_signed_flow_is_time_decayed_and_directional(monkeypatch):
+    tracker = OrderFlowTracker()
+    now = datetime(2026, 8, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr("auramaur.strategy.order_flow.datetime", type(
+        "Clock", (), {"now": staticmethod(lambda tz: now)}))
+    tracker.record_trade("m1", OrderSide.BUY, 10)
+    tracker.record_trade("m1", OrderSide.SELL, 4)
+
+    assert tracker.signed_flow(("m1",), now=now) == pytest.approx(6)
+    assert tracker.signed_flow(("m1",), now=now + timedelta(seconds=60)) == pytest.approx(3)
+
+
+@pytest.mark.asyncio
+async def test_fill_markouts_are_restart_safe_and_mode_separated(tmp_path):
+    db = Database(str(tmp_path / "observatory.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 5, tzinfo=timezone.utc)
+        observatory = MakerObservatory(
+            db, horizons=(30, 60), retention_days=45,
+            max_mark_lateness_seconds=5, holdout_days=0)
+        observation_id = await observatory.observe(_market(), _book(), observed_at=t0)
+        await observatory.record_fill(
+            observation_id=observation_id, order_id="paper-1", market_id="m1",
+            side="bid", price=.41, size=10, is_paper=True, filled_at=t0,
+            fill_evidence="synthetic",
+        )
+
+        # A new instance models a restart. Later books fill each due horizon
+        # exactly once; the earliest post-horizon book is the executable mark.
+        restarted = MakerObservatory(
+            db, horizons=(30, 60), retention_days=45,
+            max_mark_lateness_seconds=5, holdout_days=0)
+        await restarted.observe(_market(), _book(.42, .44),
+                                observed_at=t0 + timedelta(seconds=31))
+        await restarted.observe(_market(), _book(.44, .46),
+                                observed_at=t0 + timedelta(seconds=61))
+        marks = await db.fetchall(
+            "SELECT horizon_seconds,markout FROM maker_observatory_markouts "
+            "ORDER BY horizon_seconds")
+
+        assert [row["horizon_seconds"] for row in marks] == [30, 60]
+        assert [row["markout"] for row in marks] == pytest.approx([.02, .04])
+        summary = await maker_observatory_summary(db, days=3650)
+        assert [(row["horizon_seconds"], row["is_paper"]) for row in summary] == [
+            (30, 1), (60, 1),
+        ]
+        assert [row["valid_marks"] for row in summary] == [1, 1]
+        assert [row["credible_holdout_marks"] for row in summary] == [0, 0]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_books_do_not_create_observations(tmp_path):
+    db = Database(str(tmp_path / "observatory.db"))
+    await db.connect()
+    observatory = MakerObservatory(db)
+
+    with pytest.raises(ValueError, match="two-sided"):
+        await observatory.observe(_market(), OrderBook(bids=[], asks=[]))
+    assert (await db.fetchone("SELECT COUNT(*) n FROM maker_observations"))["n"] == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_late_marks_are_retained_but_never_count_as_valid(tmp_path):
+    db = Database(str(tmp_path / "late.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = MakerObservatory(
+            db, horizons=(30,), max_mark_lateness_seconds=5, holdout_days=0)
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=now - timedelta(seconds=100))
+        await observatory.record_fill(
+            observation_id=observation_id, order_id="live-late",
+            market_id="m1", side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill",
+            filled_at=now - timedelta(seconds=100),
+        )
+        await observatory.observe(_market(), _book(), observed_at=now)
+
+        mark = await db.fetchone(
+            "SELECT lateness_seconds,is_valid FROM maker_observatory_markouts")
+        assert mark["lateness_seconds"] == pytest.approx(70, abs=1)
+        assert mark["is_valid"] == 0
+        summary = await maker_observatory_summary(db, days=1)
+        assert summary[0]["late_marks"] == 1
+        assert summary[0]["credible_holdout_marks"] == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_feature_report_uses_warmup_threshold_on_holdout_only(tmp_path):
+    db = Database(str(tmp_path / "features.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = MakerObservatory(
+            db, horizons=(30,), max_mark_lateness_seconds=5, holdout_days=0)
+        for index, (imbalance_book, mark_mid) in enumerate((
+            (_book(.40, .44), .43),
+            (OrderBook(
+                bids=[OrderBookLevel(price=.40, size=5)],
+                asks=[OrderBookLevel(price=.44, size=50)]), .39),
+            (_book(.40, .44), .45),
+        )):
+            fill_at = now - timedelta(minutes=3-index)
+            observation_id = await observatory.observe(
+                _market(), imbalance_book, observed_at=fill_at)
+            await db.execute(
+                "UPDATE maker_observations SET is_holdout=? WHERE id=?",
+                (int(index > 0), observation_id))
+            await observatory.record_fill(
+                observation_id=observation_id, order_id=f"live-{index}",
+                market_id="m1", side="bid", price=.41, size=5, is_paper=False,
+                fill_evidence="venue_fill", filled_at=fill_at)
+            await observatory.observe(
+                _market(), _book(mark_mid - .01, mark_mid + .01),
+                observed_at=fill_at + timedelta(seconds=31))
+
+        report = await maker_observatory_feature_report(db, days=1)
+        imbalance = next(row for row in report
+                         if row["feature"] == "depth_imbalance")
+        assert imbalance["warmup_n"] == 1
+        assert imbalance["holdout_n"] == 2
+        assert imbalance["effect"] is not None
+    finally:
+        await db.close()

--- a/tests/test_maker_observatory.py
+++ b/tests/test_maker_observatory.py
@@ -8,6 +8,8 @@ import pytest
 from auramaur.db.database import Database
 from auramaur.exchange.models import Market, OrderBook, OrderBookLevel, OrderSide
 from auramaur.monitoring.maker_observatory import (
+    DUE_FILL_SCAN_SQL,
+    MARK_BOOK_SQL,
     MakerObservatory,
     compute_maker_features,
     maker_observatory_feature_report,
@@ -28,9 +30,10 @@ def _book(bid=.40, ask=.44):
     )
 
 
-def _market():
-    return Market(id="m1", question="fixture", clob_token_yes="yes-1",
-                  clob_token_no="no-1")
+def _market(market_id="m1"):
+    return Market(id=market_id, question="fixture",
+                  clob_token_yes=f"yes-{market_id}",
+                  clob_token_no=f"no-{market_id}")
 
 
 def test_features_are_ordering_agnostic_and_depth_weighted():
@@ -81,6 +84,7 @@ async def test_fill_markouts_are_restart_safe_and_mode_separated(tmp_path):
                                 observed_at=t0 + timedelta(seconds=31))
         await restarted.observe(_market(), _book(.44, .46),
                                 observed_at=t0 + timedelta(seconds=61))
+        await restarted.resolve_markouts(now=t0 + timedelta(seconds=61))
         marks = await db.fetchall(
             "SELECT horizon_seconds,markout FROM maker_observatory_markouts "
             "ORDER BY horizon_seconds")
@@ -126,6 +130,7 @@ async def test_late_marks_are_retained_but_never_count_as_valid(tmp_path):
             filled_at=now - timedelta(seconds=100),
         )
         await observatory.observe(_market(), _book(), observed_at=now)
+        await observatory.resolve_markouts(now=now)
 
         mark = await db.fetchone(
             "SELECT lateness_seconds,is_valid FROM maker_observatory_markouts")
@@ -166,6 +171,8 @@ async def test_feature_report_uses_warmup_threshold_on_holdout_only(tmp_path):
             await observatory.observe(
                 _market(), _book(mark_mid - .01, mark_mid + .01),
                 observed_at=fill_at + timedelta(seconds=31))
+            await observatory.resolve_markouts(
+                now=fill_at + timedelta(seconds=31))
 
         report = await maker_observatory_feature_report(db, days=1)
         imbalance = next(row for row in report
@@ -210,9 +217,10 @@ async def _fill(observatory, db, *, market_id="m1", side="bid", price=.41,
         observation_id=observation_id, order_id=order_id, market_id=market_id,
         side=side, price=price, size=size, is_paper=is_paper,
         fill_evidence=evidence, filled_at=at)
-    # A later observation is what triggers the due markout.
+    # A later observation supplies the mark; the offline resolver takes it.
     await observatory.observe(_market(), mark_book or _book(.44, .46),
                               observed_at=at + timedelta(seconds=31))
+    await observatory.resolve_markouts(now=at + timedelta(seconds=31))
     return observation_id
 
 
@@ -296,6 +304,7 @@ async def test_ask_fills_mark_out_from_the_seller_side(tmp_path):
         # Midpoint falls to .40 — good for a seller.
         await observatory.observe(_market(), _book(.39, .41),
                                   observed_at=t0 + timedelta(seconds=31))
+        await observatory.resolve_markouts(now=t0 + timedelta(seconds=31))
 
         mark = await db.fetchone("SELECT markout FROM maker_observatory_markouts")
         assert mark["markout"] == pytest.approx(.03)
@@ -309,6 +318,7 @@ async def test_ask_fills_mark_out_from_the_seller_side(tmp_path):
             fill_evidence="venue_fill", filled_at=t0 + timedelta(seconds=100))
         await observatory.observe(_market(), _book(.49, .51),
                                   observed_at=t0 + timedelta(seconds=131))
+        await observatory.resolve_markouts(now=t0 + timedelta(seconds=131))
         marks = await db.fetchall(
             "SELECT m.markout FROM maker_observatory_markouts m "
             "JOIN maker_observatory_fills f ON f.id=m.fill_id "
@@ -589,7 +599,8 @@ def _quoting_maker(db, *, observatory_enabled=True):
             op_timeout_seconds=15.0, paper=True, cash_reserve_usd=0.0),
         maker_observatory=SimpleNamespace(
             enabled=observatory_enabled, horizons_seconds=(30,),
-            retention_days=45, max_mark_lateness_seconds=45, holdout_days=0),
+            retention_days=45, max_mark_lateness_seconds=45, holdout_days=0,
+            resolve_interval_seconds=60.0, resolve_batch_fills=500),
         risk=SimpleNamespace(blocked_categories=[], allowed_categories_live=[]),
     )
     book = OrderBook(bids=[OrderBookLevel(price=.40, size=100)],
@@ -714,5 +725,699 @@ async def test_retention_runs_on_the_first_cycle_after_a_restart(tmp_path):
         await maker.run_cycle([])
         await maker.run_cycle([])
         assert pruned == [1], "retention ran again inside its 24h period"
+    finally:
+        await db.close()
+
+
+# --------------------------------------------------------------------------
+# Markout resolution belongs off the quoting path.
+# --------------------------------------------------------------------------
+
+
+async def _tracing_db(tmp_path, name):
+    """A Database that records the SQL every call issues."""
+    db = Database(str(tmp_path / name))
+    await db.connect()
+    statements: list[str] = []
+    for method in ("execute", "fetchall", "fetchone"):
+        original = getattr(db, method)
+
+        def wrap(original=original):
+            async def traced(sql, params=()):
+                statements.append(" ".join(str(sql).split()))
+                return await original(sql, params)
+            return traced
+
+        setattr(db, method, wrap())
+    return db, statements
+
+
+@pytest.mark.asyncio
+async def test_observe_never_resolves_markouts_on_the_quoting_path(tmp_path):
+    """Reachability, not latency: the scan must not be callable from a quote.
+
+    `_mark_due` used to run inside `observe()`, inside `_quote_market`, inside
+    the per-market `op_timeout` window, holding the process-wide Database
+    serializer — 93% of observe()'s cost, growing with retained history. A
+    market maker that takes seconds to requote gets picked off, so leaving it
+    there meant the instrument would cause the adverse selection it measures.
+
+    A fill overdue by an hour must therefore survive any number of
+    observations unmarked, and observe() must not so much as READ the fills or
+    markouts tables — those reads are the cost.
+    """
+    db, statements = await _tracing_db(tmp_path, "quotepath.db")
+    try:
+        t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        observatory = MakerObservatory(db, horizons=(30,), holdout_days=0,
+                                       max_mark_lateness_seconds=45)
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=t0)
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="overdue-1", market_id="m1",
+            side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=t0)
+
+        statements.clear()
+        for index in range(3):
+            await observatory.observe(
+                _market(), _book(.44, .46),
+                observed_at=t0 + timedelta(hours=1, seconds=index))
+
+        touched = [sql for sql in statements
+                   if "maker_observatory_fills" in sql
+                   or "maker_observatory_markouts" in sql]
+        assert touched == [], f"observe() read markout state: {touched}"
+        assert (await db.fetchone(
+            "SELECT COUNT(*) n FROM maker_observatory_markouts"))["n"] == 0, \
+            "the quoting path resolved a markout"
+
+        # The resolver still takes the mark, late and visibly invalid.
+        assert await observatory.resolve_markouts(
+            now=t0 + timedelta(hours=1, seconds=3)) == 1
+        mark = await db.fetchone(
+            "SELECT lateness_seconds,is_valid FROM maker_observatory_markouts")
+        assert mark["is_valid"] == 0
+        assert mark["lateness_seconds"] == pytest.approx(3570, abs=1)
+    finally:
+        await db.close()
+
+
+async def _replay(db, *, resolve_each: bool):
+    """Write one identical history; resolve every cycle, or once at the end.
+
+    The gap between the 200s and 400s books is deliberate: the second fill's
+    marks can only be taken from a book far past their horizon, so the run
+    exercises the late/invalid branch as well as the timely one.
+    """
+    t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    observatory = MakerObservatory(db, horizons=(30, 60), holdout_days=0,
+                                   max_mark_lateness_seconds=45)
+    script = (
+        (0, (.40, .44), ("bid", .41)),
+        (31, (.42, .46), None),
+        (62, (.44, .48), None),
+        (200, (.30, .34), ("ask", .43)),
+        (400, (.30, .34), None),
+    )
+    for offset, (bid, ask), fill in script:
+        at = t0 + timedelta(seconds=offset)
+        observation_id = await observatory.observe(
+            _market(), _book(bid, ask), observed_at=at)
+        if fill is not None:
+            side, price = fill
+            await observatory.record_observed_fill(
+                observation_id=observation_id, order_id=f"fill-{offset}",
+                market_id="m1", side=side, price=price, size=5,
+                is_paper=False, fill_evidence="venue_fill", filled_at=at)
+        if resolve_each:
+            await observatory.resolve_markouts(now=at)
+    if not resolve_each:
+        await observatory.resolve_markouts(now=t0 + timedelta(seconds=400))
+    return await db.fetchall(
+        """SELECT f.order_id,m.horizon_seconds,m.target_at,m.midpoint,m.markout,
+                  m.marked_at,m.lateness_seconds,m.is_valid
+             FROM maker_observatory_markouts m
+             JOIN maker_observatory_fills f ON f.id=m.fill_id
+            ORDER BY f.order_id,m.horizon_seconds""")
+
+
+@pytest.mark.asyncio
+async def test_offline_resolution_reproduces_the_inline_marks(tmp_path):
+    """Moving WHEN the scan runs must not change WHAT it concludes.
+
+    A mark is taken from the first observation at or after `filled_at +
+    horizon` — precisely the book the old inline scan used, because that scan
+    ran on the observation that first found the fill due. So resolving every
+    cycle and resolving once, 400 seconds later, must write identical rows:
+    same target, same midpoint, same markout, same lateness, same validity.
+    Only the wall-clock moment of the INSERT is allowed to differ, and nothing
+    records that.
+    """
+    eager = Database(str(tmp_path / "eager.db"))
+    lazy = Database(str(tmp_path / "lazy.db"))
+    await eager.connect()
+    await lazy.connect()
+    try:
+        each = [tuple(row) for row in await _replay(eager, resolve_each=True)]
+        once = [tuple(row) for row in await _replay(lazy, resolve_each=False)]
+
+        assert each == once, "resolver cadence changed the marks"
+        # And the marks are the right ones, so the agreement above is not two
+        # runs being identically wrong.
+        by_key = {(row[0], row[1]): row for row in each}
+        assert set(by_key) == {("fill-0", 30), ("fill-0", 60),
+                               ("fill-200", 30), ("fill-200", 60)}
+        # Timely: the 31s book (mid .44) and the 62s book (mid .46).
+        assert by_key[("fill-0", 30)][4] == pytest.approx(.03)
+        assert by_key[("fill-0", 60)][4] == pytest.approx(.05)
+        assert [by_key[("fill-0", h)][7] for h in (30, 60)] == [1, 1]
+        # Late: both marks come from the 400s book (mid .32) on an ask at .43.
+        assert by_key[("fill-200", 30)][4] == pytest.approx(.11)
+        assert by_key[("fill-200", 30)][6] == pytest.approx(170)
+        assert by_key[("fill-200", 60)][6] == pytest.approx(140)
+        assert [by_key[("fill-200", h)][7] for h in (30, 60)] == [0, 0], \
+            "a late mark was recorded as valid"
+    finally:
+        await eager.close()
+        await lazy.close()
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_pass_leaves_marks_unresolved_never_fabricated(tmp_path):
+    """Crash safety: a torn pass must resume, not invent or lose a mark."""
+    db = Database(str(tmp_path / "interrupted.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        observatory = MakerObservatory(db, horizons=(30,), holdout_days=0,
+                                       max_mark_lateness_seconds=45)
+        for index in range(2):
+            at = t0 + timedelta(seconds=index)
+            observation_id = await observatory.observe(
+                _market(), _book(), observed_at=at)
+            await observatory.record_observed_fill(
+                observation_id=observation_id, order_id=f"fill-{index}",
+                market_id="m1", side="bid", price=.41, size=5, is_paper=False,
+                fill_evidence="venue_fill", filled_at=at)
+        await observatory.observe(_market(), _book(.44, .46),
+                                  observed_at=t0 + timedelta(seconds=31))
+        later = t0 + timedelta(seconds=40)
+
+        lookups = {"n": 0}
+        original = db.fetchone
+
+        async def failing(sql, params=()):
+            if "maker_observations" in sql:
+                lookups["n"] += 1
+                if lookups["n"] == 2:
+                    raise RuntimeError("resolver killed mid-pass")
+            return await original(sql, params)
+
+        db.fetchone = failing
+        with pytest.raises(RuntimeError):
+            await observatory.resolve_markouts(now=later)
+        db.fetchone = original
+
+        async def state():
+            marks = await db.fetchall(
+                "SELECT f.order_id FROM maker_observatory_markouts m "
+                "JOIN maker_observatory_fills f ON f.id=m.fill_id "
+                "ORDER BY f.order_id")
+            pending = await db.fetchall(
+                "SELECT order_id FROM maker_observatory_fills "
+                "WHERE marks_pending=1 ORDER BY order_id")
+            return ([row["order_id"] for row in marks],
+                    [row["order_id"] for row in pending])
+
+        marked, pending = await state()
+        assert marked == ["fill-0"], "the interrupted fill was marked anyway"
+        assert pending == ["fill-1"], "the unresolved fill stopped being pending"
+
+        # The next pass finishes the job, and a third writes nothing new.
+        assert await observatory.resolve_markouts(now=later) == 1
+        marked, pending = await state()
+        assert marked == ["fill-0", "fill-1"] and pending == []
+        assert await observatory.resolve_markouts(now=later) == 0
+        assert (await state())[0] == ["fill-0", "fill-1"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_partly_marked_fill_stays_pending_until_every_horizon_is_taken(tmp_path):
+    """`marks_pending` is the resolver's only memory; retiring a fill early
+    would silently drop the horizons it still owes.
+
+    Here the 30s book exists and the 60s book does not yet. The fill must keep
+    its place in the pending index and collect the second mark when the book
+    arrives — not be written off as done.
+    """
+    db = Database(str(tmp_path / "partial.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        observatory = MakerObservatory(db, horizons=(30, 60), holdout_days=0,
+                                       max_mark_lateness_seconds=45)
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=t0)
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="partial-1", market_id="m1",
+            side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=t0)
+        await observatory.observe(_market(), _book(.44, .46),
+                                  observed_at=t0 + timedelta(seconds=31))
+
+        async def pending():
+            return (await db.fetchone(
+                "SELECT marks_pending p FROM maker_observatory_fills"))["p"]
+
+        assert await observatory.resolve_markouts(
+            now=t0 + timedelta(seconds=70)) == 1
+        horizons = [row["horizon_seconds"] for row in await db.fetchall(
+            "SELECT horizon_seconds FROM maker_observatory_markouts")]
+        assert horizons == [30]
+        assert await pending() == 1, "a fill still owing a 60s mark was retired"
+
+        # The 60s book arrives; the second mark is taken and only now is the
+        # fill retired from the pending index.
+        await observatory.observe(_market(), _book(.48, .50),
+                                  observed_at=t0 + timedelta(seconds=65))
+        assert await observatory.resolve_markouts(
+            now=t0 + timedelta(seconds=70)) == 1
+        marks = await db.fetchall(
+            "SELECT horizon_seconds,markout,is_valid FROM "
+            "maker_observatory_markouts ORDER BY horizon_seconds")
+        assert [row["horizon_seconds"] for row in marks] == [30, 60]
+        assert [row["markout"] for row in marks] == pytest.approx([.04, .08])
+        assert [row["is_valid"] for row in marks] == [1, 1]
+        assert await pending() == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_due_fill_scan_seeks_an_index_instead_of_scanning_history(tmp_path):
+    """The predicate must stay sargable, and the test must EXPLAIN the SHIPPED
+    SQL — hence the module constants rather than a copy pasted here.
+
+    The shape this replaced, `unixepoch(?) - unixepoch(filled_at) >= ?`, wraps
+    the column in a function: SQLite could seek to the market but then had to
+    walk every retained fill in it (259k per market at 45-day retention) and
+    probe the markouts index once per row, on every call.
+    """
+    db = Database(str(tmp_path / "plan.db"))
+    await db.connect()
+    try:
+        due = await db.fetchall(
+            f"EXPLAIN QUERY PLAN {DUE_FILL_SCAN_SQL}",
+            ("2026-08-06T00:00:00.000000+00:00", 30, 500))
+        plan = " ".join(str(row["detail"]) for row in due)
+        assert "idx_maker_fills_pending" in plan, plan
+        # The liveness guard must also seek, not walk a market's observations.
+        assert "idx_maker_obs_market_time" in plan, plan
+        assert "SCAN" not in plan, f"full scan of the fill history: {plan}"
+        assert "TEMP B-TREE" not in plan, f"the sort is not index-served: {plan}"
+
+        book = await db.fetchall(
+            f"EXPLAIN QUERY PLAN {MARK_BOOK_SQL}",
+            ("m1", "2026-08-06T00:00:00.000000+00:00"))
+        plan = " ".join(str(row["detail"]) for row in book)
+        assert "idx_maker_obs_market_time" in plan, plan
+        assert "SCAN" not in plan, f"full scan of the observations: {plan}"
+        assert "TEMP B-TREE" not in plan, plan
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_resolver_pass_is_bounded_and_takes_the_oldest_first(tmp_path):
+    """One pass must not be able to hold the shared serializer indefinitely.
+
+    A backlog (long outage, clock jump) is drained across passes, oldest
+    first, because the oldest marks are the ones closest to going permanently
+    invalid.
+    """
+    db = Database(str(tmp_path / "batch.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        observatory = MakerObservatory(db, horizons=(30,), holdout_days=0,
+                                       max_mark_lateness_seconds=45,
+                                       resolve_batch_fills=2)
+        for index in range(5):
+            at = t0 + timedelta(seconds=index)
+            observation_id = await observatory.observe(
+                _market(), _book(), observed_at=at)
+            await observatory.record_observed_fill(
+                observation_id=observation_id, order_id=f"fill-{index}",
+                market_id="m1", side="bid", price=.41, size=5, is_paper=False,
+                fill_evidence="venue_fill", filled_at=at)
+        await observatory.observe(_market(), _book(.44, .46),
+                                  observed_at=t0 + timedelta(seconds=60))
+        later = t0 + timedelta(seconds=90)
+
+        assert await observatory.resolve_markouts(now=later) == 2
+        marked = [row["order_id"] for row in await db.fetchall(
+            "SELECT f.order_id FROM maker_observatory_markouts m "
+            "JOIN maker_observatory_fills f ON f.id=m.fill_id "
+            "ORDER BY f.filled_at")]
+        assert marked == ["fill-0", "fill-1"], marked
+
+        assert await observatory.resolve_markouts(now=later) == 2
+        assert await observatory.resolve_markouts(now=later) == 1
+        assert await observatory.resolve_markouts(now=later) == 0
+        assert (await db.fetchone(
+            "SELECT COUNT(*) n FROM maker_observatory_markouts"))["n"] == 5
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_dead_market_cannot_starve_newer_fills_out_of_the_batch(tmp_path):
+    """The batch is oldest-first, so unmarkable fills must not hold its head.
+
+    A market that leaves the maker's five and is never observed again strands
+    fills that can never be marked at any horizon. Without the liveness guard
+    they would sit at the front of the queue until retention pruned them 45
+    days later, silently starving every newer mark — completeness would rot
+    while the resolver looked busy.
+    """
+    db = Database(str(tmp_path / "starve.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        observatory = MakerObservatory(db, horizons=(30,), holdout_days=0,
+                                       max_mark_lateness_seconds=45,
+                                       resolve_batch_fills=2)
+        # Three older fills on a market that is never observed again.
+        for index in range(3):
+            at = t0 + timedelta(seconds=index)
+            observation_id = await observatory.observe(
+                _market("gone"), _book(), observed_at=at)
+            await observatory.record_observed_fill(
+                observation_id=observation_id, order_id=f"stranded-{index}",
+                market_id="gone", side="bid", price=.41, size=5,
+                is_paper=False, fill_evidence="venue_fill", filled_at=at)
+        # A newer, markable fill on a market that keeps being observed.
+        live_at = t0 + timedelta(seconds=100)
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=live_at)
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="live-1", market_id="m1",
+            side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=live_at)
+        await observatory.observe(_market(), _book(.44, .46),
+                                  observed_at=live_at + timedelta(seconds=31))
+
+        assert await observatory.resolve_markouts(
+            now=live_at + timedelta(seconds=40)) == 1
+        marked = [row["order_id"] for row in await db.fetchall(
+            "SELECT f.order_id FROM maker_observatory_markouts m "
+            "JOIN maker_observatory_fills f ON f.id=m.fill_id")]
+        assert marked == ["live-1"], marked
+        # The stranded fills are still pending, not written off — if their
+        # market returns they take their (late, invalid) marks as usual.
+        stranded = [row["order_id"] for row in await db.fetchall(
+            "SELECT order_id FROM maker_observatory_fills "
+            "WHERE marks_pending=1 ORDER BY order_id")]
+        assert stranded == ["stranded-0", "stranded-1", "stranded-2"]
+
+        await observatory.observe(_market("gone"), _book(.44, .46),
+                                  observed_at=live_at + timedelta(seconds=60))
+        assert await observatory.resolve_markouts(
+            now=live_at + timedelta(seconds=70)) == 2  # batch of 2, oldest first
+        late = await db.fetchall(
+            "SELECT f.order_id,m.is_valid FROM maker_observatory_markouts m "
+            "JOIN maker_observatory_fills f ON f.id=m.fill_id "
+            "WHERE f.market_id='gone' ORDER BY f.order_id")
+        assert [row["order_id"] for row in late] == ["stranded-0", "stranded-1"]
+        assert [row["is_valid"] for row in late] == [0, 0]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_quoting_records_fills_but_only_the_maker_timer_marks_them(tmp_path):
+    """At the call site: `_quote_market` observes, and never marks out.
+
+    `MarketMaker.resolve_markouts` is the entry point the bot's own
+    `maker_observatory` task drives, so the growing scan runs on a timer
+    instead of between deciding a quote and placing it.
+    """
+    db = Database(str(tmp_path / "makertimer.db"))
+    await db.connect()
+    try:
+        maker, _ = _quoting_maker(db)
+
+        async def fake_place(quote, is_live):
+            return {"success": True}
+
+        maker._place_two_sided = fake_place
+        market = _market()
+        t0 = datetime.now(timezone.utc) - timedelta(seconds=300)
+
+        observation_id = await maker._observatory.observe(
+            market, _book(), observed_at=t0)
+        await maker._observatory.record_observed_fill(
+            observation_id=observation_id, order_id="due-1", market_id="m1",
+            side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=t0)
+
+        for _ in range(3):
+            maker._active_quotes.clear()
+            await maker._quote_market(market)
+        assert (await db.fetchone(
+            "SELECT COUNT(*) n FROM maker_observatory_markouts"))["n"] == 0, \
+            "quoting resolved a markout"
+
+        assert await maker.resolve_markouts() == 1
+        assert (await db.fetchone(
+            "SELECT COUNT(*) n FROM maker_observatory_markouts"))["n"] == 1
+
+        # With the instrument off, the entry point is inert rather than absent.
+        off, _ = _quoting_maker(db, observatory_enabled=False)
+        assert off._observatory is None
+        assert await off.resolve_markouts() == 0
+    finally:
+        await db.close()
+
+
+def _observatory_task_stub(maker, *, enabled=True, interval=17.0):
+    return SimpleNamespace(
+        _components=SimpleNamespace(market_maker=maker),
+        settings=SimpleNamespace(maker_observatory=SimpleNamespace(
+            enabled=enabled, resolve_interval_seconds=interval)),
+        _running=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_bot_drives_resolution_from_its_own_task(monkeypatch):
+    """Without this wiring nothing would ever mark out.
+
+    Moving the scan off the quoting path only helps if something else runs it,
+    and an observatory that records fills and never marks them would look
+    installed while measuring nothing. Also pins that the task does NOT
+    heartbeat: `check_strategy_data_delivery` fails closed on any heartbeat
+    whose strategy has no registered data contract, and this task consumes no
+    market data.
+    """
+    import auramaur.bot as bot_module
+    from auramaur.bot import AuramaurBot
+
+    beats: list = []
+
+    async def spy_beat(*args, **kwargs):
+        beats.append(args)
+
+    monkeypatch.setattr("auramaur.monitoring.heartbeat.beat", spy_beat)
+
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    class Maker:
+        async def resolve_markouts(self):
+            calls.append(len(calls))
+            return 2
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        if len(sleeps) >= 3:
+            stub._running = False
+
+    monkeypatch.setattr(bot_module.asyncio, "sleep", fake_sleep)
+    stub = _observatory_task_stub(Maker())
+    await AuramaurBot._task_maker_observatory(stub)
+
+    assert calls == [0, 1, 2], "the resolver was not driven on its own timer"
+    assert sleeps == [17.0, 17.0, 17.0], sleeps
+    assert beats == [], "the observatory task heartbeat has no data contract"
+
+    # A failing pass must not end the task; measurement never kills the loop.
+    class Exploding:
+        async def resolve_markouts(self):
+            calls.append(-1)
+            raise RuntimeError("resolver blew up")
+
+    sleeps.clear()
+    calls.clear()
+    stub = _observatory_task_stub(Exploding())
+    await AuramaurBot._task_maker_observatory(stub)
+    assert calls == [-1, -1, -1]
+
+    # Disabled or absent instrument: the task retires instead of spinning.
+    sleeps.clear()
+    calls.clear()
+    await AuramaurBot._task_maker_observatory(
+        _observatory_task_stub(Maker(), enabled=False))
+    await AuramaurBot._task_maker_observatory(_observatory_task_stub(None))
+    assert calls == [] and sleeps == []
+
+
+def test_the_observatory_task_is_registered_and_classified():
+    """A task the bot never starts is a silent no-op, and an unclassified
+    `_task_*` is how a trading task once escaped the strategy registry."""
+    import inspect
+
+    from auramaur.bot import AuramaurBot
+    from auramaur.strategy.registry import NON_STRATEGY_TASKS, STRATEGY_BY_TASK
+
+    assert "_task_maker_observatory" in NON_STRATEGY_TASKS
+    assert "_task_maker_observatory" not in STRATEGY_BY_TASK
+    source = inspect.getsource(AuramaurBot.run)
+    assert "self._task_maker_observatory()" in source, \
+        "the resolver task is defined but never started"
+
+
+# --------------------------------------------------------------------------
+# signed_flow must be able to say "no feed".
+# --------------------------------------------------------------------------
+
+
+def test_signed_flow_reports_an_absent_feed_as_none_not_zero(monkeypatch):
+    """0.0 and "no data" are different facts and must stay different values."""
+    tracker = OrderFlowTracker()
+    now = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    monkeypatch.setattr("auramaur.strategy.order_flow.datetime", type(
+        "Clock", (), {"now": staticmethod(lambda tz: now)}))
+
+    assert tracker.signed_flow(("m1", "", "yes-m1"), now=now) is None
+
+    # A market the feed HAS reached, whose flow genuinely nets to zero, is a
+    # measurement of 0.0 — not a gap.
+    tracker.record_trade("m1", OrderSide.BUY, 10)
+    tracker.record_trade("m1", OrderSide.SELL, 10)
+    balanced = tracker.signed_flow(("m1", "", "yes-m1"), now=now)
+    assert balanced is not None and balanced == pytest.approx(0.0)
+
+    # Any of the three equivalent feed keys counts as coverage.
+    tracker.record_trade("cond-2", OrderSide.BUY, 4)
+    assert tracker.signed_flow(("m2", "cond-2", "yes-m2"),
+                               now=now) == pytest.approx(4)
+
+
+@pytest.mark.asyncio
+async def test_a_market_with_no_feed_records_null_flow_and_reads_as_uncovered(tmp_path):
+    """The 2026-07-29 qwen3 failure mode, pinned at the column.
+
+    OrderFlowTracker is fed only by the websocket price monitor's `on_trade`
+    for the first 20 discovered markets; the maker picks its five by spread and
+    usually is not in that set. Writing 0.0 there would assert balanced flow
+    about a market no feed ever reached — a metric incapable of moving, looking
+    healthy forever.
+    """
+    db = Database(str(tmp_path / "flow.db"))
+    await db.connect()
+    try:
+        tracker = OrderFlowTracker()
+        now = datetime.now(timezone.utc)
+        tracker.record_trade("m1", OrderSide.BUY, 10)
+        tracker.record_trade("m1", OrderSide.SELL, 10)
+        observatory = MakerObservatory(db, flow_tracker=tracker, horizons=(30,),
+                                       holdout_days=0)
+        await observatory.observe(_market("m1"), _book(), observed_at=now)
+        await observatory.observe(_market("m2"), _book(), observed_at=now)
+
+        flows = {row["market_id"]: row["signed_flow"] for row in await db.fetchall(
+            "SELECT market_id,signed_flow FROM maker_observations")}
+        assert flows["m1"] == pytest.approx(0.0, abs=1e-3), \
+            "a covered, genuinely balanced market must record a number"
+        assert flows["m2"] is None, "no feed was recorded as balanced flow"
+
+        coverage = await maker_quote_coverage(db, days=1)
+        assert coverage["samples"] == 2
+        assert coverage["flow_samples"] == 1, "NULL flow counted as data"
+        assert coverage["flow_coverage"] == pytest.approx(.5)
+
+        # No tracker at all is also absence, not balance.
+        untracked = MakerObservatory(db, horizons=(30,), holdout_days=0)
+        await untracked.observe(_market("m3"), _book(), observed_at=now)
+        assert (await db.fetchone(
+            "SELECT signed_flow FROM maker_observations WHERE market_id='m3'")
+        )["signed_flow"] is None
+    finally:
+        await db.close()
+
+
+def test_the_cli_report_shows_flow_coverage_rather_than_implying_balance(
+        tmp_path, monkeypatch):
+    """The operator-facing surface has to say how much flow was measured.
+
+    A scorecard that prints a signed_flow effect without saying it was
+    computed over a fraction of the marks lets a reader take an absent result
+    for a negative one.
+
+    Synchronous on purpose: the command owns its own `asyncio.run`.
+    """
+    import asyncio
+
+    from click.testing import CliRunner
+
+    from auramaur.cli._base import main
+
+    path = tmp_path / "cli.db"
+
+    async def seed():
+        db = Database(str(path))
+        await db.connect()
+        try:
+            now = datetime.now(timezone.utc)
+            observatory = await _observatory(db, holdout_days=0)
+            await _set_holdout_boundary(db, observatory, now - timedelta(days=1))
+            await _fill(observatory, db, at=now - timedelta(seconds=300),
+                        order_id="cli-1")
+            # One observation carries flow data; the rest do not.
+            await db.execute("UPDATE maker_observations SET signed_flow=1.5 "
+                             "WHERE id=(SELECT MIN(id) FROM maker_observations)")
+        finally:
+            await db.close()
+
+    asyncio.run(seed())
+    monkeypatch.setattr("auramaur.web.db.runtime_db_path", lambda: path)
+    result = CliRunner().invoke(main, ["maker-observatory", "--days", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Trade-feed coverage" in result.output
+    assert "signed_flow is not fully covered" in result.output
+    assert "NOT balanced flow" in result.output
+
+
+@pytest.mark.asyncio
+async def test_feature_report_excludes_null_flow_and_surfaces_its_coverage(tmp_path):
+    """An unmeasured feature must not read as a measured null result."""
+    db = Database(str(tmp_path / "flowreport.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(seconds=350))
+        for index in range(4):
+            await _fill(observatory, db, order_id=f"live-{index}",
+                        at=now - timedelta(seconds=400 - index * 40))
+        # Exactly one warmup and one holdout observation carry flow data; the
+        # other two are NULL because no feed reached that market.
+        for order_id, value in (("live-1", 5.0), ("live-3", 9.0)):
+            await db.execute(
+                "UPDATE maker_observations SET signed_flow=? WHERE id="
+                "(SELECT observation_id FROM maker_observatory_fills "
+                " WHERE order_id=?)", (value, order_id))
+
+        report = {row["feature"]: row
+                  for row in await maker_observatory_feature_report(db, days=1)}
+        flow = report["signed_flow"]
+        assert flow["marks_n"] == 4
+        assert flow["covered_n"] == 2, "NULL flow was counted as data"
+        assert flow["coverage"] == pytest.approx(.5)
+        assert flow["warmup_n"] == 1 and flow["holdout_n"] == 1
+        assert flow["threshold"] == pytest.approx(5.0), \
+            "a NULL was folded into the warmup median"
+
+        # A feature that WAS recorded everywhere reports full coverage, so the
+        # number above is measuring something rather than being a constant.
+        imbalance = report["depth_imbalance"]
+        assert imbalance["marks_n"] == 4 and imbalance["covered_n"] == 4
+        assert imbalance["coverage"] == pytest.approx(1.0)
+        assert imbalance["warmup_n"] == 2 and imbalance["holdout_n"] == 2
     finally:
         await db.close()

--- a/tests/test_maker_observatory.py
+++ b/tests/test_maker_observatory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,6 +12,8 @@ from auramaur.monitoring.maker_observatory import (
     compute_maker_features,
     maker_observatory_feature_report,
     maker_observatory_summary,
+    maker_promotion_blockers,
+    maker_quote_coverage,
 )
 from auramaur.strategy.order_flow import OrderFlowTracker
 
@@ -63,7 +66,7 @@ async def test_fill_markouts_are_restart_safe_and_mode_separated(tmp_path):
             db, horizons=(30, 60), retention_days=45,
             max_mark_lateness_seconds=5, holdout_days=0)
         observation_id = await observatory.observe(_market(), _book(), observed_at=t0)
-        await observatory.record_fill(
+        await observatory.record_observed_fill(
             observation_id=observation_id, order_id="paper-1", market_id="m1",
             side="bid", price=.41, size=10, is_paper=True, filled_at=t0,
             fill_evidence="synthetic",
@@ -116,7 +119,7 @@ async def test_late_marks_are_retained_but_never_count_as_valid(tmp_path):
             db, horizons=(30,), max_mark_lateness_seconds=5, holdout_days=0)
         observation_id = await observatory.observe(
             _market(), _book(), observed_at=now - timedelta(seconds=100))
-        await observatory.record_fill(
+        await observatory.record_observed_fill(
             observation_id=observation_id, order_id="live-late",
             market_id="m1", side="bid", price=.41, size=5, is_paper=False,
             fill_evidence="venue_fill",
@@ -156,7 +159,7 @@ async def test_feature_report_uses_warmup_threshold_on_holdout_only(tmp_path):
             await db.execute(
                 "UPDATE maker_observations SET is_holdout=? WHERE id=?",
                 (int(index > 0), observation_id))
-            await observatory.record_fill(
+            await observatory.record_observed_fill(
                 observation_id=observation_id, order_id=f"live-{index}",
                 market_id="m1", side="bid", price=.41, size=5, is_paper=False,
                 fill_evidence="venue_fill", filled_at=fill_at)
@@ -170,5 +173,546 @@ async def test_feature_report_uses_warmup_threshold_on_holdout_only(tmp_path):
         assert imbalance["warmup_n"] == 1
         assert imbalance["holdout_n"] == 2
         assert imbalance["effect"] is not None
+    finally:
+        await db.close()
+
+
+async def _observatory(db, **kwargs):
+    """An observatory whose warmup/holdout boundary the test controls."""
+    kwargs.setdefault("horizons", (30,))
+    kwargs.setdefault("max_mark_lateness_seconds", 45)
+    observatory = MakerObservatory(db, **kwargs)
+    await observatory._register()
+    return observatory
+
+
+async def _set_holdout_boundary(db, observatory, boundary: datetime) -> None:
+    """Move the registered holdout start so `observe` classifies against it.
+
+    is_holdout is computed by a SQL CASE against strategy_experiments; setting
+    the boundary here (rather than UPDATE-ing is_holdout afterwards) keeps that
+    production expression the thing under test.
+    """
+    await db.execute(
+        "UPDATE strategy_experiments SET holdout_starts_at=? "
+        "WHERE strategy_version=?",
+        (boundary.strftime("%Y-%m-%d %H:%M:%S"), observatory.strategy_version),
+    )
+
+
+async def _fill(observatory, db, *, market_id="m1", side="bid", price=.41,
+                evidence="venue_fill", is_paper=False, at, order_id,
+                mark_book=None, size=5.0):
+    """Observe, book a fill against that observation, then mark it out."""
+    observation_id = await observatory.observe(
+        _market(), _book(), observed_at=at)
+    await observatory.record_observed_fill(
+        observation_id=observation_id, order_id=order_id, market_id=market_id,
+        side=side, price=price, size=size, is_paper=is_paper,
+        fill_evidence=evidence, filled_at=at)
+    # A later observation is what triggers the due markout.
+    await observatory.observe(_market(), mark_book or _book(.44, .46),
+                              observed_at=at + timedelta(seconds=31))
+    return observation_id
+
+
+@pytest.mark.asyncio
+async def test_synthetic_paper_fills_are_never_credible_evidence(tmp_path):
+    """The PR's core claim, isolated from the holdout and validity filters.
+
+    Both fills below are post-warmup and marked on time; the ONLY difference is
+    fill_evidence. If synthetic fills ever became credible, this would notice —
+    the previous assertion of `credible_holdout_marks == 0` could not, because
+    its fixture was also pre-holdout.
+    """
+    db = Database(str(tmp_path / "credible.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(days=1))
+
+        await _fill(observatory, db, at=now - timedelta(seconds=300),
+                    order_id="synthetic-1", evidence="synthetic", is_paper=True)
+        await _fill(observatory, db, at=now - timedelta(seconds=200),
+                    order_id="venue-1", evidence="venue_fill", is_paper=False)
+
+        summary = {row["is_paper"]: row
+                   for row in await maker_observatory_summary(db, days=1)}
+        # Both were observed in the holdout window and marked on time...
+        assert summary[1]["valid_marks"] == 1
+        assert summary[0]["valid_marks"] == 1
+        # ...but only the venue fill is admissible evidence.
+        assert summary[1]["credible_holdout_marks"] == 0
+        assert summary[0]["credible_holdout_marks"] == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_warmup_fills_are_excluded_from_holdout_evidence(tmp_path):
+    """Exercises the is_holdout CASE, holding evidence and validity constant."""
+    db = Database(str(tmp_path / "warmup.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(seconds=250))
+
+        await _fill(observatory, db, at=now - timedelta(seconds=400),
+                    order_id="warmup-1")   # before the boundary
+        await _fill(observatory, db, at=now - timedelta(seconds=200),
+                    order_id="holdout-1")  # after it
+
+        flags = [row["is_holdout"] for row in await db.fetchall(
+            "SELECT is_holdout FROM maker_observations ORDER BY observed_at")]
+        assert flags[0] == 0 and flags[-1] == 1
+
+        summary = await maker_observatory_summary(db, days=1)
+        assert [row["valid_marks"] for row in summary] == [2]
+        assert [row["credible_holdout_marks"] for row in summary] == [1]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_ask_fills_mark_out_from_the_seller_side(tmp_path):
+    """A maker ask is a SALE: a falling midpoint is favourable, so markout > 0.
+
+    The bid side is symmetric and already covered; without this the sign
+    convention on half of every quote pair was unasserted.
+    """
+    db = Database(str(tmp_path / "ask.db"))
+    await db.connect()
+    try:
+        t0 = datetime(2026, 8, 5, tzinfo=timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=t0)
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="ask-1", market_id="m1",
+            side="ask", price=.43, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=t0)
+        # Midpoint falls to .40 — good for a seller.
+        await observatory.observe(_market(), _book(.39, .41),
+                                  observed_at=t0 + timedelta(seconds=31))
+
+        mark = await db.fetchone("SELECT markout FROM maker_observatory_markouts")
+        assert mark["markout"] == pytest.approx(.03)
+
+        # And the mirror image: a rising midpoint hurts the seller.
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=t0 + timedelta(seconds=100))
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="ask-2", market_id="m1",
+            side="ask", price=.43, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=t0 + timedelta(seconds=100))
+        await observatory.observe(_market(), _book(.49, .51),
+                                  observed_at=t0 + timedelta(seconds=131))
+        marks = await db.fetchall(
+            "SELECT m.markout FROM maker_observatory_markouts m "
+            "JOIN maker_observatory_fills f ON f.id=m.fill_id "
+            "WHERE f.order_id='ask-2'")
+        assert marks[0]["markout"] == pytest.approx(-.07)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_feature_report_and_blockers_ignore_paper_fills(tmp_path):
+    """Paper evidence must not reach either the scorecard or the promotion gate."""
+    db = Database(str(tmp_path / "paperonly.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(days=1))
+        for index in range(3):
+            await _fill(observatory, db, at=now - timedelta(seconds=400 - index * 50),
+                        order_id=f"paper-{index}", evidence="synthetic",
+                        is_paper=True)
+
+        report = await maker_observatory_feature_report(db, days=1)
+        assert report == [], "paper fills leaked into the frozen-threshold report"
+
+        summary = await maker_observatory_summary(db, days=1)
+        assert summary and all(row["is_paper"] for row in summary)
+        assert maker_promotion_blockers(summary) == ["no live fills"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_promotion_blockers_name_every_unmet_bar():
+    """The gate must report the real numbers, not a bare pass/fail."""
+    rows = [{"horizon_seconds": 30, "is_paper": 0, "credible_holdout_marks": 4,
+             "markets": 1, "completeness": .5, "ci_low": -.01, "ci_high": .02}]
+    blockers = maker_promotion_blockers(
+        rows, min_fills=100, min_markets=5, min_completeness=.95)
+
+    assert blockers == [
+        "30s: 4/100 credible holdout marks",
+        "30s: 1/5 markets",
+        "30s: 50.0%/95.0% valid-mark completeness",
+        "30s: mean markout lower CI is not positive",
+    ]
+    passing = [{"horizon_seconds": 30, "is_paper": 0,
+                "credible_holdout_marks": 100, "markets": 5,
+                "completeness": .99, "ci_low": .001, "ci_high": .01}]
+    assert maker_promotion_blockers(passing) == []
+
+
+@pytest.mark.asyncio
+async def test_completeness_counts_marks_that_were_due_but_never_taken(tmp_path):
+    """A fill nobody came back to mark must drag completeness down, not be hidden."""
+    db = Database(str(tmp_path / "gaps.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(days=1))
+        await _fill(observatory, db, at=now - timedelta(seconds=300),
+                    order_id="marked-1")
+        # A due fill whose market was never observed again: due, never marked.
+        observation_id = await observatory.observe(
+            _market(), _book(), observed_at=now - timedelta(seconds=200))
+        await observatory.record_observed_fill(
+            observation_id=observation_id, order_id="unmarked-1",
+            market_id="m1", side="bid", price=.41, size=5, is_paper=False,
+            fill_evidence="venue_fill", filled_at=now - timedelta(seconds=200))
+
+        row = (await maker_observatory_summary(db, days=1))[0]
+        assert row["due_marks"] == 2
+        assert row["valid_marks"] == 1
+        assert row["completeness"] == pytest.approx(.5)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_confidence_interval_is_computed_from_the_marks(tmp_path):
+    """The CI must move with the data and stay undefined below two clusters."""
+    db = Database(str(tmp_path / "ci.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        await _set_holdout_boundary(db, observatory, now - timedelta(days=1))
+        await _fill(observatory, db, at=now - timedelta(seconds=300),
+                    order_id="one-market")
+
+        single = (await maker_observatory_summary(db, days=1))[0]
+        assert single["markets"] == 1
+        assert single["ci_low"] is None, "a single market cannot bound a mean"
+
+        # Second market, both marked at a strictly positive markout.
+        await db.execute(
+            "INSERT INTO maker_observatory_fills"
+            " (order_id,observation_id,market_id,side,fill_price,fill_size,"
+            "  is_paper,fill_evidence,filled_at)"
+            " SELECT 'm2-fill',observation_id,'m2',side,fill_price,fill_size,"
+            "        is_paper,fill_evidence,filled_at"
+            " FROM maker_observatory_fills WHERE order_id='one-market'")
+        await db.execute(
+            "INSERT INTO maker_observatory_markouts"
+            " (fill_id,horizon_seconds,target_at,midpoint,markout,marked_at,"
+            "  lateness_seconds,is_valid)"
+            " SELECT id,30,filled_at,.44,.03,filled_at,0,1"
+            " FROM maker_observatory_fills WHERE order_id='m2-fill'")
+
+        both = (await maker_observatory_summary(db, days=1))[0]
+        assert both["markets"] == 2
+        assert both["ci_low"] is not None and both["ci_high"] is not None
+        assert both["ci_low"] <= both["mean_markout"] <= both["ci_high"]
+        assert both["ci_low"] > 0, "two positive marks must bound above zero"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_drops_expired_rows_and_keeps_current_ones(tmp_path):
+    db = Database(str(tmp_path / "prune.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, retention_days=7, holdout_days=0)
+        await _fill(observatory, db, at=now - timedelta(seconds=300),
+                    order_id="fresh-1")
+        stale = now - timedelta(days=30)
+        await observatory.observe(_market(), _book(), observed_at=stale)
+        await observatory.record_observed_fill(
+            observation_id=1, order_id="stale-1", market_id="m1", side="bid",
+            price=.41, size=5, is_paper=False, fill_evidence="venue_fill",
+            filled_at=stale)
+
+        async def counts():
+            totals = []
+            for table in ("maker_observations", "maker_observatory_fills",
+                          "maker_observatory_markouts"):
+                totals.append(
+                    (await db.fetchone(f"SELECT COUNT(*) n FROM {table}"))["n"])
+            return tuple(totals)
+
+        assert await counts() == (3, 2, 1)
+        await observatory.prune()
+        observations, fills, markouts = await counts()
+        assert fills == 1, "the 30-day-old fill outlived 7-day retention"
+        assert observations == 2 and markouts == 1, "current rows were pruned"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_quote_coverage_reports_sampled_presence(tmp_path):
+    db = Database(str(tmp_path / "coverage.db"))
+    await db.connect()
+    try:
+        now = datetime.now(timezone.utc)
+        observatory = await _observatory(db, holdout_days=0)
+        active = SimpleNamespace(placed_at=now - timedelta(seconds=10),
+                                 bid_price=.40, ask_price=.44, size=10.0)
+        quote = SimpleNamespace(bid_price=.41, ask_price=.44, size=10.0)
+        await observatory.observe(_market(), _book(), observed_at=now)
+        await observatory.observe(_market(), _book(), quote=quote,
+                                  active_quote=active,
+                                  observed_at=now - timedelta(seconds=5))
+
+        coverage = await maker_quote_coverage(db, days=1)
+        assert coverage["samples"] == 2
+        assert coverage["active_samples"] == 1
+        assert coverage["changed_samples"] == 1
+        assert coverage["sampled_quote_coverage"] == pytest.approx(.5)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_registration_is_issued_once_not_on_every_observation(tmp_path):
+    """observe() runs on the quoting path; re-registering spends the shared
+    Database serializer to re-learn a constant."""
+    db = Database(str(tmp_path / "register.db"))
+    await db.connect()
+    statements: list[str] = []
+    original = db.execute
+
+    async def counting(sql, params=()):
+        statements.append(" ".join(sql.split()))
+        return await original(sql, params)
+
+    db.execute = counting
+    try:
+        observatory = MakerObservatory(db, horizons=(30, 60, 300),
+                                       holdout_days=0)
+        now = datetime.now(timezone.utc)
+        for index in range(5):
+            await observatory.observe(
+                _market(), _book(), observed_at=now + timedelta(seconds=index))
+
+        registrations = [sql for sql in statements
+                         if sql.startswith("INSERT OR IGNORE INTO "
+                                           "strategy_experiments")]
+        horizons = [sql for sql in statements
+                    if "maker_observatory_horizons" in sql]
+        assert len(registrations) == 1, registrations
+        assert len(horizons) == 3, horizons
+        assert (await db.fetchone(
+            "SELECT COUNT(*) n FROM maker_observatory_horizons"))["n"] == 3
+    finally:
+        db.execute = original
+        await db.close()
+
+
+def _frozen_market_maker_version(settings) -> str:
+    """market_maker's strategy_version, hashed exactly as the gateway does.
+
+    Mirrors ExecutionGateway._capture_decision: the strategy's own settings
+    section plus the three risk knobs, canonically serialized.
+    """
+    import hashlib
+    import json
+
+    contract = {
+        "strategy_source": "market_maker",
+        "strategy_config": settings.market_maker.model_dump(mode="json"),
+        "risk": {
+            "min_edge_pct": settings.risk.min_edge_pct,
+            "max_spread_pct": settings.risk.max_spread_pct,
+            "confidence_floor": settings.risk.confidence_floor,
+        },
+    }
+    return hashlib.sha256(
+        json.dumps(contract, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def test_observatory_config_cannot_reversion_the_strategy_it_observes():
+    """Retuning the instrument must not restart the observed holdout clock.
+
+    The nine knobs live in their own top-level `maker_observatory:` section
+    precisely because `settings.market_maker` is hashed into market_maker's
+    strategy_version, and _prospective_stats joins on the LATEST version — so a
+    knob parked in that section would silently discard the strategy's accrued
+    prospective evidence every time the observatory was adjusted.
+    """
+    from config.settings import Settings
+
+    settings = Settings()
+    assert hasattr(settings, "maker_observatory")
+    leaked = [name for name in settings.market_maker.model_dump()
+              if "observatory" in name]
+    assert leaked == [], f"observatory knobs inside the hashed section: {leaked}"
+
+    before = _frozen_market_maker_version(settings)
+    for field, value in (("review_days", 30), ("min_fills", 250),
+                         ("retention_days", 90), ("enabled", False),
+                         ("horizons_seconds", (15, 45)),
+                         ("max_mark_lateness_seconds", 90)):
+        settings.maker_observatory = settings.maker_observatory.model_copy(
+            update={field: value})
+        assert _frozen_market_maker_version(settings) == before, field
+
+    # Control: a knob that genuinely belongs to the strategy still re-versions
+    # it, so the assertion above is about placement, not a dead hash.
+    settings.market_maker = settings.market_maker.model_copy(
+        update={"quote_size": settings.market_maker.quote_size + 1})
+    assert _frozen_market_maker_version(settings) != before
+
+
+def _quoting_maker(db, *, observatory_enabled=True):
+    from auramaur.strategy.market_maker import MarketMaker
+
+    settings = SimpleNamespace(
+        is_live=False,
+        market_maker=SimpleNamespace(
+            min_spread_bps=40, max_spread_bps=1500, quote_size=10.0,
+            max_inventory=50.0, max_markets=5, refresh_seconds=30,
+            op_timeout_seconds=15.0, paper=True, cash_reserve_usd=0.0),
+        maker_observatory=SimpleNamespace(
+            enabled=observatory_enabled, horizons_seconds=(30,),
+            retention_days=45, max_mark_lateness_seconds=45, holdout_days=0),
+        risk=SimpleNamespace(blocked_categories=[], allowed_categories_live=[]),
+    )
+    book = OrderBook(bids=[OrderBookLevel(price=.40, size=100)],
+                     asks=[OrderBookLevel(price=.46, size=100)])
+
+    async def get_order_book(_token):
+        return book
+
+    maker = MarketMaker(settings=settings,
+                        exchange=SimpleNamespace(get_order_book=get_order_book),
+                        db=db)
+    return maker, book
+
+
+@pytest.mark.asyncio
+async def test_quoting_observes_the_book_without_the_observatory_gating_quotes(tmp_path):
+    """The shadow-only claim, at the call site.
+
+    Two halves: the quoting path really does record an observation (otherwise
+    the instrument measures nothing), and an observatory that throws still
+    leaves the quote fully formed and placed.
+    """
+    db = Database(str(tmp_path / "quoting.db"))
+    await db.connect()
+    try:
+        maker, book = _quoting_maker(db)
+        placed: list = []
+
+        async def fake_place(quote, is_live):
+            placed.append((quote, is_live))
+            return {"success": True}
+
+        maker._place_two_sided = fake_place
+        market = _market()
+
+        result, skip = await maker._quote_market(market)
+
+        assert skip is None and result is not None, (skip, result)
+        assert len(placed) == 1, "the observatory suppressed a quote"
+        rows = await db.fetchall(
+            "SELECT market_id,best_bid,best_ask,quote_bid FROM maker_observations")
+        assert len(rows) == 1, "the quoting path recorded no observation"
+        assert rows[0]["best_bid"] == pytest.approx(.40)
+        assert rows[0]["best_ask"] == pytest.approx(.46)
+        assert rows[0]["quote_bid"] is not None
+
+        # A broken instrument must not cost a quote.
+        async def exploding(*args, **kwargs):
+            raise RuntimeError("observatory is down")
+
+        maker._observatory.observe = exploding
+        maker._active_quotes.clear()
+        result, skip = await maker._quote_market(market)
+
+        assert skip is None and result is not None, (skip, result)
+        assert len(placed) == 2, "a failing observatory blocked the quote"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_ask_leg_fills_are_recorded_in_yes_terms(tmp_path):
+    """The ask leg BUYS NO, so its venue fill price is a NO price.
+
+    The observatory marks out against the YES-book midpoint, so the ask leg's
+    price must be converted (1 - p_NO) on the way in. Recording the raw NO
+    price would invert the markout on every ask fill — a sign error on half of
+    every quote pair, which is worse than not measuring at all.
+    """
+    from auramaur.strategy.market_maker import MMQuote
+
+    db = Database(str(tmp_path / "askleg.db"))
+    await db.connect()
+    try:
+        maker, _ = _quoting_maker(db)
+        quote = MMQuote(market_id="m1", token_yes_id="yes-1", token_no_id="no-1",
+                        bid_price=.40, ask_price=.46, size=10.0, spread_bps=600)
+        assert quote.no_leg_price == pytest.approx(.54)
+
+        def result(order_id, filled_price):
+            return SimpleNamespace(order_id=order_id, status="filled",
+                                   filled_price=filled_price, filled_size=10.0,
+                                   is_paper=False)
+
+        async def place_quote_pair(bid_order, ask_order, *, exchange):
+            # The ask leg really is priced in NO terms on the wire.
+            assert ask_order.price == pytest.approx(.54)
+            return result("bid-1", .40), result("ask-1", .55)
+
+        maker._ensure_gateway = lambda: SimpleNamespace(
+            place_quote_pair=place_quote_pair)
+
+        await maker._place_two_sided(quote, is_live=True)
+
+        rows = {row["order_id"]: row for row in await db.fetchall(
+            "SELECT order_id,side,fill_price FROM maker_observatory_fills")}
+        assert rows["bid-1"]["fill_price"] == pytest.approx(.40)
+        # Filled at .55 in NO terms == sold YES at .45.
+        assert rows["ask-1"]["side"] == "ask"
+        assert rows["ask-1"]["fill_price"] == pytest.approx(.45)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_retention_runs_on_the_first_cycle_after_a_restart(tmp_path):
+    """A cycle COUNTER would never reach its 24h period on a stack that
+    restarts more often than daily, leaving retention permanently unrun."""
+    db = Database(str(tmp_path / "retention.db"))
+    await db.connect()
+    try:
+        maker, _ = _quoting_maker(db)
+        pruned: list[int] = []
+
+        async def counting_prune():
+            pruned.append(1)
+
+        maker._observatory.prune = counting_prune
+        await maker.run_cycle([])
+        assert pruned == [1], "retention never ran after startup"
+
+        await maker.run_cycle([])
+        await maker.run_cycle([])
+        assert pruned == [1], "retention ran again inside its 24h period"
     finally:
         await db.close()


### PR DESCRIPTION
## Summary
- add a shadow-only maker observatory for L1 microprice skew, top-five depth imbalance, decayed signed flow, volatility, and quote persistence
- persist versioned observation/fill provenance with restart-safe 30/60/300-second markouts, bounded lateness, retention, and schema migration v49
- enforce prospective warmup/holdout evaluation, credible-fill rules, clustered confidence intervals, explicit promotion blockers, and read-only CLI reporting
- keep every observatory read/write isolated from quote formation and execution authority

## Evidence contract
- synthetic resting paper fills are diagnostic only and never count toward promotion
- late marks remain visible but invalid
- report windows use fill time and distinguish pending, due, valid, and credible holdout marks
- any future quote-policy change requires a separately versioned experiment

## Verification
- full suite: 2132 passed, 5 skipped
- focused observatory/governance suite: 40 passed
- Ruff: clean
- git diff --check: clean