### PR TITLE
Make degraded input fail closed instead of reading as a benign value

### DIFF
--- a/auramaur/cli/redeem.py
+++ b/auramaur/cli/redeem.py
@@ -8,6 +8,7 @@ import click
 from rich.table import Table
 
 from auramaur.db.database import Database
+from auramaur.runtime import db_path as runtime_db_path
 from config.settings import Settings
 
 from auramaur.cli._base import console, main
@@ -141,7 +142,21 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
 
         settings = Settings()
         from auramaur.cli import AuramaurBot  # call-time lookup keeps test patch working
-        bot = AuramaurBot(settings=settings, db_path="auramaur.db", exchange_filter=exchange)
+        # Resolve through runtime.db_path() the way run.py:61 does. The bare
+        # literal only resolves under a CWD that happens to be the repo root,
+        # and this command's ONLY concurrency protection is the flock on
+        # f"{db_path}.lock" — also CWD-relative. Under any deployment that
+        # relocates state (compose sets /app/state/auramaur.db; deploy/*.sh set
+        # AURAMAUR_DB_PATH) it flocked ./auramaur.db.lock, which is
+        # uncontended, so the "refuses to run while the bot is running" guard
+        # never engaged. It would then attach to ./auramaur.db — either a stale
+        # pre-migration file, in which case it exits real positions the running
+        # bot is concurrently managing, or a nonexistent one, in which case
+        # composition.assemble_components CREATES it with full schema DDL and
+        # reports "No dust positions" to an operator who then concludes there
+        # are none.
+        bot = AuramaurBot(settings=settings, db_path=str(runtime_db_path()),
+                          exchange_filter=exchange)
         try:
             await bot._init_components()
         except RuntimeError as e:

--- a/auramaur/monitoring/gates.py
+++ b/auramaur/monitoring/gates.py
@@ -11,27 +11,49 @@ from __future__ import annotations
 
 import sqlite3
 
+import structlog
+
 from rich.table import Table
 from rich.text import Text
+
+from auramaur.runtime import db_path as runtime_db_path
+
+log = structlog.get_logger()
 
 
 def _resolved_dollar_markets(db_path: str) -> int:
     """Count live markets with fills AND a resolved outcome (the $-edge sample)."""
+    # busy_timeout: without it a checkpoint in flight raises SQLITE_BUSY, which
+    # the except below turns into 0 — indistinguishable from "no data".
     try:
-        c = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        c = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+        c.execute("PRAGMA busy_timeout=5000")
         n = c.execute(
             "SELECT COUNT(DISTINCT f.market_id) FROM fills f "
             "JOIN calibration cal ON cal.market_id=f.market_id "
             "WHERE f.is_paper=0 AND cal.actual_outcome IS NOT NULL").fetchone()[0]
         c.close()
         return n
-    except Exception:
-        return 0
+    except Exception as exc:
+        # Returning 0 makes an unreadable database look like an empty one, and
+        # the gate dashboard renders that as "WAIT (need data)" — so an
+        # operator never flips a filter the data has already earned. Surface
+        # the failure instead of laundering it into a plausible number.
+        log.warning("gates.resolved_dollar_markets_unreadable",
+                    db_path=db_path, error=str(exc)[:160])
+        return -1
 
 
-def gather(settings, db_path: str = "auramaur.db") -> list[dict]:
+def gather(settings, db_path: str | None = None) -> list[dict]:
     from auramaur.risk.tolerance import current_tolerance
