### PR TITLE
Fix five ways the accounting misreported what happened

### DIFF
--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -479,13 +479,25 @@ class ExecutionGateway:
                                 reason=cap_b or "paired leg blocked by market cap"),
             )
 
-        await self._capture_decision(a, order_a)
-        await self._capture_decision(b, order_b)
+        # Keep the ids. Discarding them left order.decision_id unset, so the
+        # mark_fill block in _place_and_record never ran and EVERY paired-arb
+        # snapshot stayed filled=0 forever. With
+        # graduation.require_executable_fills true (the tracked YAML),
+        # _prospective_stats appends `AND d.filled = 1 AND d.fill_evidence IN
+        # (...)`, so cross_venue_arb and entailment_arb could never graduate
+        # paper->live on merit — while still burning the 14-day holdout clock
+        # and writing snapshots that looked like accumulating evidence.
+        # submit() at :136 plumbs these correctly; this path did not.
+        decision_id_a = await self._capture_decision(a, order_a)
+        decision_id_b = await self._capture_decision(b, order_b)
+        order_a.decision_id = decision_id_a
+        order_b.decision_id = decision_id_b
 
         res_a = await self._place_and_record(
             order_a, strategy_source=a.signal.strategy_source,
             signal_id=getattr(a.signal, "id", None),
-            exchange=exchange_a, exchange_name=exchange_name_a)
+            exchange=exchange_a, exchange_name=exchange_name_a,
+            decision_id=decision_id_a)
         if res_a.status not in _OK_STATUSES:
             # Leg A rejected — B is never placed, nothing to unwind.
             return res_a, ExecutionResult(status="skipped", reason="leg_a_not_ok")
@@ -493,7 +505,8 @@ class ExecutionGateway:
         res_b = await self._place_and_record(
             order_b, strategy_source=b.signal.strategy_source,
             signal_id=getattr(b.signal, "id", None),
-            exchange=exchange_b, exchange_name=exchange_name_b)
+            exchange=exchange_b, exchange_name=exchange_name_b,
+            decision_id=decision_id_b)
         if res_b.status not in _OK_STATUSES:
             # Leg risk: A is in, B failed. Cancel a live-pending A so we don't
             # sit on a naked directional leg (paper / already-filled A can't be

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -480,13 +480,20 @@ class ExecutionGateway:
             )
 
         # Keep the ids. Discarding them left order.decision_id unset, so the
-        # mark_fill block in _place_and_record never ran and EVERY paired-arb
-        # snapshot stayed filled=0 forever. With
+        # mark_fill block in _place_and_record never ran and any paired-arb
+        # snapshot this path wrote would stay filled=0 forever. With
         # graduation.require_executable_fills true (the tracked YAML),
         # _prospective_stats appends `AND d.filled = 1 AND d.fill_evidence IN
         # (...)`, so cross_venue_arb and entailment_arb could never graduate
-        # paper->live on merit — while still burning the 14-day holdout clock
-        # and writing snapshots that looked like accumulating evidence.
+        # paper->live on merit however long they ran.
+        #
+        # Scope of the damage so far, measured rather than assumed (live DB,
+        # 2026-08-06): ZERO decision_snapshots rows and ZERO
+        # strategy_experiments rows for either strategy. No holdout clock was
+        # ever registered and no snapshot was ever written, so nothing was
+        # corrupted and nothing was burned — the defect was a gate these two
+        # strategies could not have passed had they started producing
+        # evidence, not evidence already spoiled. Fixed before that mattered.
         # submit() at :136 plumbs these correctly; this path did not.
         decision_id_a = await self._capture_decision(a, order_a)
         decision_id_b = await self._capture_decision(b, order_b)

--- a/auramaur/cli/reporting.py
+++ b/auramaur/cli/reporting.py
@@ -187,6 +187,8 @@ def ibkr_calibration(arm: str, width: float):
     coin flip until proven otherwise.
     """
     async def _run():
+        from dataclasses import replace
+
         from auramaur.evaluation.etf_calibration import (
             COIN, CONFIDENCE_RANKS, Forecast, brier_score, clearance,
             confidence_bands, probability_bands, samples_for_reliable_edge,
@@ -206,7 +208,7 @@ def ibkr_calibration(arm: str, width: float):
                 clause, params = " WHERE model_alias = ?", [arm]
             rows = await db.fetchall(
                 f"""SELECT model_alias, probability, confidence, actual_outcome,
-                           due_at
+                           due_at, horizon_sessions
                     FROM ibkr_etf_forecasts{clause}
                     ORDER BY model_alias, id""", tuple(params))
             if not rows:
@@ -214,14 +216,23 @@ def ibkr_calibration(arm: str, width: float):
                 return
             by_arm: dict[str, list] = {}
             pending: dict[str, list[str]] = {}
+            resolved_horizons: dict[str, set[int]] = {}
             for row in rows:
                 by_arm.setdefault(row["model_alias"], []).append(Forecast(
                     float(row["probability"]), str(row["confidence"]),
                     None if row["actual_outcome"] is None
-                    else int(row["actual_outcome"])))
+                    else int(row["actual_outcome"]),
+                    # No benchmark column on ibkr_etf_forecasts, so these are
+                    # unscoreable to the gate. The COIN diagnostic below is
+                    # what keeps the kill signal readable meanwhile.
+                    None))
                 if row["actual_outcome"] is None:
                     pending.setdefault(row["model_alias"], []).append(
                         str(row["due_at"]))
+                else:
+                    resolved_horizons.setdefault(
+                        row["model_alias"], set()).add(
+                            int(row["horizon_sessions"] or 0))
 
             for alias in sorted(by_arm):
                 forecasts = by_arm[alias]
@@ -262,6 +273,60 @@ def ibkr_calibration(arm: str, width: float):
                 console.print(
                     f"  trading: {'[green]CLEARED[/]' if verdict.cleared else '[yellow]LOCKED[/]'}"
                     f" — {verdict.reason}")
+
+                # KILL SIGNAL — deliberately NOT the gate printed above.
+                #
+                # ibkr_etf_paper._clearance designates these 5-session
+                # resolutions as "an early kill signal: if the model shows no
+                # skill there within a few weeks, abandon before waiting out a
+                # 42-session clock". Passing reference=None to the gate is
+                # right — an unrecorded benchmark is not a benchmark — but it
+                # also made this report print LOCKED/"no benchmark" and
+                # nothing else, which retires the kill signal along with the
+                # trade permission. Silence is the one answer a kill signal
+                # must never give.
+                #
+                # A coin reference is unusable for CLEARING because it is the
+                # EASIER benchmark: E[Brier] of a constant r under base rate q
+                # is (r-q)^2 + q(1-q), so scoring against 0.5 instead of the
+                # ~0.56 drift adds (0.5-q)^2 ≈ +0.0036 of free edge to every
+                # forecast. That asymmetry is exactly what makes it valid in
+                # the KILL direction and only there: an arm that cannot beat
+                # the inflated benchmark certainly cannot beat the real one.
+                # So a negative number here is conclusive; a positive one
+                # proves nothing and is labelled as proving nothing.
+                #
+                # Read alongside the hit-rate table below, which measures a
+                # different thing. Direction and probability quality can and
+                # do disagree — an arm can call 67% of moves right while its
+                # stated probabilities sit near 0.5 and score worse than a
+                # coin. The trade gate is the Brier edge; the hit rate is not
+                # a substitute for it.
+                coin_view = clearance(
+                    [replace(f, reference=COIN) for f in forecasts],
+                    min_resolved=2)
+                if coin_view.resolved >= 2:
+                    if coin_view.brier_edge_lo > 0:
+                        tone, phrase = "dim", (
+                            "clears the INFLATED benchmark — not evidence of "
+                            "skill; only the recorded drift can show that")
+                    elif coin_view.brier_edge <= 0:
+                        tone, phrase = "bold red", (
+                            "NO SKILL — worse than a coin, and a coin is the "
+                            "easier benchmark. This is the kill signal")
+                    else:
+                        tone, phrase = "yellow", (
+                            "indistinguishable from a coin at 95%")
+                    spans = ", ".join(
+                        f"{h}s" for h in sorted(resolved_horizons.get(alias, ())))
+                    console.print(
+                        f"  [dim]kill-signal diagnostic (vs COIN {COIN}, an "
+                        f"inflated benchmark — valid only for killing):[/] "
+                        f"{coin_view.resolved} resolved over {spans or '—'}, "
+                        f"Brier edge {coin_view.brier_edge:+.5f} "
+                        f"(95% low {coin_view.brier_edge_lo:+.5f}) — "
+                        f"[{tone}]{phrase}[/]")
+
                 if not resolved:
                     nxt = min(pending.get(alias, [])) if pending.get(alias) else "—"
                     console.print(

--- a/auramaur/evaluation/etf_calibration.py
+++ b/auramaur/evaluation/etf_calibration.py
@@ -65,8 +65,11 @@ class Forecast:
     # No default. A coin reference is not a conservative stand-in for the
     # instrument's drift — it is EASIER to beat, by exactly (0.5 - q)^2, so
     # defaulting to it handed every forecast free measured edge. At the ~0.56
-    # five-session up-rate that is +0.0036 per forecast, and a flat forecaster
-    # with zero information cleared the gate inside a few hundred resolutions.
+    # five-session up-rate that is +0.0036 per forecast, which a flat
+    # forecaster with zero information rides through the gate on patience
+    # alone at ~1,050 resolutions (its 95% lower bound is still -0.00224 at
+    # 400, so the defect is real but slower than the first telling claimed —
+    # see test_a_coin_benchmark_hands_out_free_edge_of_exactly_the_drift_gap).
     # A forecast with no recorded benchmark cannot be scored; clearance()
     # treats it as unscoreable rather than scoring it against a coin.
     reference: float | None = None

--- a/auramaur/evaluation/etf_calibration.py
+++ b/auramaur/evaluation/etf_calibration.py
@@ -62,7 +62,14 @@ class Forecast:
     probability: float
     confidence: str
     actual_outcome: int | None
-    reference: float = COIN
+    # No default. A coin reference is not a conservative stand-in for the
+    # instrument's drift — it is EASIER to beat, by exactly (0.5 - q)^2, so
+    # defaulting to it handed every forecast free measured edge. At the ~0.56
+    # five-session up-rate that is +0.0036 per forecast, and a flat forecaster
+    # with zero information cleared the gate inside a few hundred resolutions.
+    # A forecast with no recorded benchmark cannot be scored; clearance()
+    # treats it as unscoreable rather than scoring it against a coin.
+    reference: float | None = None
 
     @property
     def resolved(self) -> bool:
@@ -275,8 +282,19 @@ def clearance(forecasts, *, min_resolved: int = 100,
     this universe whatever its calibration, and that is a different failure
     from being wrong.
     """
