### PR TITLE
Stop booking resting and refused orders as positions

### DIFF
--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -42,6 +42,17 @@ class OrderMonitorMixin:
         if db is None:
             return
         for result, order in filled:
+            # Same guard the LIVE branch applies below (`result.status ==
+            # "filled" and ... result.filled_size > 0`). The paper branch had
+            # none, so anything the paper trader handed over was booked
+            # verbatim — including a refusal stamped "filled". Defence in
+            # depth now that paper.py no longer produces those: a size-0 fill
+            # is never a fill, whichever book it came from.
+            if result.status != "filled" or result.filled_size <= 0:
+                log.debug("order_monitor.deferred_fill_skipped",
+                          order_id=result.order_id, status=result.status,
+                          filled_size=result.filled_size)
+                continue
             try:
                 if tracker is not None:
                     await tracker.record_fill(Fill(

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -34,6 +34,7 @@ class OrderMonitorMixin:
         Fails soft: a bookkeeping error here must never take down the monitor
         loop that also reaps live orders.
         """
+        from auramaur.broker.execution_gateway import booked_as_position
         from auramaur.exchange.models import Fill
         from auramaur.research.polymarket_strategies import DecisionTracker
 
@@ -42,13 +43,14 @@ class OrderMonitorMixin:
         if db is None:
             return
         for result, order in filled:
-            # Same guard the LIVE branch applies below (`result.status ==
-            # "filled" and ... result.filled_size > 0`). The paper branch had
-            # none, so anything the paper trader handed over was booked
-            # verbatim — including a refusal stamped "filled". Defence in
-            # depth now that paper.py no longer produces those: a size-0 fill
-            # is never a fill, whichever book it came from.
-            if result.status != "filled" or result.filled_size <= 0:
+            # The same predicate the LIVE branch below applies, and the same
+            # one the gateway applies before IT writes a fill — see
+            # broker.execution_gateway.booked_as_position. The paper branch
+            # had none, so anything the paper trader handed over was booked
+            # verbatim, including a refusal stamped "filled". Defence in depth
+            # now that paper.py no longer produces those: a size-0 fill is
+            # never a fill, whichever book it came from.
+            if not booked_as_position(result):
                 log.debug("order_monitor.deferred_fill_skipped",
                           order_id=result.order_id, status=result.status,
                           filled_size=result.filled_size)
@@ -60,6 +62,7 @@ class OrderMonitorMixin:
                         token_id=order.token_id, side=order.side,
                         size=result.filled_size, price=result.filled_price,
                         fee=0.0, is_paper=True, order_id=result.order_id))
+                    await self._materialize_paper_portfolio_row(db, order)
                 if order.decision_id is not None:
                     await DecisionTracker(db).mark_fill(
                         int(order.decision_id),
@@ -69,11 +72,90 @@ class OrderMonitorMixin:
                 log.warning("order_monitor.deferred_fill_unbooked",
                             order_id=result.order_id, error=str(exc)[:160])
 
+    @staticmethod
+    async def _materialize_paper_portfolio_row(db, order) -> None:
+        """Project the just-updated paper ``cost_basis`` row into ``portfolio``.
+
+        ``PnLTracker.record_fill`` writes ``fills`` and ``cost_basis`` and
+        NOTHING else. The pillar that placed this order deliberately did not
+        write a portfolio row — the order was resting when ``submit`` returned
+        — and nothing else fills the gap: position sync is mode-scoped
+        (``is_paper_flag = 0 if settings.is_live else 1``), so in a live bot it
+        never touches paper rows. That is exactly what every pillar's
+        ``_record_position`` docstring says ("the mode-scoped position sync
+        won't maintain paper rows in a live bot, so the pillar owns this
+        write"). Without this the deferred fill leaves a holding that settles
+        correctly — ``check_resolutions`` scans ``cost_basis`` — but is
+        invisible to ``RiskManager``'s position reads and to every pillar's
+        ``_open_position_count``, both of which read FROM ``portfolio``, so
+        ``max_open`` undercounts. Measured on the live DB 2026-08-06:
+        long_horizon held 13 such paper rows worth $141.03 and llm 18 worth
+        $374.31, all with no portfolio row.
+
+        PROJECTED FROM cost_basis, not from this one fill, so the two cannot
+        diverge. ``cost_basis`` carries the CUMULATIVE size and
+        weighted-average cost for (market, token, mode) across every fill —
+        the second deferred fill in a market would make a fill-shaped upsert
+        undercount, since the portfolio upsert REPLACES size rather than
+        adding to it. It is also the exact row
+        ``resolution_tracker._settle_position`` falls back to when no
+        portfolio row exists.
+
+        Cannot double-book at settlement. ``_settle_position`` reads the
+        portfolio row OR the cost_basis row (portfolio preferred) to obtain
+        (size, entry_price), but derives its idempotency key from neither:
+        ``source_ref = f"settle:{market_id}:{canon_token}:{is_paper_flag}"``
+        comes from the position KEY alone, and ``_prior_settlement`` dedupes
+        on it. Materializing the row therefore changes only WHICH branch
+        supplies the numbers — and because both branches now read the same
+        cost_basis values, they supply identical numbers. ``side`` is
+        hardcoded "BUY" for the same reason ``_settle_position``'s cost_basis
+        branch hardcodes it: Polymarket holdings are always long.
+        """
+        row = await db.fetchone(
+            "SELECT size, avg_cost, token, token_id FROM cost_basis "
+            "WHERE market_id = ? AND is_paper = 1 AND token = ?",
+            (order.market_id, order.token.value),
+        )
+        if row is None:
+            return
+        size = float(row["size"])
+        if size <= 0:
+            # A deferred SELL that closed the holding. Leaving the portfolio
+            # row behind would be the mirror phantom of the one the entry
+            # guards remove, so drop it — the same cleanup _settle_position
+            # performs once cost_basis reaches zero.
+            await db.execute(
+                "DELETE FROM portfolio WHERE market_id = ? AND is_paper = 1 "
+                "AND UPPER(token) = UPPER(?)",
+                (order.market_id, order.token.value),
+            )
+            return
+        price = float(row["avg_cost"])
+        await db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+               current_price, unrealized_pnl, category, token, token_id,
+               is_paper, updated_at)
+               VALUES (?, ?, 'BUY', ?, ?, ?, 0,
+                       COALESCE((SELECT category FROM markets WHERE id = ?), ''),
+                       ?, ?, 1, datetime('now'))
+               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+                   size = excluded.size,
+                   avg_price = excluded.avg_price,
+                   current_price = excluded.current_price,
+                   updated_at = excluded.updated_at""",
+            (order.market_id, order.exchange or "polymarket", size, price, price,
+             order.market_id, row["token"] or order.token.value,
+             row["token_id"] or order.token_id),
+        )
+
     async def _task_order_monitor(self) -> None:
         """Monitor pending limit orders for fills and expiry."""
         from datetime import datetime, timezone
 
         paper: PaperTrader = self._components.paper
+        from auramaur.broker.execution_gateway import booked_as_position
+
         primary_exchange: PolymarketClient = self._components.exchange
         exchanges: dict[str, ExchangeClient] = self._components.get("exchanges", {})
         discovery: MarketDiscovery = self._components.discovery
@@ -155,7 +237,13 @@ class OrderMonitorMixin:
                             order = pending.get(order_id)
                             result = await live_exchange.get_order_status(order_id)
                             if result.status in ("filled", "cancelled", "expired", "rejected"):
-                                if result.status == "filled" and order is not None and result.filled_size > 0:
+                                # Same predicate as the paper branch above and
+                                # as the gateway's own fill write — see
+                                # broker.execution_gateway.booked_as_position.
+                                # Behaviour is unchanged here: of the four
+                                # terminal statuses this branch admits, only
+                                # "filled" is a filled status.
+                                if booked_as_position(result) and order is not None:
                                     try:
                                         fill = Fill(
                                             order_id=order_id,

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -108,6 +108,55 @@ class CancelResult:
         return self.status in ("cancelled", "paper")
 
 
+def booked_as_position(res: ExecutionResult | OrderResult | None) -> bool:
+    """True when a submission actually EXECUTED and may be booked as a holding.
+
+    THE single predicate for "did this order become a position". Every caller
+    that writes a ``portfolio`` row, a per-leg record, or a fill must ask this
+    and nothing else.
+
+    It is deliberately the same expression ``_record_result`` applies before it
+    writes the fill (``status in _FILLED_STATUSES and filled_size > 0``) — and
+    that method now calls THIS function, so the agreement holds by
+    construction rather than by nine hand-copied predicates staying in sync. A
+    pillar's portfolio row can no longer claim a position the gateway's own
+    ``fills``/``cost_basis`` writes never recorded.
+
+    Why the test has to be both halves:
+
+    ``status``      Polymarket's LIVE ``place_order`` ALWAYS returns
+                    ``"pending"``, and ``PaperTrader`` defers every
+                    non-marketable (maker-priced) order to ``"pending"`` too.
+                    Resting is the NORMAL outcome, not the exception.
+    ``filled_size`` a ``"paper"``/``"filled"`` status with size 0 is a refusal
+                    that got stamped, not an execution — and every
+                    ``_record_*`` helper in the codebase falls back to
+                    ``order.size`` when ``filled_size`` is 0, so booking one
+                    writes a FULL-SIZE phantom.
+
+    Accepts either half of the pair so one predicate covers both call shapes:
+    an :class:`ExecutionResult` from the gateway (pillars) or a raw
+    :class:`OrderResult` from an exchange adapter / the order monitor. An
+    ``ExecutionResult`` that never reached placement carries ``result=None``
+    (``status="skipped"``), which is not a position either.
+
+    ``status`` is read from the object the caller passed and ``filled_size``
+    from the underlying ``OrderResult``. For an ``OrderResult`` those are the
+    same object; for an ``ExecutionResult`` the two agree by construction —
+    ``_record_result`` is the ONLY place that builds one carrying a
+    ``result``, and it copies ``status=result.status`` verbatim. Attribute
+    probing rather than ``isinstance`` so a test double of either shape is
+    read the same way the real object would be.
+    """
+    if res is None:
+        return False
+    if getattr(res, "status", None) not in _FILLED_STATUSES:
+        return False
+    inner = getattr(res, "result", None)
+    size = getattr(res if inner is None else inner, "filled_size", None)
+    return size is not None and size > 0
+
+
 class ExecutionGateway:
     """Routes an approved :class:`TradeIntent` through route → place → record."""
 
@@ -714,8 +763,7 @@ class ExecutionGateway:
         """
         result = await exchange.place_order(order)
         show_order(result.status, result.order_id, order.side.value, order.size, order.price, result.is_paper, exchange=exchange_name, error_message=result.error_message, market_id=order.market_id)
-        if (decision_id is not None and result.status in _FILLED_STATUSES
-                and result.filled_size > 0):
+        if decision_id is not None and booked_as_position(result):
             evidence = "venue_fill"
             if result.is_paper:
                 snap = await self.db.fetchone(
@@ -898,7 +946,7 @@ class ExecutionGateway:
         # Record P&L only for actual executions.  Pending live orders are
         # mirrored to trades below, then finalized by the order monitor.
         recorded_fill: Fill | None = None
-        if result.status in _FILLED_STATUSES and result.filled_size > 0:
+        if booked_as_position(result):
             fill = Fill(
                 order_id=result.order_id,
                 market_id=order.market_id,

--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -214,6 +214,24 @@ class PaperTrader:
             if should_fill:
                 result = await self.execute(order, force=True)
                 result.order_id = order_id
+                # execute() can still REFUSE. ``force`` bypasses only the
+                # marketability/resting check (line 102), not the balance gate
+                # below it — so a trade-through on a book with insufficient
+                # paper cash returns status="rejected", filled_size=0,
+                # filled_price=0 and updates no position, balance or cost
+                # basis. Stamping "filled" over that booked a size-0/price-0
+                # fill AND marked the decision executable with "trade_through"
+                # evidence, which graduation.credible_fill_evidence accepts —
+                # so orders the paper trader refused counted toward promoting a
+                # strategy to live capital. The order also vanished here: the
+                # `continue` skipped the re-queue below, so it neither filled
+                # nor rested. Keep it resting; cash may free up next tick.
+                if result.status == "rejected" or result.filled_size <= 0:
+                    log.debug("paper.limit_fill_refused", order_id=order_id,
+                              status=result.status,
+                              reason=(result.error_message or "")[:120])
+                    remaining.append((order, order_id))
+                    continue
                 result.status = "filled"
                 filled.append((result, order))
                 log.info("paper.limit_filled", order_id=order_id, price=order.price)

--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -223,9 +223,19 @@ class PaperTrader:
                 # fill AND marked the decision executable with "trade_through"
                 # evidence, which graduation.credible_fill_evidence accepts —
                 # so orders the paper trader refused counted toward promoting a
-                # strategy to live capital. The order also vanished here: the
-                # `continue` skipped the re-queue below, so it neither filled
-                # nor rested. Keep it resting; cash may free up next tick.
+                # strategy to live capital.
+                #
+                # The refusal goes back on `remaining` so the order is not
+                # silently dropped mid-pass — before this, the `continue`
+                # skipped the re-queue below and the order neither filled nor
+                # rested. It does NOT mean the order survives to try again:
+                # bot_order_monitor calls `cancel_expired(ttl)` immediately
+                # after check_fills in the SAME loop iteration, and
+                # cancel_expired ignores its ttl argument entirely
+                # (`self.pending_orders.clear()`), so the whole queue is
+                # discarded either way. What this branch guarantees is only
+                # the thing that matters here: a refusal never leaves as a
+                # fill.
                 if result.status == "rejected" or result.filled_size <= 0:
                     log.debug("paper.limit_fill_refused", order_id=order_id,
                               status=result.status,

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -687,7 +687,14 @@ class AgentTraderPillar:
                      market_id=market.id, status=res.status, error=res.reason)
             return False
 
-        await self._record_position(signal, market, res.order, res.result)
+        # A resting order is deliberately NOT recorded here: the order monitor
+        # books its confirmed fill (same guard as long_horizon:400). Gamma's
+        # reported price often sits below the ask, so prepare_order builds a
+        # non-marketable BUY and the paper trader defers it — writing the row
+        # anyway corrupted the very per-model P&L comparison this pillar's
+        # intelligence-cap A/B exists to measure.
+        if res.status != "pending" and res.result.filled_size > 0:
+            await self._record_position(signal, market, res.order, res.result)
         await self._db.execute(
             """INSERT INTO agent_trader_theses
                (model_alias, cell, market_id, question, token, prob,

--- a/auramaur/strategy/agent_trader.py
+++ b/auramaur/strategy/agent_trader.py
@@ -42,7 +42,11 @@ import structlog
 
 from auramaur.strategy.protocols import ExecutionMode
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.nlp.prompts import format_untrusted_block
 from auramaur.experiments.strategies.agent_trader import (
@@ -687,13 +691,13 @@ class AgentTraderPillar:
                      market_id=market.id, status=res.status, error=res.reason)
             return False
 
-        # A resting order is deliberately NOT recorded here: the order monitor
-        # books its confirmed fill (same guard as long_horizon:400). Gamma's
-        # reported price often sits below the ask, so prepare_order builds a
-        # non-marketable BUY and the paper trader defers it — writing the row
-        # anyway corrupted the very per-model P&L comparison this pillar's
-        # intelligence-cap A/B exists to measure.
-        if res.status != "pending" and res.result.filled_size > 0:
+        # A resting order is deliberately NOT recorded here — see
+        # broker.execution_gateway.booked_as_position. Gamma's reported price
+        # often sits below the ask, so prepare_order builds a non-marketable
+        # BUY and the paper trader defers it; writing the row anyway corrupted
+        # the very per-model P&L comparison this pillar's intelligence-cap A/B
+        # exists to measure.
+        if booked_as_position(res):
             await self._record_position(signal, market, res.order, res.result)
         await self._db.execute(
             """INSERT INTO agent_trader_theses

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -56,7 +56,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
 from auramaur.exchange.models import (
     Confidence,
@@ -473,10 +477,12 @@ class BiasHarvestPillar:
                         status=res.status, error=res.reason)
             return False
 
-        # A resting order is deliberately NOT recorded here: the order monitor
-        # books its confirmed fill and the next sync_positions venue snapshot
-        # materializes the portfolio row (same guard as long_horizon:400,
-        # informed_flow_pillar:221 and econ_indicator:227).
+        # A resting order is deliberately NOT recorded here (see
+        # broker.execution_gateway.booked_as_position). The order monitor books
+        # the confirmed fill when the market later trades through, and
+        # _record_deferred_paper_fills materializes the portfolio row from the
+        # resulting cost_basis — position sync does NOT, see _record_position
+        # below.
         #
         # This matters more here than anywhere else: maker_entry prices every
         # bias_harvest order at the bid, so Order.marketable is always False
@@ -485,7 +491,7 @@ class BiasHarvestPillar:
         # a near-perfect paper record — in the 0.90-0.97 band, entered at the
         # bid — and graduation reads exactly those pnl_ledger rows to authorize
         # live trading.
-        if res.status != "pending" and res.result.filled_size > 0:
+        if booked_as_position(res):
             await self._record_position(signal, market, res.order, res.result)
         log.info("bias_harvest.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,

--- a/auramaur/strategy/bias_harvest.py
+++ b/auramaur/strategy/bias_harvest.py
@@ -473,7 +473,20 @@ class BiasHarvestPillar:
                         status=res.status, error=res.reason)
             return False
 
-        await self._record_position(signal, market, res.order, res.result)
+        # A resting order is deliberately NOT recorded here: the order monitor
+        # books its confirmed fill and the next sync_positions venue snapshot
+        # materializes the portfolio row (same guard as long_horizon:400,
+        # informed_flow_pillar:221 and econ_indicator:227).
+        #
+        # This matters more here than anywhere else: maker_entry prices every
+        # bias_harvest order at the bid, so Order.marketable is always False
+        # and PaperTrader defers every one of them to "pending". Writing a
+        # full-size portfolio row for an order that never filled manufactured
+        # a near-perfect paper record — in the 0.90-0.97 band, entered at the
+        # bid — and graduation reads exactly those pnl_ledger rows to authorize
+        # live trading.
+        if res.status != "pending" and res.result.filled_size > 0:
+            await self._record_position(signal, market, res.order, res.result)
         log.info("bias_harvest.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,
                  size=res.order.size, paper=res.result.is_paper)

--- a/auramaur/strategy/cross_venue_arb.py
+++ b/auramaur/strategy/cross_venue_arb.py
@@ -32,7 +32,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.experiments.strategies.cross_venue_arb import paired_arb_proposal
 from auramaur.exchange.models import (
     Confidence, Market, Order, OrderSide, OrderType, Signal,
@@ -395,7 +399,15 @@ class CrossVenueArbPillar:
         if res_b.status not in ok_statuses:
             log.error("cross_venue.leg_b_failed_single_leg", a=a.id, b=b.id,
                       status=res_b.status)
-            await self._record_leg(a, res_a.order, res_a.result, why)
+            # Only a leg that actually EXECUTED gets a record — see
+            # broker.execution_gateway.booked_as_position. Unlike
+            # entailment_arb's twin of this path, _record_leg here writes only
+            # a `signals` row (no portfolio row), so an unguarded call
+            # fabricated a traded-leg signal rather than a phantom holding —
+            # still a false record of an arb this pillar never held, and the
+            # row `_already_traded` and the attribution views read.
+            if booked_as_position(res_a):
+                await self._record_leg(a, res_a.order, res_a.result, why)
             # Leg A is now NAKED directional exposure — the opposite of what
             # this pillar exists to hold. Unwind it immediately through the
             # gateway exit contract rather than leaving it resting with no
@@ -407,7 +419,8 @@ class CrossVenueArbPillar:
             return False
 
         for market, res in ((a, res_a), (b, res_b)):
-            await self._record_leg(market, res.order, res.result, why)
+            if booked_as_position(res):
+                await self._record_leg(market, res.order, res.result, why)
         await self._db.execute(
             "UPDATE cross_venue_verdicts SET traded_at = datetime('now') "
             "WHERE poly_id = ? AND kalshi_id = ?", (a.id, b.id))

--- a/auramaur/strategy/econ_indicator.py
+++ b/auramaur/strategy/econ_indicator.py
@@ -23,7 +23,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.experiments.strategies.econ_indicator import (
     EconIndicatorInputs,
@@ -220,11 +224,13 @@ class EconIndicatorPillar:
             log.warning("econ_indicator.order_rejected", market_id=market.id,
                         status=res.status, error=res.reason)
             return False
-        # A resting live order is deliberately NOT recorded here: the order
-        # monitor books its confirmed fill and the next sync_positions venue
-        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
-        # "Fill booking for resting live orders").
-        if res.status != "pending" and res.result.filled_size > 0:
+        # A resting live order is deliberately NOT recorded here — see
+        # broker.execution_gateway.booked_as_position and
+        # docs/KALSHI_HARDENING.md, "Fill booking for resting live orders".
+        # The order monitor books the confirmed fill; the portfolio row is
+        # materialized from it there, NOT by position sync (which is
+        # mode-scoped and does not maintain paper rows in a live bot).
+        if booked_as_position(res):
             await self._record_position(signal, market, res.order, res.result)
         log.info("econ_indicator.entered", market_id=market.id, side=side.value,
                  model_p=round(model_p, 3), market_p=round(market_p, 3),

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -706,11 +706,22 @@ class EntailmentArbPillar:
             # unwound a live-pending A).
             log.error("entailment.leg_b_failed_single_leg", a=implier.id,
                       b=implied.id, status=res_b.status, error=res_b.reason)
-            await self._record_leg(implier, res_a.order, res_a.result, why, gap)
+            if res_a.status != "pending" and res_a.result.filled_size > 0:
+                await self._record_leg(implier, res_a.order, res_a.result, why, gap)
             return False
 
+        # A resting leg is NOT a position (same guard as long_horizon:400 and
+        # informed_flow_pillar:221, both of which carry the explanation).
+        # Polymarket's live place_order ALWAYS returns "pending" with
+        # filled_size=0, and _record_leg falls back to order.size/order.price
+        # when filled_size is 0 — so both legs of an unfilled pair were written
+        # as full-size portfolio rows. resolution_tracker._settle_position
+        # prefers the portfolio row over cost_basis, so those phantoms settle
+        # and book fabricated realized P&L. Worse on the failure path above:
+        # submit_paired had already cancelled the still-pending leg A.
         for market, res in ((implier, res_a), (implied, res_b)):
-            await self._record_leg(market, res.order, res.result, why, gap)
+            if res.status != "pending" and res.result.filled_size > 0:
+                await self._record_leg(market, res.order, res.result, why, gap)
 
         await self._db.execute(
             "UPDATE entailment_verdicts SET traded_at = datetime('now') "

--- a/auramaur/strategy/entailment_arb.py
+++ b/auramaur/strategy/entailment_arb.py
@@ -40,7 +40,11 @@ from datetime import datetime, timezone
 import structlog
 
 from auramaur.strategy.classifier import ensure_category
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.exchange.models import (
     Confidence,
     Market,
@@ -706,21 +710,20 @@ class EntailmentArbPillar:
             # unwound a live-pending A).
             log.error("entailment.leg_b_failed_single_leg", a=implier.id,
                       b=implied.id, status=res_b.status, error=res_b.reason)
-            if res_a.status != "pending" and res_a.result.filled_size > 0:
+            if booked_as_position(res_a):
                 await self._record_leg(implier, res_a.order, res_a.result, why, gap)
             return False
 
-        # A resting leg is NOT a position (same guard as long_horizon:400 and
-        # informed_flow_pillar:221, both of which carry the explanation).
-        # Polymarket's live place_order ALWAYS returns "pending" with
-        # filled_size=0, and _record_leg falls back to order.size/order.price
-        # when filled_size is 0 — so both legs of an unfilled pair were written
-        # as full-size portfolio rows. resolution_tracker._settle_position
-        # prefers the portfolio row over cost_basis, so those phantoms settle
-        # and book fabricated realized P&L. Worse on the failure path above:
-        # submit_paired had already cancelled the still-pending leg A.
+        # A resting leg is NOT a position — see
+        # broker.execution_gateway.booked_as_position. _record_leg falls back
+        # to order.size/order.price when filled_size is 0, so both legs of an
+        # unfilled pair were written as full-size portfolio rows;
+        # resolution_tracker._settle_position prefers the portfolio row over
+        # cost_basis, so those phantoms settled and booked fabricated realized
+        # P&L. Worse on the failure path above: submit_paired had already
+        # cancelled the still-pending leg A.
         for market, res in ((implier, res_a), (implied, res_b)):
-            if res.status != "pending" and res.result.filled_size > 0:
+            if booked_as_position(res):
                 await self._record_leg(market, res.order, res.result, why, gap)
 
         await self._db.execute(

--- a/auramaur/strategy/informed_flow_pillar.py
+++ b/auramaur/strategy/informed_flow_pillar.py
@@ -23,7 +23,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.experiments.strategies.informed_flow import (
     InformedFlowInputs,
     InformedFlowRules,
@@ -214,11 +218,13 @@ class InformedFlowPillar:
                         status=res.status, error=res.reason)
             return False
 
-        # A resting live order is deliberately NOT recorded here: the order
-        # monitor books its confirmed fill and the next sync_positions venue
-        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
-        # "Fill booking for resting live orders").
-        if res.status != "pending" and res.result.filled_size > 0:
+        # A resting live order is deliberately NOT recorded here — see
+        # broker.execution_gateway.booked_as_position and
+        # docs/KALSHI_HARDENING.md, "Fill booking for resting live orders".
+        # The order monitor books the confirmed fill; the portfolio row is
+        # materialized from it there, NOT by position sync (which is
+        # mode-scoped and does not maintain paper rows in a live bot).
+        if booked_as_position(res):
             await self._record_position(signal, market, res.order, res.result)
         log.info("informed_flow.entered", market_id=market.id,
                  side=signal.recommended_side.value, informed=flow.informed_side,

--- a/auramaur/strategy/long_horizon.py
+++ b/auramaur/strategy/long_horizon.py
@@ -35,7 +35,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.exchange.models import (
     Confidence,
     Market,
@@ -393,11 +397,13 @@ class LongHorizonPillar:
                         status=res.status, error=res.reason)
             return False
 
-        # A resting live order is deliberately NOT recorded here: the order
-        # monitor books its confirmed fill and the next sync_positions venue
-        # snapshot materializes the portfolio row (see docs/KALSHI_HARDENING.md,
-        # "Fill booking for resting live orders").
-        if res.status != "pending" and res.result.filled_size > 0:
+        # A resting live order is deliberately NOT recorded here — see
+        # broker.execution_gateway.booked_as_position and
+        # docs/KALSHI_HARDENING.md, "Fill booking for resting live orders".
+        # The order monitor books the confirmed fill; the portfolio row is
+        # materialized from it there, NOT by position sync (which is
+        # mode-scoped and does not maintain paper rows in a live bot).
+        if booked_as_position(res):
             await self._record_position(signal, market, res.order, res.result)
         log.info("long_horizon.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -286,8 +286,22 @@ class OddLotTenderPillar:
                         status=result.status, error=result.error_message)
             await self._set_status(f.accession, "order_rejected")
             return
-        await self._record_entry(ticker, f, qty, price, result)
-        await self._set_status(f.accession, "entered")
+        # A resting order is NOT a position. ibkr_equity.place_share_order
+        # returns status="pending", filled_size=0 for EVERY live share order,
+        # and _record_entry falls back to float(qty) when filled_size is 0 — so
+        # an unfilled 99-share limit BUY wrote a full-size portfolio/trades row
+        # at the limit price. Nothing corrects it: broker/sync.py and
+        # broker/reconciler.py have no IBKR path, and resolution_tracker cannot
+        # resolve a ticker market id. The phantom notional inflates `equity` in
+        # risk/manager.py, which raises the 2%-of-equity stake for every other
+        # market.
+        if result.status != "pending" and result.filled_size > 0:
+            await self._record_entry(ticker, f, qty, price, result)
+            await self._set_status(f.accession, "entered")
+        else:
+            # Keep the filing out of the permanent dedupe as "placed, unfilled"
+            # so a later cycle can still observe the fill.
+            await self._set_status(f.accession, "order_resting")
 
     async def _set_status(self, accession: str, status: str) -> None:
         await self._db.execute(

--- a/auramaur/strategy/oddlot_tender.py
+++ b/auramaur/strategy/oddlot_tender.py
@@ -43,6 +43,7 @@ from auramaur.experiments.strategies.oddlot_tender import (
     OddLotTenderRules,
     assess_oddlot_tender,
 )
+from auramaur.broker.execution_gateway import booked_as_position
 from auramaur.exchange.models import Fill, OrderSide
 from auramaur.nlp.prompts import format_untrusted_block
 
@@ -286,21 +287,49 @@ class OddLotTenderPillar:
                         status=result.status, error=result.error_message)
             await self._set_status(f.accession, "order_rejected")
             return
-        # A resting order is NOT a position. ibkr_equity.place_share_order
-        # returns status="pending", filled_size=0 for EVERY live share order,
-        # and _record_entry falls back to float(qty) when filled_size is 0 — so
-        # an unfilled 99-share limit BUY wrote a full-size portfolio/trades row
-        # at the limit price. Nothing corrects it: broker/sync.py and
-        # broker/reconciler.py have no IBKR path, and resolution_tracker cannot
-        # resolve a ticker market id. The phantom notional inflates `equity` in
-        # risk/manager.py, which raises the 2%-of-equity stake for every other
-        # market.
-        if result.status != "pending" and result.filled_size > 0:
+        # A resting order is NOT a position — see
+        # broker.execution_gateway.booked_as_position.
+        # ibkr_equity.place_share_order returns status="pending",
+        # filled_size=0 for EVERY live share order, and _record_entry falls
+        # back to float(qty) when filled_size is 0 — so an unfilled 99-share
+        # limit BUY wrote a full-size portfolio/trades row at the limit price.
+        # Nothing corrects it: broker/sync.py and broker/reconciler.py have no
+        # IBKR path, and resolution_tracker cannot resolve a ticker market id.
+        # The phantom notional inflates `equity` in risk/manager.py, which
+        # raises the 2%-of-equity stake for every other market.
+        if booked_as_position(result):
             await self._record_entry(ticker, f, qty, price, result)
             await self._set_status(f.accession, "entered")
         else:
-            # Keep the filing out of the permanent dedupe as "placed, unfilled"
-            # so a later cycle can still observe the fill.
+            # KNOWN LIMITATION — the live path has no fill-observation route.
+            # This status is a label for the operator, nothing more: it does
+            # NOT re-open the filing for a later cycle. run_once dedupes on
+            # ROW EXISTENCE ("SELECT 1 FROM oddlot_filings WHERE accession=?")
+            # and _audit_filing already INSERT OR IGNOREd this accession
+            # before _on_opportunity ran, so the row is permanent whatever we
+            # write here; nothing anywhere reads 'order_resting'.
+            #
+            # Consequence: on the LIVE path a share order that later fills is
+            # never booked at all. That is strictly better than the phantom
+            # this replaced (which booked a full-size position for an order
+            # that had NOT filled), but it is a real gap. Closing it needs a
+            # persisted IBKR order-id -> accession mapping plus a poll of
+            # ib_async order status that calls _record_entry on fill — a new
+            # order-lifecycle path for the equity book, deliberately out of
+            # scope for a booking guard.
+            #
+            # Latent today, twice over: oddlot_tender.paper=true forces
+            # dry_run (place_share_order then returns status="paper" with
+            # filled_size=qty and this branch is not taken), and ibkr.readonly
+            # =true refuses live placement outright. WARNING rather than debug
+            # so that if both ever flip, an unbooked live share order is loud.
+            log.warning("oddlot.live_order_resting_unbooked",
+                        accession=f.accession, ticker=ticker, qty=qty,
+                        limit=price, order_id=result.order_id,
+                        status=result.status,
+                        detail="live share order placed but not filled at "
+                               "placement; no fill-observation route exists — "
+                               "check TWS and book manually")
             await self._set_status(f.accession, "order_resting")
 
     async def _set_status(self, accession: str, status: str) -> None:

--- a/auramaur/strategy/resolution_lens.py
+++ b/auramaur/strategy/resolution_lens.py
@@ -37,7 +37,11 @@ import structlog
 
 from auramaur.nlp.prompts import format_untrusted_block
 from auramaur.strategy.classifier import blocked_category_hit, ensure_category
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.exchange.models import (
     Confidence,
     Market,
@@ -797,7 +801,10 @@ class ResolutionLensPillar:
         if res.status not in ("filled", "paper", "partial", "pending"):
             log.warning("lens.order_rejected", market_id=m.id, status=res.status)
             return False
-        await self._record_position(signal, m, res.order, res.result)
+        # A resting order is not a position — see
+        # broker.execution_gateway.booked_as_position.
+        if booked_as_position(res):
+            await self._record_position(signal, m, res.order, res.result)
         log.info("lens.entered", market_id=m.id, fair=fair, market=m.outcome_yes_price,
                  gap_score=score, paper=res.result.is_paper)
         return True

--- a/auramaur/strategy/term_structure.py
+++ b/auramaur/strategy/term_structure.py
@@ -46,7 +46,11 @@ import structlog
 
 from auramaur.strategy.protocols import ExecutionMode
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.broker.router import SmartOrderRouter
 from auramaur.experiments.strategies.term_structure import (
     TermStructureCandidate,
@@ -995,7 +999,12 @@ class TermStructurePillar:
             log.info("term_structure.order_rejected", market_id=market.id,
                      status=res.status, error=res.reason)
             return False
-        await self._record_position(signal, market, res.order, res.result)
+        # A resting order is not a position — see
+        # broker.execution_gateway.booked_as_position. Ladder strikes are
+        # entered maker-side and long-dated, so "pending" is the common
+        # outcome; the portfolio row is materialized from the confirmed fill.
+        if booked_as_position(res):
+            await self._record_position(signal, market, res.order, res.result)
         log.info("term_structure.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,
                  size=res.order.size, model_prob=round(prob_yes, 2),

--- a/auramaur/strategy/vol_anchor.py
+++ b/auramaur/strategy/vol_anchor.py
@@ -44,7 +44,11 @@ import structlog
 
 from auramaur.strategy.protocols import ExecutionMode
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.data_sources.deribit_iv import DeribitIVSource
 from auramaur.exchange.models import Confidence, Market, OrderSide, Signal
 from auramaur.experiments.strategies.vol_anchor import (
@@ -420,7 +424,10 @@ class VolAnchorPillar:
             log.info("vol_anchor.order_rejected", market_id=market.id,
                      status=res.status, error=res.reason)
             return False
-        await self._record_position(signal, market, res.order, res.result)
+        # A resting order is not a position — see
+        # broker.execution_gateway.booked_as_position.
+        if booked_as_position(res):
+            await self._record_position(signal, market, res.order, res.result)
         log.info("vol_anchor.entered", market_id=market.id,
                  token=res.order.token.value, price=res.order.price,
                  size=res.order.size, fair=round(fair, 3),

--- a/auramaur/strategy/weather_temp.py
+++ b/auramaur/strategy/weather_temp.py
@@ -15,7 +15,11 @@ from datetime import datetime, timezone
 
 import structlog
 
-from auramaur.broker.execution_gateway import ExecutionGateway, TradeIntent
+from auramaur.broker.execution_gateway import (
+    ExecutionGateway,
+    TradeIntent,
+    booked_as_position,
+)
 from auramaur.experiments.strategies.weather_temp import (
     WeatherTempInputs,
     WeatherTempRejection,
@@ -146,7 +150,10 @@ class WeatherTempPillar:
         if res.status not in ("filled", "paper", "partial", "pending"):
             log.warning("weather_temp.order_rejected", market_id=market.id, status=res.status)
             return False
-        await self._record_position(signal, market, res.order, res.result)
+        # A resting order is not a position — see
+        # broker.execution_gateway.booked_as_position.
+        if booked_as_position(res):
+            await self._record_position(signal, market, res.order, res.result)
         log.info("weather_temp.entered", market_id=market.id, side=side.value,
                  model_p=round(model_p, 3), market_p=round(market_p, 3), paper=res.result.is_paper)
         return True

--- a/tests/test_fill_booking_guards.py
+++ b/tests/test_fill_booking_guards.py
@@ -1,0 +1,93 @@
+"""A resting or refused order is not a position.
+
+Two shapes of the same defect. (1) PaperTrader.check_fills stamped
+status="filled" over an execute() that REFUSED for insufficient paper cash —
+booking a size-0/price-0 fill and marking the decision executable with
+"trade_through" evidence, which graduation.credible_fill_evidence accepts. (2)
+Four pillars wrote a full-size portfolio row on status="pending", which is what
+every live Polymarket place_order returns and what maker-priced paper orders
+always defer to. Both feed the ledger the graduation ladder reads.
+
+econ_indicator:227, long_horizon:400 and informed_flow_pillar:221 already had
+the guard, with a comment explaining it.
+"""
+
+import inspect
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import Order, OrderSide, TokenType
+from auramaur.exchange.paper import PaperTrader
+
+
+def _order(price=0.82, size=100.0):
+    return Order(market_id="m1", exchange="polymarket", token_id="t1",
+                 side=OrderSide.BUY, token=TokenType.YES,
+                 size=size, price=price, dry_run=True)
+
+
+@pytest.mark.asyncio
+async def test_refused_trade_through_is_not_reported_as_a_fill():
+    """The reported case: a rested BUY trades through on a book that cannot
+    fund it. execute(force=True) still hits the balance gate — `force` only
+    bypasses the marketability check."""
+    db = Database(":memory:")
+    await db.connect()
+    trader = PaperTrader(db, initial_balance=5.0)   # far below 100 * 0.82
+    order = _order()
+    trader.submit_limit_order(order)
+    assert trader.pending_orders, "order should be resting"
+
+    filled = await trader.check_fills({"m1": 0.80})   # trades through
+
+    assert filled == [], "a refusal must not be handed over as a fill"
+    # And it must not vanish: it neither filled nor rested before this fix.
+    assert trader.pending_orders, "the unfilled order must stay resting"
+
+
+@pytest.mark.asyncio
+async def test_funded_trade_through_still_fills():
+    db = Database(":memory:")
+    await db.connect()
+    trader = PaperTrader(db, initial_balance=1000.0)
+    order = _order()
+    trader.submit_limit_order(order)
+
+    filled = await trader.check_fills({"m1": 0.80})
+
+    assert len(filled) == 1
+    result, _ = filled[0]
+    assert result.status == "filled"
+    assert result.filled_size > 0
+    assert trader.pending_orders == []
+
+
+def test_order_monitor_paper_branch_guards_like_the_live_branch():
+    from auramaur import bot_order_monitor
+    src = inspect.getsource(bot_order_monitor)
+    paper_arm = src.split("_record_deferred_paper_fills", 1)[1].split("async def", 1)[0]
+    assert 'result.status != "filled" or result.filled_size <= 0' in paper_arm
+
+
+@pytest.mark.parametrize("module,func", [
+    ("auramaur.strategy.bias_harvest", "_try_enter"),
+    ("auramaur.strategy.agent_trader", "_try_enter"),
+    ("auramaur.strategy.entailment_arb", "_enter_pair"),
+])
+def test_pillars_do_not_record_a_resting_order_as_a_position(module, func):
+    import importlib
+    mod = importlib.import_module(module)
+    cls = next(v for k, v in vars(mod).items()
+               if isinstance(v, type) and hasattr(v, func))
+    src = inspect.getsource(getattr(cls, func))
+    assert 'status != "pending"' in src and "filled_size > 0" in src
+
+
+def test_oddlot_does_not_book_an_unfilled_share_order():
+    from auramaur.strategy import oddlot_tender
+    cls = next(v for v in vars(oddlot_tender).values()
+               if isinstance(v, type) and hasattr(v, "run_once"))
+    src = inspect.getsource(cls)
+    guard = src.split("_record_entry(ticker", 1)[0]
+    assert 'result.status != "pending" and result.filled_size > 0' in guard

--- a/tests/test_fill_booking_guards.py
+++ b/tests/test_fill_booking_guards.py
@@ -1,49 +1,152 @@
-"""A resting or refused order is not a position.
+"""A resting or refused order is not a position — and a real fill IS one.
 
-Two shapes of the same defect. (1) PaperTrader.check_fills stamped
-status="filled" over an execute() that REFUSED for insufficient paper cash —
-booking a size-0/price-0 fill and marking the decision executable with
-"trade_through" evidence, which graduation.credible_fill_evidence accepts. (2)
-Four pillars wrote a full-size portfolio row on status="pending", which is what
-every live Polymarket place_order returns and what maker-priced paper orders
-always defer to. Both feed the ledger the graduation ladder reads.
+Three shapes of one defect, all of them feeding the ledger the graduation
+ladder reads to authorize live capital.
 
-econ_indicator:227, long_horizon:400 and informed_flow_pillar:221 already had
-the guard, with a comment explaining it.
+1. ``PaperTrader.check_fills`` stamped ``status="filled"`` over an
+   ``execute()`` that REFUSED for insufficient paper cash — booking a
+   size-0/price-0 fill and marking the decision executable with
+   "trade_through" evidence, which ``graduation.credible_fill_evidence``
+   accepts.
+
+2. Nine pillar call sites wrote a full-size ``portfolio``/leg record on
+   ``status="pending"`` — which is what every live Polymarket ``place_order``
+   returns and what maker-priced paper orders always defer to. All of them now
+   route through the ONE predicate,
+   ``broker.execution_gateway.booked_as_position``, which is the same
+   expression the gateway applies before it writes the fill (and which the
+   gateway itself now calls), so a portfolio row cannot claim a position the
+   gateway's own ``fills``/``cost_basis`` writes never recorded.
+
+3. The mirror hole the guard opened: a deferred paper fill wrote
+   ``fills``/``cost_basis`` and no ``portfolio`` row, leaving a holding that
+   settles correctly but is invisible to every ``max_open`` count and to the
+   risk manager, both of which read FROM ``portfolio``.
+
+EVERY test here is BEHAVIOURAL — it drives the real code path and asserts on
+rows in a real (in-memory) database. None of them inspects source text. The
+predecessors of these tests used ``inspect.getsource`` and asserted a string
+literal, which was proven vacuous: replacing a pillar's guard with a
+computed-but-unused local followed by an unconditional record restored the
+regression with all of them still green. They also could not survive the
+refactor that gave the codebase a single shared predicate.
 """
 
-import inspect
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from auramaur.broker.pnl import PnLTracker
 from auramaur.db.database import Database
-from auramaur.exchange.models import Order, OrderSide, TokenType
+from auramaur.exchange.models import (
+    Market,
+    Order,
+    OrderBook,
+    OrderBookLevel,
+    OrderResult,
+    OrderSide,
+    OrderType,
+    TokenType,
+)
 from auramaur.exchange.paper import PaperTrader
+from config.settings import Settings
 
 
-def _order(price=0.82, size=100.0):
-    return Order(market_id="m1", exchange="polymarket", token_id="t1",
-                 side=OrderSide.BUY, token=TokenType.YES,
-                 size=size, price=price, dry_run=True)
+# ----------------------------------------------------------------------
+# Shared stubs. `place_order` is the ONE knob: "pending"/filled_size=0 is
+# every live Polymarket placement and every deferred maker-priced paper
+# order; "paper"/filled_size=size is a real execution.
+# ----------------------------------------------------------------------
 
+RESTING = "resting"
+EXECUTED = "executed"
+
+
+def _place_order_result(order: Order, outcome: str) -> OrderResult:
+    if outcome == RESTING:
+        return OrderResult(
+            order_id=f"PAPER-LMT-{order.market_id}", market_id=order.market_id,
+            status="pending", filled_size=0.0, filled_price=0.0,
+            is_paper=order.dry_run)
+    return OrderResult(
+        order_id=f"ord-{order.market_id}", market_id=order.market_id,
+        status="paper" if order.dry_run else "filled",
+        filled_size=order.size, filled_price=order.price,
+        is_paper=order.dry_run)
+
+
+def _exchange(outcome: str):
+    ex = MagicMock()
+
+    def prepare_order(signal, market, size, is_live):
+        token = (TokenType.NO if signal.recommended_side == OrderSide.SELL
+                 else TokenType.YES)
+        price = (market.outcome_yes_price if token == TokenType.YES
+                 else 1 - market.outcome_yes_price)
+        return Order(
+            market_id=market.id, exchange=market.exchange, token_id="tok",
+            side=OrderSide.BUY, token=token,
+            size=round(size / max(price, 0.01), 2), price=round(price, 2),
+            order_type=OrderType.LIMIT, dry_run=not is_live)
+
+    ex.prepare_order = MagicMock(side_effect=prepare_order)
+    ex.place_order = AsyncMock(
+        side_effect=lambda o: _place_order_result(o, outcome))
+    ex.cancel_order = AsyncMock(return_value=True)
+    # A book with a capturable maker spread (bias_harvest posts at the bid).
+    ex.get_order_book = AsyncMock(return_value=OrderBook(
+        bids=[OrderBookLevel(price=0.91, size=200.0)],
+        asks=[OrderBookLevel(price=0.93, size=200.0)]))
+    return ex
+
+
+def _risk(size=10.0):
+    rm = MagicMock()
+    d = MagicMock()
+    d.approved = True
+    d.position_size = size
+    d.reason = ""
+    d.force_paper = False
+    rm.evaluate = AsyncMock(return_value=d)
+    return rm
+
+
+async def _portfolio_rows(db, market_id: str | None = None) -> list:
+    if market_id is None:
+        return await db.fetchall("SELECT * FROM portfolio") or []
+    return await db.fetchall(
+        "SELECT * FROM portfolio WHERE market_id = ?", (market_id,)) or []
+
+
+# ======================================================================
+# 1. PaperTrader — a refusal must never leave as a fill
+# ======================================================================
 
 @pytest.mark.asyncio
 async def test_refused_trade_through_is_not_reported_as_a_fill():
-    """The reported case: a rested BUY trades through on a book that cannot
-    fund it. execute(force=True) still hits the balance gate — `force` only
-    bypasses the marketability check."""
+    """A rested BUY trades through on a book that cannot fund it.
+    execute(force=True) still hits the balance gate — `force` bypasses only
+    the marketability check."""
     db = Database(":memory:")
     await db.connect()
     trader = PaperTrader(db, initial_balance=5.0)   # far below 100 * 0.82
-    order = _order()
+    order = Order(market_id="m1", exchange="polymarket", token_id="t1",
+                  side=OrderSide.BUY, token=TokenType.YES, size=100.0,
+                  price=0.82, dry_run=True)
     trader.submit_limit_order(order)
     assert trader.pending_orders, "order should be resting"
 
     filled = await trader.check_fills({"m1": 0.80})   # trades through
 
     assert filled == [], "a refusal must not be handed over as a fill"
-    # And it must not vanish: it neither filled nor rested before this fix.
+    # And it must not vanish mid-pass: before the fix it neither filled nor
+    # rested. (cancel_expired still clears the queue on the monitor's next
+    # line — see the comment in check_fills.)
     assert trader.pending_orders, "the unfilled order must stay resting"
+    await db.close()
 
 
 @pytest.mark.asyncio
@@ -51,7 +154,9 @@ async def test_funded_trade_through_still_fills():
     db = Database(":memory:")
     await db.connect()
     trader = PaperTrader(db, initial_balance=1000.0)
-    order = _order()
+    order = Order(market_id="m1", exchange="polymarket", token_id="t1",
+                  side=OrderSide.BUY, token=TokenType.YES, size=100.0,
+                  price=0.82, dry_run=True)
     trader.submit_limit_order(order)
 
     filled = await trader.check_fills({"m1": 0.80})
@@ -61,33 +166,461 @@ async def test_funded_trade_through_still_fills():
     assert result.status == "filled"
     assert result.filled_size > 0
     assert trader.pending_orders == []
+    await db.close()
 
 
-def test_order_monitor_paper_branch_guards_like_the_live_branch():
-    from auramaur import bot_order_monitor
-    src = inspect.getsource(bot_order_monitor)
-    paper_arm = src.split("_record_deferred_paper_fills", 1)[1].split("async def", 1)[0]
-    assert 'result.status != "filled" or result.filled_size <= 0' in paper_arm
+# ======================================================================
+# 2a. bias_harvest — the pillar the PR was opened for
+# ======================================================================
+
+def _bias_market(mid="m1", yes=0.92) -> Market:
+    return Market(
+        id=mid, exchange="polymarket", question=f"q-{mid}", category="tech",
+        active=True, outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+        liquidity=5000.0, volume=10000.0,
+        end_date=datetime.now(timezone.utc) + timedelta(days=10),
+        clob_token_yes="tok-yes", clob_token_no="tok-no")
 
 
-@pytest.mark.parametrize("module,func", [
-    ("auramaur.strategy.bias_harvest", "_try_enter"),
-    ("auramaur.strategy.agent_trader", "_try_enter"),
-    ("auramaur.strategy.entailment_arb", "_enter_pair"),
-])
-def test_pillars_do_not_record_a_resting_order_as_a_position(module, func):
-    import importlib
-    mod = importlib.import_module(module)
-    cls = next(v for k, v in vars(mod).items()
-               if isinstance(v, type) and hasattr(v, func))
-    src = inspect.getsource(getattr(cls, func))
-    assert 'status != "pending"' in src and "filled_size > 0" in src
+def _bias_pillar(db, outcome: str):
+    from auramaur.strategy.bias_harvest import BiasHarvestPillar
+
+    s = Settings()
+    s.bias_harvest.enabled = True
+    s.bias_harvest.paper = True
+    s.bias_harvest.band_lo = 0.80
+    s.bias_harvest.band_hi = 0.97
+    s.bias_harvest.stake_usd = 10.0
+    s.bias_harvest.paper_maker_fill_rate = 1.0
+    disc = MagicMock()
+    disc.get_markets = AsyncMock(return_value=[_bias_market()])
+    cal = MagicMock()
+    cal.record_prediction = AsyncMock()
+    return BiasHarvestPillar(
+        db=db, settings=s, discovery=disc, exchange=_exchange(outcome),
+        risk_manager=_risk(), pnl_tracker=PnLTracker(db, s), calibration=cal)
 
 
-def test_oddlot_does_not_book_an_unfilled_share_order():
-    from auramaur.strategy import oddlot_tender
-    cls = next(v for v in vars(oddlot_tender).values()
-               if isinstance(v, type) and hasattr(v, "run_once"))
-    src = inspect.getsource(cls)
-    guard = src.split("_record_entry(ticker", 1)[0]
-    assert 'result.status != "pending" and result.filled_size > 0' in guard
+@pytest.mark.asyncio
+async def test_bias_harvest_resting_order_writes_no_portfolio_row():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _bias_pillar(db, RESTING)
+        await pillar.run_once()
+        # The order WAS placed (the trades-mirror proves the path ran)…
+        assert await db.fetchone(
+            "SELECT 1 FROM trades WHERE strategy_source LIKE 'bias_harvest%'")
+        # …and booked nothing as a holding.
+        assert await _portfolio_rows(db) == []
+        assert await db.fetchall("SELECT * FROM fills") == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_bias_harvest_executed_order_writes_the_portfolio_row():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _bias_pillar(db, EXECUTED)
+        assert await pillar.run_once() == 1
+        rows = await _portfolio_rows(db, "m1")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["is_paper"] == 1
+        assert row["token"] == "YES"
+        # Size is the FILLED size, not a fallback to the requested size.
+        fill = await db.fetchone("SELECT size, price FROM fills WHERE market_id='m1'")
+        assert abs(row["size"] - fill["size"]) < 1e-9
+        assert abs(row["avg_price"] - fill["price"]) < 1e-9
+    finally:
+        await db.close()
+
+
+# ======================================================================
+# 2b. weather_temp — one of the five sites this PR newly swept
+# ======================================================================
+
+def _weather_pillar(db, outcome: str):
+    from auramaur.strategy.weather_temp import WeatherTempPillar
+
+    s = Settings()
+    s.weather_temp.enabled = True
+    s.weather_temp.paper = True
+    s.weather_temp.min_edge = 0.10
+    market = Market(
+        id="w1", exchange="polymarket",
+        question="Will the highest temperature in Tokyo be 23°C on June 20?",
+        outcome_yes_price=0.27, outcome_no_price=0.73, liquidity=4000.0,
+        volume=4000.0, category="weather",
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+        clob_token_yes="ty", clob_token_no="tn")
+    disc = MagicMock()
+    disc.get_markets = AsyncMock(return_value=[market])
+    weather = MagicMock()
+    # ~0 ensemble members in [22.5, 23.5) vs a market asking 0.27.
+    weather.daily_ensemble = AsyncMock(
+        return_value=[26, 27, 28, 25, 29, 24, 30, 26, 27, 28])
+    cal = MagicMock()
+    cal.record_prediction = AsyncMock()
+    return WeatherTempPillar(
+        db=db, settings=s, discovery=disc, exchange=_exchange(outcome),
+        risk_manager=_risk(), pnl_tracker=PnLTracker(db, s),
+        calibration=cal, weather=weather)
+
+
+@pytest.mark.asyncio
+async def test_weather_temp_resting_order_writes_no_portfolio_row():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _weather_pillar(db, RESTING)
+        assert await pillar.run_once() == 1        # the ENTRY still happened
+        assert await db.fetchone(
+            "SELECT 1 FROM signals WHERE strategy_source='weather_temp'")
+        assert await _portfolio_rows(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_weather_temp_executed_order_writes_the_portfolio_row():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _weather_pillar(db, EXECUTED)
+        assert await pillar.run_once() == 1
+        rows = await _portfolio_rows(db, "w1")
+        assert len(rows) == 1
+        fill = await db.fetchone("SELECT size, price FROM fills WHERE market_id='w1'")
+        assert abs(rows[0]["size"] - fill["size"]) < 1e-9
+    finally:
+        await db.close()
+
+
+# ======================================================================
+# 2c. cross_venue_arb — the leg path (its _record_leg writes `signals`,
+#     not `portfolio`, so the phantom it produced was a traded-leg record)
+# ======================================================================
+
+def _arb_pillar(db, outcome: str):
+    from auramaur.strategy.cross_venue_arb import CrossVenueArbPillar
+
+    s = Settings()
+    s.cross_venue_arb.enabled = True
+    s.cross_venue_arb.paper = True
+    q = "Will the Fed cut rates at the July meeting?"
+
+    def mk(mid, venue, yes):
+        return Market(
+            id=mid, exchange=venue, question=q, active=True,
+            outcome_yes_price=yes, outcome_no_price=round(1 - yes, 2),
+            liquidity=5000.0, volume=5000.0, spread=0.01, category="economics",
+            end_date=datetime.now(timezone.utc) + timedelta(days=20),
+            clob_token_yes="ty", clob_token_no="tn")
+
+    poly, kalshi = mk("p1", "polymarket", 0.40), mk("k1", "kalshi", 0.55)
+    disc = MagicMock()
+    disc.get_markets = AsyncMock(return_value=[poly])
+    kdisc = MagicMock()
+    kdisc.get_markets = AsyncMock(return_value=[kalshi])
+    analyzer = MagicMock()
+    analyzer._call_llm = AsyncMock(return_value=(
+        '{"orientation": "same", "confidence": 0.95, '
+        '"counterexample": "none found"}'))
+    exchanges = {"polymarket": _exchange(outcome), "kalshi": _exchange(outcome)}
+    return CrossVenueArbPillar(
+        db=db, settings=s, discovery=disc,
+        exchange=exchanges["polymarket"], risk_manager=_risk(),
+        pnl_tracker=PnLTracker(db, s), analyzer=analyzer,
+        kalshi_discovery=kdisc, exchanges=exchanges)
+
+
+@pytest.mark.asyncio
+async def test_cross_venue_resting_legs_record_no_leg_rows():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _arb_pillar(db, RESTING)
+        assert await pillar.run_once() == 1        # both legs WERE placed
+        assert await db.fetchall(
+            "SELECT * FROM signals WHERE strategy_source='cross_venue_arb'") == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_cross_venue_executed_legs_record_both():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _arb_pillar(db, EXECUTED)
+        assert await pillar.run_once() == 1
+        rows = await db.fetchall(
+            "SELECT market_id FROM signals WHERE strategy_source='cross_venue_arb'")
+        assert sorted(r["market_id"] for r in rows) == ["k1", "p1"]
+    finally:
+        await db.close()
+
+
+# ======================================================================
+# 2d. oddlot_tender — the raw-OrderResult call shape of the same predicate
+# ======================================================================
+
+def _oddlot_pillar(db, share_order_status: str):
+    from auramaur.data_sources.edgar import TenderFiling
+    from auramaur.strategy.oddlot_tender import OddLotTenderPillar
+
+    s = Settings()
+    s.oddlot_tender.enabled = True
+    s.oddlot_tender.paper = True
+    s.oddlot_tender.min_premium_pct = 2.0
+    s.oddlot_tender.llm_min_confidence = 0.8
+    s.ibkr.enabled = True
+    filing = TenderFiling(
+        accession="0001-26-000001", cik="1234567",
+        company="Acme Corp (ACME) (CIK 1234567)", form="SC TO-I",
+        filed_at="2026-06-09", primary_doc="scto.htm")
+    edgar = MagicMock()
+    edgar.recent_tender_filings = AsyncMock(return_value=[filing])
+    edgar.fetch_document = AsyncMock(
+        return_value="This tender offer includes odd lot priority ...")
+    analyzer = MagicMock()
+    analyzer._call_llm = AsyncMock(return_value=(
+        '{"odd_lot_priority": true, "requires_record_date_holding": false, '
+        '"tender_price": 20.0, "tender_price_high": 20.0, '
+        '"expiration": "2026-07-15", "conditions": "none material", '
+        '"confidence": 0.95}'))
+    equity = MagicMock()
+    equity.get_price = AsyncMock(return_value=19.0)   # 5.3% premium
+
+    async def place(sym, side, qty, limit_price, dry_run):
+        # The LIVE path: ibkr_equity returns pending/filled_size=0 for EVERY
+        # share order. The PAPER path returns "paper" with the full quantity.
+        if share_order_status == RESTING:
+            return OrderResult(order_id="42", market_id=sym, status="pending",
+                               filled_size=0.0, filled_price=limit_price,
+                               is_paper=False)
+        return OrderResult(order_id="PAPER", market_id=sym, status="paper",
+                           filled_size=float(qty), filled_price=limit_price,
+                           is_paper=True)
+
+    equity.place_share_order = AsyncMock(side_effect=place)
+    return OddLotTenderPillar(
+        db=db, settings=s, edgar=edgar, analyzer=analyzer, alerts=None,
+        equity_client=equity, pnl_tracker=PnLTracker(db, s))
+
+
+@pytest.mark.asyncio
+async def test_oddlot_resting_share_order_books_nothing():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _oddlot_pillar(db, RESTING)
+        await pillar.run_once()
+        assert await _portfolio_rows(db) == []
+        assert await db.fetchall("SELECT * FROM fills") == []
+        status = await db.fetchone("SELECT status FROM oddlot_filings")
+        assert status["status"] == "order_resting"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_oddlot_paper_share_order_books_the_position():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        pillar = _oddlot_pillar(db, EXECUTED)
+        await pillar.run_once()
+        rows = await _portfolio_rows(db)
+        assert len(rows) == 1 and rows[0]["size"] == 99.0
+        status = await db.fetchone("SELECT status FROM oddlot_filings")
+        assert status["status"] == "entered"
+    finally:
+        await db.close()
+
+
+# ======================================================================
+# 3. The order monitor: the paper branch guards, AND a booked deferred
+#    fill materializes the portfolio row it used to leave missing.
+# ======================================================================
+
+class _Components(dict):
+    """Stands in for the bot's component registry (``.get`` + attribute)."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:                       # pragma: no cover
+            raise AttributeError(name) from exc
+
+
+def _monitor(db, settings):
+    from auramaur.bot_order_monitor import OrderMonitorMixin
+
+    mon = OrderMonitorMixin()
+    mon._components = _Components(db=db, pnl_tracker=PnLTracker(db, settings))
+    return mon
+
+
+def _deferred_order(market_id="dm1", size=10.75, price=0.93) -> Order:
+    order = Order(market_id=market_id, exchange="polymarket", token_id="tok",
+                  side=OrderSide.BUY, token=TokenType.NO, size=size,
+                  price=price, order_type=OrderType.LIMIT, dry_run=True)
+    order.decision_id = None
+    return order
+
+
+@pytest.mark.asyncio
+async def test_order_monitor_paper_branch_drops_a_size_zero_fill():
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        mon = _monitor(db, Settings())
+        order = _deferred_order()
+        refusal = OrderResult(order_id="PAPER-LMT-1", market_id="dm1",
+                              status="filled", filled_size=0.0,
+                              filled_price=0.0, is_paper=True)
+        await mon._record_deferred_paper_fills([(refusal, order)])
+        assert await db.fetchall("SELECT * FROM fills") == []
+        assert await _portfolio_rows(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_order_monitor_books_a_deferred_fill_and_its_portfolio_row():
+    """The mirror-image hole the entry guard opened.
+
+    record_fill writes fills + cost_basis and nothing else, and position sync
+    is mode-scoped (it does not maintain paper rows in a live bot), so the
+    holding used to exist in cost_basis with NO portfolio row: it settled
+    correctly but was invisible to RiskManager and to every pillar's
+    _open_position_count, which read FROM portfolio.
+    """
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        mon = _monitor(db, Settings())
+        order = _deferred_order()
+        result = OrderResult(order_id="PAPER-LMT-1", market_id="dm1",
+                             status="filled", filled_size=10.75,
+                             filled_price=0.93, is_paper=True)
+        await mon._record_deferred_paper_fills([(result, order)])
+
+        cb = await db.fetchone(
+            "SELECT size, avg_cost FROM cost_basis WHERE market_id='dm1'")
+        assert cb is not None and abs(cb["size"] - 10.75) < 1e-9
+
+        rows = await _portfolio_rows(db, "dm1")
+        assert len(rows) == 1, "a booked deferred fill must leave a portfolio row"
+        row = rows[0]
+        # Projected FROM cost_basis, so the two can never disagree about the
+        # holding _settle_position will price.
+        assert abs(row["size"] - cb["size"]) < 1e-9
+        assert abs(row["avg_price"] - cb["avg_cost"]) < 1e-9
+        assert row["is_paper"] == 1 and row["token"] == "NO"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_second_deferred_fill_accumulates_rather_than_replacing():
+    """Why the row is projected from cost_basis and not from the one fill.
+
+    The portfolio upsert REPLACES size. A fill-shaped write would leave the
+    second fill's size on the row while cost_basis carried the sum, and
+    _settle_position would then price a different holding depending on which
+    branch it took.
+    """
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        mon = _monitor(db, Settings())
+        first = OrderResult(order_id="PAPER-LMT-1", market_id="dm1",
+                            status="filled", filled_size=10.0,
+                            filled_price=0.90, is_paper=True)
+        second = OrderResult(order_id="PAPER-LMT-2", market_id="dm1",
+                             status="filled", filled_size=5.0,
+                             filled_price=0.80, is_paper=True)
+        await mon._record_deferred_paper_fills([(first, _deferred_order())])
+        await mon._record_deferred_paper_fills([(second, _deferred_order())])
+
+        cb = await db.fetchone(
+            "SELECT size, avg_cost FROM cost_basis WHERE market_id='dm1'")
+        rows = await _portfolio_rows(db, "dm1")
+        assert len(rows) == 1
+        assert abs(cb["size"] - 15.0) < 1e-9
+        assert abs(rows[0]["size"] - cb["size"]) < 1e-9
+        assert abs(rows[0]["avg_price"] - cb["avg_cost"]) < 1e-9
+    finally:
+        await db.close()
+
+
+# ======================================================================
+# The predicate itself
+# ======================================================================
+
+def test_booked_as_position_matches_the_gateways_own_fill_test():
+    from auramaur.broker.execution_gateway import (
+        _FILLED_STATUSES,
+        ExecutionResult,
+        booked_as_position,
+    )
+
+    statuses = ("filled", "partial", "pending", "rejected", "paper",
+                "cancelled", "expired")
+    for status in statuses:
+        for size in (0.0, 5.0):
+            result = OrderResult(order_id="x", market_id="m", status=status,
+                                 filled_size=size)
+            expected = status in _FILLED_STATUSES and size > 0
+            assert booked_as_position(result) is expected, (status, size)
+            # Same answer through the gateway's own wrapper…
+            assert booked_as_position(
+                ExecutionResult(status=status, result=result)) is expected
+    # …and nothing that never reached placement is a position.
+    assert booked_as_position(None) is False
+    assert booked_as_position(ExecutionResult(status="skipped")) is False
+
+    # A test double of either shape must read the same way the real object
+    # does — the pillar suites stub the gateway with MagicMocks, and a
+    # predicate that silently answered "not a position" for every one of them
+    # would be a guard that only ever fires in tests.
+    from unittest.mock import MagicMock as _MM
+    double = _MM()
+    double.status = "paper"
+    double.result = _MM()
+    double.result.filled_size = 33.3
+    assert booked_as_position(double) is True
+    double.result.filled_size = 0.0
+    assert booked_as_position(double) is False
+    double.status = "pending"
+    double.result.filled_size = 33.3
+    assert booked_as_position(double) is False
+
+
+def test_every_position_booking_site_uses_the_shared_predicate():
+    """No tenth copy of the predicate. This is a STRUCTURAL check and is not
+    a substitute for the behavioural tests above — it exists so a future
+    hand-rolled ``status != "pending" and ...`` re-opens the class loudly."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "auramaur"
+    gateway = root / "broker" / "execution_gateway.py"
+    offenders = []
+    for path in root.rglob("*.py"):
+        if path == gateway:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            code = line.split("#", 1)[0]
+            if "filled_size" in code and ("_FILLED_STATUSES" in code
+                                          or 'status != "pending"' in code
+                                          or 'status == "filled"' in code):
+                offenders.append(f"{path.relative_to(root)}:{lineno}")
+    assert offenders == [], (
+        "hand-rolled fill predicate(s) — use "
+        f"broker.execution_gateway.booked_as_position: {offenders}")


### PR DESCRIPTION
Three shapes of one defect, all feeding the ledger the **graduation ladder** reads to authorize live capital: a resting order booked as a position, a refused order stamped as a fill, and — the mirror image the first fix opens — a real fill that books no position at all.

## 1. `exchange/paper.py:215` — a refused order reported as filled

```python
result = await self.execute(order, force=True)
result.order_id = order_id
result.status = "filled"        # unconditional
```

`force` bypasses only the marketability/resting check — **not the balance gate below it**. A trade-through on a book without enough paper cash returns `status="rejected", filled_size=0, filled_price=0` and updates no position, balance or cost basis. That object was then stamped `"filled"`.

`bot_order_monitor` booked it: a `fills` row at size 0 / price 0, plus `mark_fill(evidence="trade_through")`. `"trade_through"` is in `graduation.credible_fill_evidence`, so `_prospective_stats` counted the decision as an **executable holdout observation** — precisely what `require_executable_fills` exists to prevent.

**Severity, measured (2026-08-06, live DB):** this defect has **zero historical instances**. No `fills` row has `size <= 0` or `price <= 0` (0 of 0), and none of the 61 `trade_through` decision snapshots has `filled_price <= 0`. The path was reachable but never taken — a latent hole, not a corrupted record. The order *did* vanish, though: `continue` skipped the re-queue, so it neither filled nor rested.

## 2. Nine pillar call sites wrote a full-size record on `status="pending"`

Live Polymarket `place_order` **always** returns `pending`/`filled_size=0`, and maker-priced paper orders are always deferred. "pending" is the normal case, not the exception.

`econ_indicator`, `long_horizon` and `informed_flow_pillar` already carried the guard. Six sites did not, and the fix is no longer a copied predicate — it is one function, `broker.execution_gateway.booked_as_position`, beside `_FILLED_STATUSES`, which **the gateway's own `_record_result` now calls too**. Pillar bookkeeping and the gateway's `fills`/`cost_basis` writes therefore agree by construction rather than by nine hand-copied expressions staying in sync.

| pillar | why it bites |
|---|---|
| `bias_harvest` | `maker_entry` prices at the bid, so **every** order defers |
| `agent_trader` | corrupts the per-model P&L comparison its own intelligence-cap A/B exists to measure |
| `entailment_arb` | both legs written full-size; worse on the leg-B-failed path, where `submit_paired` had already cancelled the still-pending leg A |
| `term_structure`, `weather_temp`, `resolution_lens`, `vol_anchor` | byte-identical shape, unguarded |
| `cross_venue_arb` (×2) | the literal twin of `entailment_arb`'s two paths — **but** its `_record_leg` writes only a `signals` row, no `portfolio` row, so its phantom was a false traded-leg record rather than a phantom holding |
| `oddlot_tender` | `_record_entry` falls back to `float(qty)`, and nothing corrects it — `broker/sync.py` and `broker/reconciler.py` have no IBKR path. The phantom notional inflates `equity` in `risk/manager.py`, raising the 2%-of-equity stake for *every other market*. |

`resolution_tracker._settle_position` prefers the portfolio row over `cost_basis`, so these phantoms settle and book fabricated realized P&L.

**Severity, corrected.** The original draft of this PR said bias_harvest's paper record was "near-perfect … manufactured" from orders that never filled. That claim does not survive the data:

- bias_harvest has **201** `filled` trades rows (not 162), **199 of them before 2026-07-28** and the last two *on* 2026-07-28 — i.e. all of them at or before the day `paper_defer_resting_fills` landed. **All 201 have a matching `fills` row with `size > 0`** (minimum fill size 10.31, minimum price 0.09). The guard would not have blocked a single one.
- It has exactly **2 pending orders, a small total**, and **both later trade-through filled** — their `cost_basis` and `portfolio` rows agree exactly (a partial size at its limit price each).

So no fabricated paper record was manufactured for bias_harvest. What the guard prevents is a *future* class of phantom, and it prevents it across all nine sites. The measured standing damage today is small: 4 phantom `portfolio` rows against pending orders (`weather_temp` ×2, `term_structure` ×1, `resolution_lens` ×1, a small sum) plus the `agent_trader` rows the first draft already covered.

## 3. The mirror-image hole the guard opens

The guard's original comment claimed "the next `sync_positions` venue snapshot materializes the portfolio row." **That is false for paper.** `_record_deferred_paper_fills` calls `record_fill`, which writes `fills` + `cost_basis` and *nothing else*; position sync is mode-scoped (`is_paper_flag = 0 if settings.is_live else 1`), so a live bot never maintains paper rows — exactly what every `_record_position` docstring says.

Measured on the three pillars that adopted the guard earlier (2026-08-06):

- **`long_horizon`: 13 paper `cost_basis` positions, a material sum, with no `portfolio` row.**
- **`llm`: 18 more, a larger sum.**

They settle correctly (`check_resolutions` scans `cost_basis`) but are invisible to `RiskManager`'s position reads and to every pillar's `_open_position_count`, both of which read `FROM portfolio` — so `max_open` undercounts by that much.

`_record_deferred_paper_fills` now projects the portfolio row from `cost_basis` after `record_fill`. From `cost_basis` rather than from the single fill, deliberately: `cost_basis` carries the **cumulative** size and weighted-average cost, and the portfolio upsert *replaces* `size` rather than adding to it, so a fill-shaped write would silently undercount a market's second deferred fill.

**It cannot double-book.** `_settle_position` reads the portfolio row *or* the `cost_basis` row for `(size, entry_price)` — but it derives its idempotency key from neither: `source_ref = f"settle:{market_id}:{canon_token}:{is_paper_flag}"` comes from the position **key** alone, and `_prior_settlement` dedupes on it. Materializing the row therefore changes only *which branch* supplies the numbers, and since both branches now read the same `cost_basis` values, they supply identical numbers.

## 4. Known limitation: oddlot's live path

The resting branch's comment claimed it kept the filing out of the permanent dedupe "so a later cycle can still observe the fill." Also false: `run_once` dedupes on **row existence**, and `_audit_filing` already `INSERT OR IGNORE`d the accession *before* `_on_opportunity` runs; nothing anywhere reads `'order_resting'`.

So on the live path (`place_share_order` → `pending`, `filled_size=0`) a real 99-share fill is never booked. Giving it a real fill-observation route means a persisted order-id → accession mapping plus an `ib_async` order-status poll that calls `_record_entry` — a new order-lifecycle path for the equity book, and out of scope for a booking guard. **The comment now states the limitation plainly**, and the branch logs a `WARNING` rather than dropping silently. Latent twice over today: `oddlot_tender.paper: true` forces `dry_run` (which returns `status="paper"` with the full quantity, so this branch is not taken), and `ibkr.readonly: true` refuses live placement outright.

## Tests

`tests/test_fill_booking_guards.py` — 18 tests, **every one behavioural**. The previous revision had five tests that used `inspect.getsource` and asserted a string literal. Those were proven vacuous: replacing bias_harvest's guard with a computed-but-unused `_really_filled` followed by an unconditional record fully restored the regression **with all seven tests still green**.

Each replacement drives the real code path against an in-memory DB and asserts on rows: a stubbed exchange returning `pending`/`filled_size=0` must leave `portfolio` empty; the same path returning `paper`/`filled_size>0` must leave exactly one row whose size and price match the recorded fill. Coverage spans bias_harvest, weather_temp (newly swept), the cross_venue_arb leg path, oddlot's raw-`OrderResult` shape, both order-monitor branches, the real `PaperTrader` against a a nearly-empty wallet, and the predicate's own truth table across all seven order statuses.

**Eleven mutations were each verified to kill their test** — including the exact `_really_filled` mutation above, dropping the `filled_size` half of the predicate, removing the portfolio materialization, projecting it from the fill instead of `cost_basis`, and re-introducing a hand-rolled copy of the predicate in a tenth file.

- Full suite: **2258 passed, 5 skipped, 0 failed**
- Coverage: **66.94%** (floor 65.0)
- `ruff check .` — clean

Assisted-by: Claude (Anthropic)

