### PR TITLE
Give a Position the book it belongs to so live exits can run again

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -486,50 +486,74 @@ class AuramaurBot(
                         continue
 
                     for pos, reason in exit_list:
-                        # Key by POSITION, not market: check_exits yields one row
-                        # per (market, token, mode), and a sub-minimum dust leg
-                        # can never sell — a market-wide key let that dust pin
-                        # its sibling legs (2026-07-25: a 1.49-share leg pinned
-                        # $322 of exposure in the same market).
-                        exit_key = (f"exit:{name}:{pos.market_id}:"
-                                    f"{getattr(pos.token, 'value', pos.token)}:"
-                                    f"{int(bool(pos.is_paper))}")
-                        if exit_key in self._exit_pending:
-                            continue
-                        retry_at = self._exit_failures.get(exit_key)
-                        if retry_at is not None and time.monotonic() < retry_at:
-                            continue
-                        log.info(
-                            "exit.triggered",
-                            exchange=name,
-                            market_id=pos.market_id,
-                            reason=reason.value,
-                            pnl=pos.unrealized_pnl,
-                        )
+                        # Per-position containment. A defect in THIS block used
+                        # to escape to the tick-level handler below, which
+                        # abandons every remaining position and every remaining
+                        # exchange for the whole tick — that is how one bad
+                        # attribute read stopped all exits for 12 days. Venue
+                        # errors keep their own inner handler; anything landing
+                        # here is a bug, so it is logged at error (readiness's
+                        # _ERROR_LEVELS) and skips only its own position.
                         try:
-                            if name == "polymarket":
-                                ok = await self._execute_poly_exit(pos, reason, discovery, exchange_client, alerts)
-                            elif name == "kalshi":
-                                ok = await self._execute_kalshi_exit(pos, reason, discovery, exchange_client, alerts)
-                            elif name == "ibkr":
-                                ok = await self._execute_ibkr_exit(pos, reason, discovery, exchange_client, alerts)
-                            else:
+                            # Key by POSITION, not market: check_exits yields one row
+                            # per (market, token, mode), and a sub-minimum dust leg
+                            # can never sell — a market-wide key let that dust pin
+                            # its sibling legs (2026-07-25: a 1.49-share leg pinned
+                            # $322 of exposure in the same market).
+                            exit_key = (f"exit:{name}:{pos.market_id}:"
+                                        f"{getattr(pos.token, 'value', pos.token)}:"
+                                        f"{int(bool(pos.is_paper))}")
+                            if exit_key in self._exit_pending:
+                                continue
+                            retry_at = self._exit_failures.get(exit_key)
+                            if retry_at is not None and time.monotonic() < retry_at:
+                                continue
+                            log.info(
+                                "exit.triggered",
+                                exchange=name,
+                                market_id=pos.market_id,
+                                reason=reason.value,
+                                pnl=pos.unrealized_pnl,
+                            )
+                            try:
+                                if name == "polymarket":
+                                    ok = await self._execute_poly_exit(pos, reason, discovery, exchange_client, alerts)
+                                elif name == "kalshi":
+                                    ok = await self._execute_kalshi_exit(pos, reason, discovery, exchange_client, alerts)
+                                elif name == "ibkr":
+                                    ok = await self._execute_ibkr_exit(pos, reason, discovery, exchange_client, alerts)
+                                else:
+                                    ok = False
+                            except Exception as e:
+                                log.warning("exit.execute_error", exchange=name, market_id=pos.market_id, error=str(e))
                                 ok = False
+                            if ok:
+                                self._exit_pending.add(exit_key)
+                                self._exit_failures.pop(exit_key, None)
+                            else:
+                                self._exit_failures[exit_key] = (
+                                    time.monotonic() + _EXIT_RETRY_BACKOFF_SECONDS)
+                                log.warning(
+                                    "exit.suppressed_until_retry", exchange=name,
+                                    market_id=pos.market_id, reason=reason.value,
+                                    backoff_seconds=_EXIT_RETRY_BACKOFF_SECONDS)
                         except Exception as e:
-                            log.warning("exit.execute_error", exchange=name, market_id=pos.market_id, error=str(e))
-                            ok = False
-                        if ok:
-                            self._exit_pending.add(exit_key)
-                            self._exit_failures.pop(exit_key, None)
-                        else:
-                            self._exit_failures[exit_key] = (
-                                time.monotonic() + _EXIT_RETRY_BACKOFF_SECONDS)
-                            log.warning(
-                                "exit.suppressed_until_retry", exchange=name,
-                                market_id=pos.market_id, reason=reason.value,
-                                backoff_seconds=_EXIT_RETRY_BACKOFF_SECONDS)
+                            log.error(
+                                "exit.loop_error", exchange=name,
+                                market_id=getattr(pos, "market_id", "?"),
+                                error_type=type(e).__name__, error=str(e))
+                            continue
             except Exception as e:
-                log.debug("portfolio_monitor_error", error=str(e))
+                # This aborts the ENTIRE tick — every venue's exits, the equity
+                # mark, the cash read. At debug that is invisible: readiness
+                # scores logs by level and never reads debug, so the 12-day
+                # exit outage (2026-07-25 → 08-06) left no operator-visible
+                # trace anywhere. Every routine failure above has its own
+                # handler (sync, note_equity, attribution, check_exits, and now
+                # the per-position block), so reaching here means the tick
+                # broke, and a broken tick is an error.
+                log.error("portfolio_monitor_error",
+                          error_type=type(e).__name__, error=str(e))
             await asyncio.sleep(interval)
 
     async def _task_cache_cleanup(self) -> None:

--- a/auramaur/cli/redeem.py
+++ b/auramaur/cli/redeem.py
@@ -223,6 +223,8 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
                         current_price=float(row["current_price"] or 0.0),
                         category=live_cat,
                         token=tok, token_id=row["token_id"] or "",
+                        # The SELECT above is scoped to this bot's book.
+                        is_paper=bool(is_paper),
                     )
                     # Pre-filter on the stored value so we only hit the API for
                     # likely-dust positions, then refresh their price to confirm.

