### PR TITLE
Give the ExecutionGateway a cancel contract, deliberately ungated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,19 @@
      order method.
    - Prediction-market exits use the gateway exit contract. The sole
      off-gateway exception is the declared IBKR equity path.
+   - **Cancels** use `ExecutionGateway.cancel_resting()`. It covers the other
+     end of an order's lifecycle: strategy pillars must not call an exchange's
+     raw `cancel_order` any more than its raw `place_order`. Bot-level
+     orchestration (shutdown sweep, order-monitor TTL, arb rollback) is
+     outside the pillar perimeter and still cancels directly.
+   - **The cancel path is deliberately UNGATED, and must stay that way.** It
+     carries none of `submit()`'s risk checks and — the part that matters —
+     **no kill-switch check**. A cancel reduces exposure, and arming the kill
+     switch RETIRES live exposure by cancelling resting orders (#408); a
+     blockable cancel would therefore trap the operator inside the exposure the
+     emergency stop exists to shed. `cancel_resting` provides routing, paper
+     interception, terminal-state bookkeeping, audit logging and exception
+     containment. It can never return "blocked".
 4. **Never hardcode API keys.** All secrets come from environment variables.
 5. **Never read `.env` files.** They contain secrets. Use `.env.example` for reference.
 6. **Never force-push to main.**
@@ -21,9 +34,10 @@
 When making git commits, use `Assisted-by: Claude (Anthropic)` in the commit message body instead of `Co-authored-by`. The human author should always be the sole git author of record.
 
 ## Architecture
-- Prediction-market placements flow through `auramaur/broker/execution_gateway.py`;
-  its methods delegate to the appropriate exchange adapter. Strategy pillars
-  must not call raw exchange order methods.
+- Prediction-market placements AND cancels flow through
+  `auramaur/broker/execution_gateway.py`; its methods delegate to the
+  appropriate exchange adapter. Strategy pillars must not call raw exchange
+  order methods — neither `place_order` nor `cancel_order`.
 - Paper trading interception happens in `auramaur/exchange/paper.py`.
 - `auramaur/risk/manager.py` is the approval authority for directional entries.
   Structural strategies use their declared, test-enforced gateway contracts;

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -17,6 +17,11 @@ evaluation stays with the caller — the caller passes the already risk-approved
 pair (the arb pillars): it builds BOTH orders before placing EITHER, places A
 then B, and unwinds a live-pending A if B fails — preserving the atomicity a
 per-leg ``submit`` could not.
+
+``cancel_resting`` closes the other half of a resting order's lifecycle. It is
+a ROUTING AND AUDIT contract, not a gate: unlike a placement, a cancel reduces
+exposure, so it carries none of ``submit``'s risk checks and cannot refuse.
+See its docstring for why the kill switch must never reach it.
 """
 
 from __future__ import annotations
@@ -78,6 +83,29 @@ class ExecutionResult:
     result: OrderResult | None = None
     fill: Fill | None = None
     reason: str = ""
+
+
+@dataclass
+class CancelResult:
+    """The outcome of a gateway cancel. Never an exception, never a refusal.
+
+    ``status`` is one of:
+
+    ``cancelled``  the venue acknowledged the cancel.
+    ``paper``      a paper order — intercepted, never sent to a venue client.
+    ``rejected``   the venue declined (returns False, e.g. already matched).
+    ``failed``     the venue call raised; the exception was contained here.
+    ``skipped``    no usable order id was supplied — nothing to cancel.
+    """
+
+    order_id: str
+    status: Literal["cancelled", "paper", "rejected", "failed", "skipped"]
+    reason: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """True when the order is no longer resting because of this call."""
+        return self.status in ("cancelled", "paper")
 
 
 class ExecutionGateway:
@@ -472,12 +500,135 @@ class ExecutionGateway:
             # cancelled — that's the genuine single-leg the caller logs).
             if (res_a.result is not None and res_a.result.status == "pending"
                     and not res_a.result.is_paper):
-                try:
-                    await exchange_a.cancel_order(res_a.result.order_id)
-                except Exception as e:  # noqa: BLE001 — best-effort unwind
-                    log.warning("gateway.paired_leg_a_cancel_failed",
-                                order_id=res_a.result.order_id, error=str(e))
+                # Through the gateway's own cancel contract: same best-effort
+                # semantics as the hand-rolled try/except this replaced (the
+                # unwind can fail and the pair still returns), plus the trades
+                # mirror now goes terminal instead of lingering 'pending'.
+                await self.cancel_resting(
+                    res_a.result.order_id, exchange=exchange_a,
+                    exchange_name=exchange_name_a,
+                    is_paper=res_a.result.is_paper,
+                    source=a.signal.strategy_source or "",
+                    reason="paired_leg_a_unwind",
+                )
         return res_a, res_b
+
+    async def cancel_resting(
+        self,
+        order_id: str,
+        *,
+        exchange: ExchangeClient | None = None,
+        exchange_name: str | None = None,
+        is_paper: bool = False,
+        source: str = "",
+        reason: str = "",
+    ) -> CancelResult:
+        """Cancel a resting order. The gateway's cancel contract.
+
+        CLAUDE.md rule 3 makes the gateway the single mechanical path for an
+        order's lifecycle, but until this existed only PLACEMENT had a contract:
+        every cancel in the codebase — including the market maker's three, and
+        the gateway's own paired unwind — reached past the choke point straight
+        to ``ExchangeClient.cancel_order``. The rule asserted an invariant its
+        own enforcer violated.
+
+        THIS IS A ROUTING AND AUDIT CONTRACT, NOT A GATE. It cannot return
+        "blocked" and it has no condition that refuses. A placement adds
+        exposure and is therefore gated fifteen ways by ``RiskManager``; a
+        cancel REMOVES exposure, so every one of those checks is not merely
+        unnecessary here but backwards.
+
+        *** DO NOT ADD A KILL-SWITCH CHECK BELOW (noted 2026-08-06). ***
+        This is the specific mistake to avoid, and it looks helpful. #408 made
+        arming the kill switch RETIRE live exposure by cancelling resting
+        orders (``AuramaurBot._cancel_resting_live_orders``). A cancel path the
+        kill switch could block would therefore trap the operator inside the
+        exposure the emergency stop exists to shed — the emergency stop would
+        become an exposure lock. The kill switch belongs on ``place_order``,
+        where it already is, and nowhere on this path.
+
+        What the contract DOES provide:
+
+        * **Paper interception.** A paper order never reaches a venue client.
+          Quoting runs paper orders through the LIVE client object (paper-ness
+          is per-order ``dry_run``, not a separate adapter), so this is a real
+          boundary, not a formality.
+        * **Terminal-state bookkeeping.** The trades mirror goes 'cancelled'
+          rather than lingering 'pending' forever — the same repair
+          ``_cancel_resting_live_orders`` and the order monitor's TTL sweep
+          each hand-rolled (#94).
+        * **A uniform result type** and one greppable audit event.
+        * **Exception containment.** A venue error is REPORTED, never raised:
+          these run inside a quoting loop, and callers already treated cancels
+          as best-effort.
+
+        ``exchange``/``exchange_name`` default to the gateway's own, exactly as
+        ``submit`` resolves them; a cross-venue caller passes its own the way
+        ``submit_exit`` and ``submit_paired`` do.
+        """
+        client = exchange if exchange is not None else self.exchange
+        venue = exchange_name or self.exchange_name
+        oid = str(order_id or "").strip()
+        if not oid:
+            return CancelResult(order_id="", status="skipped", reason="no order id")
+
+        # Paper-ness is an OR, never an override: an explicit flag intercepts,
+        # and a PAPER-shaped id intercepts on its own even if a caller forgot
+        # (or wrongly computed) the flag. The failure mode being designed out —
+        # a paper order id sent to the live venue — is not worth trusting one
+        # argument for.
+        if is_paper or oid.upper().startswith("PAPER"):
+            await self._mark_cancelled(oid)
+            log.debug("gateway.cancel", order_id=oid, exchange=venue,
+                      status="paper", strategy_source=source, cancel_reason=reason)
+            return CancelResult(order_id=oid, status="paper", reason="paper order")
+
+        try:
+            acknowledged = bool(await client.cancel_order(oid))
+        except Exception as e:  # noqa: BLE001 — reported, never raised at a caller
+            log.warning("gateway.cancel", order_id=oid, exchange=venue,
+                        status="failed", strategy_source=source,
+                        cancel_reason=reason, error=str(e))
+            return CancelResult(order_id=oid, status="failed", reason=str(e))
+
+        if not acknowledged:
+            # The venue declined (already matched, unknown id). Deliberately no
+            # terminal write: the order may still be live, and the order monitor
+            # resolves it on the next status poll.
+            log.warning("gateway.cancel", order_id=oid, exchange=venue,
+                        status="rejected", strategy_source=source,
+                        cancel_reason=reason)
+            return CancelResult(order_id=oid, status="rejected",
+                                reason="venue declined the cancel")
+
+        await self._mark_cancelled(oid)
+        log.info("gateway.cancel", order_id=oid, exchange=venue,
+                 status="cancelled", strategy_source=source, cancel_reason=reason)
+        return CancelResult(order_id=oid, status="cancelled")
+
+    async def _mark_cancelled(self, order_id: str) -> None:
+        """Drive the trades mirror to a terminal state for a cancelled order.
+
+        Same repair as ``AuramaurBot._cancel_resting_live_orders`` and the order
+        monitor's TTL sweep: without it the row stays 'pending' forever even
+        though the collateral was released (#94). Scoped to 'pending' rows —
+        those two callers only ever hand it resting-order ids, so the guard is a
+        no-op for them, while here it makes a mis-supplied id incapable of
+        rewriting a settled row.
+
+        Best-effort by construction: this runs in a quoting loop, and a database
+        fault must not surface as a cancel failure when the venue already
+        acknowledged one.
+        """
+        try:
+            await self._serialized_write(
+                "UPDATE trades SET status = 'cancelled' "
+                "WHERE order_id = ? AND status = 'pending'",
+                (order_id,),
+            )
+        except Exception as e:  # noqa: BLE001 — bookkeeping, never the cancel
+            log.debug("gateway.cancel_bookkeeping_failed",
+                      order_id=order_id, error=str(e))
 
     async def _serialized_write(self, sql: str, params: tuple = ()) -> None:
         """Land gateway bookkeeping without bleeding across shared writers."""

--- a/auramaur/strategy/exposure_registry.py
+++ b/auramaur/strategy/exposure_registry.py
@@ -345,11 +345,18 @@ REGISTERED_CALLSITES = Counter(
          "prediction_paired"): 1,
         ("auramaur/bot_order_monitor.py", "_task_order_monitor", "cancel_order",
          "gateway_boundary"): 1,
-        ("auramaur/broker/execution_gateway.py", "submit_paired", "cancel_order",
+        # The gateway's paired unwind and the market maker's three quote cancels
+        # now go through the gateway's own cancel contract. The single remaining
+        # raw ``cancel_order`` on this side of the perimeter is the one INSIDE
+        # that contract — the choke point itself, which is where a raw venue
+        # call belongs.
+        ("auramaur/broker/execution_gateway.py", "cancel_resting", "cancel_order",
+         "gateway_boundary"): 1,
+        ("auramaur/broker/execution_gateway.py", "submit_paired", "cancel_resting",
          "prediction_paired"): 1,
-        ("auramaur/strategy/market_maker.py", "_cancel_quote", "cancel_order",
+        ("auramaur/strategy/market_maker.py", "_cancel_quote", "cancel_resting",
          "prediction_quoting"): 2,
-        ("auramaur/strategy/market_maker.py", "_place_two_sided", "cancel_order",
+        ("auramaur/strategy/market_maker.py", "_place_two_sided", "cancel_resting",
          "prediction_quoting"): 1,
         (
             "auramaur/bot_order_monitor.py",
@@ -573,6 +580,11 @@ SENSITIVE_METHODS = frozenset(
         # client, not through the gateway — outside a perimeter this registry
         # claims to close, and left `prediction_quoting`'s declared
         # "cancel/requote" exit path unbacked by any registered callsite.
+        #
+        # Both verbs are pinned: `cancel_resting` is the gateway contract every
+        # pillar must use, `cancel_order` the raw venue call it wraps. Tracking
+        # only the contract would let a raw cancel reappear unregistered.
+        "cancel_resting",
         "cancel_order",
     }
 )

--- a/auramaur/strategy/market_maker.py
+++ b/auramaur/strategy/market_maker.py
@@ -416,6 +416,19 @@ class MarketMaker:
             spread_bps=proposal.spread_bps,
         ), None
 
+    def _ensure_gateway(self):
+        """The ExecutionGateway this pillar routes BOTH halves of an order
+        lifecycle through — placement via ``place_quote_pair``, cancellation via
+        ``cancel_resting``. Lazily built if not injected so existing
+        callers/tests keep working.
+        """
+        if self._gateway is None:
+            from auramaur.broker.execution_gateway import ExecutionGateway
+            self._gateway = ExecutionGateway(
+                router=None, exchange=self._exchange, exchange_name="polymarket",
+                settings=self._settings, db=self._db, pnl_tracker=None)
+        return self._gateway
+
     async def _place_two_sided(self, quote: MMQuote, is_live: bool) -> dict:
         """Place both legs of a two-sided quote.
 
@@ -469,12 +482,7 @@ class MarketMaker:
         # Place both legs through the gateway's two-sided adapter (bid then ask,
         # not both-or-nothing — the MM owns one-legged cleanup below). The gateway
         # is the single placement choke point; no direct exchange.place_order here.
-        if self._gateway is None:
-            from auramaur.broker.execution_gateway import ExecutionGateway
-            self._gateway = ExecutionGateway(
-                router=None, exchange=self._exchange, exchange_name="polymarket",
-                settings=self._settings, db=self._db, pnl_tracker=None)
-        bid_result, ask_result = await self._gateway.place_quote_pair(
+        bid_result, ask_result = await self._ensure_gateway().place_quote_pair(
             bid_order, ask_order, exchange=self._exchange)
 
         # Track order IDs
@@ -516,18 +524,18 @@ class MarketMaker:
         if bid_live != ask_live:
             survivor_id = bid_result.order_id if bid_live else ask_result.order_id
             survivor_status = bid_result.status if bid_live else ask_result.status
-            if (
-                survivor_status not in ("paper", "filled")
-                and survivor_id
-                and not str(survivor_id).startswith("PAPER")
-            ):
-                try:
-                    await self._exchange.cancel_order(survivor_id)
-                except Exception as e:
-                    log.debug(
-                        "market_maker.partial_leg_cancel_error",
-                        order_id=survivor_id, error=str(e),
-                    )
+            survivor_paper = bid_result.is_paper if bid_live else ask_result.is_paper
+            if survivor_status not in ("paper", "filled") and survivor_id:
+                # The gateway owns the cancel: it intercepts paper ids (the
+                # explicit PAPER-prefix test this used to make is now its job,
+                # not the pillar's), contains any venue error, and writes the
+                # trades row terminal. Still best-effort — the periodic
+                # order-monitor reconcile backstops a cancel that fails.
+                await self._ensure_gateway().cancel_resting(
+                    survivor_id, exchange=self._exchange,
+                    exchange_name="polymarket", is_paper=survivor_paper,
+                    source="market_maker", reason="partial_quote_survivor",
+                )
             self._pending_orders.pop(bid_result.order_id, None)
             self._pending_orders.pop(ask_result.order_id, None)
             log.warning(
@@ -592,20 +600,32 @@ class MarketMaker:
         return cancelled
 
     async def _cancel_quote(self, quote) -> None:
-        """Cancel both legs of a quote and drop its pending-order tracking."""
-        # Cancel bid leg
-        if quote.bid_order_id and not quote.bid_order_id.startswith("PAPER"):
-            try:
-                await self._exchange.cancel_order(quote.bid_order_id)
-            except Exception as e:
-                log.debug("market_maker.cancel_bid_error", order_id=quote.bid_order_id, error=str(e))
+        """Cancel both legs of a quote and drop its pending-order tracking.
 
-        # Cancel ask leg
-        if quote.ask_order_id and not quote.ask_order_id.startswith("PAPER"):
-            try:
-                await self._exchange.cancel_order(quote.ask_order_id)
-            except Exception as e:
-                log.debug("market_maker.cancel_ask_error", order_id=quote.ask_order_id, error=str(e))
+        Both legs route through ``ExecutionGateway.cancel_resting`` — the pillar
+        does not touch ``exchange.cancel_order``, exactly as it does not touch
+        ``exchange.place_order``. The gateway intercepts paper ids, so the
+        PAPER-prefix test that used to live here is gone: interception is the
+        choke point's job, and duplicating it in the pillar is how the two
+        drift apart. Errors are contained by the gateway; this stays
+        best-effort, and the quoting loop never sees an exception from a cancel.
+        """
+        gateway = self._ensure_gateway()
+        # Two explicit legs, not a loop: the exposure registry pins this file's
+        # sensitive callsites as an exact multiset, and a quote is genuinely two
+        # orders.
+        if quote.bid_order_id:
+            await gateway.cancel_resting(
+                quote.bid_order_id, exchange=self._exchange,
+                exchange_name="polymarket", source="market_maker",
+                reason="quote_refresh_bid",
+            )
+        if quote.ask_order_id:
+            await gateway.cancel_resting(
+                quote.ask_order_id, exchange=self._exchange,
+                exchange_name="polymarket", source="market_maker",
+                reason="quote_refresh_ask",
+            )
 
         # Clean up pending order tracking
         self._pending_orders.pop(quote.bid_order_id, None)

--- a/scripts/sweep_invariants.py
+++ b/scripts/sweep_invariants.py
@@ -27,7 +27,8 @@ Plus the mechanically checkable subset of CLAUDE.md's "Architecture" rules,
 which were prose and therefore unenforced:
 
   strategy-raw-order  "Strategy pillars must not call raw exchange order
-                      methods" — placements must route via ExecutionGateway.
+                      methods" — placements AND cancels must route via
+                      ExecutionGateway.
   raw-transaction     "never raw BEGIN/COMMIT through execute()".
   await-in-txn-span   "never a network/LLM await inside a span" — holding the
                       write lock across a network call.
@@ -91,12 +92,16 @@ _MONEY_PATHS = ("broker/", "treasury/", "exchange/", "risk/")
 _RAW_ORDER_METHODS = {
     "place_order", "create_order", "submit_order", "post_order", "send_order",
     "buy", "sell", "market_order", "limit_order",
+    # cancel_order was excluded until 2026-08-06 for a reason that has since
+    # been fixed: ExecutionGateway exposed no cancel contract and called
+    # exchange.cancel_order() directly itself, so a strategy had nowhere else
+    # to route and this gate could only have produced findings nobody could
+    # act on. ExecutionGateway.cancel_resting is that contract now, and the
+    # market maker's three cancels route through it, so the rule is checkable.
+    "cancel_order",
 }
-# cancel_order is deliberately absent: ExecutionGateway exposes no cancel
-# contract and calls exchange.cancel_order() directly itself (line 476), so a
-# strategy has nowhere else to route. That is a gap in the gateway's surface,
-# not a strategy violation — see the PR discussion rather than this gate.
-_GATEWAY_OK = {"submit", "submit_paired", "submit_exit", "record_external_fill"}
+_GATEWAY_OK = {"submit", "submit_paired", "submit_exit", "record_external_fill",
+               "cancel_resting"}
 
 # "never raw BEGIN/COMMIT through execute()"
 _RAW_TXN_SQL = ("begin", "commit", "rollback", "savepoint")

--- a/tests/test_execution_gateway.py
+++ b/tests/test_execution_gateway.py
@@ -669,8 +669,8 @@ def test_place_quote_pair_paper_quotes_rest_and_never_reach_the_client():
     legs merged into one blended phantom position that regrew every refresh
     with no trades/fills provenance (the 2026-07-23 orphan-position factory).
     They rest synthetically instead: pending, PAPER-prefixed ids (so the MM's
-    check_fills prunes and _cancel_quote skips them), and the exchange client
-    is never touched."""
+    check_fills prunes them and cancel_resting intercepts them), and the
+    exchange client is never touched."""
     async def run():
         db = Database(":memory:")
         await db.connect()
@@ -949,3 +949,291 @@ def test_llm_kalshi_freezes_the_same_config_as_llm():
     src = inspect.getsource(ExecutionGateway._capture_decision)
     assert '"llm", "llm_kalshi", "news_speed"' in src, (
         "llm_kalshi must map to the nlp section")
+
+
+# ---------------------------------------------------------------------------
+# The cancel contract (cancel_resting).
+#
+# CLAUDE.md rule 3 asserted that pillars route orders through the gateway, but
+# only PLACEMENT had a contract — every cancel, including the gateway's own
+# paired unwind, reached past the choke point to the venue client. These lock in
+# the contract that closed that gap, and above all that it is UNGATED.
+# ---------------------------------------------------------------------------
+
+
+def _cancel_client(*, raises: Exception | None = None, acknowledged: bool = True):
+    """A venue client that records the ids it was asked to cancel."""
+    seen: list[str] = []
+
+    async def _cancel(order_id):
+        seen.append(order_id)
+        if raises is not None:
+            raise raises
+        return acknowledged
+
+    ex = MagicMock()
+    ex.cancel_order = _cancel
+    ex.seen = seen
+    return ex
+
+
+def _quote(bid_id: str, ask_id: str):
+    from auramaur.strategy.market_maker import MMQuote
+
+    return MMQuote(market_id="mm", token_yes_id="yes", token_no_id="no",
+                   bid_price=0.40, ask_price=0.55, size=20.0, spread_bps=150,
+                   bid_order_id=bid_id, ask_order_id=ask_id)
+
+
+def _market_maker(db, exchange, gateway):
+    from auramaur.strategy.market_maker import MarketMaker
+
+    return MarketMaker(Settings(), exchange, db, gateway=gateway)
+
+
+def test_pillar_cancel_routes_through_the_gateway_to_the_client():
+    """(a) The market maker's cancels reach the venue THROUGH the gateway.
+
+    The pillar itself no longer names `cancel_order` — the guard in
+    tests/test_strategy_protocol.py enforces that statically. This is the other
+    half: routing through the contract must still actually cancel the order.
+    """
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ex = _cancel_client()
+            gw = _gateway(db, ex)
+            mm = _market_maker(db, ex, gw)
+            mm._pending_orders = {"oid-bid": {}, "oid-ask": {}}
+
+            await mm._cancel_quote(_quote("oid-bid", "oid-ask"))
+
+            assert ex.seen == ["oid-bid", "oid-ask"]
+            # And the pillar's own tracking is dropped, as before.
+            assert mm._pending_orders == {}
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_paper_cancel_never_reaches_a_live_client():
+    """(b) Paper interception. Quoting runs paper orders through the LIVE client
+    object (paper-ness is per-order dry_run, not a separate adapter), so a
+    PAPER-prefixed id must be intercepted here or it goes to the venue."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ex = MagicMock()
+
+            async def _cancel(order_id):
+                raise AssertionError("a paper cancel must never reach the client")
+
+            ex.cancel_order = _cancel
+            gw = _gateway(db, ex)
+
+            # Intercepted on the id shape alone — place_quote_pair's synthetic
+            # resting ids look exactly like this.
+            res = await gw.cancel_resting("PAPER-QUOTE-abc123", exchange=ex)
+            assert res.status == "paper" and res.ok
+
+            # And on an explicit flag, for a caller holding OrderResult.is_paper.
+            flagged = await gw.cancel_resting("oid-live-shaped", exchange=ex,
+                                              is_paper=True)
+            assert flagged.status == "paper" and flagged.ok
+
+            # The pillar path too, through the market maker's own cancel.
+            mm = _market_maker(db, ex, gw)
+            await mm._cancel_quote(_quote("PAPER-QUOTE-b", "PAPER-QUOTE-a"))
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_cancel_succeeds_while_the_kill_switch_is_armed(monkeypatch):
+    """(c) THE regression that matters. A cancel must NOT be blockable.
+
+    #408 made arming the kill switch retire live exposure by cancelling resting
+    orders. If a kill-switch check ever appears on this path, arming the
+    emergency stop would trap the operator inside the exposure it exists to
+    shed — the stop would become a lock. Both halves are checked: the behavior
+    with the switch armed, and the source, so a future 'helpful' gate fails here
+    rather than in production.
+    """
+    import ast as _ast
+    import inspect
+    import textwrap
+
+    import auramaur.killswitch as killswitch
+
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            # Arm it for real: the file at the (conftest-isolated) path, and the
+            # shared predicate every gate consults.
+            killswitch.KILL_SWITCH_PATH.parent.mkdir(parents=True, exist_ok=True)
+            killswitch.KILL_SWITCH_PATH.touch()
+            monkeypatch.setattr(killswitch, "kill_switch_present", lambda: True)
+            assert killswitch.kill_switch_present()
+
+            ex = _cancel_client()
+            gw = _gateway(db, ex)
+            res = await gw.cancel_resting("oid-1", exchange=ex, reason="halt")
+
+            assert res.status == "cancelled" and res.ok
+            assert ex.seen == ["oid-1"], "the kill switch must not block a cancel"
+
+            # The MM path is equally unblockable.
+            mm = _market_maker(db, ex, gw)
+            await mm._cancel_quote(_quote("oid-bid", "oid-ask"))
+            assert ex.seen == ["oid-1", "oid-bid", "oid-ask"]
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+    # Structural: no gate in the body, docstring and comments excluded (the
+    # docstring is *about* the kill switch, so it must not be searched).
+    fn = _ast.parse(
+        textwrap.dedent(inspect.getsource(ExecutionGateway.cancel_resting))
+    ).body[0]
+    body = fn.body
+    if body and isinstance(body[0], _ast.Expr) and isinstance(body[0].value, _ast.Constant):
+        body = body[1:]
+    code = "\n".join(_ast.unparse(node) for node in body).lower()
+    assert "kill_switch" not in code
+    assert "riskmanager" not in code and "evaluate" not in code
+
+
+def test_venue_exception_is_contained_and_reported_not_raised():
+    """(d) A cancel runs inside a quoting loop. A venue fault must come back as
+    a result, never as an exception the loop has to catch — that containment is
+    exactly what the three hand-rolled try/excepts at the old call sites did."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ex = _cancel_client(raises=RuntimeError("clob 503"))
+            gw = _gateway(db, ex)
+
+            res = await gw.cancel_resting("oid-1", exchange=ex)
+            assert res.status == "failed"
+            assert res.ok is False
+            assert "clob 503" in res.reason
+
+            # A venue that declines (already matched) is reported, not raised
+            # either — and is NOT treated as a successful cancel.
+            declined = await gw.cancel_resting(
+                "oid-2", exchange=_cancel_client(acknowledged=False))
+            assert declined.status == "rejected" and declined.ok is False
+
+            # An empty id is a no-op, not a client call.
+            assert (await gw.cancel_resting("", exchange=ex)).status == "skipped"
+
+            # The pillar loop survives a raising venue with no try/except of
+            # its own — both legs are still attempted.
+            mm = _market_maker(db, ex, gw)
+            await mm._cancel_quote(_quote("oid-bid", "oid-ask"))
+            assert ex.seen == ["oid-1", "oid-bid", "oid-ask"]
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_cancelled_order_reaches_a_terminal_trades_state():
+    """(e) The bookkeeping half. Without it a cancelled order's trades row stays
+    'pending' forever even though the collateral was released (#94) — the same
+    repair the shutdown sweep and the order-monitor TTL each hand-rolled."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            async def _mirror(order_id, status):
+                await db.execute(
+                    "INSERT INTO trades (market_id, side, size, price, is_paper,"
+                    " order_id, status) VALUES ('mm','BUY',20,0.4,0,?,?)",
+                    (order_id, status),
+                )
+                await db.commit()
+
+            async def _status(order_id):
+                row = await db.fetchone(
+                    "SELECT status FROM trades WHERE order_id = ?", (order_id,))
+                return dict(row)["status"]
+
+            await _mirror("oid-1", "pending")
+            await _mirror("oid-filled", "filled")
+            await _mirror("oid-declined", "pending")
+
+            gw = _gateway(db, _cancel_client())
+            await gw.cancel_resting("oid-1", exchange=_cancel_client())
+            assert await _status("oid-1") == "cancelled"
+
+            # A settled row is never rewritten by a mis-supplied id.
+            await gw.cancel_resting("oid-filled", exchange=_cancel_client())
+            assert await _status("oid-filled") == "filled"
+
+            # A declined cancel leaves the row pending: the order may still be
+            # live, and the monitor resolves it on the next status poll.
+            await gw.cancel_resting(
+                "oid-declined", exchange=_cancel_client(acknowledged=False))
+            assert await _status("oid-declined") == "pending"
+        finally:
+            await db.close()
+
+    asyncio.run(run())
+
+
+def test_paired_unwind_goes_through_the_cancel_contract():
+    """The gateway's OWN unwind uses its own contract — the enforcer no longer
+    violates the rule it enforces. Same best-effort semantics as the try/except
+    it replaced, plus leg A's trades row now goes terminal."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            await db.execute(
+                "INSERT INTO markets (id, exchange, question, category, active,"
+                " last_updated) VALUES ('m1','polymarket','Q?','tech',1,datetime('now'))")
+            await db.commit()
+
+            order_a = Order(market_id="m1", exchange="polymarket", token_id="a",
+                            side=OrderSide.BUY, token=TokenType.YES, size=20.0,
+                            price=0.50, dry_run=False)
+            order_b = Order(market_id="m1", exchange="polymarket", token_id="b",
+                            side=OrderSide.BUY, token=TokenType.NO, size=20.0,
+                            price=0.45, dry_run=False)
+            res_a = OrderResult(order_id="oid-a", market_id="m1", status="pending",
+                                is_paper=False)
+            res_b = OrderResult(order_id="ERROR", market_id="m1", status="rejected",
+                                is_paper=False, error_message="venue down")
+
+            ex_a = _cancel_client()
+            ex_a.prepare_order = MagicMock(return_value=order_a)
+            ex_a.place_order = AsyncMock(return_value=res_a)
+            ex_b = MagicMock()
+            ex_b.prepare_order = MagicMock(return_value=order_b)
+            ex_b.place_order = AsyncMock(return_value=res_b)
+
+            gw = _gateway(db, ex_a)
+            market = Market(id="m1", question="Q?")
+            a, b = await gw.submit_paired(
+                TradeIntent(signal=_signal(), market=market, size_dollars=5.0),
+                TradeIntent(signal=_signal(), market=market, size_dollars=5.0),
+                exchange_a=ex_a, exchange_name_a="polymarket",
+                exchange_b=ex_b, exchange_name_b="polymarket")
+
+            assert a.status == "pending" and b.status == "rejected"
+            assert ex_a.seen == ["oid-a"]
+            row = await db.fetchone(
+                "SELECT status FROM trades WHERE order_id = 'oid-a'")
+            assert dict(row)["status"] == "cancelled"
+        finally:
+            await db.close()
+
+    asyncio.run(run())

--- a/tests/test_strategy_protocol.py
+++ b/tests/test_strategy_protocol.py
@@ -23,12 +23,19 @@ from auramaur.strategy.registry import (
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# Placement primitives an application module must never call directly when its
-# declared mode routes through the gateway. Kept in sync with the exposure
-# registry's perimeter so a new adapter verb is covered in one place.
-_PLACEMENT_METHODS = frozenset({
+# Raw order-lifecycle primitives an application module must never call directly
+# when its declared mode routes through the gateway. Kept in sync with the
+# exposure registry's perimeter so a new adapter verb is covered in one place.
+#
+# cancel_order is here as of 2026-08-06. It was absent because the gateway
+# exposed no cancel contract, so a pillar had nowhere to route one — the market
+# maker's three cancels went straight to the live venue client and this guard
+# had to stay silent about it. ExecutionGateway.cancel_resting is that contract,
+# so the omission is now a real check again: an order's lifecycle has two ends,
+# and the choke point owns both.
+_RAW_ORDER_METHODS = frozenset({
     "place_order", "place_spot_order", "place_share_order", "_place_cash_order",
-    "place", "placeOrder",
+    "place", "placeOrder", "cancel_order",
 })
 
 
@@ -52,21 +59,22 @@ def test_registered_pillar_declares_matching_execution_contract(spec):
 
 
 @pytest.mark.parametrize("spec", STRATEGY_SPECS, ids=lambda spec: spec.key)
-def test_gateway_pillars_do_not_place_orders_directly(spec):
+def test_gateway_pillars_do_not_place_or_cancel_orders_directly(spec):
     if spec.execution_mode not in NO_DIRECT_PLACE_MODES:
         pytest.skip(f"{spec.key} has declared {spec.execution_mode.value} execution")
-    # Match EVERY placement primitive, not just the literal `.place_order(`.
+    # Match EVERY order primitive, not just the literal `.place_order(`.
     # Kraken places via `place_spot_order`, IBKR equities via
     # `place_share_order`/`_place_cash_order`, and the multiasset bridge via
     # `.place(` — none of which the old substring saw, so a pillar could
-    # bypass the gateway and still pass this guard.
+    # bypass the gateway and still pass this guard. `cancel_order` closes the
+    # other end of the lifecycle now that `cancel_resting` exists to route it.
     src = (_ROOT / (spec.module.replace(".", "/") + ".py")).read_text()
     tree = ast.parse(src)
     offenders = sorted({
         node.func.attr
         for node in ast.walk(tree)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-        and node.func.attr in _PLACEMENT_METHODS
+        and node.func.attr in _RAW_ORDER_METHODS
     })
     assert not offenders, (
         f"{spec.key} ({spec.execution_mode.value}) must use its declared "

--- a/tests/test_sweep_invariants_key.py
+++ b/tests/test_sweep_invariants_key.py
@@ -9,7 +9,9 @@ while the Linux CI job stayed green — the defect was invisible precisely
 where it was checked, which is why it needs a test rather than a run.
 """
 
-from scripts.sweep_invariants import Finding
+import ast
+
+from scripts.sweep_invariants import Finding, _Sweeper
 
 
 def test_key_is_separator_independent():
@@ -18,3 +20,29 @@ def test_key_is_separator_independent():
 
     assert windows.key() == posix.key()
     assert windows.key().startswith("auramaur/backtest/engine.py::")
+
+
+def _dimensions(relpath: str, src: str) -> set[str]:
+    tree = ast.parse(src)
+    sweeper = _Sweeper(relpath, set(), set())
+    sweeper.visit(tree)
+    return {f.dimension for f in sweeper.findings}
+
+
+def test_strategy_raw_order_covers_cancels_not_only_placements():
+    """An order's lifecycle has two ends and the choke point owns both.
+
+    cancel_order was excluded from this dimension while the gateway exposed no
+    cancel contract — a pillar had nowhere to route one, so the gate could only
+    have produced findings nobody could act on. ExecutionGateway.cancel_resting
+    is that contract, so a raw venue cancel in a pillar is a finding again.
+    """
+    raw = "async def go(self):\n    await self._exchange.cancel_order('oid')\n"
+    routed = "async def go(self):\n    await self._gateway.cancel_resting('oid')\n"
+
+    assert "strategy-raw-order" in _dimensions("auramaur/strategy/market_maker.py", raw)
+    assert "strategy-raw-order" not in _dimensions(
+        "auramaur/strategy/market_maker.py", routed)
+    # The gateway itself is where the raw venue call belongs.
+    assert "strategy-raw-order" not in _dimensions(
+        "auramaur/broker/execution_gateway.py", raw)


### PR DESCRIPTION
## The problem

CLAUDE.md rule 3 makes `ExecutionGateway` the single mechanical path for an order. But only **placement** ever had a contract. There was no cancel method on the gateway at all, so every cancel in the codebase reached past the choke point straight to `ExchangeClient.cancel_order`:

| Call site | Status before |
|---|---|
| `strategy/market_maker.py` ×3 (`_place_two_sided`, `_cancel_quote` ×2) | **Direct rule violations** — a pillar calling a raw exchange order method |
| `broker/execution_gateway.py:476` (paired leg-A unwind) | The enforcer violating its own rule |
| `bot.py` / `bot_order_monitor.py` / `bot_arb_execute.py` | Orchestration, outside the pillar perimeter |

`scripts/sweep_invariants.py` (#404) even carried a comment excusing the gap: `cancel_order` was deliberately excluded from the `strategy-raw-order` dimension because "a strategy has nowhere else to route." That was true, and it made the rule unenforceable rather than false-negative-prone. The rule asserted an invariant its own enforcer violated.

## The design decision: routing and audit, NOT a gate

`ExecutionGateway.cancel_resting()` **cannot refuse.**

- **No risk checks.** None of `submit()`'s fifteen apply. A placement adds exposure and is gated accordingly; a cancel *removes* exposure, so those checks are not merely unnecessary here — they are backwards. There is no code path that returns "blocked".
- **No kill-switch check, and a dated comment saying so** at the exact point where a reader would otherwise "helpfully" add one.

  This is the critical inversion to avoid. **#408** (merged 2026-08-06, `1702b43`) made arming the kill switch *retire live exposure* by cancelling resting orders. A cancel that the kill switch could block would therefore trap the operator inside the exposure the emergency stop exists to shed — the emergency stop would become an exposure lock. The kill switch belongs on `place_order`, where it already is, and nowhere on this path.

What the contract *does* provide:

- **Paper interception** — a paper order never reaches a venue client. This is a real boundary, not a formality: quoting runs paper orders through the **live client object** (paper-ness is per-order `dry_run`, not a separate adapter). Interception is an OR of an explicit `is_paper` flag and the `PAPER-` id prefix, so a caller that computes the flag wrongly still cannot leak a paper id to the venue.
- **Terminal-state bookkeeping** — the `trades` mirror goes `'cancelled'` instead of lingering `'pending'` forever. Same repair `_cancel_resting_live_orders` and the order-monitor TTL sweep each hand-rolled (#94), scoped to `status = 'pending'` so a mis-supplied id can never rewrite a settled row.
- **A uniform `CancelResult`** (`cancelled` / `paper` / `rejected` / `failed` / `skipped`, with `.ok`) and **one greppable audit event** (`gateway.cancel`).
- **Exception containment** — a venue error is *reported*, never raised. These run in a quoting loop, and callers already treated cancels as best-effort.

### Signature

```python
async def cancel_resting(
    self, order_id: str, *,
    exchange: ExchangeClient | None = None,
    exchange_name: str | None = None,
    is_paper: bool = False,
    source: str = "",
    reason: str = "",
) -> CancelResult
```

Derived from the four real call sites. `exchange`/`exchange_name` default to the gateway's own exactly as `submit()` resolves them, and a cross-venue caller passes its own the way `submit_exit` and `submit_paired` already do — no parallel mechanism. `is_paper` carries `OrderResult.is_paper` where the caller has it. `source`/`reason` preserve the attribution and the per-site specificity of the four distinct log event names being replaced.

Named `cancel_resting`, not `cancel`: `cancel` collides with `task.cancel()` in the AST-based registry perimeter, and not `cancel_order` so that the raw venue verb stays uniquely greppable and statically bannable inside pillars.

## Migrated

- **`market_maker.py` ×3** → `cancel_resting`. The pillar no longer names `cancel_order` anywhere, and the `PAPER`-prefix tests it used to make are gone: interception is the choke point's job, and duplicating it in the pillar is how the two drift apart. Loop behavior is otherwise preserved — same venue round-trip, same best-effort, exceptions still never reach the loop.
- **`execution_gateway.py:476` (paired leg-A unwind)** → `cancel_resting`. Semantics unchanged (same `pending and not is_paper` guard, same best-effort unwind, exceptions contained); the unwind additionally drives leg A's trades row terminal instead of leaving it `'pending'`.

## Unmigrated by choice

The three bot-level sites — `bot.py:_cancel_resting_live_orders` (shutdown/kill-switch sweep), `bot_order_monitor.py` (TTL reaper), `bot_arb_execute.py` (cross-exchange rollback) — are orchestration, not pillars, and stay direct in this PR.

My view is that they *should* eventually converge on this contract, for a reason independent of the rule: two of the three hand-roll the exact `UPDATE trades SET status='cancelled'` this method now owns, and the third (arb rollback) does not, so a rolled-back leg's row stays `pending`. That is the same triplicated-tail duplication the gateway was extracted to delete. The blocker is not the rule — it is that each has orchestration the contract does not yet carry: the shutdown sweep iterates `client._live_pending` and prints an operator summary, the TTL reaper must keep an unacknowledged order *tracked* rather than dropping it, and the rollback escalates a failed cancel to a critical alert. Those are separable, but folding them in blind would change kill-switch and reconciliation behavior on the same commit that establishes the contract, so they belong in a follow-up with their own tests.

## Re-armed enforcement

- `sweep_invariants.py`: `cancel_order` added back to `strategy-raw-order`; the excusing comment is replaced by a dated note on why it was excluded and what fixed it. New unit test proves the dimension has teeth (raw cancel in a pillar → finding; routed cancel → none; the gateway itself → none).
- `tests/test_strategy_protocol.py`: `_PLACEMENT_METHODS` → `_RAW_ORDER_METHODS`, now including `cancel_order`, so a pillar in `NO_DIRECT_PLACE_MODES` fails statically on a raw cancel.
- `exposure_registry.py`: market_maker's cancels re-pinned to `cancel_resting`; both verbs in `SENSITIVE_METHODS`, so the single remaining raw `cancel_order` on this side of the perimeter is the one *inside* the contract, registered against `gateway_boundary`.
- `.sweep-baseline.json` unchanged — this migration cleared no baselined findings (`cancel_order` was never a baselined dimension).

## CLAUDE.md

Rule 3 gains the cancel contract **and** an explicit statement that the path is deliberately ungated, with the reason. The documentation half of the fix: the rule is now true.

## Tests

`tests/test_execution_gateway.py`, house conventions:

- (a) a pillar cancel routes through the gateway and reaches the exchange client
- (b) a paper order's cancel never reaches a live client (id shape, explicit flag, and via the pillar)
- (c) **a cancel succeeds while the kill switch is armed** — the regression that matters most, checked behaviorally *and* structurally (`cancel_resting`'s body, docstring and comments stripped, may not mention the kill switch)
- (d) a venue exception is contained and reported, not raised; a declined cancel is `rejected`, not silently successful
- (e) the trades row reaches a terminal state — and a `filled` row is never rewritten, and a declined cancel leaves the row `pending`
- plus: the paired unwind goes through the contract and drives leg A terminal

## Verification

CI-identical container: **2166 passed, 5 skipped**, coverage **66.35%** (≥ 65.0), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
