### PR TITLE
Harden take-profit discipline

### DIFF
--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -404,6 +404,11 @@ class Database:
                 size REAL NOT NULL);
             CREATE INDEX IF NOT EXISTS idx_exit_decisions_position_time
               ON exit_decisions(market_id, token, is_paper, observed_at);
+            -- observed_at is the composite's FOURTH column and the retention
+            -- delete constrains nothing else, so that index offers no seekable
+            -- prefix. Without this one the per-cycle prune full-scans.
+            CREATE INDEX IF NOT EXISTS idx_exit_decisions_observed_at
+              ON exit_decisions(observed_at);
             UPDATE schema_version SET version = 50;
         """)
         await self._db.commit()

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -384,6 +384,30 @@ class Database:
             await self._migrate_v47_to_v48()
         if from_version < 49:
             await self._migrate_v48_to_v49()
+        if from_version < 50:
+            await self._migrate_v49_to_v50()
+
+    async def _migrate_v49_to_v50(self) -> None:
+        """Add auditable exit-policy observations for holdout calibration."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS exit_decisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                observed_at TEXT NOT NULL DEFAULT (datetime('now')),
+                market_id TEXT NOT NULL, exchange TEXT NOT NULL DEFAULT '',
+                token TEXT NOT NULL DEFAULT 'YES',
+                is_paper INTEGER NOT NULL DEFAULT 1,
+                policy_action TEXT NOT NULL DEFAULT 'HOLD',
+                gross_pnl_pct REAL NOT NULL, net_pnl_pct REAL NOT NULL,
+                peak_pnl_pct REAL NOT NULL, target_pct REAL,
+                estimated_fees REAL NOT NULL DEFAULT 0,
+                current_price REAL NOT NULL, entry_price REAL NOT NULL,
+                size REAL NOT NULL);
+            CREATE INDEX IF NOT EXISTS idx_exit_decisions_position_time
+              ON exit_decisions(market_id, token, is_paper, observed_at);
+            UPDATE schema_version SET version = 50;
+        """)
+        await self._db.commit()
+        log.info("database.migrated", from_version=49, to_version=50)
 
     async def _migrate_v48_to_v49(self) -> None:
         """Record the deterministic pair post-check on entailment verdicts (#405).

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 49
+SCHEMA_VERSION = 50
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -792,6 +792,26 @@ CREATE TABLE IF NOT EXISTS position_peaks (
     peak_pnl_pct REAL NOT NULL DEFAULT 0.0,
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS exit_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    market_id TEXT NOT NULL,
+    exchange TEXT NOT NULL DEFAULT '',
+    token TEXT NOT NULL DEFAULT 'YES',
+    is_paper INTEGER NOT NULL DEFAULT 1,
+    policy_action TEXT NOT NULL DEFAULT 'HOLD',
+    gross_pnl_pct REAL NOT NULL,
+    net_pnl_pct REAL NOT NULL,
+    peak_pnl_pct REAL NOT NULL,
+    target_pct REAL,
+    estimated_fees REAL NOT NULL DEFAULT 0,
+    current_price REAL NOT NULL,
+    entry_price REAL NOT NULL,
+    size REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_exit_decisions_position_time
+    ON exit_decisions(market_id, token, is_paper, observed_at);
 
 CREATE TABLE IF NOT EXISTS rebalance_blocks (
     event_key TEXT PRIMARY KEY,

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -812,6 +812,11 @@ CREATE TABLE IF NOT EXISTS exit_decisions (
 );
 CREATE INDEX IF NOT EXISTS idx_exit_decisions_position_time
     ON exit_decisions(market_id, token, is_paper, observed_at);
+-- The composite above cannot serve the per-cycle retention delete: its
+-- predicate constrains observed_at alone, and the three leading columns are
+-- unconstrained, so SQLite has no seekable prefix and full-scans the table.
+CREATE INDEX IF NOT EXISTS idx_exit_decisions_observed_at
+    ON exit_decisions(observed_at);
 
 CREATE TABLE IF NOT EXISTS rebalance_blocks (
     event_key TEXT PRIMARY KEY,

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -351,6 +351,7 @@ class OrderBook(BaseModel):
 class ExitReason(str, Enum):
     STOP_LOSS = "STOP_LOSS"
     PROFIT_TARGET = "PROFIT_TARGET"
+    TRAILING_STOP = "TRAILING_STOP"
     EDGE_EROSION = "EDGE_EROSION"
     TIME_DECAY = "TIME_DECAY"
     DUST_CLEANUP = "DUST_CLEANUP"

--- a/auramaur/risk/exit_policy.py
+++ b/auramaur/risk/exit_policy.py
@@ -10,25 +10,42 @@ class ExitEconomics:
     gross_pnl_pct: float
     net_pnl_pct: float
     estimated_fees: float
+    # Reported, never charged — see binary_exit_economics. Kept so calibration
+    # can measure the entry leg without the exit gate paying for it.
+    entry_fee: float = 0.0
 
 
 def binary_exit_economics(
     *, entry_price: float, exit_price: float, size: float, fee_coefficient: float,
     is_long: bool = True,
 ) -> ExitEconomics:
-    """Return executable SELL economics for a long binary-token position."""
+    """Return executable SELL economics for a long binary-token position.
+
+    Only the EXIT fee is charged, because only the exit fee is ever realized.
+    ``broker/pnl.py`` books ``pnl = (fill.price - old_avg_cost) * size -
+    fill.fee`` — the exit leg alone — and builds the ``pnl_ledger`` event only
+    on the SELL branch, so the entry fee never reaches the ledger at all. The
+    BUY branch stores ``total_cost = price * size``, making ``avg_cost``
+    fee-EXCLUSIVE; nothing downstream ever recovers the entry fee.
+
+    Charging both legs here therefore made the gate demand a cost the
+    accounting does not record, holding every winner past its target by the
+    entry leg's drag. The entry fee is still computed and reported, so the
+    diagnostic survives without binding the decision.
+    """
     cost = entry_price * size
     if cost <= 0:
-        return ExitEconomics(0.0, 0.0, 0.0)
+        return ExitEconomics(0.0, 0.0, 0.0, 0.0)
     direction = 1.0 if is_long else -1.0
     gross = direction * (exit_price - entry_price) * size
     coefficient = max(0.0, fee_coefficient)
-    # Conservative when maker/taker ancestry is unavailable: reserve both
-    # sides at the taker schedule. Calibration sees the same economics.
+    # Conservative when maker/taker ancestry is unavailable: reserve the
+    # executable side at the taker schedule. Calibration sees the same
+    # economics.
     entry_fee = coefficient * entry_price * (1.0 - entry_price) * size
     exit_fee = coefficient * exit_price * (1.0 - exit_price) * size
-    fee = entry_fee + exit_fee
-    return ExitEconomics(gross / cost * 100.0, (gross - fee) / cost * 100.0, fee)
+    return ExitEconomics(gross / cost * 100.0, (gross - exit_fee) / cost * 100.0,
+                         exit_fee, entry_fee)
 
 
 def lifecycle_profit_target(
@@ -48,4 +65,16 @@ def trailing_stop_triggered(
     *, peak_pct: float, current_pct: float, activation_pct: float,
     giveback_fraction: float,
 ) -> bool:
+    """Trailing stop, where zero in EITHER knob means DISABLED.
+
+    Zero used to mean the opposite of off. ``activation_pct = 0`` arms the
+    stop against every non-negative peak, and ``giveback_fraction = 0``
+    reduces the second test to ``peak > current`` — together they sell every
+    position on its first adverse tick. ``Field(gt=0)`` only converted that
+    footgun into a startup crash, which is stricter than the neighbouring
+    ``stop_loss_pct`` / ``profit_target_pct`` and left an operator no way to
+    turn the tier off. Honour the intent instead: 0 disables.
+    """
+    if activation_pct <= 0 or giveback_fraction <= 0:
+        return False
     return peak_pct >= activation_pct and peak_pct - current_pct > peak_pct * giveback_fraction

--- a/auramaur/risk/exit_policy.py
+++ b/auramaur/risk/exit_policy.py
@@ -1,0 +1,51 @@
+"""Pure exit-policy economics shared by runtime and calibration code."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExitEconomics:
+    gross_pnl_pct: float
+    net_pnl_pct: float
+    estimated_fees: float
+
+
+def binary_exit_economics(
+    *, entry_price: float, exit_price: float, size: float, fee_coefficient: float,
+    is_long: bool = True,
+) -> ExitEconomics:
+    """Return executable SELL economics for a long binary-token position."""
+    cost = entry_price * size
+    if cost <= 0:
+        return ExitEconomics(0.0, 0.0, 0.0)
+    direction = 1.0 if is_long else -1.0
+    gross = direction * (exit_price - entry_price) * size
+    coefficient = max(0.0, fee_coefficient)
+    # Conservative when maker/taker ancestry is unavailable: reserve both
+    # sides at the taker schedule. Calibration sees the same economics.
+    entry_fee = coefficient * entry_price * (1.0 - entry_price) * size
+    exit_fee = coefficient * exit_price * (1.0 - exit_price) * size
+    fee = entry_fee + exit_fee
+    return ExitEconomics(gross / cost * 100.0, (gross - fee) / cost * 100.0, fee)
+
+
+def lifecycle_profit_target(
+    *, base_pct: float, early_pct: float, late_pct: float,
+    fraction_remaining: float | None, early_fraction: float, late_fraction: float,
+) -> float:
+    if fraction_remaining is None:
+        return base_pct
+    if fraction_remaining > early_fraction:
+        return early_pct
+    if fraction_remaining < late_fraction:
+        return late_pct
+    return base_pct
+
+
+def trailing_stop_triggered(
+    *, peak_pct: float, current_pct: float, activation_pct: float,
+    giveback_fraction: float,
+) -> bool:
+    return peak_pct >= activation_pct and peak_pct - current_pct > peak_pct * giveback_fraction

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -9,6 +9,12 @@ import structlog
 
 from auramaur.db.database import Database
 from auramaur.exchange.models import ExitReason, OrderSide, Position, TokenType
+from auramaur.risk.exit_policy import (
+    binary_exit_economics,
+    lifecycle_profit_target,
+    trailing_stop_triggered,
+)
+from auramaur.strategy.signals import taker_fee_rate
 
 log = structlog.get_logger()
 
@@ -438,6 +444,7 @@ class PortfolioTracker:
         peak_prices = await self._get_peak_prices()
         await self._prune_orphan_peaks()
         prices_updated = False
+        decisions_updated = False
 
         unmarkable: list[str] = []
         for pos in positions:
@@ -519,53 +526,90 @@ class PortfolioTracker:
                 exits.append((pos, ExitReason.STOP_LOSS))
                 continue
 
-            # 2. Trailing stop — if position was up 12%+ but has dropped
-            #    back 45%+ of peak gains, exit to lock in profit.
-            if peak_pnl_pct >= 12.0:
-                drawdown_from_peak = peak_pnl_pct - pnl_pct
-                if drawdown_from_peak > peak_pnl_pct * 0.45:
-                    log.info(
-                        "exit.trailing_stop",
-                        market_id=pos.market_id,
-                        peak_pnl=round(peak_pnl_pct, 1),
-                        current_pnl=round(pnl_pct, 1),
-                    )
-                    exits.append((pos, ExitReason.PROFIT_TARGET))
-                    continue
+            # 2. Trailing stop — config-driven so calibration can change policy
+            # without changing runtime code.
+            if trailing_stop_triggered(
+                peak_pct=peak_pnl_pct,
+                current_pct=pnl_pct,
+                activation_pct=settings.execution.trailing_stop_activation_pct,
+                giveback_fraction=settings.execution.trailing_stop_giveback_fraction,
+            ):
+                decisions_updated |= await self._record_exit_decision(
+                    pos, mode_flag, ExitReason.TRAILING_STOP.value,
+                    pnl_pct, pnl_pct, peak_pnl_pct, None, 0.0)
+                log.info(
+                    "exit.trailing_stop",
+                    market_id=pos.market_id,
+                    peak_pnl=round(peak_pnl_pct, 1),
+                    current_pnl=round(pnl_pct, 1),
+                )
+                exits.append((pos, ExitReason.TRAILING_STOP))
+                continue
 
             # 3. Profit target — time-aware: tighten near expiry, widen early
-            profit_target = settings.execution.profit_target_pct  # default +50%
+            fraction_remaining = None
             if market.end_date is not None:
                 end_dt = market.end_date if market.end_date.tzinfo else market.end_date.replace(tzinfo=timezone.utc)
                 now = datetime.now(timezone.utc)
-                # Look up when position was first entered
-                entry_sql = "SELECT MIN(timestamp) as first_entry FROM trades WHERE market_id = ?"
-                entry_params: list[object] = [pos.market_id]
-                if mode_flag is not None:
-                    entry_sql += " AND is_paper = ?"
-                    entry_params.append(mode_flag)
-                entry_row = await self.db.fetchone(entry_sql, tuple(entry_params))
-                if entry_row and entry_row["first_entry"]:
-                    entry_dt = datetime.fromisoformat(entry_row["first_entry"]).replace(tzinfo=timezone.utc)
-                else:
-                    entry_dt = now  # fallback: assume just entered
+                entry_dt = await self._current_position_entry_time(pos, mode_flag)
+                if entry_dt is None:
+                    entry_dt = now  # unknown age fails safe as newly entered
 
                 total_lifetime = (end_dt - entry_dt).total_seconds()
                 elapsed = (now - entry_dt).total_seconds()
 
                 if total_lifetime > 0:
-                    lifetime_fraction_remaining = 1.0 - (elapsed / total_lifetime)
-                    if lifetime_fraction_remaining > 0.50:
-                        # Early in position lifetime — let winners run
-                        profit_target = 75.0
-                    elif lifetime_fraction_remaining < 0.10:
-                        # Near expiry — take what you can
-                        profit_target = 25.0
-                    # else: keep default (50%)
+                    fraction_remaining = 1.0 - (elapsed / total_lifetime)
 
-            if pnl_pct >= profit_target:
+            profit_target = lifecycle_profit_target(
+                base_pct=settings.execution.profit_target_pct,
+                early_pct=settings.execution.profit_target_early_pct,
+                late_pct=settings.execution.profit_target_late_pct,
+                fraction_remaining=fraction_remaining,
+                early_fraction=settings.execution.profit_target_early_fraction_remaining,
+                late_fraction=settings.execution.profit_target_late_fraction_remaining,
+            )
+
+            binary_venue = exchange in (None, "polymarket", "kalshi", "cryptodotcom")
+            net_pnl_pct = pnl_pct
+            estimated_fees = 0.0
+            if binary_venue:
+                actual_fee_rate = getattr(market, "fee_rate", None)
+                if not isinstance(actual_fee_rate, (int, float)):
+                    actual_fee_rate = None
+                fees_enabled = getattr(market, "fees_enabled", None)
+                if not isinstance(fees_enabled, bool):
+                    fees_enabled = None
+                fee_coefficient = taker_fee_rate(
+                    exchange or pos.exchange, pos.category,
+                    settings.arbitrage.exchange_fees,
+                    actual_fee_rate=actual_fee_rate,
+                    fees_enabled=fees_enabled,
+                )
+                economics = binary_exit_economics(
+                    entry_price=pos.avg_price, exit_price=pos.current_price,
+                    size=pos.size, fee_coefficient=fee_coefficient,
+                    is_long=pos.side == OrderSide.BUY,
+                )
+                net_pnl_pct = economics.net_pnl_pct
+                estimated_fees = economics.estimated_fees
+
+            if net_pnl_pct >= profit_target:
+                decisions_updated |= await self._record_exit_decision(
+                    pos, mode_flag, ExitReason.PROFIT_TARGET.value,
+                    pnl_pct, net_pnl_pct, peak_pnl_pct, profit_target,
+                    estimated_fees)
+                log.info("exit.profit_target", market_id=pos.market_id,
+                         gross_pnl_pct=round(pnl_pct, 2),
+                         net_pnl_pct=round(net_pnl_pct, 2),
+                         estimated_fees=round(estimated_fees, 4),
+                         target_pct=profit_target)
                 exits.append((pos, ExitReason.PROFIT_TARGET))
                 continue
+
+            decisions_updated |= await self._record_exit_decision(
+                pos, mode_flag, "HOLD", pnl_pct, net_pnl_pct, peak_pnl_pct,
+                profit_target, estimated_fees)
 
             # Edge-erosion / capital-efficiency / time-decay assume binary 0-1
             # resolution semantics (price converges to $0 or $1). They're
@@ -573,7 +617,6 @@ class PortfolioTracker:
             # premiums aren't probabilities — so they only run for prediction
             # venues. Non-binary venues rely on the P&L-ratio exits above
             # (stop-loss / profit-target / trailing) plus dust cleanup below.
-            binary_venue = exchange in (None, "polymarket", "kalshi", "cryptodotcom")
             if binary_venue:
                 # 4. Edge erosion — price converging on resolution boundary
                 #    measures how much room is left for the position to pay out
@@ -632,7 +675,7 @@ class PortfolioTracker:
                     0.01 <= (pos.current_price or 0.0)
                     and pos.size >= min_size
                     and current_value < settings.execution.dust_max_notional
-                    and await self._position_age_hours(pos.market_id, mode_flag)
+                    and await self._position_age_hours(pos, mode_flag)
                         >= settings.execution.dust_min_age_hours
                 ):
                     log.info(
@@ -647,16 +690,74 @@ class PortfolioTracker:
         if unmarkable:
             await self._warn_unmarkable(exchange, unmarkable)
 
-        if prices_updated:
+        if prices_updated or decisions_updated:
             await self.db.commit()
 
         return exits
 
-    async def _position_age_hours(self, market_id: str, mode_flag: int | None) -> float:
+    @staticmethod
+    def _as_utc(value: str) -> datetime:
+        parsed = datetime.fromisoformat(value)
+        return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
+
+    async def _record_exit_decision(
+        self, pos, mode_flag: int | None, reason: str, gross_pct: float,
+        net_pct: float, peak_pct: float, target_pct: float | None,
+        estimated_fees: float,
+    ) -> bool:
+        """Best-effort observation; telemetry must never block a protective exit."""
+        try:
+            await self.db.execute(
+                """INSERT INTO exit_decisions
+                   (market_id, exchange, token, is_paper, policy_action,
+                    gross_pnl_pct, net_pnl_pct, peak_pnl_pct, target_pct,
+                    estimated_fees, current_price, entry_price, size)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (pos.market_id, pos.exchange,
+                 getattr(pos.token, "value", pos.token),
+                 1 if mode_flag is None else mode_flag, reason, gross_pct,
+                 net_pct, peak_pct, target_pct, estimated_fees,
+                 pos.current_price, pos.avg_price, pos.size),
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — never compromise exits
+            log.debug("exit.decision_record_failed", market_id=pos.market_id,
+                      error=str(exc))
+            return False
+
+    async def _current_position_entry_time(self, pos, mode_flag: int | None) -> datetime | None:
+        """Oldest fill still contributing to the current token inventory."""
+        mode = 1 if mode_flag is None else mode_flag
+        try:
+            row = await self.db.fetchone(
+                """WITH reverse_inventory AS (
+                       SELECT timestamp,
+                              SUM(CASE WHEN side = 'BUY' THEN size ELSE -size END)
+                                OVER (ORDER BY timestamp DESC, id DESC) AS qty
+                         FROM fills
+                        WHERE market_id = ? AND token = ? AND is_paper = ?)
+                   SELECT timestamp FROM reverse_inventory
+                    WHERE qty >= ? ORDER BY timestamp DESC LIMIT 1""",
+                (pos.market_id, getattr(pos.token, "value", pos.token), mode, pos.size),
+            )
+            if row and row["timestamp"]:
+                return self._as_utc(row["timestamp"])
+        except (ValueError, TypeError, KeyError):
+            return None
+        return None
+
+    async def _position_age_hours(self, pos, mode_flag: int | None) -> float:
         """Hours since the position's first recorded fill. Returns 0.0 when the
         entry time is unknown, so dust-sweep treats it as 'too new to touch'."""
+        current_entry = await self._current_position_entry_time(pos, mode_flag)
+        if current_entry is not None:
+            return ((datetime.now(timezone.utc) - current_entry).total_seconds()
+                    / 3600.0)
+        # Legacy fallback for databases whose old trades predate the fills
+        # ledger. It cannot distinguish tokens, so it is used only when no
+        # token-scoped fill ancestry exists.
         sql = "SELECT MIN(timestamp) AS first_entry FROM trades WHERE market_id = ?"
-        params: list[object] = [market_id]
+        params: list[object] = [pos.market_id]
         if mode_flag is not None:
             sql += " AND is_paper = ?"
             params.append(mode_flag)
@@ -664,7 +765,7 @@ class PortfolioTracker:
             row = await self.db.fetchone(sql, tuple(params))
             if not row or not row["first_entry"]:
                 return 0.0
-            entry_dt = datetime.fromisoformat(row["first_entry"]).replace(tzinfo=timezone.utc)
+            entry_dt = self._as_utc(row["first_entry"])
         except (ValueError, TypeError, KeyError):
             return 0.0
         return (datetime.now(timezone.utc) - entry_dt).total_seconds() / 3600.0

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -726,6 +726,12 @@ class PortfolioTracker:
          estimated_fees, current_price, entry_price, size)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
+    # Named so a test can plan the SHIPPED statement rather than a copy of it:
+    # this predicate must stay index-seekable, and only the real string proves
+    # it. See test_retention_prune_never_scans_the_exit_decision_table.
+    _EXIT_DECISION_PRUNE = (
+        "DELETE FROM exit_decisions WHERE observed_at < datetime('now', ?)")
+
     def _exit_decision_row(
         self, pos, mode_flag: int | None, reason: str, gross_pct: float,
         net_pct: float, peak_pct: float, target_pct: float | None,
@@ -764,9 +770,15 @@ class PortfolioTracker:
                 # candidate_dispositions: cheap when nothing has expired, and
                 # it cannot be missed by an interrupted deployment the way a
                 # separate cleanup job can.
+                #
+                # "Indexed" is load-bearing and was not free: the composite
+                # index leads with market_id, and this predicate constrains
+                # only observed_at, so it took a dedicated single-column index
+                # (idx_exit_decisions_observed_at) to make the seek possible.
+                # Without it this ran as a full scan of a table that gains rows
+                # every cycle, while holding the write lock on the exit path.
                 await self.db.execute(
-                    "DELETE FROM exit_decisions WHERE observed_at < datetime('now', ?)",
-                    (f"-{retention_days} days",))
+                    self._EXIT_DECISION_PRUNE, (f"-{retention_days} days",))
         except Exception as exc:  # noqa: BLE001 — never compromise exits
             log.debug("exit.decision_record_failed", count=len(rows), error=str(exc))
 

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -18,6 +18,10 @@ from auramaur.strategy.signals import taker_fee_rate
 
 log = structlog.get_logger()
 
+# Mirrors ExecutionConfig.exit_decision_retention_days; used when a caller's
+# settings object cannot supply a usable value (tests, degraded config).
+_DEFAULT_RETENTION_DAYS = 14
+
 
 class PortfolioTracker:
     """Reads and writes portfolio / daily-stats tables to provide exposure
@@ -444,7 +448,8 @@ class PortfolioTracker:
         peak_prices = await self._get_peak_prices()
         await self._prune_orphan_peaks()
         prices_updated = False
-        decisions_updated = False
+        # Accumulated, never written inside the loop: see _record_exit_decisions.
+        decisions: list[tuple] = []
 
         unmarkable: list[str] = []
         for pos in positions:
@@ -534,9 +539,9 @@ class PortfolioTracker:
                 activation_pct=settings.execution.trailing_stop_activation_pct,
                 giveback_fraction=settings.execution.trailing_stop_giveback_fraction,
             ):
-                decisions_updated |= await self._record_exit_decision(
+                decisions.append(self._exit_decision_row(
                     pos, mode_flag, ExitReason.TRAILING_STOP.value,
-                    pnl_pct, pnl_pct, peak_pnl_pct, None, 0.0)
+                    pnl_pct, pnl_pct, peak_pnl_pct, None, 0.0))
                 log.info(
                     "exit.trailing_stop",
                     market_id=pos.market_id,
@@ -553,7 +558,13 @@ class PortfolioTracker:
                 now = datetime.now(timezone.utc)
                 entry_dt = await self._current_position_entry_time(pos, mode_flag)
                 if entry_dt is None:
-                    entry_dt = now  # unknown age fails safe as newly entered
+                    # Last resort only — fills, then trades, are consulted
+                    # first. This branch pins fraction_remaining at exactly 1.0
+                    # on EVERY tick, so the target is frozen in its widest band
+                    # and the near-expiry band is permanently unreachable. It
+                    # is safe (wide, never premature) but it is not free, which
+                    # is why the trades fallback exists.
+                    entry_dt = now
 
                 total_lifetime = (end_dt - entry_dt).total_seconds()
                 elapsed = (now - entry_dt).total_seconds()
@@ -595,10 +606,10 @@ class PortfolioTracker:
                 estimated_fees = economics.estimated_fees
 
             if net_pnl_pct >= profit_target:
-                decisions_updated |= await self._record_exit_decision(
+                decisions.append(self._exit_decision_row(
                     pos, mode_flag, ExitReason.PROFIT_TARGET.value,
                     pnl_pct, net_pnl_pct, peak_pnl_pct, profit_target,
-                    estimated_fees)
+                    estimated_fees))
                 log.info("exit.profit_target", market_id=pos.market_id,
                          gross_pnl_pct=round(pnl_pct, 2),
                          net_pnl_pct=round(net_pnl_pct, 2),
@@ -607,9 +618,9 @@ class PortfolioTracker:
                 exits.append((pos, ExitReason.PROFIT_TARGET))
                 continue
 
-            decisions_updated |= await self._record_exit_decision(
+            decisions.append(self._exit_decision_row(
                 pos, mode_flag, "HOLD", pnl_pct, net_pnl_pct, peak_pnl_pct,
-                profit_target, estimated_fees)
+                profit_target, estimated_fees))
 
             # Edge-erosion / capital-efficiency / time-decay assume binary 0-1
             # resolution semantics (price converges to $0 or $1). They're
@@ -690,8 +701,17 @@ class PortfolioTracker:
         if unmarkable:
             await self._warn_unmarkable(exchange, unmarkable)
 
-        if prices_updated or decisions_updated:
+        if prices_updated:
             await self.db.commit()
+
+        # After every exit is decided, so nothing here can hold one up. A
+        # malformed retention setting must not disable pruning, so it degrades
+        # to the tracked default rather than to "keep everything".
+        retention = getattr(
+            settings.execution, "exit_decision_retention_days", _DEFAULT_RETENTION_DAYS)
+        if not isinstance(retention, int) or isinstance(retention, bool) or retention < 1:
+            retention = _DEFAULT_RETENTION_DAYS
+        await self._record_exit_decisions(decisions, retention)
 
         return exits
 
@@ -700,75 +720,153 @@ class PortfolioTracker:
         parsed = datetime.fromisoformat(value)
         return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
 
-    async def _record_exit_decision(
+    _EXIT_DECISION_INSERT = """INSERT INTO exit_decisions
+        (market_id, exchange, token, is_paper, policy_action,
+         gross_pnl_pct, net_pnl_pct, peak_pnl_pct, target_pct,
+         estimated_fees, current_price, entry_price, size)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+
+    def _exit_decision_row(
         self, pos, mode_flag: int | None, reason: str, gross_pct: float,
         net_pct: float, peak_pct: float, target_pct: float | None,
         estimated_fees: float,
-    ) -> bool:
-        """Best-effort observation; telemetry must never block a protective exit."""
+    ) -> tuple:
+        """Build one observation. Pure: no I/O, so it cannot touch the exit."""
+        mode = self._position_mode(pos, mode_flag)
+        return (pos.market_id, pos.exchange,
+                getattr(pos.token, "value", pos.token),
+                # The column is NOT NULL; a position that cannot name its book
+                # takes the schema's own paper default rather than claiming to
+                # be live.
+                1 if mode is None else mode, reason, gross_pct,
+                net_pct, peak_pct, target_pct, estimated_fees,
+                pos.current_price, pos.avg_price, pos.size)
+
+    async def _record_exit_decisions(self, rows: list[tuple], retention_days: int) -> None:
+        """Write one cycle's exit-policy observations as a single batch.
+
+        Deliberately OFF the money path. Written inline, this took the shared
+        serialized write lock once per evaluated position — and the HOLD branch
+        observes every non-exiting position on every tick, so a full book cost
+        hundreds of lock acquisitions per cycle on the path that closes
+        positions. One ``executemany`` after the loop costs one, and by then
+        every exit decision is already in the returned list.
+
+        A telemetry write must never prevent a position from closing, so the
+        whole batch stays contained: callers ignore the outcome.
+        """
+        if not rows:
+            return
         try:
-            await self.db.execute(
-                """INSERT INTO exit_decisions
-                   (market_id, exchange, token, is_paper, policy_action,
-                    gross_pnl_pct, net_pnl_pct, peak_pnl_pct, target_pct,
-                    estimated_fees, current_price, entry_price, size)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (pos.market_id, pos.exchange,
-                 getattr(pos.token, "value", pos.token),
-                 1 if mode_flag is None else mode_flag, reason, gross_pct,
-                 net_pct, peak_pct, target_pct, estimated_fees,
-                 pos.current_price, pos.avg_price, pos.size),
-            )
-            return True
+            async with self.db.transaction(owner="portfolio.exit_decisions"):
+                await self.db.executemany(self._EXIT_DECISION_INSERT, rows)
+                # Bounded delete per cycle on the indexed time column, matching
+                # candidate_dispositions: cheap when nothing has expired, and
+                # it cannot be missed by an interrupted deployment the way a
+                # separate cleanup job can.
+                await self.db.execute(
+                    "DELETE FROM exit_decisions WHERE observed_at < datetime('now', ?)",
+                    (f"-{retention_days} days",))
         except Exception as exc:  # noqa: BLE001 — never compromise exits
-            log.debug("exit.decision_record_failed", market_id=pos.market_id,
-                      error=str(exc))
-            return False
+            log.debug("exit.decision_record_failed", count=len(rows), error=str(exc))
+
+    # Fill sizes accumulate through float arithmetic, so a reverse-inventory
+    # sum that should equal the stored size can land a few ULPs below it. An
+    # exact ``qty >= size`` then reports NO ancestry for a position whose fills
+    # plainly cover it.
+    _SIZE_TOLERANCE = 1e-6
+
+    @staticmethod
+    def _position_mode(pos, mode_flag: int | None) -> int | None:
+        """The book to scope a per-position read to, or None for unscoped.
+
+        ``mode_flag`` is None when ``settings.is_live`` is not a bool and the
+        tracker holds no settings of its own — ``get_positions`` is then
+        UNSCOPED and its list can hold BOTH books. A real ``Settings.is_live``
+        ANDs three bools and so always is one (with the kill switch armed it
+        is False, which scopes the read to paper rather than unscoping it), so
+        this is the duck-typed/no-settings path rather than a live-trading one.
+
+        It still must not hardcode a book. ``1 if mode_flag is None else
+        mode_flag`` answered a LIVE position's history off the PAPER ledger,
+        silently and with no way for the caller to notice. Since #420 a
+        Position carries ``is_paper``, so ask the position; only one that
+        cannot answer falls back to an unscoped read, which is imprecise for
+        everyone rather than wrong for live.
+        """
+        if mode_flag is not None:
+            return mode_flag
+        is_paper = getattr(pos, "is_paper", None)
+        if isinstance(is_paper, bool):
+            return int(is_paper)
+        return None
 
     async def _current_position_entry_time(self, pos, mode_flag: int | None) -> datetime | None:
-        """Oldest fill still contributing to the current token inventory."""
-        mode = 1 if mode_flag is None else mode_flag
+        """When the currently-held inventory was entered.
+
+        Preferred source is the oldest fill still contributing to the current
+        ``(market, token, book)`` inventory: old round trips and opposite
+        tokens do not age a re-entry.
+
+        A miss falls back to the market's first trade rather than reporting
+        nothing. Positions predating the fills ledger, and live rows owned by a
+        venue mirror that never wrote fills, have no fill ancestry at all —
+        and an unknown entry time pins ``fraction_remaining`` at 1.0 forever,
+        which freezes the profit target in its widest band and makes the
+        near-expiry band unreachable. The fallback cannot be token-scoped
+        (``trades`` has no token column, as ``broker/ledger.py`` also notes),
+        so it is market-and-book scoped: coarser than the fills path, but
+        strictly more information than ``None``.
+
+        ``cost_basis`` is deliberately NOT used here despite being the
+        authoritative holdings table: its only timestamp is ``updated_at``,
+        stamped on every write, so it records when inventory last moved, not
+        when it was entered.
+        """
+        mode = self._position_mode(pos, mode_flag)
+        scope = ""
+        params: list[object] = [pos.market_id, getattr(pos.token, "value", pos.token)]
+        if mode is not None:
+            scope = " AND is_paper = ?"
+            params.append(mode)
         try:
             row = await self.db.fetchone(
-                """WITH reverse_inventory AS (
+                f"""WITH reverse_inventory AS (
                        SELECT timestamp,
                               SUM(CASE WHEN side = 'BUY' THEN size ELSE -size END)
                                 OVER (ORDER BY timestamp DESC, id DESC) AS qty
                          FROM fills
-                        WHERE market_id = ? AND token = ? AND is_paper = ?)
+                        WHERE market_id = ? AND token = ?{scope})
                    SELECT timestamp FROM reverse_inventory
                     WHERE qty >= ? ORDER BY timestamp DESC LIMIT 1""",
-                (pos.market_id, getattr(pos.token, "value", pos.token), mode, pos.size),
+                tuple([*params, pos.size - self._SIZE_TOLERANCE]),
             )
             if row and row["timestamp"]:
                 return self._as_utc(row["timestamp"])
+        except (ValueError, TypeError, KeyError):
+            pass  # fall through to the trades ledger
+
+        sql = "SELECT MIN(timestamp) AS first_entry FROM trades WHERE market_id = ?"
+        trade_params: list[object] = [pos.market_id]
+        if mode is not None:
+            sql += " AND is_paper = ?"
+            trade_params.append(mode)
+        try:
+            row = await self.db.fetchone(sql, tuple(trade_params))
+            if row and row["first_entry"]:
+                return self._as_utc(row["first_entry"])
         except (ValueError, TypeError, KeyError):
             return None
         return None
 
     async def _position_age_hours(self, pos, mode_flag: int | None) -> float:
-        """Hours since the position's first recorded fill. Returns 0.0 when the
+        """Hours since the current inventory was entered. Returns 0.0 when the
         entry time is unknown, so dust-sweep treats it as 'too new to touch'."""
         current_entry = await self._current_position_entry_time(pos, mode_flag)
-        if current_entry is not None:
-            return ((datetime.now(timezone.utc) - current_entry).total_seconds()
-                    / 3600.0)
-        # Legacy fallback for databases whose old trades predate the fills
-        # ledger. It cannot distinguish tokens, so it is used only when no
-        # token-scoped fill ancestry exists.
-        sql = "SELECT MIN(timestamp) AS first_entry FROM trades WHERE market_id = ?"
-        params: list[object] = [pos.market_id]
-        if mode_flag is not None:
-            sql += " AND is_paper = ?"
-            params.append(mode_flag)
-        try:
-            row = await self.db.fetchone(sql, tuple(params))
-            if not row or not row["first_entry"]:
-                return 0.0
-            entry_dt = self._as_utc(row["first_entry"])
-        except (ValueError, TypeError, KeyError):
+        if current_entry is None:
             return 0.0
-        return (datetime.now(timezone.utc) - entry_dt).total_seconds() / 3600.0
+        return ((datetime.now(timezone.utc) - current_entry).total_seconds()
+                / 3600.0)
 
     @staticmethod
     def _peak_key(pos, mode_flag: int | None) -> str:

--- a/auramaur/strategy/ibkr_multiasset_paper.py
+++ b/auramaur/strategy/ibkr_multiasset_paper.py
@@ -434,6 +434,15 @@ class IBKRMultiAssetPaperBook:
                     gain_pct = (quote.bid / entry - 1) * 100
                     pnl = ((quote.bid - entry) * float(held["quantity"])
                            * quote.multiplier * mark_fx)
+                    exit_notional = (quote.bid * float(held["quantity"])
+                                     * quote.multiplier * mark_fx)
+                    exit_commission = self._commission(
+                        spec, float(held["quantity"]), exit_notional)
+                    entry_commission = float(held["entry_commission_usd"] or 0)
+                    basis_usd = (entry * float(held["quantity"])
+                                 * quote.multiplier * mark_fx)
+                    net_gain_pct = ((pnl - entry_commission - exit_commission)
+                                    / basis_usd * 100 if basis_usd > 0 else gain_pct)
                     await self._db.execute(
                         """UPDATE ibkr_paper_positions SET current_price=?,
                            unrealized_pnl_usd=?, price_source=?, updated_at=datetime('now')
@@ -443,7 +452,7 @@ class IBKRMultiAssetPaperBook:
                     stored_stop = float(held["stop_price"] or 0)
                     hard_exit = ((stored_stop > 0 and quote.bid <= stored_stop)
                                  or gain_pct <= -cfg.stop_loss_pct
-                                 or gain_pct >= cfg.take_profit_pct)
+                                 or net_gain_pct >= cfg.take_profit_pct)
                     momentum_exit = False
                     if not hard_exit:
                         bars = await self._client.get_daily_bars_by_con_id(spec, held_con_id)

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -34,8 +34,10 @@ execution:
   profit_target_late_pct: 25.0
   profit_target_early_fraction_remaining: 0.50
   profit_target_late_fraction_remaining: 0.10
+  # Set either to 0 to disable the trailing tier entirely.
   trailing_stop_activation_pct: 12.0
   trailing_stop_giveback_fraction: 0.45
+  exit_decision_retention_days: 14
   edge_erosion_min_pct: 2.0
   time_decay_hours: 12.0
   # Free capital from near-certain winners far from resolution (sell early to

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -29,6 +29,13 @@ execution:
   spread_capture_min_bps: 50
   stop_loss_pct: 30.0
   profit_target_pct: 50.0
+  # Lifecycle bands remain behavior-compatible, but are explicit and calibratable.
+  profit_target_early_pct: 75.0
+  profit_target_late_pct: 25.0
+  profit_target_early_fraction_remaining: 0.50
+  profit_target_late_fraction_remaining: 0.10
+  trailing_stop_activation_pct: 12.0
+  trailing_stop_giveback_fraction: 0.45
   edge_erosion_min_pct: 2.0
   time_decay_hours: 12.0
   # Free capital from near-certain winners far from resolution (sell early to

--- a/config/settings.py
+++ b/config/settings.py
@@ -185,8 +185,14 @@ class ExecutionConfig(BaseModel):
     profit_target_late_pct: float = Field(default=25.0, gt=0)
     profit_target_early_fraction_remaining: float = Field(default=0.50, ge=0, le=1)
     profit_target_late_fraction_remaining: float = Field(default=0.10, ge=0, le=1)
-    trailing_stop_activation_pct: float = Field(default=12.0, gt=0)
-    trailing_stop_giveback_fraction: float = Field(default=0.45, gt=0, le=1)
+    # ge=0, not gt=0: zero is how an operator turns the trailing tier OFF, and
+    # `trailing_stop_triggered` honours that. Rejecting it crashed startup for
+    # a setting the neighbouring stop_loss_pct/profit_target_pct accept freely.
+    trailing_stop_activation_pct: float = Field(default=12.0, ge=0)
+    trailing_stop_giveback_fraction: float = Field(default=0.45, ge=0, le=1)
+    # Exit-decision telemetry is an observation log, not evidence of record;
+    # bound it so a holdout cannot grow the trading DB without limit.
+    exit_decision_retention_days: int = Field(default=14, ge=1, le=365)
     edge_erosion_min_pct: float = 2.0
     time_decay_hours: float = 12.0
     # Free capital from near-certain winners that are still far from resolution:

--- a/config/settings.py
+++ b/config/settings.py
@@ -181,6 +181,12 @@ class ExecutionConfig(BaseModel):
     book_capacity_fraction: float = 0.5
     stop_loss_pct: float = 30.0
     profit_target_pct: float = 50.0
+    profit_target_early_pct: float = Field(default=75.0, gt=0)
+    profit_target_late_pct: float = Field(default=25.0, gt=0)
+    profit_target_early_fraction_remaining: float = Field(default=0.50, ge=0, le=1)
+    profit_target_late_fraction_remaining: float = Field(default=0.10, ge=0, le=1)
+    trailing_stop_activation_pct: float = Field(default=12.0, gt=0)
+    trailing_stop_giveback_fraction: float = Field(default=0.45, gt=0, le=1)
     edge_erosion_min_pct: float = 2.0
     time_decay_hours: float = 12.0
     # Free capital from near-certain winners that are still far from resolution:

--- a/docs/take-profit-policy.md
+++ b/docs/take-profit-policy.md
@@ -1,0 +1,23 @@
+# Take-profit policy
+
+The shared portfolio monitor evaluates exits in this order: stop loss,
+configurable trailing stop, fee-net lifecycle profit target, binary-market
+capital-efficiency rules, then dust cleanup.
+
+Position age comes from the oldest fill still contributing to the current
+`(market, token, paper/live)` inventory. Old round trips and opposite tokens do
+not affect a re-entry's lifecycle target. A missing fill history is treated as
+a new position, which widens rather than prematurely tightens the target.
+
+Every profit-target evaluation writes an `exit_decisions` observation whose
+`policy_action` describes this policy component, not necessarily the later
+capital-efficiency or time-decay decision. These
+records are measurement data, not permission to tune against the same sample.
+Run `python scripts/calibrate_exit_policy.py auramaur.db`; it uses an oldest-70%
+training/newest-30% holdout split and refuses to recommend changes below the
+minimum sample. Threshold changes remain manual and reviewable in
+`config/defaults.yaml`.
+
+Asset semantics remain intentionally distinct: binary venues use the
+`rate * price * (1-price)` round-trip taker-fee model, IBKR uses executable bid and explicit
+commissions, and Kraken retains its percentage fee/slippage model.

--- a/docs/take-profit-policy.md
+++ b/docs/take-profit-policy.md
@@ -4,20 +4,79 @@ The shared portfolio monitor evaluates exits in this order: stop loss,
 configurable trailing stop, fee-net lifecycle profit target, binary-market
 capital-efficiency rules, then dust cleanup.
 
-Position age comes from the oldest fill still contributing to the current
-`(market, token, paper/live)` inventory. Old round trips and opposite tokens do
-not affect a re-entry's lifecycle target. A missing fill history is treated as
-a new position, which widens rather than prematurely tightens the target.
+## Only the exit fee is charged
 
-Every profit-target evaluation writes an `exit_decisions` observation whose
-`policy_action` describes this policy component, not necessarily the later
-capital-efficiency or time-decay decision. These
-records are measurement data, not permission to tune against the same sample.
-Run `python scripts/calibrate_exit_policy.py auramaur.db`; it uses an oldest-70%
-training/newest-30% holdout split and refuses to recommend changes below the
-minimum sample. Threshold changes remain manual and reviewable in
+The binary profit gate nets off the **exit** fee alone. That is not an
+approximation — it is what the accounting does. `broker/pnl.py` realizes
+`(fill.price - old_avg_cost) * size - fill.fee` on the SELL branch and builds
+the `pnl_ledger` event only there; the BUY branch stores
+`total_cost = price * size`, so `avg_cost` is fee-exclusive and the entry fee
+never reaches the ledger at all. A gate that charged both legs demanded a cost
+the books never record, holding every winner past its target by the entry
+leg's drag. The entry fee is still computed and reported on `ExitEconomics`
+as a diagnostic, so calibration can see it without it binding the decision.
+
+## Position age
+
+Age resolves in three steps, most specific first:
+
+1. the oldest fill still contributing to the current
+   `(market, token, paper/live)` inventory — old round trips and the opposite
+   token do not age a re-entry;
+2. failing that, the market's first `trades` row, scoped to the same book.
+   `trades` has no token column, so this leg cannot be token-scoped; it is
+   coarser than the fills path but strictly more information than nothing;
+3. failing that, "just entered".
+
+Step 2 exists because step 3 is not free. Positions predating the fills ledger,
+and live rows a venue mirror created without ever writing a fill, have no
+reverse-inventory answer — and an unknown entry time pins `fraction_remaining`
+at exactly 1.0 on every tick, freezing the target in its widest band and making
+the near-expiry band permanently unreachable. The fills comparison also carries
+a small size tolerance, because summed fill quantities land a few ULPs below
+the stored size often enough to erase a position's whole ancestry.
+
+`cost_basis` is deliberately not consulted here. It is the authoritative
+holdings table, but its only timestamp is `updated_at`, stamped on every write:
+it records when inventory last moved, not when it was entered.
+
+## Trailing stop
+
+`trailing_stop_activation_pct` and `trailing_stop_giveback_fraction` are both
+calibratable, and **0 in either disables the tier**. Without that guard zero
+meant the opposite of off: a zero activation arms the stop against every
+non-negative peak, and a zero giveback reduces the test to `peak > current`, so
+"disabled" would have sold every position on its first adverse tick.
+
+## Decision telemetry
+
+Every profit-target evaluation contributes an `exit_decisions` observation
+whose `policy_action` describes this policy component, not necessarily the
+later capital-efficiency or time-decay decision.
+
+The observations are accumulated during the cycle and written **after** every
+exit has been decided, as a single `executemany`. This is deliberate: the HOLD
+branch observes every non-exiting position on every tick, so writing inline
+took the shared serialized write lock hundreds of times per cycle on the path
+that closes positions. A failure in the batch is contained and ignored —
+telemetry must never be able to keep a position open.
+
+Rows are pruned to `execution.exit_decision_retention_days` (default 14) by a
+bounded per-cycle delete on the indexed time column, following the same pattern
+as `candidate_dispositions`. HOLD rows are kept rather than dropped because
+they are the counterfactual: a calibration that sees only exits cannot say what
+a different threshold would have done. Lower the retention if the volume
+outweighs that.
+
+These records are measurement data, not permission to tune against the same
+sample. Run `python scripts/calibrate_exit_policy.py auramaur.db`; it uses an
+oldest-70% training/newest-30% holdout split and refuses to recommend changes
+below the minimum sample. Threshold changes remain manual and reviewable in
 `config/defaults.yaml`.
 
+## Venue semantics
+
 Asset semantics remain intentionally distinct: binary venues use the
-`rate * price * (1-price)` round-trip taker-fee model, IBKR uses executable bid and explicit
-commissions, and Kraken retains its percentage fee/slippage model.
+`rate * price * (1-price)` taker-fee model on the executable exit leg, IBKR
+uses the executable bid and its two explicit commissions (both known exactly,
+so both are charged), and Kraken retains its percentage fee/slippage model.

--- a/scripts/calibrate_exit_policy.py
+++ b/scripts/calibrate_exit_policy.py
@@ -1,0 +1,70 @@
+"""Chronological exit-policy audit; never mutates config or the database.
+
+Usage: python scripts/calibrate_exit_policy.py auramaur.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+
+
+MIN_TRAIN_EXITS = 30
+MIN_TEST_EXITS = 15
+
+
+def load(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute("""
+        SELECT d.observed_at, d.exchange, d.policy_action, d.net_pnl_pct,
+               d.peak_pnl_pct, d.target_pct, d.market_id, d.token, d.is_paper,
+               COALESCE((SELECT SUM(l.pnl) FROM pnl_ledger l
+                         WHERE l.market_id=d.market_id AND l.token=d.token
+                           AND l.is_paper=d.is_paper
+                           AND l.realized_at >= d.observed_at), 0) AS realized_pnl
+          FROM exit_decisions d
+         WHERE d.policy_action <> 'HOLD'
+         ORDER BY d.observed_at, d.id
+    """).fetchall()
+
+
+def summarize(label: str, rows: list[sqlite3.Row]) -> None:
+    groups: dict[tuple[str, str], list[sqlite3.Row]] = defaultdict(list)
+    for row in rows:
+        groups[(row["exchange"], row["policy_action"])].append(row)
+    print(f"\n{label}: {len(rows)} exits")
+    for (venue, reason), values in sorted(groups.items()):
+        pnl = sum(float(v["realized_pnl"]) for v in values)
+        net = sum(float(v["net_pnl_pct"]) for v in values) / len(values)
+        print(f"  {venue or 'unknown':14} {reason:16} n={len(values):4} "
+              f"mean_net_at_decision={net:+7.2f}% realized=${pnl:+9.2f}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("database", type=Path)
+    args = parser.parse_args()
+    uri = f"file:{args.database.resolve().as_posix()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = load(conn)
+        except sqlite3.OperationalError as exc:
+            print(f"No exit telemetry yet: {exc}")
+            return 2
+    cut = int(len(rows) * 0.7)
+    train, test = rows[:cut], rows[cut:]
+    summarize("TRAIN (oldest 70%)", train)
+    summarize("HOLDOUT (newest 30%)", test)
+    if len(train) < MIN_TRAIN_EXITS or len(test) < MIN_TEST_EXITS:
+        print("\nNO RECOMMENDATION: insufficient chronological evidence "
+              f"(need {MIN_TRAIN_EXITS} train and {MIN_TEST_EXITS} holdout exits).")
+        return 2
+    print("\nEvidence threshold met. Compare policy candidates in TRAIN, then accept "
+          "only candidates whose direction and net result persist in HOLDOUT.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_exit_policy.py
+++ b/tests/test_exit_policy.py
@@ -1,9 +1,14 @@
+import ast
+import inspect
+import re
+import textwrap
 from datetime import timezone
 from types import SimpleNamespace
 
 import pytest
 
 from auramaur.db.database import Database
+from auramaur.db.models import SCHEMA_VERSION
 from auramaur.exchange.models import TokenType
 from auramaur.risk.exit_policy import (
     binary_exit_economics,
@@ -13,12 +18,24 @@ from auramaur.risk.exit_policy import (
 from auramaur.risk.portfolio import PortfolioTracker
 
 
-def test_binary_profit_is_net_of_executable_exit_fee():
+def test_binary_profit_is_net_of_the_executable_exit_fee_only():
+    """Only the exit fee is charged, because only the exit fee is realized.
+
+    ``broker/pnl.py`` realizes ``(price - avg_cost) * size - fee`` on the SELL
+    branch and builds the ledger event only there, so ``avg_cost`` is
+    fee-exclusive and the entry fee never reaches ``pnl_ledger``. Charging it
+    in the gate demanded a cost the accounting never records.
+    """
     result = binary_exit_economics(
         entry_price=0.40, exit_price=0.60, size=10, fee_coefficient=0.25)
     assert result.gross_pnl_pct == pytest.approx(50.0)
-    assert result.estimated_fees == pytest.approx(1.20)
-    assert result.net_pnl_pct == pytest.approx(20.0)
+    # 0.25 * 0.60 * 0.40 * 10 — the exit leg alone.
+    assert result.estimated_fees == pytest.approx(0.60)
+    assert result.net_pnl_pct == pytest.approx(35.0)
+    # The entry leg survives as a diagnostic, and is NOT netted off.
+    assert result.entry_fee == pytest.approx(0.60)
+    assert result.net_pnl_pct == pytest.approx(
+        result.gross_pnl_pct - result.estimated_fees / (0.40 * 10) * 100)
 
     short = binary_exit_economics(
         entry_price=0.60, exit_price=0.40, size=10,
@@ -36,29 +53,72 @@ def test_lifecycle_bands_and_trailing_policy_are_pure_and_configurable():
                                    activation_pct=12, giveback_fraction=0.45)
 
 
+def test_zero_disables_the_trailing_stop_instead_of_arming_it():
+    """Zero in either knob must mean OFF, not 'fire on the first downtick'.
+
+    Unguarded, ``activation_pct = 0`` arms the tier against every non-negative
+    peak and ``giveback_fraction = 0`` reduces the giveback test to
+    ``peak > current`` — so an operator disabling the tier would have got the
+    most aggressive possible trailing stop instead.
+    """
+    armed = dict(peak_pct=50.0, current_pct=49.0)
+    assert not trailing_stop_triggered(
+        activation_pct=0.0, giveback_fraction=0.45, **armed)
+    assert not trailing_stop_triggered(
+        activation_pct=12.0, giveback_fraction=0.0, **armed)
+    assert not trailing_stop_triggered(
+        activation_pct=0.0, giveback_fraction=0.0, **armed)
+    # And the configured tier is unaffected by the guard.
+    assert trailing_stop_triggered(peak_pct=50.0, current_pct=10.0,
+                                   activation_pct=12.0, giveback_fraction=0.45)
+
+
+def test_config_accepts_zero_for_both_trailing_knobs():
+    """``Field(gt=0)`` turned "disable the trailing stop" into a startup crash,
+    stricter than the neighbouring stop_loss_pct / profit_target_pct."""
+    from config.settings import ExecutionConfig
+
+    cfg = ExecutionConfig(trailing_stop_activation_pct=0.0,
+                          trailing_stop_giveback_fraction=0.0)
+    assert cfg.trailing_stop_activation_pct == 0.0
+    assert cfg.trailing_stop_giveback_fraction == 0.0
+
+
+async def _seed_fills(db, rows):
+    for order_id, token, side, size, paper, timestamp in rows:
+        await db.execute(
+            """INSERT INTO fills
+               (order_id, market_id, token, side, size, price, is_paper, timestamp)
+               VALUES (?, 'M1', ?, ?, ?, 0.5, ?, ?)""",
+            (order_id, token, side, size, paper, timestamp))
+    await db.commit()
+
+
 @pytest.mark.asyncio
 async def test_current_entry_uses_only_inventory_surviving_reentry(tmp_path):
+    """Old round trips, the opposite token and the other book must not age the
+    current inventory — even when they are NEWER than the entry we want.
+
+    The ordering matters: the reverse-inventory walk starts at the newest fill,
+    so a fixture whose newest fill is already the answer cannot detect a lost
+    token or mode scope. Here both contaminants sit after the real entry, so
+    dropping either scope returns a visibly different timestamp.
+    """
     db = Database(str(tmp_path / "entry-age.db"))
     await db.connect()
     try:
-        # Old round trip, then the current position. NO and live fills must not
-        # contaminate the paper YES inventory clock.
-        rows = [
+        await _seed_fills(db, [
             ("old-buy", "YES", "BUY", 10, 1, "2026-01-01T00:00:00+00:00"),
             ("old-sell", "YES", "SELL", 10, 1, "2026-01-02T00:00:00+00:00"),
-            ("no-buy", "NO", "BUY", 20, 1, "2026-02-01T00:00:00+00:00"),
-            ("live-buy", "YES", "BUY", 20, 0, "2026-03-01T00:00:00+00:00"),
+            # The entry that actually opened the held paper YES inventory.
             ("new-buy", "YES", "BUY", 5, 1, "2026-04-01T12:00:00+02:00"),
-        ]
-        for order_id, token, side, size, paper, timestamp in rows:
-            await db.execute(
-                """INSERT INTO fills
-                   (order_id, market_id, token, side, size, price, is_paper, timestamp)
-                   VALUES (?, 'M1', ?, ?, ?, 0.5, ?, ?)""",
-                (order_id, token, side, size, paper, timestamp))
-        await db.commit()
+            # Newer, and each large enough to satisfy qty >= size on its own.
+            ("no-buy", "NO", "BUY", 20, 1, "2026-05-01T00:00:00+00:00"),
+            ("live-buy", "YES", "BUY", 20, 0, "2026-06-01T00:00:00+00:00"),
+        ])
         tracker = PortfolioTracker(db)
-        pos = SimpleNamespace(market_id="M1", token=TokenType.YES, size=5)
+        pos = SimpleNamespace(market_id="M1", token=TokenType.YES, size=5,
+                              is_paper=True)
         entered = await tracker._current_position_entry_time(pos, 1)
         assert entered.isoformat() == "2026-04-01T10:00:00+00:00"
         assert entered.tzinfo == timezone.utc
@@ -67,7 +127,98 @@ async def test_current_entry_uses_only_inventory_surviving_reentry(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_v49_migration_adds_exit_decision_telemetry(tmp_path):
+async def test_entry_time_falls_back_to_trades_when_no_fill_ancestry(tmp_path):
+    """No fill ancestry must not read as "entered just now".
+
+    Positions predating the fills ledger — and live rows a venue mirror
+    created without ever writing a fill — have no reverse-inventory answer.
+    Returning None there pins ``fraction_remaining`` at exactly 1.0 on every
+    tick, so the profit target freezes in its widest band and the near-expiry
+    band becomes permanently unreachable.
+    """
+    db = Database(str(tmp_path / "trades-fallback.db"))
+    await db.connect()
+    try:
+        for stamp in ("2026-02-01T00:00:00+00:00", "2026-03-01T00:00:00+00:00"):
+            await db.execute(
+                """INSERT INTO trades
+                   (market_id, timestamp, side, size, price, is_paper)
+                   VALUES ('M1', ?, 'BUY', 10, 0.5, 1)""", (stamp,))
+        await db.commit()
+        tracker = PortfolioTracker(db)
+        pos = SimpleNamespace(market_id="M1", token=TokenType.YES, size=10,
+                              is_paper=True)
+        entered = await tracker._current_position_entry_time(pos, 1)
+        assert entered is not None, "an old position must not read as brand new"
+        assert entered.isoformat() == "2026-02-01T00:00:00+00:00"
+
+        # The fallback is still book-scoped: the live book has no trades here.
+        live = SimpleNamespace(market_id="M1", token=TokenType.YES, size=10,
+                               is_paper=False)
+        assert await tracker._current_position_entry_time(live, 0) is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fills_a_hair_short_of_the_stored_size_still_count(tmp_path):
+    """Float accumulation must not erase a position's whole fill ancestry.
+
+    0.7 + 0.1 is 0.7999999999999999 in IEEE-754, so an exact ``qty >= 0.8``
+    reports NO ancestry for a position whose fills plainly cover it.
+    """
+    db = Database(str(tmp_path / "epsilon.db"))
+    await db.connect()
+    try:
+        await _seed_fills(db, [
+            ("a", "YES", "BUY", 0.7, 1, "2026-01-01T00:00:00+00:00"),
+            ("b", "YES", "BUY", 0.1, 1, "2026-01-02T00:00:00+00:00"),
+        ])
+        tracker = PortfolioTracker(db)
+        pos = SimpleNamespace(market_id="M1", token=TokenType.YES, size=0.8,
+                              is_paper=True)
+        entered = await tracker._current_position_entry_time(pos, 1)
+        assert entered is not None, "an exact >= comparison lost this position"
+        assert entered.isoformat() == "2026-01-01T00:00:00+00:00"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unscoped_read_uses_the_positions_own_book_not_paper(tmp_path):
+    """An unscoped read must ask the position which book it belongs to.
+
+    ``check_exits`` passes ``is_paper=None`` when ``settings.is_live`` is not a
+    bool, leaving ``get_positions`` unscoped over BOTH books. Defaulting that
+    to paper answered a LIVE position's lifecycle question off the paper
+    ledger — silently, and with no way for the caller to notice. Since #420 the
+    Position carries ``is_paper``, so it can answer for itself.
+    """
+    db = Database(str(tmp_path / "mode.db"))
+    await db.connect()
+    try:
+        await _seed_fills(db, [
+            ("live", "YES", "BUY", 5, 0, "2026-01-01T00:00:00+00:00"),
+            ("paper", "YES", "BUY", 5, 1, "2026-02-01T00:00:00+00:00"),
+        ])
+        tracker = PortfolioTracker(db)
+        live = SimpleNamespace(market_id="M1", token=TokenType.YES, size=5,
+                               is_paper=False)
+        paper = SimpleNamespace(market_id="M1", token=TokenType.YES, size=5,
+                                is_paper=True)
+        assert (await tracker._current_position_entry_time(live, None)).isoformat() \
+            == "2026-01-01T00:00:00+00:00"
+        assert (await tracker._current_position_entry_time(paper, None)).isoformat() \
+            == "2026-02-01T00:00:00+00:00"
+        # An explicit mode flag still wins over the position's own field.
+        assert (await tracker._current_position_entry_time(live, 1)).isoformat() \
+            == "2026-02-01T00:00:00+00:00"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v50_migration_adds_exit_decision_telemetry(tmp_path):
     path = tmp_path / "migration.db"
     db = Database(str(path))
     await db.connect()
@@ -87,3 +238,54 @@ async def test_v49_migration_adds_exit_decision_telemetry(tmp_path):
         }
     finally:
         await upgraded.close()
+
+
+_MIGRATION_STEP = re.compile(r"^_migrate_v(\d+)_to_v(\d+)$")
+
+
+def test_every_schema_step_dispatches_to_a_distinct_migration():
+    """Two branches claiming the same version step must be impossible to merge.
+
+    A duplicate ``async def _migrate_vN_to_vM`` in the class body is silently
+    shadowed — Python keeps the last definition and ruff does not flag it — so
+    one migration's DDL never runs against a live database while the version
+    counter still advances. That collision has now happened twice, each time
+    surviving review and CI.
+
+    Three properties close it: every step is DECLARED once, every declared step
+    is DISPATCHED exactly once, and the dispatch resolves to as many distinct
+    function objects as there are version steps.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(Database))).body[0]
+    definitions = [
+        node.name for node in tree.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and _MIGRATION_STEP.match(node.name)
+    ]
+    shadowed = sorted({n for n in definitions if definitions.count(n) > 1})
+    assert not shadowed, f"silently shadowed migration definitions: {shadowed}"
+
+    runner = next(node for node in tree.body
+                  if isinstance(node, ast.AsyncFunctionDef)
+                  and node.name == "_run_migrations")
+    dispatched = [
+        node.func.attr for node in ast.walk(runner)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and _MIGRATION_STEP.match(node.func.attr)
+    ]
+    repeated = sorted({n for n in dispatched if dispatched.count(n) > 1})
+    assert not repeated, f"migration dispatched more than once: {repeated}"
+    assert set(dispatched) == set(definitions), (
+        "declared and dispatched migrations disagree: "
+        f"{sorted(set(definitions) ^ set(dispatched))}")
+
+    # The property stated directly: as many DISTINCT method objects as steps.
+    assert len({getattr(Database, name) for name in dispatched}) == len(dispatched)
+
+    # And the steps form one unbroken chain up to the declared schema version,
+    # so a renumber cannot leave a hole or overshoot SCHEMA_VERSION.
+    targets = sorted(int(_MIGRATION_STEP.match(n).group(2)) for n in dispatched)
+    assert targets == list(range(targets[0], SCHEMA_VERSION + 1))
+    for name in dispatched:
+        start, end = (int(g) for g in _MIGRATION_STEP.match(name).groups())
+        assert end == start + 1, f"{name} is not a single-version step"

--- a/tests/test_exit_policy.py
+++ b/tests/test_exit_policy.py
@@ -1,0 +1,89 @@
+from datetime import timezone
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import TokenType
+from auramaur.risk.exit_policy import (
+    binary_exit_economics,
+    lifecycle_profit_target,
+    trailing_stop_triggered,
+)
+from auramaur.risk.portfolio import PortfolioTracker
+
+
+def test_binary_profit_is_net_of_executable_exit_fee():
+    result = binary_exit_economics(
+        entry_price=0.40, exit_price=0.60, size=10, fee_coefficient=0.25)
+    assert result.gross_pnl_pct == pytest.approx(50.0)
+    assert result.estimated_fees == pytest.approx(1.20)
+    assert result.net_pnl_pct == pytest.approx(20.0)
+
+    short = binary_exit_economics(
+        entry_price=0.60, exit_price=0.40, size=10,
+        fee_coefficient=0.0, is_long=False)
+    assert short.net_pnl_pct == pytest.approx(100 / 3)
+
+
+def test_lifecycle_bands_and_trailing_policy_are_pure_and_configurable():
+    args = dict(base_pct=50, early_pct=75, late_pct=25,
+                early_fraction=0.5, late_fraction=0.1)
+    assert lifecycle_profit_target(fraction_remaining=0.8, **args) == 75
+    assert lifecycle_profit_target(fraction_remaining=0.3, **args) == 50
+    assert lifecycle_profit_target(fraction_remaining=0.05, **args) == 25
+    assert trailing_stop_triggered(peak_pct=20, current_pct=10,
+                                   activation_pct=12, giveback_fraction=0.45)
+
+
+@pytest.mark.asyncio
+async def test_current_entry_uses_only_inventory_surviving_reentry(tmp_path):
+    db = Database(str(tmp_path / "entry-age.db"))
+    await db.connect()
+    try:
+        # Old round trip, then the current position. NO and live fills must not
+        # contaminate the paper YES inventory clock.
+        rows = [
+            ("old-buy", "YES", "BUY", 10, 1, "2026-01-01T00:00:00+00:00"),
+            ("old-sell", "YES", "SELL", 10, 1, "2026-01-02T00:00:00+00:00"),
+            ("no-buy", "NO", "BUY", 20, 1, "2026-02-01T00:00:00+00:00"),
+            ("live-buy", "YES", "BUY", 20, 0, "2026-03-01T00:00:00+00:00"),
+            ("new-buy", "YES", "BUY", 5, 1, "2026-04-01T12:00:00+02:00"),
+        ]
+        for order_id, token, side, size, paper, timestamp in rows:
+            await db.execute(
+                """INSERT INTO fills
+                   (order_id, market_id, token, side, size, price, is_paper, timestamp)
+                   VALUES (?, 'M1', ?, ?, ?, 0.5, ?, ?)""",
+                (order_id, token, side, size, paper, timestamp))
+        await db.commit()
+        tracker = PortfolioTracker(db)
+        pos = SimpleNamespace(market_id="M1", token=TokenType.YES, size=5)
+        entered = await tracker._current_position_entry_time(pos, 1)
+        assert entered.isoformat() == "2026-04-01T10:00:00+00:00"
+        assert entered.tzinfo == timezone.utc
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v49_migration_adds_exit_decision_telemetry(tmp_path):
+    path = tmp_path / "migration.db"
+    db = Database(str(path))
+    await db.connect()
+    await db.execute("DROP TABLE exit_decisions")
+    await db.execute("UPDATE schema_version SET version = 49")
+    await db.commit()
+    await db.close()
+
+    upgraded = Database(str(path))
+    await upgraded.connect()
+    try:
+        version = await upgraded.fetchone("SELECT version FROM schema_version")
+        columns = await upgraded.fetchall("PRAGMA table_info(exit_decisions)")
+        assert version["version"] == 50
+        assert {row["name"] for row in columns} >= {
+            "policy_action", "net_pnl_pct", "estimated_fees", "peak_pnl_pct"
+        }
+    finally:
+        await upgraded.close()

--- a/tests/test_exit_policy.py
+++ b/tests/test_exit_policy.py
@@ -240,6 +240,65 @@ async def test_v50_migration_adds_exit_decision_telemetry(tmp_path):
         await upgraded.close()
 
 
+async def _prune_plan(db) -> list[str]:
+    """Query plan for the SHIPPED retention delete, not a copy of it."""
+    rows = await db.fetchall(
+        f"EXPLAIN QUERY PLAN {PortfolioTracker._EXIT_DECISION_PRUNE}",
+        ("-14 days",))
+    return [row["detail"] for row in rows]
+
+
+@pytest.mark.asyncio
+async def test_retention_prune_never_scans_the_exit_decision_table(tmp_path):
+    """The per-cycle prune must SEEK, on a fresh schema and a migrated one.
+
+    ``idx_exit_decisions_position_time`` looks like it covers this — it ends in
+    ``observed_at`` — but that is its FOURTH column and the predicate
+    constrains none of the three before it, so SQLite has no seekable prefix
+    and reports ``SCAN exit_decisions``. That scan runs inside the
+    ``portfolio.exit_decisions`` write span on every exit cycle, holding the
+    process-wide write lock against a table that only grows: the one place
+    where a full scan costs closing a position.
+
+    Both schema paths are checked because they are written in different files
+    and can drift: a fresh database gets ``db/models.py``'s TABLES script, an
+    existing one gets the v49 -> v50 migration in ``db/database.py``.
+
+    The migration half calls the step DIRECTLY rather than reconnecting.
+    ``_init_schema`` executes TABLES *before* dispatching migrations, so a
+    reconnect would create the table and its indexes from TABLES and then run
+    the migration against a schema that already satisfies it — the migration's
+    own DDL would never be observed, and an index missing there would pass.
+    """
+    fresh = Database(str(tmp_path / "fresh.db"))
+    await fresh.connect()
+    try:
+        plan = await _prune_plan(fresh)
+        assert not any("SCAN" in step for step in plan), (
+            f"retention delete full-scans a growing table: {plan}")
+        assert any("SEARCH" in step for step in plan), plan
+    finally:
+        await fresh.close()
+
+    # And the same for a database that arrives at v50 by migration.
+    migrated = Database(str(tmp_path / "migrated-plan.db"))
+    await migrated.connect()
+    try:
+        # Dropping the table takes its indexes with it, so what follows is
+        # built by the migration script alone.
+        await migrated.execute("DROP TABLE exit_decisions")
+        await migrated.execute("UPDATE schema_version SET version = 49")
+        await migrated.commit()
+        await migrated._migrate_v49_to_v50()
+
+        plan = await _prune_plan(migrated)
+        assert not any("SCAN" in step for step in plan), (
+            f"the v49 -> v50 migration omitted the index: {plan}")
+        assert any("SEARCH" in step for step in plan), plan
+    finally:
+        await migrated.close()
+
+
 _MIGRATION_STEP = re.compile(r"^_migrate_v(\d+)_to_v(\d+)$")
 
 

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -124,19 +124,133 @@ async def test_stop_loss_triggered(mock_db, settings):
 
 @pytest.mark.asyncio
 async def test_profit_target_triggered(mock_db, settings):
-    """Position at +55% → PROFIT_TARGET."""
+    """Position at +57.5% gross → PROFIT_TARGET, and still clears net."""
     mock_db.fetchall = AsyncMock(return_value=[
         _make_position("m1", avg_price=0.40),
     ])
     gamma = AsyncMock()
-    # Current price rose to 0.63: target still clears after conservative
-    # round-trip taker fees (gross-only checks are intentionally insufficient).
+    # Current price rose to 0.63: target still clears after the executable
+    # exit fee (gross-only checks are intentionally insufficient).
     gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.63))
 
     tracker = PortfolioTracker(db=mock_db)
     exits = await tracker.check_exits(settings, gamma)
     assert len(exits) == 1
     assert exits[0][1] == ExitReason.PROFIT_TARGET