--- a/auramaur/exchange/models.py
+++ b/auramaur/exchange/models.py
@@ -250,6 +250,16 @@ class Position(BaseModel):
     category: str = ""
     token: TokenType = TokenType.YES
     token_id: str = ""
+    # Which book this position belongs to. The DB key is
+    # (market_id, is_paper, token), so a Position without it is only 2/3 of a
+    # position identity — and ``PortfolioTracker.get_positions`` can return
+    # BOTH books at once (its mode filter is skipped when settings.is_live is
+    # not a bool), so callers cannot recover it from a mode flag of their own.
+    # bot.py's exit loop keys on it; reading it off an object that lacked the
+    # field raised AttributeError on every tick from 2026-07-25 to 08-06.
+    # Defaults to PAPER, like Fill/OrderResult and the portfolio.is_paper
+    # column (NOT NULL DEFAULT 1): an unstated book must never read as live.
+    is_paper: bool = True
 
     @property
     def unrealized_pnl(self) -> float:

--- a/auramaur/exchange/paper.py
+++ b/auramaur/exchange/paper.py
@@ -50,6 +50,7 @@ class PaperTrader:
                 category=row["category"] or "",
                 token=TokenType(token_str) if token_str else TokenType.YES,
                 token_id=token_id or "",
+                is_paper=True,  # the query above is WHERE is_paper = 1
             )
 
         self.balance = await self._compute_balance()
@@ -169,6 +170,7 @@ class PaperTrader:
                 current_price=order.price,
                 token=order.token if hasattr(order, 'token') else TokenType.YES,
                 token_id=order.token_id if hasattr(order, 'token_id') else "",