-    resolved = [f for f in forecasts if f.resolved]
+    # Only forecasts carrying the benchmark they were scored against can
+    # contribute. Scoring against a coin overstates edge; scoring against
+    # nothing is not scoring. Both fail CLOSED here, which is what the gate is
+    # for — an arm that cannot demonstrate edge does not get to trade.
+    resolved = [f for f in forecasts if f.resolved and f.reference is not None]
+    unscoreable = sum(1 for f in forecasts if f.resolved and f.reference is None)
     conviction = max((abs(f.probability - 0.5) for f in forecasts), default=0.0)
+    if unscoreable and not resolved:
+        return TradingClearance(
+            False,
+            f"{unscoreable} resolved forecast(s) carry no benchmark to score "
+            "against; record horizon_up_rate per forecast to open this gate",
+            0, 0.0, float("-inf"), conviction)
     # Two is the floor regardless of configuration: sample variance is
     # undefined below it, so a single lucky forecast could otherwise open the
     # gate (or divide by zero trying).

--- a/auramaur/monitoring/attribution.py
+++ b/auramaur/monitoring/attribution.py
@@ -11,6 +11,17 @@ from auramaur.db.database import Database
 log = structlog.get_logger()
 
 
+# NOTE ON JOIN SCOPE
+# portfolio and cost_basis are BOTH keyed (market_id, is_paper, token). Every
+# join between them must match all three. Joining on market_id + is_paper alone
+# fans each row out per token side, so a market held on BOTH YES and NO
+# double-counts positions, exposure, unrealized and realized P&L — 4 positions
+# and $160 exposure where the truth is 2 and $80. That shape is structurally
+# normal for entailment_arb's both-or-nothing legs and for paired arbitrage.
+# cockpit.py:126 documents the same bug and fixes it there (found via the web
+# UI's duplicate-key warning); these queries were the siblings that did not get
+# the fix.
+
 class PerformanceAttributor:
     """Tracks per-category PnL and computes Kelly multipliers based on demonstrated edge."""
 
@@ -149,6 +160,7 @@ class PerformanceAttributor:
                LEFT JOIN markets m ON p.market_id = m.id
                LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
                                        AND cb.is_paper = p.is_paper
+                                       AND cb.token = p.token
                WHERE p.is_paper = ? OR p.exchange != 'polymarket'
                GROUP BY cat
                ORDER BY exposure DESC""",
@@ -189,6 +201,7 @@ class PerformanceAttributor:
                FROM cost_basis cb
                LEFT JOIN portfolio p ON cb.market_id = p.market_id
                                      AND p.is_paper = cb.is_paper
+                                     AND p.token = cb.token
                LEFT JOIN markets m ON cb.market_id = m.id
                WHERE cb.is_paper = ? {resolved_exclusion}
                GROUP BY cat""",
@@ -272,6 +285,7 @@ class PerformanceAttributor:
                FROM portfolio p
                LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
                                        AND cb.is_paper = p.is_paper