+
+
+@pytest.mark.asyncio
+async def test_profit_target_holds_when_only_the_gross_clears(mock_db, settings):
+    """The discriminating case: gross over target, net under it.
+
+    At 0.61 the gross gain is +52.5% on a 50% target, so a gross-only gate
+    sells. The executable exit fee (0.05 * p * (1-p) * size for this category)
+    costs ~3 points, leaving +49.5% net — under the target, so the position is
+    held. A price that clears BOTH legs cannot tell the two gates apart.
+    """
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.40),
+    ])
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.61))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+    assert exits == [], "a net-of-fees gate must not sell on the gross alone"
+
+
+@pytest.mark.asyncio
+async def test_trailing_stop_exit_is_emitted_by_check_exits(settings, tmp_path):
+    """The trailing tier must be reachable through the real exit path.
+
+    ``trailing_stop_triggered`` was only ever exercised as a pure function, so
+    nothing proved ``check_exits`` wires the peak, the configured bands and the
+    TRAILING_STOP reason together — and until #420 the exit loop raised on
+    every tick, so production could not have shown it either.
+    """
+    db = Database(str(tmp_path / "trailing.db"))
+    await db.connect()
+    try:
+        settings.is_live = True
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES ('m1', 'polymarket', 'BUY', 10, 0.50, 0.50,
+                       'test', 'YES', 'tok', 0)""")
+        # Peaked at +40%; the mark below leaves +10%. 40 >= the 12% activation
+        # and the 30-point giveback exceeds 45% of the peak, so the tier fires
+        # before the profit target is ever considered.
+        await db.execute(
+            "INSERT INTO position_peaks (market_id, peak_pnl_pct) "
+            "VALUES ('m1:YES:0', 40.0)")
+        await db.commit()
+
+        gamma = AsyncMock()
+        gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.55))
+
+        tracker = PortfolioTracker(db=db, settings=settings)
+        exits = await tracker.check_exits(settings, gamma, exchange="polymarket")
+
+        assert [reason for _, reason in exits] == [ExitReason.TRAILING_STOP]
+        assert exits[0][0].market_id == "m1"
+        # And the decision is observed under its own action, not as a HOLD.
+        row = await db.fetchone(
+            "SELECT policy_action, peak_pnl_pct FROM exit_decisions "
+            "WHERE market_id = 'm1'")
+        assert row["policy_action"] == "TRAILING_STOP"
+        assert row["peak_pnl_pct"] == pytest.approx(40.0)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_exit_survives_a_telemetry_write_failure(mock_db, settings):
+    """Observability must never be able to trap a position.
+
+    The decision log is written after every exit is decided, in one batch, and
+    a failure there is contained: a broken or missing telemetry table cannot
+    stop a protective exit from being returned to the caller.
+    """
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position("m1", avg_price=0.40),
+    ])
+    mock_db.executemany = AsyncMock(side_effect=RuntimeError("exit_decisions is gone"))
+    gamma = AsyncMock()
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.63))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+
+    assert [reason for _, reason in exits] == [ExitReason.PROFIT_TARGET]
+    mock_db.executemany.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_decision_telemetry_costs_one_write_per_cycle(mock_db, settings):
+    """The HOLD branch observes every non-exiting position on every tick.
+
+    Written inline, that took the shared serialized write lock once per
+    position on the path that closes positions. Batched, a whole book costs a
+    single ``executemany`` after every exit has already been decided — so the
+    write count must not grow with the number of positions held.
+    """
+    mock_db.fetchall = AsyncMock(return_value=[
+        _make_position(f"m{i}", avg_price=0.50) for i in range(12)
+    ])
+    mock_db.executemany = AsyncMock()
+    gamma = AsyncMock()
+    # Flat marks: every position holds, so every one emits a HOLD observation.
+    gamma.get_market = AsyncMock(side_effect=lambda mid: _make_market(mid, 0.50))
+
+    tracker = PortfolioTracker(db=mock_db)
+    exits = await tracker.check_exits(settings, gamma)
+
+    assert exits == []
+    assert mock_db.executemany.await_count == 1
+    rows = mock_db.executemany.await_args.args[1]
+    assert len(rows) == 12, "one observation per evaluated position"
+    assert {row[4] for row in rows} == {"HOLD"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -30,6 +30,13 @@ def settings():
     s = MagicMock()
     s.execution.stop_loss_pct = 30.0
     s.execution.profit_target_pct = 50.0
+    s.execution.profit_target_early_pct = 75.0
+    s.execution.profit_target_late_pct = 25.0
+    s.execution.profit_target_early_fraction_remaining = 0.50
+    s.execution.profit_target_late_fraction_remaining = 0.10
+    s.execution.trailing_stop_activation_pct = 12.0
+    s.execution.trailing_stop_giveback_fraction = 0.45
+    s.arbitrage.exchange_fees = {}
     s.execution.edge_erosion_min_pct = 2.0
     s.execution.time_decay_hours = 12.0
     # Off by default so existing exit tests are unaffected; opted in per-test.
@@ -122,8 +129,9 @@ async def test_profit_target_triggered(mock_db, settings):
         _make_position("m1", avg_price=0.40),
     ])
     gamma = AsyncMock()
-    # Current price rose to 0.62 → gain = (0.62-0.40)*10 = 2.20, cost = 4.0, pct = +55%
-    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.62))
+    # Current price rose to 0.63: target still clears after conservative
+    # round-trip taker fees (gross-only checks are intentionally insufficient).
+    gamma.get_market = AsyncMock(return_value=_make_market("m1", 0.63))
 
     tracker = PortfolioTracker(db=mock_db)
     exits = await tracker.check_exits(settings, gamma)

--- a/tests/test_ibkr_multiasset_paper.py
+++ b/tests/test_ibkr_multiasset_paper.py
@@ -627,3 +627,59 @@ async def test_entries_off_blocks_new_risk_but_keeps_managing_held():
     assert len(rows) == 1  # no new risk, held position not stranded
     assert rows[0]["current_price"] is not None  # still being marked
     await db.close()
+
+
+@pytest.mark.parametrize(
+    "bid, expect_sell",
+    [
+        # Round-trip commissions straddle take_profit_pct (10%). Entry 100.0,
+        # 1 unit: $1.00 charged on the way in and $1.00 on the way out.
+        (111.0, False),  # gross +11.0%, net +9.0% — under the threshold
+        (113.0, True),   # gross +13.0%, net +11.0% — clears it
+    ],
+)
+@pytest.mark.asyncio
+async def test_take_profit_waits_for_commissions_to_clear_the_threshold(
+        bid, expect_sell):
+    """IBKR take-profit measures the NET gain, not the quoted one.
+
+    Both commissions are known exactly here — the entry's is stored on the
+    position and the exit's is priced off the executable bid — so a gross
+    comparison sells a winner the round trip has not actually earned. The two
+    bids bracket the threshold, which a single-sided case cannot.
+    """
+    class _BidQuotes(FakeMarketData):
+        async def get_quote_by_con_id(self, spec, con_id):
+            return MarketDataQuote(spec.key, bid, bid * 1.0001, time.time(),
+                                   con_id, spec.currency, spec.multiplier)
+
+    db = Database(":memory:")
+    await db.connect()
+    settings = Settings()
+    settings.ibkr.multiasset_paper_enabled = True
+    settings.ibkr.multiasset_registry_required = False
+    cfg = settings.ibkr.multiasset_books["global_etf"]
+    cfg.entries_enabled = False  # isolate exit management from new risk
+    cfg.take_profit_pct = 10.0
+    spec = BY_BOOK[IBKRBook.GLOBAL_ETF][0]
+    await db.execute(
+        """INSERT INTO ibkr_paper_positions
+           (book, instrument_key, con_id, currency, quantity, multiplier,
+            fx_to_usd, avg_cost, current_price, stop_price,
+            entry_commission_usd, entry_fill_ref)
+           VALUES ('global_etf', ?, 42, ?, 1, ?, 1, 100.0, 100.0, 0, 1.0,
+                   'seed')""",
+        (spec.key, spec.currency, spec.multiplier))
+    await db.commit()
+
+    pillar = IBKRMultiAssetPaperBook(settings, _BidQuotes(), db, IBKRBook.GLOBAL_ETF)
+    pillar.market_open = lambda now=None: True
+    await pillar.run_once()
+
+    sells = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM ibkr_paper_fills WHERE side = 'SELL'")
+    assert bool(sells["n"]) is expect_sell
+    held = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM ibkr_paper_positions WHERE book='global_etf'")
+    assert bool(held["n"]) is not expect_sell
+    await db.close()


### PR DESCRIPTION
## Summary

Calculates take-profit decisions from token-scoped current inventory and
fee-net executable economics; distinguishes trailing stops; makes the
lifecycle and trailing bands configurable; adds schema-v50 decision telemetry
plus a read-only chronological calibration report.

**Rebased onto main after #420 and #421.** Until #420 the portfolio monitor's
exit loop raised on every tick, so no live exit ever executed and this policy
was being tuned against a dead path. It runs now, so every threshold here
moves money on the next tick. Six amendments followed, in descending order of
what they cost:

1. **Entry-time fallback restored.** Sourcing position age only from a
   token-scoped `fills` walk, and setting `entry_dt = now` on a miss, pins
   `fraction_remaining` at 1.0 on *every* tick — the target freezes in its
   widest band and the near-expiry band becomes unreachable. 37% of open
   positions have no fill ancestry (they predate the fills ledger, or are live
   rows a venue mirror created without writing a fill); 40% of those have a
   `trades` row the old path used. Resolution is now fills → trades → "just
   entered". The trades leg is book-scoped but not token-scoped, because
   `trades` has no token column. A size tolerance was added too: `qty >= size`
   is an exact float compare against a summed quantity.
   `cost_basis` was evaluated and rejected as the source — its only timestamp
   is `updated_at`, which records when inventory last moved, not when it was
   entered.
2. **Entry fee dropped from the gate.** `broker/pnl.py` realizes the exit fee
   only and builds the ledger event only on the SELL branch, so `avg_cost` is
   fee-exclusive and the entry fee is never booked. Charging it demanded a cost
   the books never record. Drag removed: 1.47 points median, 4.00 p90, 6.86
   max. The entry leg survives as a reported diagnostic.
3. **HOLD telemetry off the money path.** The write was awaited inline before
   `exits.append(...)`, taking the shared serialized write lock once per
   evaluated position, every tick. It is now one `executemany` after the loop
   (>99% fewer lock acquisitions on a full book), with
   `execution.exit_decision_retention_days` (default 14) pruning via a bounded
   per-cycle delete. HOLD rows are kept as the calibration counterfactual.
4. **Migration collision class closed.** v50 is kept here; #411 renumbers to
   v51. A duplicate `_migrate_vN_to_vM` is silently shadowed by Python and
   ruff does not catch it — that has now happened twice. A new test AST-parses
   the class and asserts each step is declared once, dispatched once, resolves
   to a distinct function object, and forms an unbroken chain to
   `SCHEMA_VERSION`.
5. **An unscoped read no longer defaults a live position to paper.**
   `mode_flag` is None when `settings.is_live` is not a bool and the tracker
   holds no settings of its own, leaving the read unscoped over both books.
   (A real `Settings.is_live` ANDs three bools and so always is one — with the
   kill switch armed it is `False`, which scopes the read to paper rather than
   unscoping it — so this is the duck-typed path, not a live-trading one. It
   still must not hardcode a book: the wrong answer was silent.) #420 gave
   `Position` an `is_paper` field, so the position is now asked directly.
6. **Zero disables the trailing stop.** `Field(gt=0)` crashed startup on 0.
   Relaxing to `ge=0` alone would have been worse: unguarded, zero arms the
   most aggressive possible trailing stop rather than turning it off.

Stop-loss and trailing-stop band **values** are unchanged (byte-identical to
the originals). `bot.py`'s exit loop and #421's readiness criterion are
untouched.

## Verification

- 2304 passed, 5 skipped, 1 deselected
- Coverage 67.44% against the 65.0 floor
- `ruff check .` clean
- 17 mutations run against the six new behaviours, **17 killed** — each
  behaviour was broken, the test confirmed failing, then restored

## Migration

Upgrades schema v49 → v50, adding the `exit_decisions` telemetry table and a
position/time index.