+                is_paper=True,  # PaperTrader books nothing else
             )
 
         # Trade row is written by TradingEngine for every fill (paper/live/limit)

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -73,6 +73,19 @@ class PortfolioTracker:
             token_str = row["token"] if "token" in keys else "YES"
             token_id = row["token_id"] if "token_id" in keys else ""
             exchange_name = row["exchange"] if "exchange" in keys else "polymarket"
+            # The book is part of the position's identity (the portfolio PK is
+            # (market_id, is_paper, token)) and this read can be UNSCOPED — when
+            # settings.is_live is not a bool, mode_flag is None and the rows
+            # below hold BOTH books. Dropping the column left every consumer
+            # unable to tell them apart. Guarded like token/token_id for older
+            # DBs: a mode-scoped read already knows what it asked for, and an
+            # unknown book reads as paper, never as live.
+            if "is_paper" in keys:
+                row_is_paper = bool(row["is_paper"])
+            elif mode_flag is not None:
+                row_is_paper = mode_flag == 1
+            else:
+                row_is_paper = True
             positions.append(Position(
                 market_id=row["market_id"],
                 exchange=exchange_name or "polymarket",
@@ -86,6 +99,7 @@ class PortfolioTracker:
                           else (row["category"] or "other")),
                 token=TokenType(token_str) if token_str else TokenType.YES,
                 token_id=token_id or "",
+                is_paper=row_is_paper,
             ))
         return positions
 