+                                       AND cb.token = p.token
                WHERE (p.is_paper = ? OR p.exchange != 'polymarket') AND p.size > 0
                GROUP BY venue""",
             (paper_flag,),
@@ -447,6 +461,7 @@ class PerformanceAttributor:
                     FROM portfolio p
                     LEFT JOIN cost_basis cb ON p.market_id = cb.market_id
                                             AND cb.is_paper = p.is_paper
+                                            AND cb.token = p.token
                     WHERE (p.is_paper = ? OR p.exchange != 'polymarket') AND p.size > 0
                 ) op
                 WHERE strat IS NOT NULL

--- a/auramaur/monitoring/ledger_report.py
+++ b/auramaur/monitoring/ledger_report.py
@@ -146,8 +146,20 @@ async def gather_ledger_report(db, *, is_paper: bool, settings=None) -> dict:
     return {
         "is_paper": is_paper,
         "benchmark": risk_free_benchmark(
-            net_pnl=float((total["pnl"] if total else 0) or 0)
-            - float((total["fees"] if total else 0) or 0),
+            # pnl_ledger.pnl is ALREADY NET OF FEES — every writer books it that
+            # way: pnl.py:137 `(price - avg_cost) * size - fill.fee`,
+            # ledger.py:299 the same, kalshi_settlements:152 `payout - cost -
+            # fee`, instrument_booking:127 `pnl=-fee_usd, fees=0.0`. The `fees`
+            # column is the informational breakdown of what is already
+            # deducted, not a second charge.
+            #
+            # Subtracting it again double-counted fees in the one number this
+            # panel labels "net of fees": with SUM(pnl)=+$40 and SUM(fees)=$55
+            # the header printed net +$40.00 and, two lines down, "net of fees
+            # -$15.00 ... behind cash" in bold red. The true figure is +$40.
+            # readiness.py:579 states this convention correctly and explicitly;
+            # this consumer contradicted it.
+            net_pnl=float((total["pnl"] if total else 0) or 0),
             first_at=(span["first_at"] if span else None),
             last_at=(span["last_at"] if span else None),
             settings=settings,

--- a/auramaur/monitoring/ledger_report.py
+++ b/auramaur/monitoring/ledger_report.py
@@ -213,10 +213,23 @@ def render_ledger_report(state: dict) -> Panel:
     bench = state.get("benchmark") or {}
     if bench.get("available"):
         head.append("\n")
-        # "net of fees" stated explicitly: the header's `net` above is
-        # SUM(pnl) with fees broken out separately, while this annualises
-        # SUM(pnl - fees) — the same figure graduation judges cells on. Same
-        # word, two meanings, so name which one this is.
+        # Both numbers on this panel are the SAME quantity: SUM(pnl), which is
+        # already net of fees because every ledger writer books it that way.
+        # readiness.check_pnl_after_fees states the convention outright — it
+        # comments `# already net of fees` on SUM(pnl) and then recovers gross
+        # as `net + fees`. The `fees ${...}` in the header is therefore the
+        # informational breakdown of what has already been deducted, not a
+        # further charge, and this line annualises the identical figure over
+        # the span of the record.
+        #
+        # This comment used to claim the two differed — that the header was
+        # SUM(pnl) while this annualised SUM(pnl - fees). That was accurate
+        # while the call above subtracted fees a second time, and the
+        # difference it named was the double-count itself: at SUM(pnl)=+$40
+        # with SUM(fees)=$55 the header read +$40.00 and this line read
+        # -$15.00 "behind cash" in bold red, two lines apart. The subtraction
+        # is gone (see the call site above) and so is the discrepancy; the
+        # phrase "net of fees" now has exactly one meaning on this panel.
         head.append(
             f"\n{bench['days']}d of record ({bench['first_at']} → "
             f"{bench['last_at']}), net of fees ")

--- a/auramaur/risk/graduation.py
+++ b/auramaur/risk/graduation.py
@@ -25,6 +25,26 @@ Safety properties:
     a risk check and never upsizes beyond the risk manager's Kelly size.
   * Exempt strategies (arbitrage, market_maker by default) bypass the
     ladder: they are structural/two-sided, not directional conviction.
+
+LEDGER CONVENTION, and it is the whole reason the SQL below reads SUM(pnl)
+rather than SUM(pnl - fees). ``pnl_ledger.pnl`` is ALREADY NET OF FEES at
+every one of its six writers — pnl.py `(price - avg_cost) * size - fill.fee`,
+ledger.py the same, kalshi_settlements `payout - cost - fee`,
+instrument_booking `pnl=-fee_usd, fees=0.0`, manual_trades and
+resolution_tracker `fees=0.0`. The `fees` column is the informational
+breakdown of what has already been deducted, not a second charge —
+readiness.check_pnl_after_fees says so outright, commenting `# already net of
+fees` on SUM(pnl) and then recovering gross as `net + fees`.
+
+Subtracting it again charged every fee twice on the paper->live PROMOTION
+path. The error is conservative (it understates P&L, so it holds a cell back
+rather than promoting one that has not earned it), which is why it survived
+unnoticed, but a promotion gate that judges cells on a number that is not
+their P&L is judging the wrong thing. Corrected 2026-08-06 alongside the same
+defect in ledger_report's benchmark panel; measured on the live DB the change
+moves exactly one of 127 cells (kraken_directional/kraken_spot, -$43.98 ->
+-$36.53, negative under both conventions and carrying no decision_snapshots),
+so no verdict flips today.
 """
 
 from __future__ import annotations
@@ -97,7 +117,9 @@ class GraduationLadder:
         # decision. See GraduationConfig.strategy_level_strategies.
         if strategy in self._settings.graduation.strategy_level_strategies:
             rows = await self._db.fetchall(
-                """SELECT market_id, is_paper, SUM(pnl - fees) AS pnl
+                # SUM(pnl), not SUM(pnl - fees): pnl is already net at every
+                # writer. See LEDGER CONVENTION in the module docstring.
+                """SELECT market_id, is_paper, SUM(pnl) AS pnl
                    FROM pnl_ledger
                    WHERE strategy_source = ?
                      AND realized_at >= datetime('now', ?)
@@ -107,7 +129,8 @@ class GraduationLadder:
             )
         else:
             rows = await self._db.fetchall(
-                """SELECT market_id, is_paper, SUM(pnl - fees) AS pnl
+                # SUM(pnl), not SUM(pnl - fees) — see the module docstring.
+                """SELECT market_id, is_paper, SUM(pnl) AS pnl
                    FROM pnl_ledger
                    WHERE strategy_source = ? AND category = ?
                      AND realized_at >= datetime('now', ?)
@@ -153,7 +176,9 @@ class GraduationLadder:
                     SELECT strategy_version FROM strategy_experiments
                     WHERE strategy_source = ? ORDER BY registered_at DESC LIMIT 1
                 ), pnl AS (
-                    SELECT market_id, is_paper, SUM(pnl - fees) AS net_pnl
+                    -- SUM(pnl): already net of fees at every writer. See the
+                    -- module docstring. This is the promotion path.
+                    SELECT market_id, is_paper, SUM(pnl) AS net_pnl
                     FROM pnl_ledger WHERE strategy_source = ?
                     GROUP BY market_id, is_paper
                 )
@@ -282,9 +307,10 @@ class GraduationLadder:
         rows = await self._db.fetchall(
             """SELECT strategy_source AS strategy, category,
                  SUM(CASE WHEN is_paper = 0 THEN 1 ELSE 0 END) AS live_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 0 THEN pnl - fees ELSE 0 END), 0) AS live_pnl,
+                 -- pnl only; already net of fees (module docstring).
+                 COALESCE(SUM(CASE WHEN is_paper = 0 THEN pnl ELSE 0 END), 0) AS live_pnl,
                  SUM(CASE WHEN is_paper = 1 THEN 1 ELSE 0 END) AS paper_n,
-                 COALESCE(SUM(CASE WHEN is_paper = 1 THEN pnl - fees ELSE 0 END), 0) AS paper_pnl
+                 COALESCE(SUM(CASE WHEN is_paper = 1 THEN pnl ELSE 0 END), 0) AS paper_pnl
                FROM pnl_ledger
                WHERE realized_at >= datetime('now', ?)
                GROUP BY 1, 2 ORDER BY 1, 2""",

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -475,11 +475,26 @@ class IBKRETFPaperPillar:
             forecasts.append(Forecast(
                 float(row["probability"]), str(row["confidence"]),
                 None if outcome is None else int(outcome),
-                # The benchmark each forecast was scored against. Stored
-                # forecasts predate the benchmark column, so fall back to a
-                # coin -- which UNDERSTATES the edge and therefore keeps the
-                # gate shut rather than opening it by accident.
-                0.5))
+                # The benchmark each forecast was scored against. There is no
+                # benchmark column on ibkr_etf_forecasts yet, so this is None
+                # and clearance() treats these as unscoreable.
+                #
+                # It previously passed 0.5 on the reasoning that a coin
+                # "UNDERSTATES the edge and therefore keeps the gate shut".
+                # That is backwards. E[Brier] of a constant forecast r under
+                # base rate q is (r-q)^2 + q(1-q), so a coin benchmark is
+                # EASIER to beat than the instrument's own drift by exactly
+                # (0.5-q)^2 — +0.0036 at the ~0.56 five-session up-rate — and
+                # that constant was added to every forecast's brier_edge. A
+                # flat forecaster answering 0.56 on everything (zero
+                # information: it IS the up-rate) cleared the gate at ~400
+                # resolutions against a min of 100.
+                #
+                # Failing closed is the honest state until the benchmark is
+                # recorded per forecast from risk/ibkr_math.horizon_up_rate,
+                # which already computes exactly the right number and is
+                # currently written only into a different ledger.
+                None))
         return clearance(forecasts,
                          min_resolved=self._s.ibkr.etf_min_resolved_to_trade)
 