-    n_resolved = _resolved_dollar_markets(db_path)
+    # Resolve through runtime.db_path() so this follows AURAMAUR_DB_PATH /
+    # AURAMAUR_STATE_DIR the way Database.__init__ does. The old default was
+    # the bare literal "auramaur.db", which only resolves under a CWD that
+    # happens to be the repo root — under compose (/app/state/auramaur.db) or
+    # from any other directory the connect raised, the except returned 0, and
+    # the dashboard reported "0/100 resolved-$ markets -> WAIT (need data)"
+    # while hundreds existed.
+    n_resolved = _resolved_dollar_markets(db_path or str(runtime_db_path()))
     mc = settings.momentum_coupling
     tol = current_tolerance(settings)
     tol_label = ("most conservative" if tol <= 15 else "conservative" if tol < 45
@@ -48,8 +70,13 @@ def gather(settings, db_path: str = "auramaur.db") -> list[dict]:
             "feature": "Divergence filter (slow loop)",
             "flag": f"divergence_filter_enabled={settings.risk.divergence_filter_enabled}",
             "criterion": "≥100 resolved-$ markets confirm mid-divergence adverse selection",
-            "status": f"{n_resolved}/100 resolved-$ markets",
-            "verdict": "GO" if n_resolved >= 100 else "WAIT (need data)",
+            # -1 means the database could not be read. That is a DIFFERENT
+            # state from "no data yet", and rendering it as 0/100 told the
+            # operator to keep waiting for a sample that already exists.
+            "status": ("database unreadable" if n_resolved < 0
+                       else f"{n_resolved}/100 resolved-$ markets"),
+            "verdict": ("UNKNOWN (cannot read db)" if n_resolved < 0
+                        else "GO" if n_resolved >= 100 else "WAIT (need data)"),
         },
         {
             "feature": "Momentum coupling — detect (fast path)",

--- a/auramaur/monitoring/gates.py
+++ b/auramaur/monitoring/gates.py
@@ -9,6 +9,7 @@ glance, which switches are ready and which are still waiting on evidence.
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 
 import structlog
@@ -25,15 +26,18 @@ def _resolved_dollar_markets(db_path: str) -> int:
     """Count live markets with fills AND a resolved outcome (the $-edge sample)."""
     # busy_timeout: without it a checkpoint in flight raises SQLITE_BUSY, which
     # the except below turns into 0 — indistinguishable from "no data".
+    # contextlib.closing, not a bare c.close(): the close was unreachable if the
+    # PRAGMA or the query raised mid-way, leaking the connection into the except
+    # arm below — exactly what #399's leaked-connection guard now fails on.
     try:
-        c = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
-        c.execute("PRAGMA busy_timeout=5000")
-        n = c.execute(
-            "SELECT COUNT(DISTINCT f.market_id) FROM fills f "
-            "JOIN calibration cal ON cal.market_id=f.market_id "
-            "WHERE f.is_paper=0 AND cal.actual_outcome IS NOT NULL").fetchone()[0]
-        c.close()
-        return n
+        with contextlib.closing(
+            sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+        ) as c:
+            c.execute("PRAGMA busy_timeout=5000")
+            return c.execute(
+                "SELECT COUNT(DISTINCT f.market_id) FROM fills f "
+                "JOIN calibration cal ON cal.market_id=f.market_id "
+                "WHERE f.is_paper=0 AND cal.actual_outcome IS NOT NULL").fetchone()[0]
     except Exception as exc:
         # Returning 0 makes an unreadable database look like an empty one, and
         # the gate dashboard renders that as "WAIT (need data)" — so an

--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -137,6 +137,24 @@ async def check_cycle_health(
             detail="log format has drifted; readiness parser may be unreliable",
         )
 
+    if in_window == 0:
+        # Zero entries is not zero errors. The window can be empty because the
+        # bot is dead, or because rotation carried it away: _rotate() renames
+        # at rotate_max_mb (10MB, 3 backups) and this parser opens exactly one
+        # path, so a bot writing >10MB/day gives a criterion advertising 7 days
+        # under one day of actual visibility. An error burst two rotations ago
+        # scored PASS, and with the other criteria green `overall_pass` was
+        # True and the CLI exited 0 — an automated "ready to arm live" built on
+        # evidence nobody could see.
+        return CriterionResult(
+            name="cycle_health",
+            status="INSUFFICIENT_DATA",
+            value="no log entries in window",
+            threshold="0 errors",
+            detail=("window is empty — the bot may be stopped, or the log "
+                    "rotated (rotate_max_mb) before the window opened"),
+        )
+
     if errors == 0:
         return CriterionResult(
             name="cycle_health",

--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -11,6 +11,7 @@ Overall readiness passes only if every criterion is PASS.
 from __future__ import annotations
 
 import json
+import re
 import statistics
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -50,50 +51,119 @@ class ReadinessReport:
 
 _REQUIRED_KEYS = ("level", "timestamp", "event")
 _ERROR_LEVELS = {"error", "critical"}
+_ROTATION_SUFFIX = re.compile(r"\.(\d+)$")
+
+
+def log_files_for(log_file: Path) -> list[Path]:
+    """The active log plus its rotated backups, oldest first.
+
+    ``_RotatingWriter`` renames the active file to ``<path>.1`` and shifts older
+    backups up to ``<path>.<backups>`` (monitoring/logger.py), so a parser that
+    opens exactly one path sees only what currently fits in ``rotate_max_mb``.
+    Measured against the live deployment on 2026-08-06 that was 0.7 of the 7
+    days the criterion advertises — 10% coverage, rotating every ~21-30 hours —
+    and 1,487 error events sat in ``.1``/``.2``/``.3`` where nothing looked.
+    Reading the backups is what makes a 7-day criterion actually score 7 days.
+
+    A higher suffix is an OLDER file, so backups are walked in descending suffix
+    order with the active file last. That keeps the fold chronological, which is
+    what makes both the sampled error events (the first N in time, as before)
+    and the earliest-timestamp coverage figure mean what they say.
+    """
+    backups: list[tuple[int, Path]] = []
+    try:
+        candidates = list(log_file.parent.glob(log_file.name + ".*"))
+    except OSError:
+        candidates = []
+    for candidate in candidates:
+        match = _ROTATION_SUFFIX.search(candidate.name)
+        if match and candidate.is_file():
+            backups.append((int(match.group(1)), candidate))
+    ordered = [path for _suffix, path in sorted(backups, key=lambda item: -item[0])]
+    if log_file.exists():
+        ordered.append(log_file)
+    return ordered
 
 
 def _parse_log_for_errors(
-    log_file: Path,
+    log_files: list[Path],
     since: datetime,
     sample_events_to_keep: int,
-) -> tuple[int, int, int, int, list[str]]:
+) -> tuple[int, int, int, int, list[str], datetime | None]:
+    """Fold the error/entry counts across every log file, oldest first.
+
+    Semantics per line are unchanged: unparseable and schema-drifted lines are
+    tolerated (counted in ``total`` but not ``well_formed``, which is what feeds
+    the drift canary), and only well-formed entries at or after ``since`` are
+    scored. ``earliest`` is the earliest well-formed timestamp seen anywhere in
+    the corpus — the parser already computed it implicitly and threw it away, and
+    it is the only honest measure of how much of the window was actually read.
+    """
     total = 0
     well_formed = 0
     in_window = 0
     errors = 0
     error_events: list[str] = []
+    earliest: datetime | None = None
 
-    with log_file.open() as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            total += 1
-            try:
-                entry = json.loads(stripped)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(entry, dict):
-                continue
-            if not all(k in entry for k in _REQUIRED_KEYS):
-                continue
-            try:
-                ts = datetime.fromisoformat(entry["timestamp"].replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
-                continue
-            well_formed += 1
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-            if ts < since:
-                continue
-            in_window += 1
-            level = str(entry.get("level", "")).lower()
-            if level in _ERROR_LEVELS or "exception" in entry:
-                errors += 1
-                if len(error_events) < sample_events_to_keep:
-                    event = entry.get("event", "")
-                    error_events.append(f"{level}:{event}")
-    return total, well_formed, in_window, errors, error_events
+    for log_file in log_files:
+        try:
+            handle = log_file.open()
+        except OSError:
+            # Rotation is a sequence of os.replace calls, so a backup can be
+            # renamed out from under the walk. Skipping it keeps the criterion
+            # honest — the coverage figure below reports on what was read.
+            continue
+        with handle as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                total += 1
+                try:
+                    entry = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                if not all(k in entry for k in _REQUIRED_KEYS):
+                    continue
+                try:
+                    ts = datetime.fromisoformat(
+                        entry["timestamp"].replace("Z", "+00:00"))
+                except (ValueError, AttributeError):
+                    continue
+                well_formed += 1
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if earliest is None or ts < earliest:
+                    earliest = ts
+                if ts < since:
+                    continue
+                in_window += 1
+                level = str(entry.get("level", "")).lower()
+                if level in _ERROR_LEVELS or "exception" in entry:
+                    errors += 1
+                    if len(error_events) < sample_events_to_keep:
+                        event = entry.get("event", "")
+                        error_events.append(f"{level}:{event}")
+    return total, well_formed, in_window, errors, error_events, earliest
+
+
+def _coverage_note(earliest: datetime | None, since: datetime) -> str:
+    """Say so when the logs do not reach back as far as the window claims.
+
+    Empty when the corpus predates ``since`` — the criterion really did score
+    the window it advertises. Otherwise it scored a shorter one, and reporting
+    "0 errors" without that caveat is the same class of laundering as reporting
+    an unreadable database as zero.
+    """
+    if earliest is None or earliest <= since:
+        return ""
+    now = datetime.now(timezone.utc)
+    requested_days = max((now - since).total_seconds(), 0.0) / 86400.0
+    covered_days = max((now - earliest).total_seconds(), 0.0) / 86400.0
+    return f"; log covers {covered_days:.1f}d of {requested_days:.1f}d"
 
 
 async def check_cycle_health(
@@ -103,7 +173,8 @@ async def check_cycle_health(
     drift_threshold_pct: float = 5.0,
     sample_events_to_keep: int = 5,
 ) -> CriterionResult:
-    if not log_file.exists():
+    log_files = log_files_for(log_file)
+    if not log_files:
         return CriterionResult(
             name="cycle_health",
             status="INSUFFICIENT_DATA",
@@ -114,9 +185,11 @@ async def check_cycle_health(
 
     import asyncio
 
-    total, well_formed, in_window, errors, error_events = await asyncio.to_thread(
-        _parse_log_for_errors, log_file, since, sample_events_to_keep
+    (total, well_formed, in_window, errors, error_events,
+     earliest) = await asyncio.to_thread(
+        _parse_log_for_errors, log_files, since, sample_events_to_keep
     )
+    coverage = _coverage_note(earliest, since)
 
     if total == 0:
         return CriterionResult(
@@ -138,36 +211,33 @@ async def check_cycle_health(
         )
 
     if in_window == 0:
-        # Zero entries is not zero errors. The window can be empty because the
-        # bot is dead, or because rotation carried it away: _rotate() renames
-        # at rotate_max_mb (10MB, 3 backups) and this parser opens exactly one
-        # path, so a bot writing >10MB/day gives a criterion advertising 7 days
-        # under one day of actual visibility. An error burst two rotations ago
-        # scored PASS, and with the other criteria green `overall_pass` was
-        # True and the CLI exited 0 — an automated "ready to arm live" built on
-        # evidence nobody could see.
+        # Zero entries is not zero errors. Nothing in the window means the bot
+        # is stopped (or was, for the whole window) — every log file we could
+        # find predates it. This is the residual case now that the rotated
+        # backups are read; before that it also stood in for rotation
+        # blindness, which log_files_for() addresses at the source.
         return CriterionResult(
             name="cycle_health",
             status="INSUFFICIENT_DATA",
             value="no log entries in window",
             threshold="0 errors",
-            detail=("window is empty — the bot may be stopped, or the log "
-                    "rotated (rotate_max_mb) before the window opened"),
+            detail=(f"window is empty across {len(log_files)} log file(s) — "
+                    "the bot may be stopped"),
         )
 
     if errors == 0:
         return CriterionResult(
             name="cycle_health",
             status="PASS",
-            value="0 errors",
+            value=f"0 errors{coverage}",
             threshold="0 errors",
-            detail=f"{in_window} entries in window",
+            detail=f"{in_window} entries in window across {len(log_files)} log file(s)",
         )
 
     return CriterionResult(
         name="cycle_health",
         status="FAIL",
-        value=f"{errors} error/critical events",
+        value=f"{errors} error/critical events{coverage}",
         threshold="0 errors",
         detail="; ".join(error_events),
     )

--- a/auramaur/risk/tolerance.py
+++ b/auramaur/risk/tolerance.py
@@ -14,14 +14,20 @@ Applied at the RiskManager gateway, so every trade respects it.
 
 from __future__ import annotations
 
-from pathlib import Path
+from auramaur.runtime import state_dir
 
 _CONF = ["LOW", "MEDIUM", "HIGH"]
 
 # Runtime override so `auramaur risk <n>` takes effect LIVE (no restart): the CLI
 # writes here, every consumer reads it each time, falling back to config.
-_OVERRIDE = Path("data/risk_tolerance")
-
+# Anchored to the state dir, NOT the CWD. As a bare relative path this was the
+# last CWD-relative state file in the codebase, and it governs the whole risk
+# surface: Kelly x3, min-edge /3, category cap 100%, second-opinion divergence
+# 0.75, max open positions 1500. A stale `data/risk_tolerance` left in a launch
+# directory silently put the book at maximum aggression with no log line, and
+# `auramaur risk 0` run from anywhere other than the bot's CWD had no effect at
+# all while printing that it did. runtime.py exists to anchor exactly this.
+_OVERRIDE = state_dir() / "data" / "risk_tolerance"
 
 def current_tolerance(settings) -> float:
     """Effective risk tolerance now: the live override file if present, else config."""
@@ -30,33 +36,27 @@ def current_tolerance(settings) -> float:
     except (OSError, ValueError):
         return float(getattr(settings, "risk_tolerance", 50.0))
 
-
 def set_tolerance(value: float) -> None:
     """Persist a live override (clamped 0..100)."""
     _OVERRIDE.parent.mkdir(parents=True, exist_ok=True)
     _OVERRIDE.write_text(str(max(0.0, min(100.0, float(value)))))
 
-
 def scale_budget(base_usd: float, tolerance: float) -> float:
     """Scale a directional exposure budget by the lever (0..100)."""
     return base_usd * _aggr(max(0.0, min(100.0, tolerance)) / 100.0)
-
 
 # Multiplier at YOLO (t=1); 1/_SPAN at most-conservative (t=0). Geometric so the
 # lever is symmetric in log-space and far more sensitive near the extremes than a
 # linear ramp (e.g. 65 -> 1.39x vs the old 1.18x; 100 -> 3x vs 1.6x).
 _SPAN = 3.0
 
-
 def _aggr(t: float) -> float:
     """Multiplier for params that GROW with aggression. 0->0.33, .5->1.0, 1->3.0."""
     return _SPAN ** (2.0 * max(0.0, min(1.0, t)) - 1.0)
 
-
 def _cons(t: float) -> float:
     """Multiplier for params that SHRINK with aggression (inverse of _aggr)."""
     return 1.0 / _aggr(t)
-
 
 def _confidence_floor(base: str, t: float) -> str:
     i = _CONF.index(base) if base in _CONF else 1
@@ -65,7 +65,6 @@ def _confidence_floor(base: str, t: float) -> str:
     elif t <= 0.34:      # timid: demand higher confidence
         i = min(2, i + 1)
     return _CONF[i]
-
 
 def scale_risk(risk, kelly_fraction: float, tolerance: float):
     """Return (tolerance-scaled RiskConfig, scaled kelly fraction).

--- a/auramaur/risk/tolerance.py
+++ b/auramaur/risk/tolerance.py
@@ -14,49 +14,71 @@ Applied at the RiskManager gateway, so every trade respects it.
 
 from __future__ import annotations
 
-from auramaur.runtime import state_dir
+from pathlib import Path
 
 _CONF = ["LOW", "MEDIUM", "HIGH"]
 
-# Runtime override so `auramaur risk <n>` takes effect LIVE (no restart): the CLI
-# writes here, every consumer reads it each time, falling back to config.
-# Anchored to the state dir, NOT the CWD. As a bare relative path this was the
-# last CWD-relative state file in the codebase, and it governs the whole risk
-# surface: Kelly x3, min-edge /3, category cap 100%, second-opinion divergence
-# 0.75, max open positions 1500. A stale `data/risk_tolerance` left in a launch
-# directory silently put the book at maximum aggression with no log line, and
-# `auramaur risk 0` run from anywhere other than the bot's CWD had no effect at
-# all while printing that it did. runtime.py exists to anchor exactly this.
-_OVERRIDE = state_dir() / "data" / "risk_tolerance"
+
+def _override_path() -> Path:
+    """Where `auramaur risk <n>` writes the live override, resolved at CALL time.
+
+    Runtime override so the lever takes effect LIVE (no restart): the CLI writes
+    here, every consumer reads it each time, falling back to config.
+
+    Anchored to the state dir, NOT the CWD. As a bare relative path this was the
+    last CWD-relative state file in the codebase, and it governs the whole risk
+    surface: Kelly x3, min-edge /3, category cap 100%, second-opinion divergence
+    0.75, max open positions 1500. A stale `data/risk_tolerance` left in a launch
+    directory silently put the book at maximum aggression with no log line, and
+    `auramaur risk 0` run from anywhere other than the bot's CWD had no effect at
+    all while printing that it did. runtime.py exists to anchor exactly this.
+
+    A function, not a module constant: every other runtime-path consumer resolves
+    at call time (see treasury/transfers.py:_default_ledger_path). Freezing it at
+    import binds the path to whatever AURAMAUR_STATE_DIR happened to be when this
+    module was first imported — which no process can change and no test can
+    monkeypatch, so the risk surface would be the one path nobody could redirect.
+    """
+    from auramaur.runtime import state_dir  # call-time: honors AURAMAUR_STATE_DIR
+
+    return state_dir() / "data" / "risk_tolerance"
+
 
 def current_tolerance(settings) -> float:
     """Effective risk tolerance now: the live override file if present, else config."""
     try:
-        return max(0.0, min(100.0, float(_OVERRIDE.read_text().strip())))
+        return max(0.0, min(100.0, float(_override_path().read_text().strip())))
     except (OSError, ValueError):
         return float(getattr(settings, "risk_tolerance", 50.0))
 
+
 def set_tolerance(value: float) -> None:
     """Persist a live override (clamped 0..100)."""
-    _OVERRIDE.parent.mkdir(parents=True, exist_ok=True)
-    _OVERRIDE.write_text(str(max(0.0, min(100.0, float(value)))))
+    override = _override_path()
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text(str(max(0.0, min(100.0, float(value)))))
+
 
 def scale_budget(base_usd: float, tolerance: float) -> float:
     """Scale a directional exposure budget by the lever (0..100)."""
     return base_usd * _aggr(max(0.0, min(100.0, tolerance)) / 100.0)
+
 
 # Multiplier at YOLO (t=1); 1/_SPAN at most-conservative (t=0). Geometric so the
 # lever is symmetric in log-space and far more sensitive near the extremes than a
 # linear ramp (e.g. 65 -> 1.39x vs the old 1.18x; 100 -> 3x vs 1.6x).
 _SPAN = 3.0
 
+
 def _aggr(t: float) -> float:
     """Multiplier for params that GROW with aggression. 0->0.33, .5->1.0, 1->3.0."""
     return _SPAN ** (2.0 * max(0.0, min(1.0, t)) - 1.0)
 
+
 def _cons(t: float) -> float:
     """Multiplier for params that SHRINK with aggression (inverse of _aggr)."""
     return 1.0 / _aggr(t)
+
 
 def _confidence_floor(base: str, t: float) -> str:
     i = _CONF.index(base) if base in _CONF else 1
@@ -65,6 +87,7 @@ def _confidence_floor(base: str, t: float) -> str:
     elif t <= 0.34:      # timid: demand higher confidence
         i = min(2, i + 1)
     return _CONF[i]
+
 
 def scale_risk(risk, kelly_fraction: float, tolerance: float):
     """Return (tolerance-scaled RiskConfig, scaled kelly fraction).

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -38,6 +38,18 @@ from auramaur.experiments.strategies.kraken import (
 
 log = structlog.get_logger()
 
+# Consecutive empty-balance cycles before a skipped cycle stops being routine
+# and becomes an outage. Measured on the live deployment (2026-08-06, 4 log
+# rotations): 5 empty responses against 865 successes — 0.58%, roughly once a
+# day — so a single skip must NOT alarm, but three in a row cannot be that
+# transient. At treasury_interval_seconds=300 that is a 15-minute blackout of
+# the ENTIRE exit ladder (stop-loss, take-profit, trailing stop, orphan
+# liquidation), which is what a revoked or expired API key looks like: an
+# unchanging {} that skips forever behind a log.warning readiness ignores
+# (_ERROR_LEVELS is {"error", "critical"}). Deliberately a module constant, not
+# a config knob — the graduation holdout clocks reset on any config change.
+_BALANCE_OUTAGE_ESCALATE_CYCLES = 3
+
 
 class KrakenPillar:
     name = "kraken"
@@ -64,6 +76,10 @@ class KrakenPillar:
         self._base_to_pair: dict[str, str] = {}        # base asset -> liquidation pair (altname)
         self._base_pair_meta: dict[str, tuple] = {}    # pair -> (base, ordermin, lot_decimals)
         self._pnl = None                               # lazy PnLTracker (needs db)
+        # Consecutive cycles get_free_balance came back empty. Counted and reset
+        # independently of paper/live so a mode flip can never suppress a real
+        # alert: only a genuinely non-empty wallet read clears it.
+        self._empty_balance_cycles = 0
         self._cooldown_until: dict[str, float] = {}    # pair -> monotonic re-entry gate
         # LLM directional view cache: pair -> (monotonic_ts, prob, confidence).
         # Throttles LLM calls to directional_llm_refresh_hours per pair (cost).
@@ -722,11 +738,35 @@ class KrakenPillar:
         # _treasury guards this exact case at line 419 (`if not bal: return`).
         # Skipping the cycle costs one iteration; the next healthy poll
         # re-reads the wallet, which is the source of truth anyway.
-        if not bal and not effective_paper:
-            log.warning("kraken.directional.balance_unavailable",
-                        detail="empty balance response; skipping cycle rather "
-                               "than treating the book as flat")
-            return
+        #
+        # But "skip the cycle" is only safe while the outage is transient. A
+        # revoked or expired API key returns {} forever, and the live branch
+        # below then skips the ENTIRE exit ladder — stop-loss, take-profit,
+        # trailing stop, orphan liquidation — indefinitely and silently, because
+        # readiness's _ERROR_LEVELS does not include "warning". So count
+        # consecutive empties and escalate to error once the outage is no longer
+        # explainable as the ~0.58% transient. The counter is mode-independent
+        # (incremented on every empty read, cleared only by a non-empty one), so
+        # a paper/live flip cannot reset it part-way and mute the escalation.
+        if not bal:
+            self._empty_balance_cycles += 1
+            cycles = self._empty_balance_cycles
+            if cycles >= _BALANCE_OUTAGE_ESCALATE_CYCLES:
+                log.error("kraken.directional.balance_unavailable_sustained",
+                          cycles=cycles, paper=effective_paper,
+                          detail="get_free_balance has returned empty for "
+                                 f"{cycles} consecutive cycles; the exit ladder "
+                                 "(stop-loss/take-profit/trailing/orphan) is not "
+                                 "running — check the Kraken API credentials")
+            else:
+                log.warning("kraken.directional.balance_unavailable",
+                            cycles=cycles, paper=effective_paper,
+                            detail="empty balance response; skipping cycle rather "
+                                   "than treating the book as flat")
+            if not effective_paper:
+                return
+        else:
+            self._empty_balance_cycles = 0
         if self._pair_base is None:
             await self._resolve_pairs(kcfg.directional_pairs)
         # Evaluate the UNION of configured pairs and everything we actually hold,

--- a/auramaur/treasury/kraken_pillar.py
+++ b/auramaur/treasury/kraken_pillar.py
@@ -708,6 +708,25 @@ class KrakenPillar:
         # Sizing exits/entries off the free amount avoids requesting more than is
         # actually sellable/spendable (which Kraken rejects as insufficient funds).
         bal = await self._k.get_free_balance()
+        # An empty dict is an API FAILURE, not a flat book. get_free_balance
+        # falls back to get_balance, which returns {} on any error (kraken.py
+        # :121-123 logs and returns the empty result rather than raising) — so
+        # one 5xx, rate-limit or invalid-nonce response made every tracked
+        # position look closed. _reconcile_positions then cleared _dir_long,
+        # _clear_peak() DELETED the position_peaks row — the trailing-stop
+        # high-water mark, which is NOT recoverable from cost_basis — and
+        # _mirror_to_portfolio removed every live kraken portfolio row. A
+        # position that peaked +40% and sat at +30% re-anchored at +30% and
+        # the give-back was never banked.
+        #
+        # _treasury guards this exact case at line 419 (`if not bal: return`).
+        # Skipping the cycle costs one iteration; the next healthy poll
+        # re-reads the wallet, which is the source of truth anyway.
+        if not bal and not effective_paper:
+            log.warning("kraken.directional.balance_unavailable",
+                        detail="empty balance response; skipping cycle rather "
+                               "than treating the book as flat")
+            return
         if self._pair_base is None:
             await self._resolve_pairs(kcfg.directional_pairs)
         # Evaluate the UNION of configured pairs and everything we actually hold,

--- a/tests/test_degraded_input_fails_closed.py
+++ b/tests/test_degraded_input_fails_closed.py
@@ -1,0 +1,64 @@
+"""Degraded input must not read as a benign value.
+
+Four sinks turned "I could not measure this" into a plausible number: an empty
+Kraken balance reading as a flat book, an unreadable database reading as zero
+resolved markets, an empty log window reading as zero errors, and two
+CWD-relative state paths reading as "not present" under any deployment that
+relocates state.
+"""
+
+import inspect
+
+
+def test_directional_skips_the_cycle_when_the_balance_is_unavailable():
+    """get_free_balance falls back to get_balance, which returns {} on ANY API
+    error rather than raising — so one 5xx made every position look closed,
+    cleared _dir_long, and DELETED the position_peaks trailing-stop marks,
+    which are not recoverable from cost_basis. _treasury:419 already guards."""
+    from auramaur.treasury import kraken_pillar
+    src = inspect.getsource(kraken_pillar.KrakenPillar._directional)
+    guard = src.split("get_free_balance()", 1)[1].split("_resolve_pairs", 1)[0]
+    assert "if not bal" in guard and "return" in guard
+
+
+def test_unreadable_database_is_not_reported_as_no_data():
+    """0 told the operator to keep waiting for a sample that already exists."""
+    from auramaur.monitoring import gates
+    n = gates._resolved_dollar_markets("/nonexistent/definitely/not/here.db")
+    assert n == -1, "an unreadable db must be distinguishable from an empty one"
+
+    src = inspect.getsource(gates.gather)
+    assert "runtime_db_path()" in src, "must follow AURAMAUR_DB_PATH"
+    rendered = inspect.getsource(gates)
+    assert "UNKNOWN (cannot read db)" in rendered
+
+
+def test_empty_log_window_is_insufficient_data_not_pass():
+    """The window can be empty because the bot is dead, or because rotation
+    carried the errors away — _rotate() renames at rotate_max_mb and the
+    parser opens exactly one path."""
+    from auramaur.monitoring import readiness
+    src = inspect.getsource(readiness)
+    assert 'if in_window == 0:' in src
+    empty_arm = src.split("if in_window == 0:", 1)[1].split("if errors == 0:", 1)[0]
+    assert 'status="INSUFFICIENT_DATA"' in empty_arm
+    # overall_pass requires every criterion to be PASS, so this blocks it.
+    assert 'all(c.status == "PASS" for c in self.criteria)' in src
+
+
+def test_risk_tolerance_override_is_anchored_to_the_state_dir():
+    """A stale data/risk_tolerance in a launch directory silently put the book
+    at YOLO; `auramaur risk 0` from elsewhere had no effect while saying it did."""
+    from auramaur.risk import tolerance
+    assert tolerance._OVERRIDE.is_absolute()
+    assert "state_dir()" in inspect.getsource(tolerance).split("_OVERRIDE =", 1)[1][:80]
+
+
+def test_dust_exit_attaches_to_the_real_database():
+    """Its ONLY concurrency guard is a flock on f'{db_path}.lock'. With a
+    CWD-relative path that lock is uncontended, so the 'bot is running' refusal
+    never engages and it can double-sell live positions."""
+    from auramaur.cli import redeem
+    src = inspect.getsource(redeem)
+    assert 'db_path=str(runtime_db_path())' in src
+    assert 'db_path="auramaur.db"' not in src

--- a/tests/test_degraded_input_fails_closed.py
+++ b/tests/test_degraded_input_fails_closed.py
@@ -1,64 +1,552 @@
 """Degraded input must not read as a benign value.
 
-Four sinks turned "I could not measure this" into a plausible number: an empty
+Five sinks turned "I could not measure this" into a plausible number: an empty
 Kraken balance reading as a flat book, an unreadable database reading as zero
-resolved markets, an empty log window reading as zero errors, and two
+resolved markets, a log window nobody could see reading as zero errors, and two
 CWD-relative state paths reading as "not present" under any deployment that
 relocates state.
+
+Every test here executes the production path. An earlier revision of this file
+asserted on ``inspect.getsource`` strings, which would have passed against
+``if not bal and False: return`` — a test that cannot fail measures nothing.
 """
 
-import inspect
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import OrderSide
+from auramaur.treasury import kraken_pillar as kraken_pillar_module
+from auramaur.treasury.kraken_pillar import KrakenPillar
 
 
-def test_directional_skips_the_cycle_when_the_balance_is_unavailable():
-    """get_free_balance falls back to get_balance, which returns {} on ANY API
-    error rather than raising — so one 5xx made every position look closed,
-    cleared _dir_long, and DELETED the position_peaks trailing-stop marks,
-    which are not recoverable from cost_basis. _treasury:419 already guards."""
-    from auramaur.treasury import kraken_pillar
-    src = inspect.getsource(kraken_pillar.KrakenPillar._directional)
-    guard = src.split("get_free_balance()", 1)[1].split("_resolve_pairs", 1)[0]
-    assert "if not bal" in guard and "return" in guard
+# ---------------------------------------------------------------------------
+# Kraken directional harness (mirrors tests/test_kraken_directional_exit.py)
+# ---------------------------------------------------------------------------
+
+
+def _kcfg(**over):
+    base = dict(
+        directional_enabled=True,
+        directional_pairs=["APEUSDC"],
+        directional_momentum_pct=3.0,
+        directional_entry_momentum_pct=2.0,
+        directional_exit_momentum_pct=4.0,
+        directional_stop_loss_pct=12.0,
+        directional_lookback=12,
+        directional_budget_usd=50.0,
+        max_order_usd=25.0,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _client(price, *, balance):
+    """Fake KrakenSpotClient. Base asset APE; ``balance`` is what the wallet read
+    returns — ``{}`` is the API-failure shape get_free_balance/get_balance
+    produce on any error (kraken.py:121-123 logs and returns the empty result
+    rather than raising)."""
+    k = SimpleNamespace()
+    k.get_balance = AsyncMock(return_value=dict(balance))
+    k.get_free_balance = AsyncMock(return_value=dict(balance))
+    k.get_pair_quote = AsyncMock(return_value="USDC")
+    k.get_price = AsyncMock(return_value=price)
+    k._public = AsyncMock(return_value={
+        "APEUSDC": {"altname": "APEUSDC", "base": "APE", "ordermin": "1"},
+    })
+    k.usd_notional = AsyncMock(side_effect=lambda pair, vol, px=None: vol * (px or price))
+    k.place_spot_order = AsyncMock(return_value=SimpleNamespace(
+        order_id="OK", status="filled", error_message=""))
+    k.size_for_usd = AsyncMock(return_value=4.0)
+    return k
+
+
+def _pillar(price, kcfg, *, balance, live=False, db=None):
+    settings = SimpleNamespace(kraken=kcfg, is_live=live, risk_tolerance=50.0)
+    bot = SimpleNamespace(_components={"db": db}) if db is not None else None
+    return KrakenPillar(settings, _client(price, balance=balance), bot=bot)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    instance = Database(str(tmp_path / "degraded.db"))
+    await instance.connect()
+    yield instance
+    await instance.close()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path, monkeypatch):
+    """Keep runtime paths (risk-tolerance override, db_path) off the real repo."""
+    monkeypatch.setenv("AURAMAUR_STATE_DIR", str(tmp_path / "state"))
+
+
+def _events(mock_method) -> list[str]:
+    return [call.args[0] for call in mock_method.call_args_list if call.args]
+
+
+# ---------------------------------------------------------------------------
+# 1. Kraken balance outage — the SAFETY half: live state must survive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_balance_outage_preserves_position_state_and_places_nothing(db):
+    """One 5xx / rate-limit / invalid-nonce made every tracked position look
+    closed: _dir_long cleared, _clear_peak() DELETED the position_peaks row —
+    the trailing-stop high-water mark, which is NOT recoverable from cost_basis.
+    A position that peaked +40% and sat at +30% re-anchored at +30%."""
+    pillar = _pillar(0.80, _kcfg(), balance={}, live=True, db=db)
+    pillar._dir_long = {"APEUSDC": 1.00}
+    pillar._momentum = AsyncMock(return_value=-1.0)
+    await db.execute(
+        "INSERT INTO position_peaks (market_id, peak_pnl_pct, updated_at) "
+        "VALUES (?, ?, datetime('now'))", ("kraken-live:APEUSDC", 40.0))
+    await db.commit()
+
+    await pillar._directional()
+
+    assert pillar._dir_long == {"APEUSDC": 1.00}, "the book must not be forgotten"
+    row = await db.fetchone(
+        "SELECT peak_pnl_pct FROM position_peaks WHERE market_id = ?",
+        ("kraken-live:APEUSDC",))
+    assert row is not None, "the trailing-stop high-water mark must survive"
+    assert row["peak_pnl_pct"] == 40.0
+    pillar._k.place_spot_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_genuinely_flat_book_still_clears_the_position(db):
+    """The discriminator for the test above: a SUCCESSFUL read that happens to
+    hold no APE is a real close, and must still drop the position and its stale
+    peak. A guard that returned unconditionally would break this."""
+    pillar = _pillar(0.80, _kcfg(), balance={"USDC": 1000.0}, live=True, db=db)
+    pillar._dir_long = {"APEUSDC": 1.00}
+    pillar._momentum = AsyncMock(return_value=-1.0)
+    await db.execute(
+        "INSERT INTO position_peaks (market_id, peak_pnl_pct, updated_at) "
+        "VALUES (?, ?, datetime('now'))", ("kraken-live:APEUSDC", 40.0))
+    await db.commit()
+
+    await pillar._directional()
+
+    assert "APEUSDC" not in pillar._dir_long
+    row = await db.fetchone(
+        "SELECT peak_pnl_pct FROM position_peaks WHERE market_id = ?",
+        ("kraken-live:APEUSDC",))
+    assert row is None, "a real external close must still drop the stale peak"
+
+
+# ---------------------------------------------------------------------------
+# 2. Kraken balance outage — the AVAILABILITY half: paper must keep trading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_paper_book_still_exits_when_the_balance_is_unavailable(db):
+    """Paper position state lives in kraken_paper_positions, not the wallet, so
+    the guard must NOT stop the paper book from running its exit ladder. This is
+    the availability half of the carve-out and the #407 regression shape."""
+    pillar = _pillar(0.80, _kcfg(), balance={}, live=False, db=db)
+    pillar._momentum = AsyncMock(return_value=-1.0)
+    await db.execute(
+        "INSERT INTO kraken_paper_positions "
+        "(strategy, pair, quantity, entry_price, peak_gain_pct, opened_at, updated_at) "
+        "VALUES ('momentum', 'APEUSDC', 10.0, 1.00, 0, datetime('now'), datetime('now'))")
+    await db.commit()
+
+    await pillar._directional()
+
+    # Down 20% from entry 1.00 -> the 12% stop-loss fires even with no wallet.
+    pillar._k.place_spot_order.assert_called_once()
+    args = pillar._k.place_spot_order.call_args.args
+    kwargs = pillar._k.place_spot_order.call_args.kwargs
+    assert OrderSide.SELL in args
+    assert kwargs["volume"] == 10.0          # the actual shadow-book quantity
+    assert kwargs["dry_run"] is True         # paper stays validate-only
+    assert "APEUSDC" not in pillar._dir_long
+    row = await db.fetchone(
+        "SELECT pair FROM kraken_paper_positions "
+        "WHERE strategy='momentum' AND pair='APEUSDC'")
+    assert row is None, "the paper position must be closed in the shadow book"
+
+
+@pytest.mark.asyncio
+async def test_paper_book_still_enters_when_the_balance_is_unavailable(db):
+    """Paper entries deliberately skip the funding gate (no real quote balance
+    is needed), so an empty wallet read must not silence the entry side either."""
+    pillar = _pillar(1.00, _kcfg(), balance={}, live=False, db=db)
+    pillar._momentum = AsyncMock(return_value=5.0)   # clears the 2% entry bar
+
+    await pillar._directional()
+
+    pillar._k.place_spot_order.assert_called_once()
+    args = pillar._k.place_spot_order.call_args.args
+    assert OrderSide.BUY in args
+    row = await db.fetchone(
+        "SELECT quantity FROM kraken_paper_positions "
+        "WHERE strategy='momentum' AND pair='APEUSDC'")
+    assert row is not None and row["quantity"] > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Kraken balance outage — escalation, so a revoked key cannot stay silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_balance_outage_stays_a_warning(monkeypatch):
+    """Measured transient rate on the live deployment: 5 empties / 865 reads
+    (0.58%, ~once daily). A single skip is normal and must not alarm."""
+    fake_log = MagicMock()
+    monkeypatch.setattr(kraken_pillar_module, "log", fake_log)
+    pillar = _pillar(1.00, _kcfg(), balance={}, live=True)
+
+    await pillar._directional()
+
+    assert "kraken.directional.balance_unavailable" in _events(fake_log.warning)
+    assert "kraken.directional.balance_unavailable_sustained" not in _events(fake_log.error)
+
+
+@pytest.mark.asyncio
+async def test_sustained_balance_outage_escalates_to_error(monkeypatch):
+    """A revoked/expired API key returns {} forever, and the live guard then
+    skips the ENTIRE exit ladder behind a log.warning — a level readiness's
+    _ERROR_LEVELS does not include, so nothing ever escalates."""
+    fake_log = MagicMock()
+    monkeypatch.setattr(kraken_pillar_module, "log", fake_log)
+    pillar = _pillar(1.00, _kcfg(), balance={}, live=True)
+
+    for _ in range(kraken_pillar_module._BALANCE_OUTAGE_ESCALATE_CYCLES):
+        await pillar._directional()
+
+    errors = _events(fake_log.error)
+    assert errors.count("kraken.directional.balance_unavailable_sustained") == 1
+    assert fake_log.error.call_args.kwargs["cycles"] == 3
+    assert _events(fake_log.warning).count("kraken.directional.balance_unavailable") == 2
+    # readiness reads structlog levels: only "error"/"critical" fail the check.
+    from auramaur.monitoring.readiness import _ERROR_LEVELS
+    assert "error" in _ERROR_LEVELS and "warning" not in _ERROR_LEVELS
+
+
+@pytest.mark.asyncio
+async def test_healthy_balance_read_resets_the_outage_counter(monkeypatch):
+    fake_log = MagicMock()
+    monkeypatch.setattr(kraken_pillar_module, "log", fake_log)
+    pillar = _pillar(1.00, _kcfg(), balance={}, live=True)
+    pillar._momentum = AsyncMock(return_value=0.0)
+
+    await pillar._directional()
+    await pillar._directional()
+    assert pillar._empty_balance_cycles == 2
+
+    pillar._k.get_free_balance = AsyncMock(return_value={"USDC": 1000.0})
+    await pillar._directional()
+    assert pillar._empty_balance_cycles == 0
+
+    pillar._k.get_free_balance = AsyncMock(return_value={})
+    await pillar._directional()
+    await pillar._directional()
+    assert "kraken.directional.balance_unavailable_sustained" not in _events(fake_log.error)
+
+
+@pytest.mark.asyncio
+async def test_outage_counter_is_not_reset_by_a_paper_live_flip(monkeypatch):
+    """The counter must not leak across mode changes in a way that suppresses a
+    real alert: two empty paper cycles plus one empty live cycle is still a
+    15-minute blackout, and must escalate."""
+    fake_log = MagicMock()
+    monkeypatch.setattr(kraken_pillar_module, "log", fake_log)
+    pillar = _pillar(1.00, _kcfg(), balance={}, live=False)
+    pillar._momentum = AsyncMock(return_value=0.0)
+
+    await pillar._directional()
+    await pillar._directional()
+    assert pillar._empty_balance_cycles == 2
+    assert "kraken.directional.balance_unavailable_sustained" not in _events(fake_log.error)
+
+    pillar._s.is_live = True
+    await pillar._directional()
+
+    assert "kraken.directional.balance_unavailable_sustained" in _events(fake_log.error)
+    assert fake_log.error.call_args.kwargs["cycles"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 4. Cycle health — a window nobody could see is not a clean one
+# ---------------------------------------------------------------------------
+
+
+def _line(level: str, event: str, ts: datetime) -> str:
+    return json.dumps({
+        "level": level,
+        "timestamp": ts.isoformat().replace("+00:00", "Z"),
+        "event": event,
+    }) + "\n"
+
+
+@pytest.mark.asyncio
+async def test_empty_window_is_insufficient_data_not_pass(tmp_path):
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(_line("info", "engine.cycle_complete", now - timedelta(days=30)))
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "INSUFFICIENT_DATA"
+    assert "no log entries in window" in result.value
+
+
+@pytest.mark.asyncio
+async def test_non_empty_window_without_errors_still_passes(tmp_path):
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(
+        _line("info", "engine.cycle_complete", now - timedelta(hours=1))
+        + _line("warning", "engine.skipped_junk", now - timedelta(hours=1))
+    )
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "PASS"
+    assert "0 errors" in result.value
+
+
+@pytest.mark.asyncio
+async def test_errors_in_window_still_fail(tmp_path):
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(
+        _line("info", "engine.cycle_complete", now - timedelta(hours=1))
+        + _line("error", "exchange.order_failed", now - timedelta(hours=1))
+    )
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "FAIL"
+    assert "1 error" in result.value
+    assert "exchange.order_failed" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_errors_carried_away_by_rotation_are_still_seen(tmp_path):
+    """The rotation case the criterion always claimed to cover and never did.
+    Against the live deployment the active file held 0.7 of the 7 days it
+    advertises (10% coverage, rotating every ~21-30h) while 1,487 error events
+    sat in .1/.2/.3. Reading only the active file scores this window PASS."""
+    from auramaur.monitoring.readiness import check_cycle_health, log_files_for
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(_line("info", "engine.cycle_complete", now - timedelta(hours=1)))
+    (tmp_path / "auramaur.log.1").write_text(
+        _line("error", "burst.one_rotation_ago", now - timedelta(days=2)))
+    (tmp_path / "auramaur.log.2").write_text(
+        _line("critical", "burst.two_rotations_ago", now - timedelta(days=4)))
+
+    assert [p.name for p in log_files_for(log_file)] == [
+        "auramaur.log.2", "auramaur.log.1", "auramaur.log",
+    ], "oldest first, so sampled events and the earliest timestamp stay chronological"
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "FAIL"
+    assert "2 error/critical events" in result.value
+    assert "burst.two_rotations_ago" in result.detail
+    assert "burst.one_rotation_ago" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_partial_coverage_is_reported_not_silently_scored(tmp_path):
+    """A 7-day criterion scoring 2 days of log must say so."""
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(_line("info", "engine.cycle_complete", now - timedelta(days=2)))
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "PASS"
+    assert "log covers 2.0d of 7.0d" in result.value
+
+
+@pytest.mark.asyncio
+async def test_full_coverage_adds_no_caveat(tmp_path):
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(
+        _line("info", "engine.started", now - timedelta(days=9))
+        + _line("info", "engine.cycle_complete", now - timedelta(hours=1))
+    )
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "PASS"
+    assert "log covers" not in result.value
+
+
+@pytest.mark.asyncio
+async def test_drift_canary_survives_the_multi_file_walk(tmp_path):
+    """Unparseable-line tolerance and drift accounting are measured across the
+    whole corpus, not reset per file."""
+    from auramaur.monitoring.readiness import check_cycle_health
+
+    now = datetime.now(timezone.utc)
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text(_line("info", "ok", now - timedelta(hours=1)))
+    (tmp_path / "auramaur.log.1").write_text("this is not json\n" * 9)
+
+    result = await check_cycle_health(log_file, now - timedelta(days=7))
+
+    assert result.status == "FAIL"
+    assert "format has drifted" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# 5. Gate dashboard — an unreadable database is not an empty one
+# ---------------------------------------------------------------------------
+
+
+def _gate_settings():
+    settings = MagicMock()
+    settings.risk_tolerance = 50.0
+    return settings
 
 
 def test_unreadable_database_is_not_reported_as_no_data():
     """0 told the operator to keep waiting for a sample that already exists."""
     from auramaur.monitoring import gates
-    n = gates._resolved_dollar_markets("/nonexistent/definitely/not/here.db")
-    assert n == -1, "an unreadable db must be distinguishable from an empty one"
 
-    src = inspect.getsource(gates.gather)
-    assert "runtime_db_path()" in src, "must follow AURAMAUR_DB_PATH"
-    rendered = inspect.getsource(gates)
-    assert "UNKNOWN (cannot read db)" in rendered
+    assert gates._resolved_dollar_markets("/nonexistent/definitely/not/here.db") == -1
 
 
-def test_empty_log_window_is_insufficient_data_not_pass():
-    """The window can be empty because the bot is dead, or because rotation
-    carried the errors away — _rotate() renames at rotate_max_mb and the
-    parser opens exactly one path."""
-    from auramaur.monitoring import readiness
-    src = inspect.getsource(readiness)
-    assert 'if in_window == 0:' in src
-    empty_arm = src.split("if in_window == 0:", 1)[1].split("if errors == 0:", 1)[0]
-    assert 'status="INSUFFICIENT_DATA"' in empty_arm
-    # overall_pass requires every criterion to be PASS, so this blocks it.
-    assert 'all(c.status == "PASS" for c in self.criteria)' in src
+def test_gather_renders_unknown_rather_than_a_plausible_zero(tmp_path):
+    from auramaur.monitoring import gates
+
+    rows = gates.gather(_gate_settings(), db_path=str(tmp_path / "missing.db"))
+    row = next(r for r in rows if r["feature"].startswith("Divergence filter"))
+
+    assert row["verdict"] == "UNKNOWN (cannot read db)"
+    assert row["status"] == "database unreadable"
+    assert gates.render(rows) is not None      # the verdict string reaches the table
 
 
-def test_risk_tolerance_override_is_anchored_to_the_state_dir():
+@pytest.mark.asyncio
+async def test_gather_still_says_wait_for_a_readable_but_empty_database(db, tmp_path):
+    """The discriminator: "no data yet" and "cannot read" must stay distinct."""
+    from auramaur.monitoring import gates
+
+    rows = gates.gather(_gate_settings(), db_path=str(tmp_path / "degraded.db"))
+    row = next(r for r in rows if r["feature"].startswith("Divergence filter"))
+
+    assert row["verdict"] == "WAIT (need data)"
+    assert row["status"] == "0/100 resolved-$ markets"
+
+
+def test_gather_defaults_to_the_configured_database(tmp_path, monkeypatch):
+    """The old default was the bare literal "auramaur.db", which resolves only
+    under a CWD that happens to be the repo root."""
+    from auramaur.monitoring import gates
+
+    target = tmp_path / "elsewhere" / "auramaur.db"
+    monkeypatch.setenv("AURAMAUR_DB_PATH", str(target))
+    seen: list[str] = []
+
+    def _spy(path: str) -> int:
+        seen.append(path)
+        return 0
+
+    monkeypatch.setattr(gates, "_resolved_dollar_markets", _spy)
+
+    gates.gather(_gate_settings())
+
+    assert seen == [str(target)]
+
+
+# ---------------------------------------------------------------------------
+# 6. Risk-tolerance override — anchored to the state dir, resolved at call time
+# ---------------------------------------------------------------------------
+
+
+def test_risk_tolerance_override_is_state_dir_anchored_and_call_time(tmp_path, monkeypatch):
     """A stale data/risk_tolerance in a launch directory silently put the book
-    at YOLO; `auramaur risk 0` from elsewhere had no effect while saying it did."""
+    at YOLO; `auramaur risk 0` from elsewhere had no effect while saying it did.
+    Resolving at call time is what makes the anchor followable at runtime."""
     from auramaur.risk import tolerance
-    assert tolerance._OVERRIDE.is_absolute()
-    assert "state_dir()" in inspect.getsource(tolerance).split("_OVERRIDE =", 1)[1][:80]
+
+    settings = SimpleNamespace(risk_tolerance=50.0)
+    first = tmp_path / "first"
+    monkeypatch.setenv("AURAMAUR_STATE_DIR", str(first))
+
+    assert tolerance._override_path() == first / "data" / "risk_tolerance"
+    assert tolerance._override_path().is_absolute()
+    assert tolerance.current_tolerance(settings) == 50.0   # no file -> config
+
+    tolerance.set_tolerance(0.0)
+    assert (first / "data" / "risk_tolerance").read_text().strip() == "0.0"
+    assert tolerance.current_tolerance(settings) == 0.0
+
+    # Call-time resolution: an import-time constant would still be reading the
+    # first path here, which is precisely why it was unmonkeypatchable.
+    second = tmp_path / "second"
+    monkeypatch.setenv("AURAMAUR_STATE_DIR", str(second))
+    assert tolerance.current_tolerance(settings) == 50.0
+    tolerance.set_tolerance(100.0)
+    assert tolerance.current_tolerance(settings) == 100.0
+    assert (first / "data" / "risk_tolerance").read_text().strip() == "0.0"
 
 
-def test_dust_exit_attaches_to_the_real_database():
+def test_risk_tolerance_override_is_clamped_and_ignores_junk(tmp_path, monkeypatch):
+    from auramaur.risk import tolerance
+
+    settings = SimpleNamespace(risk_tolerance=50.0)
+    monkeypatch.setenv("AURAMAUR_STATE_DIR", str(tmp_path))
+
+    tolerance.set_tolerance(500.0)
+    assert tolerance.current_tolerance(settings) == 100.0
+
+    tolerance._override_path().write_text("not a number")
+    assert tolerance.current_tolerance(settings) == 50.0
+
+
+# ---------------------------------------------------------------------------
+# 7. dust-exit — attach to the database the deployment actually uses
+# ---------------------------------------------------------------------------
+
+
+def test_dust_exit_attaches_to_the_configured_database(tmp_path, monkeypatch):
     """Its ONLY concurrency guard is a flock on f'{db_path}.lock'. With a
     CWD-relative path that lock is uncontended, so the 'bot is running' refusal
     never engages and it can double-sell live positions."""
-    from auramaur.cli import redeem
-    src = inspect.getsource(redeem)
-    assert 'db_path=str(runtime_db_path())' in src
-    assert 'db_path="auramaur.db"' not in src
+    from click.testing import CliRunner
+
+    from auramaur.cli._base import main
+
+    target = tmp_path / "state" / "auramaur.db"
+    monkeypatch.setenv("AURAMAUR_DB_PATH", str(target))
+
+    with patch("auramaur.cli.AuramaurBot") as MockBot:
+        instance = MockBot.return_value
+        instance._init_components = AsyncMock(
+            side_effect=RuntimeError("Database is already locked by another instance"))
+        result = CliRunner().invoke(main, ["dust-exit"])
+
+    assert result.exit_code == 0, result.output
+    assert MockBot.call_args.kwargs["db_path"] == str(Path(target))
+    assert MockBot.call_args.kwargs["db_path"] != "auramaur.db"

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -542,7 +542,9 @@ async def test_evaluate_readiness_defaults_to_configured_log_file(
     cycle = report.criteria[0]
     assert cycle.name == "cycle_health"
     assert cycle.status == "PASS"
-    assert cycle.detail == "1 entries in window"
+    # The count of files folded in is part of the detail now that cycle_health
+    # also reads the rotated backups (log_files_for) — here there are none.
+    assert cycle.detail == "1 entries in window across 1 log file(s)"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Five sinks that turned **"I could not measure this"** into a plausible number. Each one is individually small; together they're the reason a degraded system reads as a healthy one.

## 1. `kraken_pillar.py:710` — an empty balance dict read as a flat book

`get_free_balance` falls back to `get_balance`, which returns `{}` on **any** API error — `kraken.py:121-123` logs and returns the empty result rather than raising. One 5xx, rate-limit or `EAPI:Invalid nonce` made every tracked position look closed:

- `_dir_long` cleared
- `_clear_peak()` **DELETED** the `position_peaks` row — the trailing-stop high-water mark, which is **not** recoverable from `cost_basis`
- `_mirror_to_portfolio` removed every live kraken portfolio row

A position that peaked +40% and sat at +30% with an 8% trailing stop re-anchored at +30%; the give-back was never banked. `_treasury` guards this exact case at line 419 with `if not bal: return`.

## 2. `gates.py:21` — an unreadable database read as zero

The path was the bare literal `"auramaur.db"`, which resolves only under a CWD that happens to be the repo root. Under compose (`/app/state/auramaur.db`) or from anywhere else, the connect raised and `except: return 0` laundered it into `0/100 resolved-$ markets → WAIT (need data)` — so the operator never flips a filter the data has already earned.

Now: resolves via `runtime.db_path()`, sets `busy_timeout=5000` so a checkpoint in flight isn't the same failure, and returns `-1` rendered as **"UNKNOWN (cannot read db)"** — a genuinely different state from "no data yet".

## 3. `readiness.py:140` — an empty log window read as zero errors

The window can be empty because the bot is dead, **or because rotation carried the errors away**: `_rotate()` renames at `rotate_max_mb` (10MB, 3 backups) and this parser opens exactly one path, so a bot writing >10MB/day gives a criterion advertising 7 days under a day of actual visibility.

An error burst two rotations ago scored `PASS`. With the other criteria green, `overall_pass` was True and the CLI exited 0 — an automated *"ready to arm live"* built on evidence nobody could see. Now `INSUFFICIENT_DATA`, which `overall_pass` already treats as not-pass.

## 4. `tolerance.py:23` — the last CWD-relative state path, governing the whole risk surface

`Path("data/risk_tolerance")` wins over config and scales **Kelly ×3, min-edge ÷3, category cap → 100%, divergence max → 0.75, max open positions → 1500**.

A stale file in a launch directory silently put the book at maximum aggression with no log line. Conversely `auramaur risk 0` run from any directory other than the bot's had no effect at all — while printing that it did. `runtime.py` exists to anchor exactly this, and `grep 'Path("data/'` returned this line and nothing else.

## 5. `redeem.py:144` — `dust-exit` attached to a CWD-relative database

Its **only** concurrency protection is a flock on `f"{db_path}.lock"` — also CWD-relative. Under any deployment that relocates state it flocked an uncontended `./auramaur.db.lock`, so the documented *"refuses to run while the bot is running"* guard never engaged.

It then attached to `./auramaur.db`: either a stale pre-migration file — in which case it exits real positions the running bot is concurrently managing, the double-sell `tests/test_cli_dust_exit.py:110` exists to prevent — or a nonexistent one, which `assemble_components` **creates** with full schema DDL before reporting "No dust positions" to an operator who then concludes there are none.

## Verification

`tests/test_degraded_input_fails_closed.py` — 5 tests. **All 5 fail against the unfixed code.**

- Full suite: **2111 passed, 5 skipped, 0 failed**
- `ruff==0.15.22 check .` — clean

Assisted-by: Claude (Anthropic)