--- a/tests/test_bot_exit_loop.py
+++ b/tests/test_bot_exit_loop.py
@@ -1,0 +1,231 @@
+"""The portfolio monitor's exit loop — the block that actually sells.
+
+Nothing drove ``AuramaurBot._task_portfolio_monitor``'s ``for pos, reason in
+exit_list`` block, so from 2026-07-25 (fdf79fc) to 2026-08-06 it raised
+``AttributeError: 'Position' object has no attribute 'is_paper'`` on the FIRST
+position of every tick. The raise escaped to the tick-level ``except
+Exception: log.debug(...)``, which abandoned the rest of the tick and left no
+operator-visible trace: live prediction-market stop-losses, profit targets and
+trailing stops were structurally dead for 12 days (last live SELL fill
+2026-07-25T13:04:06Z; 29 live BUY fills and zero live SELL fills after it).
+
+The exit *policy* was well covered (tests/test_exits.py) and the exit *key* was
+covered by rebuilding the f-string in the test (test_exits.py's
+``test_exit_suppression_expires_and_is_keyed_per_position``) — a reimplementation
+cannot fail when the real loop does. These tests run the real loop instead: one
+tick of ``_task_portfolio_monitor`` with injected components, asserting that an
+exit is ATTEMPTED for a position ``check_exits`` flagged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from structlog.testing import capture_logs
+
+from auramaur.bot import AuramaurBot
+from auramaur.components import Components
+from auramaur.exchange.models import ExitReason, OrderSide, Position, TokenType
+
+
+def _position(market_id: str = "M1", *, is_paper: bool,
+              token: TokenType = TokenType.YES) -> Position:
+    return Position(
+        market_id=market_id, exchange="polymarket", side=OrderSide.BUY,
+        size=20.0, avg_price=0.50, current_price=0.30, category="politics",
+        token=token, token_id="tok", is_paper=is_paper,
+    )
+
+
+def _bot(exit_list: list, *, is_live: bool = True):
+    """A bare bot wired for exactly one portfolio-monitor tick.
+
+    ``check_exits`` clears ``_running`` so the ``while`` loop runs once, and
+    ``portfolio_check_seconds`` is 0 so the trailing sleep returns immediately.
+    """
+    bot = AuramaurBot.__new__(AuramaurBot)
+    bot._running = True
+    bot._exit_pending = set()
+    bot._exit_failures = {}
+    bot._last_known_cash = 0.0
+    bot.settings = SimpleNamespace(
+        is_live=is_live,
+        intervals=SimpleNamespace(portfolio_check_seconds=0,
+                                  adaptive_enabled=False),
+    )
+
+    async def _check_exits(_settings, _discovery, exchange=None):
+        bot._running = False  # one tick
+        return list(exit_list)
+
+    tracker = SimpleNamespace(check_exits=_check_exits, note_equity=AsyncMock())
+    attempted: list[tuple] = []
+
+    async def _execute_poly_exit(pos, reason, _discovery, _exchange, _alerts):
+        attempted.append((pos, reason))
+        return True
+
+    bot._execute_poly_exit = _execute_poly_exit
+    bot._components = Components({
+        "db": AsyncMock(),
+        "syncers": [],
+        "pnl_tracker": SimpleNamespace(get_total_pnl=AsyncMock(return_value=0.0)),
+        "discoveries": {"polymarket": SimpleNamespace()},
+        # No _live_pending to walk; the reserved-collateral sum skips it.
+        "exchanges": {"polymarket": SimpleNamespace(_live_pending={})},
+        "alerts": AsyncMock(),
+        "risk_manager": SimpleNamespace(portfolio=tracker),
+        "attributor": None,
+        "reconciler": None,
+    })
+    return bot, attempted
+
+
+async def _one_tick(bot) -> list[dict]:
+    """Run a single monitor tick, returning the structlog events it emitted."""
+    with capture_logs() as events:
+        # Bounded: if a defect aborts the tick before check_exits can clear
+        # _running, this fails loudly instead of hanging CI.
+        await asyncio.wait_for(bot._task_portfolio_monitor(), timeout=10)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_flagged_position_reaches_the_exit_executor():
+    """The regression itself: a flagged live position must be sold.
+
+    Under the bug the loop raised on ``pos.is_paper`` while building the exit
+    key — before any executor was called — so this asserts the *execution path
+    was reached*, not merely that nothing propagated.
+    """
+    pos = _position(is_paper=False)
+    bot, attempted = _bot([(pos, ExitReason.STOP_LOSS)])
+
+    events = await _one_tick(bot)
+
+    assert attempted == [(pos, ExitReason.STOP_LOSS)], (
+        "no exit was attempted for a position check_exits flagged")
+    # And the accepted exit is suppressed under its own per-position key.
+    assert bot._exit_pending == {"exit:polymarket:M1:YES:0"}
+    assert bot._exit_failures == {}
+    # The tick completed: nothing fell through to the tick-level handler.
+    assert not [e for e in events if e["event"] == "portfolio_monitor_error"]
+
+
+@pytest.mark.asyncio
+async def test_paper_and_live_legs_of_one_market_get_distinct_keys():
+    """Why the field exists at all.
+
+    ``check_exits`` passes ``is_paper=None`` whenever ``settings.is_live`` is
+    not a bool, which leaves ``get_positions`` UNSCOPED — the list can hold
+    both books. A caller-side mode flag would collapse the two legs of one
+    (market, token) onto a single key, so the second leg would read as already
+    pending and never sell: the same dust-pinning failure the per-position key
+    was introduced to fix on 2026-07-25.
+    """
+    live = _position(is_paper=False)
+    paper = _position(is_paper=True)
+    bot, attempted = _bot([(live, ExitReason.STOP_LOSS),
+                           (paper, ExitReason.STOP_LOSS)])
+
+    await _one_tick(bot)
+
+    assert [p for p, _ in attempted] == [live, paper], (
+        "both books' legs must be attempted, not just the first")
+    assert bot._exit_pending == {"exit:polymarket:M1:YES:0",
+                                 "exit:polymarket:M1:YES:1"}
+
+
+@pytest.mark.asyncio
+async def test_a_broken_position_surfaces_and_does_not_abort_the_rest():
+    """The swallowing ``except`` must not hide this class of defect again.
+
+    Two properties, both absent on 2026-07-25: an unexpected AttributeError in
+    the loop body is logged at a level ``readiness._ERROR_LEVELS`` scores (so
+    12 days of silence becomes a failed cycle-health criterion), and it costs
+    only its own position instead of the whole tick.
+    """
+    from auramaur.monitoring.readiness import _ERROR_LEVELS
+
+    # A position-shaped object missing is_paper: the exact 2026-07-25 shape.
+    broken = SimpleNamespace(market_id="M0", token=TokenType.YES,
+                             unrealized_pnl=-4.20)
+    healthy = _position("M2", is_paper=False)
+    bot, attempted = _bot([(broken, ExitReason.STOP_LOSS),
+                           (healthy, ExitReason.STOP_LOSS)])
+
+    events = await _one_tick(bot)
+
+    assert [p for p, _ in attempted] == [healthy], (
+        "one bad position must not abort the remaining exits")
+    loop_errors = [e for e in events if e["event"] == "exit.loop_error"]
+    assert len(loop_errors) == 1, events
+    assert loop_errors[0]["log_level"] in _ERROR_LEVELS, (
+        "a swallowed defect that readiness cannot see is a silent outage")
+    assert loop_errors[0]["error_type"] == "AttributeError"
+    assert loop_errors[0]["market_id"] == "M0"
+    # The tick itself survived, so the tick-level handler never fired.
+    assert not [e for e in events if e["event"] == "portfolio_monitor_error"]
+
+
+@pytest.mark.asyncio
+async def test_tick_level_failures_are_no_longer_debug_only():
+    """A tick that dies takes every venue's exits with it — that is an error.
+
+    ``log.debug`` is the reason the outage was invisible: readiness parses logs
+    by level and never reads debug.
+    """
+    from auramaur.monitoring.readiness import _ERROR_LEVELS
+
+    bot, attempted = _bot([(_position(is_paper=False), ExitReason.STOP_LOSS)])
+
+    async def _boom(_positions):
+        bot._running = False  # one tick
+        raise TypeError("total_pnl exploded")
+
+    bot._components["pnl_tracker"] = SimpleNamespace(get_total_pnl=_boom)
+
+    events = await _one_tick(bot)
+
+    aborted = [e for e in events if e["event"] == "portfolio_monitor_error"]
+    assert aborted, "a dead tick must say so"
+    assert aborted[0]["log_level"] in _ERROR_LEVELS
+    assert aborted[0]["error_type"] == "TypeError"
+    # And the cost of a dead tick is exactly what went unseen for 12 days.
+    assert attempted == []
+
+
+@pytest.mark.asyncio
+async def test_get_positions_carries_the_book_it_read(tmp_path):
+    """The model field is only useful if the DB read populates it.
+
+    ``SELECT p.*`` already returned ``is_paper``; the model dropped it. With an
+    unscoped read (settings.is_live not a bool) both books come back in one
+    list, which is precisely when the flag has to be per-row.
+    """
+    from auramaur.db.database import Database
+    from auramaur.risk.portfolio import PortfolioTracker
+
+    db = Database(str(tmp_path / "book.db"))
+    await db.connect()
+    try:
+        await db.execute(
+            """INSERT INTO portfolio
+               (market_id, exchange, side, size, avg_price, current_price,
+                category, token, token_id, is_paper)
+               VALUES
+               ('M1','polymarket','BUY',10,0.50,0.30,'politics','YES','t',0),
+               ('M1','polymarket','BUY',10,0.50,0.30,'politics','YES','t',1)""")
+        await db.commit()
+
+        tracker = PortfolioTracker(db, SimpleNamespace(is_live=None))
+        positions = await tracker.get_positions(exchange="polymarket")
+        assert sorted(p.is_paper for p in positions) == [False, True]
+
+        scoped = await tracker.get_positions(exchange="polymarket", is_paper=False)
+        assert [p.is_paper for p in scoped] == [False]
+    finally:
+        await db.close()


### PR DESCRIPTION
## The portfolio monitor's exit loop raised on every tick

`auramaur/bot.py`'s portfolio monitor builds its per-position exit key from
`int(bool(pos.is_paper))`. `Position` (`auramaur/exchange/models.py`) has no
`is_paper` field, so the **first** position of every tick raised
`AttributeError: 'Position' object has no attribute 'is_paper'` — before any
executor was called. The raise escaped to the tick-level
`except Exception: log.debug("portfolio_monitor_error")`, which abandons the
rest of the tick: every remaining position and every remaining venue.

Net effect: no stop-loss, profit target or trailing stop could fire from this
loop. Introduced by fdf79fc, which added the mode component to the key.

Reproduced at runtime: constructing a `Position` and touching `.is_paper`
raises `AttributeError` (pydantic 2.13.4).

### Why nobody saw it

The only trace was that one `log.debug` line. `monitoring/readiness.py` scores
cycle health by log level and reads nothing below error
(`_ERROR_LEVELS = {"error", "critical"}`), so a tick that died on every pass
still reported clean.

And nothing drove the loop in tests. `tests/test_exits.py` covers the exit
*policy*; the exit *key* was covered by rebuilding the same f-string inside the
test (`test_exit_suppression_expires_and_is_keyed_per_position`) — a
reimplementation cannot fail when the real loop does.

## The fix

`Position` gains `is_paper: bool = True`, and `PortfolioTracker.get_positions`
populates it from the row it already selects (`SELECT p.*`), guarded via
`row.keys()` the way `token`/`token_id` are: column present → use it; absent
but the read was mode-scoped → use the queried mode; absent and unscoped →
paper.

The field belongs on the model rather than the caller. A position's DB identity
is `(market_id, is_paper, token)` — the book is a third of its primary key — and
`check_exits` computes `is_paper = None if not isinstance(settings.is_live,
bool) else not settings.is_live`, so when that is None the read is unscoped and
the returned list can hold both books. A single caller-side fallback would
collide keys across modes, reintroducing the dust-pinning bug documented at
`bot.py:490-495`.

The default is `True` (paper): `Fill.is_paper` and `OrderResult.is_paper` both
default `True`, the `portfolio.is_paper` column is `NOT NULL DEFAULT 1`, and an
unstated book reading as *live* is the dangerous direction. Every real
construction site states its book explicitly.

## Error visibility

The per-position block gains its own handler — `log.error("exit.loop_error", …)`
then `continue`, so a defect costs one position rather than the tick. The
tick-level handler moves from `log.debug` to `log.error`: every routine failure
already has its own handler, so anything reaching it means the whole tick died,
which is what readiness must see.

## Tests

`tests/test_bot_exit_loop.py` drives the real `_task_portfolio_monitor` loop
(`AuramaurBot.__new__` + injected `Components`). It asserts the executor is
*reached*, covers the mixed-mode distinct-key case, asserts a broken position
logs at an `_ERROR_LEVELS` level without aborting the remaining exits, asserts a
dead tick is error-level, and asserts `get_positions` carries the book.

Mutation-proven: with the sources reverted to `main`, all five fail — the
headline one as `AssertionError: no exit was attempted for a position
check_exits flagged`.

## Related bugs found, deliberately not fixed here

1. `bot_exits.py:104-115` — the Polymarket exit resolves `token_id` with
   `WHERE … is_paper = 0`, commented "only fires for live positions". That is
   false in a paper-mode bot, where `check_exits` hands it paper positions.
   Now trivially correctable as `int(pos.is_paper)`.
2. `bot_exits.py:46` `_clear_exit_suppression` clears by market prefix, so a
   terminal SELL on one book un-suppresses the other book's leg of the same
   market.
3. All three executors take mode/`dry_run` from `self.settings.is_live` rather
   than from the position — the same second assumption that caused this bug.
   Safe only while `check_exits` scopes on that same setting.
4. `_prune_zero_onchain_poly_position` deletes only `is_paper = 0` rows, coupled
   to the same assumption.