--- a/auramaur/strategy/ibkr_etf_paper.py
+++ b/auramaur/strategy/ibkr_etf_paper.py
@@ -454,7 +454,11 @@ class IBKRETFPaperPillar:
         still resolve and are readable through `auramaur ibkr-calibration`,
         where they serve as an early kill signal: if the model shows no skill
         there within a few weeks, abandon before waiting out a 42-session
-        clock.
+        clock. That report prints the signal as an explicit "kill-signal
+        diagnostic" line, scored against a coin and labelled kill-only —
+        because this gate returns "unscoreable" (below) for every one of those
+        rows, and a gate's honest refusal must not take the kill signal down
+        with it.
 
         Deliberately fails closed. Any error, and the arm does not trade.
         """
@@ -487,8 +491,11 @@ class IBKRETFPaperPillar:
                 # (0.5-q)^2 — +0.0036 at the ~0.56 five-session up-rate — and
                 # that constant was added to every forecast's brier_edge. A
                 # flat forecaster answering 0.56 on everything (zero
-                # information: it IS the up-rate) cleared the gate at ~400
-                # resolutions against a min of 100.
+                # information: it IS the up-rate) rides that constant through
+                # the gate at ~1,050 resolutions, against a min of 100. Not
+                # ~400: at 400 its 95% lower bound is still -0.00224. The
+                # defect is patience, not speed, and at ~125 scoreable calls a
+                # week it is about two months of free pass.
                 #
                 # Failing closed is the honest state until the benchmark is
                 # recorded per forecast from risk/ibkr_math.horizon_up_rate,

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -726,11 +726,24 @@ class ResolutionTracker:
             # doesn't delete a live position for the same market (and vice versa).
             # When the caller settled a specific token, only that row goes: a
             # YES+NO pair (mergeable) settles leg by leg.
-            if token_scope is not None:
+            # Scope to the token actually settled, NOT to token_scope. They
+            # differ exactly when the caller passed token_scope=None: the SELECT
+            # above reads ONE row via fetchone, but this DELETE removed EVERY
+            # token row for the market. A market held on both YES and NO booked
+            # one leg's P&L and dropped the other outright — the winning side
+            # never settled and could never settle, because its portfolio row
+            # was gone while its cost_basis row survived at size > 0.
+            #
+            # The cost_basis UPDATE directly above already scopes by `token`,
+            # with a comment explaining precisely this. The DELETE did not.
+            # Using `token` here means an unscoped call settles one leg per
+            # pass and the next pass picks up the other via the cost_basis arm
+            # of check_resolutions' union.
+            if token:
                 await self._db.execute(
                     "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? "
                     "AND UPPER(token) = UPPER(?)",
-                    (market_id, is_paper_flag, token_scope),
+                    (market_id, is_paper_flag, token),
                 )
             else:
                 await self._db.execute(

--- a/auramaur/strategy/resolution_tracker.py
+++ b/auramaur/strategy/resolution_tracker.py
@@ -739,17 +739,17 @@ class ResolutionTracker:
             # Using `token` here means an unscoped call settles one leg per
             # pass and the next pass picks up the other via the cost_basis arm
             # of check_resolutions' union.
-            if token:
-                await self._db.execute(
-                    "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? "
-                    "AND UPPER(token) = UPPER(?)",
-                    (market_id, is_paper_flag, token),
-                )
-            else:
-                await self._db.execute(
-                    "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ?",
-                    (market_id, is_paper_flag),
-                )
+            #
+            # Unconditional, because `token` cannot be falsy: it was
+            # normalised to `(token or "YES").upper()` above, so an `if token:`
+            # guard here would be a branch that always takes the same arm and
+            # an unscoped-DELETE fallback that can never run — which is exactly
+            # the whole-market DELETE this fix removes.
+            await self._db.execute(
+                "DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? "
+                "AND UPPER(token) = UPPER(?)",
+                (market_id, is_paper_flag, token),
+            )
 
             # Remove peak tracking
             await self._db.execute(

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -1194,7 +1194,17 @@ class KrakenPillar:
     async def _realised_pnl_usd(self) -> float:
         try:
             row = await self._db.fetchone(
-                "SELECT COALESCE(SUM(pnl - fees), 0) AS v FROM pnl_ledger "
+                # SUM(pnl), not SUM(pnl - fees). pnl_ledger.pnl is already net
+                # of fees at every writer (pnl.py books
+                # `(price - avg_cost) * size - fill.fee`); `fees` is the
+                # breakdown of what was already deducted. Subtracting it again
+                # charged this desk's Kraken commissions twice — the only book
+                # in the ledger carrying non-zero fees, so this was the one
+                # place the defect had a live dollar effect: it reported
+                # -$43.98 realised against a true -$36.53 as of 2026-08-06.
+                # Corrected with the same defect in risk/graduation.py and
+                # monitoring/ledger_report.py.
+                "SELECT COALESCE(SUM(pnl), 0) AS v FROM pnl_ledger "
                 "WHERE strategy_source = 'kraken_directional'")
         except Exception:  # noqa: BLE001
             return 0.0

--- a/tests/test_accounting_scope.py
+++ b/tests/test_accounting_scope.py
@@ -1,0 +1,94 @@
+"""Accounting that decides capital must measure what actually happened.
+
+Four independent ways it did not: a token-blind join double-counting both
+sides of a market, a fee subtracted twice, a settle that dropped the winning
+leg, and a Brier gate scored against a coin instead of the instrument's drift.
+"""
+
+import inspect
+
+
+from auramaur.evaluation.etf_calibration import Forecast, clearance
+
+
+# --- token scoping ---------------------------------------------------------
+
+def test_every_attribution_cost_basis_join_is_token_scoped():
+    """portfolio and cost_basis are both keyed (market_id, is_paper, token).
+    A join on two of three fans out per side: 4 positions / $160 exposure
+    where the truth is 2 / $80."""
+    from auramaur.monitoring import attribution
+    src = inspect.getsource(attribution)
+    joins = src.count("JOIN cost_basis cb") + src.count("JOIN portfolio p ON cb.market_id")
+    scoped = src.count("cb.token = p.token") + src.count("p.token = cb.token")
+    assert joins > 0
+    assert scoped == joins, f"{joins - scoped} join(s) still unscoped by token"
+
+
+def test_settlement_deletes_only_the_leg_it_settled():
+    """With token_scope=None the SELECT reads ONE row; the DELETE removed
+    every token row, so the unsettled side vanished and could never settle."""
+    from auramaur.strategy import resolution_tracker
+    src = inspect.getsource(resolution_tracker)
+    delete = src.split("DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? ", 1)[1]
+    guard = src.split("# Scope to the token actually settled", 1)
+    assert len(guard) == 2, "the scoping rationale must stay with the code"
+    assert "if token:" in guard[1].split("await")[0]
+    assert "UPPER(token) = UPPER(?)" in delete
+
+
+# --- fees ------------------------------------------------------------------
+
+def test_benchmark_does_not_subtract_fees_twice():
+    """pnl_ledger.pnl is already net of fees at every writer; the fees column
+    is the breakdown of what is already deducted. readiness.py:579 states
+    this convention — ledger_report contradicted it."""
+    from auramaur.monitoring import ledger_report
+    src = inspect.getsource(ledger_report)
+    call = src.split("risk_free_benchmark(", 1)[1].split(")", 1)[0]
+    assert 'total["fees"]' not in call
+
+
+# --- decision ids ----------------------------------------------------------
+
+def test_paired_submission_plumbs_decision_ids():
+    """Discarding them left every paired-arb snapshot filled=0 forever, so
+    require_executable_fills filtered out the entire holdout cohort."""
+    from auramaur.broker import execution_gateway
+    src = inspect.getsource(execution_gateway.ExecutionGateway.submit_paired)
+    assert "decision_id_a = await self._capture_decision" in src
+    assert "decision_id=decision_id_a" in src
+    assert "decision_id=decision_id_b" in src
+
+
+# --- Brier benchmark -------------------------------------------------------
+
+def _flat_forecaster(n: int, up_rate: float, reference):
+    """A forecaster with ZERO information: it answers the base rate itself."""
+    outcomes = [1 if i < round(n * up_rate) else 0 for i in range(n)]
+    return [Forecast(up_rate, "MEDIUM", o, reference) for o in outcomes]
+
+
+def test_zero_skill_arm_no_longer_clears_against_a_coin():
+    """E[Brier] of a constant r under base rate q is (r-q)^2 + q(1-q), so a
+    0.5 benchmark is EASIER than the drift by (0.5-q)^2 — free edge."""
+    result = clearance(_flat_forecaster(400, 0.56, reference=None),
+                       min_resolved=100)
+    assert result.cleared is False
+    assert "benchmark" in result.reason
+
+
+def test_zero_skill_arm_scored_against_its_own_drift_does_not_clear():
+    result = clearance(_flat_forecaster(400, 0.56, reference=0.56),
+                       min_resolved=100)
+    assert result.cleared is False
+
+
+def test_a_genuinely_skilled_arm_still_clears():
+    """The gate must not be merely shut — a real edge has to pass it."""
+    forecasts = []
+    for i in range(400):
+        outcome = 1 if i % 2 == 0 else 0
+        forecasts.append(Forecast(0.9 if outcome else 0.1, "HIGH", outcome, 0.56))
+    result = clearance(forecasts, min_resolved=100)
+    assert result.cleared is True

--- a/tests/test_accounting_scope.py
+++ b/tests/test_accounting_scope.py
@@ -1,22 +1,73 @@
 """Accounting that decides capital must measure what actually happened.
 
-Four independent ways it did not: a token-blind join double-counting both
-sides of a market, a fee subtracted twice, a settle that dropped the winning
-leg, and a Brier gate scored against a coin instead of the instrument's drift.
+Five independent ways it did not: a token-blind join double-counting both
+sides of a market, a fee subtracted twice (in a display panel, in the
+paper->live promotion gate, and in the Kraken desk's realised P&L), a settle
+that dropped the winning leg, paired-arb decision ids thrown away, and a Brier
+gate scored against a coin instead of the instrument's drift.
+
+Claims about BEHAVIOUR are tested by running the behaviour against the real
+SQLite schema. Source-text assertions appear only where the property really is
+about the source — "no join anywhere in this module is unscoped" is such a
+property, and it guards joins not yet written; "this query returns two rows,
+not four" is not, and a string test standing in for one proves nothing. The
+fee test in the first draft of this file was exactly that mistake: it split on
+``risk_free_benchmark(``, which matches the ``def`` line 127 lines earlier, so
+it inspected the function SIGNATURE and passed identically before and after
+the fix it was supposed to be pinning.
 """
 
+from __future__ import annotations
+
+import asyncio
 import inspect
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from auramaur.db.database import Database
+from auramaur.evaluation.etf_calibration import COIN, Forecast, clearance
+from auramaur.monitoring.attribution import PerformanceAttributor
 
 
-from auramaur.evaluation.etf_calibration import Forecast, clearance
+def _bench_settings():
+    """Enough of Settings for risk_free_benchmark; no config file needed."""
+    return SimpleNamespace(benchmark=SimpleNamespace(
+        risk_free_annual_rate=0.04, book_capital_usd=1000.0))
+
+
+async def _both_sided_market(db, *, market_id="mkt-both", is_paper=1,
+                             size=100.0, avg=0.40, mark=0.50):
+    """A market held on BOTH sides — structurally normal for entailment_arb's
+    both-or-nothing legs and for paired arbitrage. Two portfolio rows and two
+    cost_basis rows, keyed (market_id, is_paper, token) exactly as the schema
+    keys them."""
+    await db.execute(
+        """INSERT INTO markets (id, question, category, last_updated)
+           VALUES (?, 'Both sides?', 'crypto', datetime('now'))""",
+        (market_id,))
+    for token in ("YES", "NO"):
+        await db.execute(
+            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+                                      current_price, token, category, is_paper,
+                                      updated_at)
+               VALUES (?, 'polymarket', 'BUY', ?, ?, ?, ?, 'crypto', ?,
+                       datetime('now'))""",
+            (market_id, size, avg, mark, token, is_paper))
+        await db.execute(
+            """INSERT INTO cost_basis (market_id, token, token_id, size, avg_cost,
+                                       total_cost, realized_pnl, is_paper)
+               VALUES (?, ?, ?, ?, ?, ?, 0, ?)""",
+            (market_id, token, f"tok-{token}", size, avg, avg * size, is_paper))
+    await db.commit()
 
 
 # --- token scoping ---------------------------------------------------------
 
 def test_every_attribution_cost_basis_join_is_token_scoped():
-    """portfolio and cost_basis are both keyed (market_id, is_paper, token).
-    A join on two of three fans out per side: 4 positions / $160 exposure
-    where the truth is 2 / $80."""
+    """A source-level property gets a source-level test: no join added LATER
+    may be unscoped either. What those joins actually return is pinned by the
+    DB-backed tests below."""
     from auramaur.monitoring import attribution
     src = inspect.getsource(attribution)
     joins = src.count("JOIN cost_basis cb") + src.count("JOIN portfolio p ON cb.market_id")
@@ -25,38 +76,197 @@ def test_every_attribution_cost_basis_join_is_token_scoped():
     assert scoped == joins, f"{joins - scoped} join(s) still unscoped by token"
 
 
+def test_category_summary_does_not_fan_out_a_both_sided_market():
+    """portfolio and cost_basis are BOTH keyed (market_id, is_paper, token).
+    Joining on two of the three fans each portfolio row out per cost_basis
+    token: 4 positions and $160 exposure where the truth is 2 and $80."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _both_sided_market(db)
+            rows = await PerformanceAttributor(db).get_category_summary(
+                is_live=False)
+            crypto = [r for r in rows if r["category"] == "crypto"]
+            assert len(crypto) == 1, rows
+            row = crypto[0]
+            # Two legs, not four. $80 committed, not $160.
+            assert row["positions"] == 2, row
+            assert abs(row["exposure"] - 80.0) < 1e-9, row
+            # (0.50 mark - 0.40 cost) * 100 per leg = $20 together, not $40.
+            assert abs(row["unrealized_pnl"] - 20.0) < 1e-9, row
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_category_summary_realized_does_not_double_count_both_sides():
+    """The sold_rows arm joins the other direction (cost_basis -> portfolio)
+    and fanned out the same way: $28 reported for $14 earned."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _both_sided_market(db)
+            # Each leg realized $7 by selling; $14 together.
+            await db.execute("UPDATE cost_basis SET realized_pnl = 7.0 "
+                             "WHERE market_id = 'mkt-both'")
+            await db.commit()
+            rows = await PerformanceAttributor(db).get_category_summary(
+                is_live=False)
+            crypto = [r for r in rows if r["category"] == "crypto"][0]
+            assert abs(crypto["realized_pnl"] - 14.0) < 1e-9, crypto
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_venue_summary_does_not_fan_out_a_both_sided_market():
+    """The same join, grouped by exchange instead of by category."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _both_sided_market(db)
+            rows = await PerformanceAttributor(db).get_venue_summary(
+                is_live=False)
+            poly = [r for r in rows if r["venue"] == "polymarket"]
+            assert len(poly) == 1, rows
+            assert poly[0]["positions"] == 2, poly[0]
+            assert abs(poly[0]["exposure"] - 80.0) < 1e-9, poly[0]
+            assert abs(poly[0]["unrealized_pnl"] - 20.0) < 1e-9, poly[0]
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
 def test_settlement_deletes_only_the_leg_it_settled():
-    """With token_scope=None the SELECT reads ONE row; the DELETE removed
-    every token row, so the unsettled side vanished and could never settle."""
-    from auramaur.strategy import resolution_tracker
-    src = inspect.getsource(resolution_tracker)
-    delete = src.split("DELETE FROM portfolio WHERE market_id = ? AND is_paper = ? ", 1)[1]
-    guard = src.split("# Scope to the token actually settled", 1)
-    assert len(guard) == 2, "the scoping rationale must stay with the code"
-    assert "if token:" in guard[1].split("await")[0]
-    assert "UPPER(token) = UPPER(?)" in delete
+    """With token_scope=None the SELECT reads ONE row via fetchone, but the
+    DELETE removed EVERY token row for the market. The unsettled side vanished
+    from the portfolio while its cost_basis row survived at size > 0 — so the
+    winning leg never settled and never could."""
+    async def run():
+        from auramaur.strategy.resolution_tracker import ResolutionTracker
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await _both_sided_market(db, is_paper=0)
+            tracker = ResolutionTracker(db=db, calibration=AsyncMock(),
+                                        discoveries={})
+            # Unscoped call: the caller names no token, so ONE leg settles.
+            await tracker._settle_position("mkt-both", outcome=True)
+
+            survivors = await db.fetchall(
+                "SELECT token FROM portfolio WHERE market_id = 'mkt-both'")
+            assert len(survivors) == 1, (
+                "settling one leg must delete one leg, got "
+                f"{[dict(r) for r in survivors]}")
+            other = survivors[0]["token"].upper()
+
+            # The surviving leg must still be settleable, not orphaned.
+            cb = await db.fetchone(
+                "SELECT size FROM cost_basis WHERE market_id='mkt-both' "
+                "AND UPPER(token) = ?", (other,))
+            assert cb["size"] > 0, "the unsettled leg must keep its cost basis"
+
+            # A second pass picks it up instead of finding nothing.
+            await tracker._settle_position("mkt-both", outcome=True)
+            left = await db.fetchall(
+                "SELECT token FROM portfolio WHERE market_id = 'mkt-both'")
+            assert len(left) == 0, [dict(r) for r in left]
+            booked = await db.fetchall(
+                "SELECT token FROM pnl_ledger WHERE market_id = 'mkt-both'")
+            assert {r["token"].upper() for r in booked} == {"YES", "NO"}, (
+                f"both legs must reach the ledger, got {[dict(r) for r in booked]}")
+        finally:
+            await db.close()
+    asyncio.run(run())
 
 
 # --- fees ------------------------------------------------------------------
 
 def test_benchmark_does_not_subtract_fees_twice():
-    """pnl_ledger.pnl is already net of fees at every writer; the fees column
-    is the breakdown of what is already deducted. readiness.py:579 states
-    this convention — ledger_report contradicted it."""
-    from auramaur.monitoring import ledger_report
-    src = inspect.getsource(ledger_report)
-    call = src.split("risk_free_benchmark(", 1)[1].split(")", 1)[0]
-    assert 'total["fees"]' not in call
+    """pnl_ledger.pnl is ALREADY net of fees at every writer (pnl.py books
+    ``(price - avg_cost) * size - fill.fee``); the fees column is the
+    breakdown of what has already been deducted. Subtracting it again printed
+    "net of fees -$15.00 ... behind cash" in bold red two lines under a
+    +$40.00 header."""
+    async def run():
+        from auramaur.monitoring.ledger_report import gather_ledger_report
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # A book at +$40 realized, on which $55 of fees were ALREADY
+            # charged before pnl was written. Two rows so the span is > 1 day
+            # and the benchmark is computable.
+            await db.execute(
+                """INSERT INTO pnl_ledger (market_id, venue, category,
+                       strategy_source, kind, token, qty, pnl, fees, is_paper,
+                       source_ref, realized_at)
+                   VALUES ('fee-mkt', 'polymarket', 'crypto', 'fee_test',
+                           'sell', 'YES', 1, 40.0, 55.0, 1, 'fee-ref-1',
+                           datetime('now', '-30 days'))""")
+            await db.execute(
+                """INSERT INTO pnl_ledger (market_id, venue, category,
+                       strategy_source, kind, token, qty, pnl, fees, is_paper,
+                       source_ref, realized_at)
+                   VALUES ('fee-mkt-2', 'polymarket', 'crypto', 'fee_test',
+                           'sell', 'YES', 1, 0.0, 0.0, 1, 'fee-ref-2',
+                           datetime('now'))""")
+            await db.commit()
+
+            state = await gather_ledger_report(db, is_paper=True,
+                                               settings=_bench_settings())
+            assert abs(state["total"]["pnl"] - 40.0) < 1e-9, state["total"]
+            assert abs(state["total"]["fees"] - 55.0) < 1e-9, state["total"]
+            # THE assertion: the benchmark's "net of fees" is +$40, not -$15.
+            assert abs(state["benchmark"]["net_pnl"] - 40.0) < 1e-9, \
+                state["benchmark"]
+            assert state["benchmark"]["available"] is True
+            assert state["benchmark"]["annualised"] > 0, \
+                "a profitable book must not annualise negative"
+        finally:
+            await db.close()
+    asyncio.run(run())
+
+
+def test_kraken_desk_realised_pnl_does_not_subtract_fees_twice():
+    """kraken_directional is the only book in the live ledger carrying
+    non-zero fees, so this is the one site where the double-count had a dollar
+    effect rather than a $0 one: -$43.98 reported against a true -$36.53."""
+    async def run():
+        from auramaur.treasury.kraken_pillar import KrakenPillar
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await db.execute(
+                """INSERT INTO pnl_ledger (market_id, venue, category,
+                       strategy_source, kind, token, qty, pnl, fees, is_paper,
+                       source_ref)
+                   VALUES ('XBTUSD', 'kraken', 'crypto', 'kraken_directional',
+                           'sell', 'YES', 1, -36.5336, 7.4414, 0, 'k-ref-1')""")
+            await db.commit()
+            pillar = KrakenPillar.__new__(KrakenPillar)
+            pillar._db = db
+            got = await pillar._realised_pnl_usd()
+            assert abs(got - (-36.5336)) < 1e-9, \
+                f"double-counted fees read -43.9750; got {got}"
+        finally:
+            await db.close()
+    asyncio.run(run())
 
 
 # --- decision ids ----------------------------------------------------------
 
 def test_paired_submission_plumbs_decision_ids():
-    """Discarding them left every paired-arb snapshot filled=0 forever, so
-    require_executable_fills filtered out the entire holdout cohort."""
+    """Discarding them left order.decision_id unset, so the mark_fill block in
+    _place_and_record never ran and every paired-arb snapshot stayed filled=0
+    forever — and require_executable_fills then filtered out the whole holdout
+    cohort."""
     from auramaur.broker import execution_gateway
     src = inspect.getsource(execution_gateway.ExecutionGateway.submit_paired)
     assert "decision_id_a = await self._capture_decision" in src
+    assert "decision_id_b = await self._capture_decision" in src
     assert "decision_id=decision_id_a" in src
     assert "decision_id=decision_id_b" in src
 
@@ -69,19 +279,41 @@ def _flat_forecaster(n: int, up_rate: float, reference):
     return [Forecast(up_rate, "MEDIUM", o, reference) for o in outcomes]
 
 
+def test_a_coin_benchmark_hands_out_free_edge_of_exactly_the_drift_gap():
+    """E[Brier] of a constant forecast r under base rate q is (r-q)^2 + q(1-q),
+    so scoring against 0.5 instead of the instrument's own ~0.56 drift adds
+    exactly (0.5-q)^2 to every forecast's edge, information or not.
+
+    The SIZE of that constant is the whole argument, so it is pinned here
+    rather than asserted in prose — and it is small: 0.0036 does NOT clear the
+    gate at a few hundred resolutions. A flat forecaster needs over a
+    thousand. Anything claiming ~400 is wrong."""
+    view = clearance(_flat_forecaster(400, 0.56, reference=COIN),
+                     min_resolved=100)
+    assert abs(view.brier_edge - 0.0036) < 1e-9, view       # (0.5 - 0.56)^2
+    assert view.cleared is False
+    assert -0.00225 < view.brier_edge_lo < -0.00224, view
+    # It does clear eventually — the defect is real, just slower than claimed.
+    assert clearance(_flat_forecaster(1100, 0.56, reference=COIN),
+                     min_resolved=100).cleared is True
+
+
 def test_zero_skill_arm_no_longer_clears_against_a_coin():
-    """E[Brier] of a constant r under base rate q is (r-q)^2 + q(1-q), so a
-    0.5 benchmark is EASIER than the drift by (0.5-q)^2 — free edge."""
-    result = clearance(_flat_forecaster(400, 0.56, reference=None),
+    """With no recorded benchmark the gate refuses, rather than substituting
+    one that is easier to beat."""
+    result = clearance(_flat_forecaster(1100, 0.56, reference=None),
                        min_resolved=100)
     assert result.cleared is False
     assert "benchmark" in result.reason
 
 
 def test_zero_skill_arm_scored_against_its_own_drift_does_not_clear():
-    result = clearance(_flat_forecaster(400, 0.56, reference=0.56),
-                       min_resolved=100)
-    assert result.cleared is False
+    """The correct benchmark gives it exactly nothing, at any sample size."""
+    for n in (400, 1100, 3000):
+        result = clearance(_flat_forecaster(n, 0.56, reference=0.56),
+                           min_resolved=100)
+        assert result.cleared is False, n
+        assert abs(result.brier_edge) < 1e-12, (n, result)
 
 
 def test_a_genuinely_skilled_arm_still_clears():
@@ -92,3 +324,19 @@ def test_a_genuinely_skilled_arm_still_clears():
         forecasts.append(Forecast(0.9 if outcome else 0.1, "HIGH", outcome, 0.56))
     result = clearance(forecasts, min_resolved=100)
     assert result.cleared is True
+
+
+def test_unscoreable_forecasts_do_not_silence_the_kill_signal():
+    """`auramaur ibkr-calibration` re-scores the same forecasts against a coin
+    and prints it as a KILL-ONLY diagnostic, because the gate's honest refusal
+    would otherwise retire the early kill signal along with the trade
+    permission. The asymmetry is what licenses that: the coin is the EASIER
+    benchmark, so failing it is conclusive while passing it proves nothing."""
+    unscoreable = _flat_forecaster(200, 0.56, reference=None)
+    gate = clearance(unscoreable, min_resolved=100)
+    assert gate.cleared is False and gate.resolved == 0
+
+    diagnostic = clearance([replace(f, reference=COIN) for f in unscoreable],
+                           min_resolved=2)
+    assert diagnostic.resolved == 200, "the diagnostic must still see the rows"
+    assert diagnostic.brier_edge_lo > gate.brier_edge_lo

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -365,10 +365,25 @@ def test_strategy_level_election_aggregates_categories():
 
 
 
-def test_graduation_uses_pnl_net_of_fees():
+def test_graduation_does_not_subtract_fees_twice():
+    """``pnl_ledger.pnl`` is ALREADY net of fees at every one of its writers —
+    pnl.py books ``(price - avg_cost) * size - fill.fee`` and records the fee
+    separately in ``fees`` as the breakdown of what it just deducted. The
+    ladder read ``SUM(pnl - fees)``, charging every fee a second time on the
+    paper->live PROMOTION path.
+
+    The error was conservative (it understates P&L, holding a cell back rather
+    than promoting one that has not earned it), which is why it survived
+    unnoticed. It is still the wrong number: a gate that judges a cell on
+    something which is not its P&L judges the wrong thing.
+
+    This test used to assert the opposite, with a fixture — pnl=+1 alongside
+    fees=2 — that no writer can produce: a $2 fee on a $1 gross books pnl=-1
+    with fees=2, never pnl=+1. It encoded the defect as the contract."""
     async def run():
         db = Database(":memory:")
         await db.connect()
+        # Five markets that each NETTED +$1 after a $2 fee was already taken.
         for i in range(5):
             await db.execute(
                 """INSERT INTO pnl_ledger
@@ -378,10 +393,22 @@ def test_graduation_uses_pnl_net_of_fees():
                            1, 1, 2, 1, ?)""",
                 (f"fee-{i}", f"fee-ref-{i}"),
             )
+        await db.commit()
         ladder = GraduationLadder(db, _settings(min_markets=5))
+
+        stats = await ladder._cell_stats("fee_test", "crypto")
+        assert abs(stats["paper_pnl"] - 5.0) < 1e-9, \
+            f"SUM(pnl - fees) would read -5.0; got {stats['paper_pnl']}"
+        assert stats["paper_n"] == 5
+
+        # And the verdict follows the true number: paper-positive is
+        # probation, not the paper_negative the double-count produced.
         decision = await ladder.decide("fee_test", "crypto")
-        assert decision.status == "paper_negative"
-        assert decision.force_paper is True
+        assert decision.status == "probation", decision
+
+        report = await ladder.report()
+        cell = [r for r in report if r["strategy"] == "fee_test"][0]
+        assert abs(cell["paper_pnl"] - 5.0) < 1e-9, cell
         await db.close()
 
     asyncio.run(run())


### PR DESCRIPTION
Five defects across four files, every one feeding a decision about capital —
plus the sibling of one of them on the promotion path, corrected in the second
commit after review.

## 1. `attribution.py` — token-blind `cost_basis` joins (4 sites)

`portfolio` and `cost_basis` are **both** keyed `(market_id, is_paper, token)`. Four joins matched only two of the three, so any market held on both sides fans out:

| | truth | reported |
|---|---|---|
| positions | 2 | **4** |
| exposure | a portion | **the remainder** |
| unrealized | the stake | **the gross figure** |
| realized (`sold_rows`) | the true value | **twice that** |

That shape is structurally normal for `entailment_arb`'s both-or-nothing legs and paired arbitrage. `cockpit.py:126` documents this exact bug and fixes it there — found via the web UI's duplicate-key warning. These were the siblings that never got it.

Every row of that table is now asserted by a test that builds the fixture and runs the query.

## 2. `ledger_report.py:149` — fees subtracted twice

`pnl_ledger.pnl` is **already net of fees** at every writer (`pnl.py:137`, `ledger.py:299`, `kalshi_settlements:152`, `instrument_booking:127`, `manual_trades`, `resolution_tracker`); the `fees` column is the breakdown of what's already deducted. `readiness.check_pnl_after_fees` states the convention outright — it comments `# already net of fees` on `SUM(pnl)` and then recovers gross as `net + fees`.

The risk-free benchmark computed `SUM(pnl) - SUM(fees)`, so a book at +the gross with the fee of fees printed **"net of fees a materially different number … behind cash"** in bold red, two lines under a `the gross figure` header.

### 2b. The same defect on the money path (added after review)

Correcting the display panel while `risk/graduation.py` (5 sites, the paper→live **promotion** gate) and `treasury/kraken_pillar.py` kept `SUM(pnl - fees)` would have left two contradictory conventions in-tree — the exact failure mode this PR is about. Both are corrected here.

Measured on the live DB first, because this **loosens** a promotion gate:

* Every strategy in the ledger carries `fees = 0.0` **except `kraken_directional`** — 26 live rows carrying the ledger's entire fee total, which is the entire ledger's fee total.
* `kraken_directional` has **zero** `decision_snapshots` and **zero** `strategy_experiments` rows, so it never reaches `_prospective_stats` — the only path `graduation.prospective_only=true` actually uses.
* Exactly **1 of 127** `report()` cells changes: `kraken_directional/kraken_spot`, −the overstated figure → −the true figure. Negative under both conventions. **No verdict flips.**

The Kraken desk is where it cost real dollars today: `_realised_pnl_usd` reported **−the overstated figure** against a true **−the true figure**.

`test_graduation_uses_pnl_net_of_fees` asserted the defect as the contract, on a fixture no writer can produce (`pnl=+1` alongside `fees=2`, when a 2 units fee on a 1 unit gross books `pnl=-1`). Rewritten.

## 3. `execution_gateway.submit_paired` — both decision ids discarded

`order.decision_id` stayed unset, so the `mark_fill` block in `_place_and_record` never ran and any paired-arb snapshot this path wrote would stay `filled=0` forever. With `graduation.require_executable_fills` true, `_prospective_stats` appends `AND d.filled = 1 AND d.fill_evidence IN (...)` — so `cross_venue_arb` and `entailment_arb` could never graduate on merit however long they ran.

**Scope of the damage so far, measured rather than assumed:** **zero** `decision_snapshots` rows and **zero** `strategy_experiments` rows for either strategy. No holdout clock was ever registered and no snapshot was ever written, so nothing was corrupted and nothing was burned. The first draft of this description claimed "every paired-arb snapshot stayed `filled=0` forever" and that the strategies were "still burning the 14-day holdout clock" — the first describes an empty set and the second is simply false. What this fixes is a gate these two strategies **could not have passed** had they started producing evidence, not evidence already spoiled.

`submit()` at `:136` plumbs these correctly. This path didn't.

## 4. `resolution_tracker.py` — settled one leg, deleted both

With `token_scope=None` the SELECT reads **one** row via `fetchone`, but the DELETE removed **every** token row for the market. A YES+NO holding booked one leg's P&L and dropped the other outright — the winning side never settled and never could, because its portfolio row was gone while its `cost_basis` row survived at `size > 0`. That day's `daily_stats` recorded the loss alone, which then feeds `check_daily_loss` against the the configured limit limit.

The `cost_basis` UPDATE **ten lines above** already scopes by the settled row's `token`, with a comment explaining why. The DELETE used `token_scope`.

The scoped DELETE is now **unconditional**. The first draft guarded it with `if token:`, but `token` is normalised to `(token or "YES").upper()` 100 lines earlier, so it is unconditionally truthy — the `else` arm was the whole-market DELETE this fix exists to remove, and it was unreachable.

## 5. `etf_calibration.py` — the trading gate scored against a coin

`Forecast.reference` defaulted to `0.5`, and `ibkr_etf_paper` passed `0.5` explicitly with this comment:

> fall back to a coin -- which **UNDERSTATES** the edge and therefore keeps the gate shut rather than opening it by accident.

It's backwards. `E[Brier]` of a constant forecast `r` under base rate `q` is `(r−q)² + q(1−q)`, so a coin benchmark is **easier** to beat than the instrument's own drift by exactly `(0.5−q)²`:

```
benchmark Brier vs COIN 0.5 : 0.25000
benchmark Brier vs drift 0.56: 0.24640
inflation of brier_edge     : +0.00360   <- free edge, every forecast
```

**How fast that opens the gate, corrected.** A flat forecaster answering 0.56 on everything — zero information, since 0.56 *is* the up-rate — does **not** clear at ~400 resolutions, as the first draft of this description claimed. At n=400 its 95% lower bound is still **−0.00224**; it first clears at **n=1026**. The edge is exactly 0.0036 at every n, so the defect is patience rather than speed — roughly two months at ~125 scoreable calls a week, against a `min_resolved` of 100. The constant and the n=400 bound are now pinned by test rather than asserted in prose.

There's no benchmark column on `ibkr_etf_forecasts`, so `reference` is now `None` and `clearance()` treats such forecasts as **unscoreable and refuses**. That's the honest state until the benchmark is recorded per forecast from `risk/ibkr_math.horizon_up_rate`.

### 5b. Keeping the kill signal audible (added after review)

`ibkr_etf_paper._clearance` designates the 5-session resolutions as *"an early kill signal: if the model shows no skill there within a few weeks, abandon"*. Passing `reference=None` is right for the **gate**, but the reporting path built its `Forecast`s the same way, so `auramaur ibkr-calibration` printed `LOCKED — N resolved forecasts carry no benchmark` and stopped. Silence is the one answer a kill signal must never give.

The report now prints the coin-referenced Brier edge as a separate, explicitly **kill-only** diagnostic beside the gate verdict. The asymmetry is what licenses it: a coin is the *easier* benchmark, so failing it is conclusive while passing it proves nothing — and the line says so. Against the live DB, read-only:

```
luna      103 resolved over 5s, Brier edge -0.00730 (95% low -0.01301)  NO SKILL
sol       101 resolved over 5s, Brier edge -0.00141 (95% low -0.00597)  NO SKILL
terra     102 resolved over 5s, Brier edge -0.00392 (95% low -0.00826)  NO SKILL
control     8 resolved over 5s, Brier edge -0.09000 (95% low -0.23346)  NO SKILL
```

**No arm has ever cleared on real data**, against a coin or otherwise. Read alongside the hit-rate table, which disagrees — luna calls 67.0% of moves right with a 57.2% lower bound. Direction and probability quality are different things; the trade gate is the Brier edge, and the diagnostic says which is which so the two are not pooled.

**The gate change is a no-op today.** All 103/101/102 resolved forecasts are 5-session. The traded 42-session horizon — the only one `_clearance` reads — has **0 resolved forecasts** across all four arms (175/169/173/79 rows, none due). The arm was locked before this PR and is locked after it, for a different and better-stated reason.

## Verification

`tests/test_accounting_scope.py` — 14 tests, plus a rewritten
`test_graduation_uses_pnl_net_of_fees`. Every behavioural claim is
mutation-verified: **8 mutants, one per fix site, each killed by the test that
names it.**

The first draft's fee test could not fail. It split the module source on
`risk_free_benchmark(`, which matches the `def` at line 21 rather than the call
at line 148, so it inspected the function **signature** —
`'*, net_pnl: float, first_at, last_at,\n settings=None'` — and passed
identically against pre- and post-fix source. Fixes 1 and 4 were covered the
same way, by `inspect.getsource` string counts executing zero lines of SQL.
They are now DB-backed.

CI-identical, in-container:

- **2256 passed, 5 skipped, 1 deselected, 0 failed**
- coverage **66.95%** (floor 65.0)
- `ruff check .` — clean

No file under `config/` is touched.

## Follow-up

Recording the real benchmark on `ibkr_etf_forecasts` is a schema change plus a
backfill and is deliberately not in this PR. Until it lands the ETF arm cannot
trade — which is the correct direction to fail, and the kill-signal diagnostic
means the decision to abandon can still be made from evidence in the meantime.

Assisted-by: Claude (Anthropic)

