### PR TITLE
Fail readiness when a book keeps entering and stops exiting

### DIFF
--- a/auramaur/monitoring/readiness.py
+++ b/auramaur/monitoring/readiness.py
@@ -1,6 +1,6 @@
 """Readiness checks — gate live trading until all criteria pass.
 
-Eight criteria produce a CriterionResult with one of three statuses:
+Each criterion produces a CriterionResult with one of three statuses:
   PASS              — measurable and within threshold
   FAIL              — measurable and outside threshold
   INSUFFICIENT_DATA — not enough samples to evaluate honestly
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
+from auramaur.broker.ledger import PHANTOM_STRATEGY, VENUE_STRATEGY
 from auramaur.db.database import Database
 
 Status = Literal["PASS", "FAIL", "INSUFFICIENT_DATA"]
@@ -752,8 +753,219 @@ async def check_divergence(
 
 
 # ---------------------------------------------------------------------------
+# Criterion 9 — exit liveness (entries continue while exits are absent)
+# ---------------------------------------------------------------------------
+
+# Calibrated by replaying the criterion over the full trade history; see
+# docs/exit-liveness-criterion.md for the measurement and the evidence.
+_EXIT_LIVENESS_WINDOW_DAYS = 7
+_EXIT_LIVENESS_MIN_ENTRIES = 3
+
+# A realization event. `commission` rows are cash adjustments booked against a
+# still-open position — money moving is not a position leaving.
+_EXIT_KINDS = ("sell", "settlement")
+
+# Attribution buckets, not strategy books. The ledger's entry-strategy
+# resolution refuses to credit any of these as the entrant
+# (broker/ledger.py::_market_context), so a realization can never be booked
+# back to them and their exit count is zero *by construction*. Judging them
+# would be a permanent structural false alarm rather than a signal. `exit` is
+# the exit path's own attribution on the trades mirror, which is exactly why
+# exits are counted from the ledger (entry-attributed) and not from trades.
+_UNJUDGEABLE_BOOKS = frozenset({
+    "", "exit", "order_monitor", "legacy_unattributed", "adopted_unknown",
+    PHANTOM_STRATEGY, VENUE_STRATEGY,
+})
+
+
+def _exit_cell_label(venue: str, book: str, is_paper: int) -> str:
+    return f"{venue or '?'}/{book} [{'paper' if is_paper else 'live'}]"
+
+
+async def _exit_events_by_cell(
+    db: Database, *, since: datetime, exchange: str | None, before: bool,
+) -> dict[tuple[str, str, int], int]:
+    """Realization counts per (venue, book, mode), either side of ``since``.
+
+    ``datetime(col)`` rather than a raw string compare: realized_at is written
+    both as ``YYYY-MM-DD HH:MM:SS`` (settlements) and as an offset-aware ISO
+    string with a ``T`` (sell fills), and lexical ordering disagrees with
+    chronological ordering across those two forms inside a single day.
+    """
+    comparison = "<" if before else ">="
+    kinds = ", ".join("?" for _ in _EXIT_KINDS)
+    params: list = [*_EXIT_KINDS, since.astimezone(timezone.utc).isoformat()]
+    clause = ""
+    if exchange:
+        clause = " AND venue = ?"
+        params.append(exchange)
+    rows = await db.fetchall(
+        f"""SELECT venue, strategy_source AS book, is_paper, COUNT(*) AS n
+              FROM pnl_ledger
+             WHERE kind IN ({kinds})
+               AND datetime(realized_at) {comparison} datetime(?){clause}
+             GROUP BY 1, 2, 3""",
+        tuple(params),
+    )
+    return {
+        ((r["venue"] or ""), (r["book"] or "").strip(), int(r["is_paper"] or 0)):
+            int(r["n"] or 0)
+        for r in rows
+    }
+
+
+async def check_exit_liveness(
+    db: Database,
+    *,
+    since: datetime,
+    exchange: str | None,
+    min_entries: int = _EXIT_LIVENESS_MIN_ENTRIES,
+) -> CriterionResult:
+    """FAIL when a book keeps taking entries while its exits have stopped.
+
+    Watches OUTCOMES, not mechanisms. The live prediction-market exit loop
+    once raised on every tick, and the raise landed in a ``debug``-level
+    handler — so cycle_health, which scores cycles by log level, reported
+    clean while entries continued and exits were absent for an extended
+    period. Any cause with that shape (an exception, a config mistake, a stuck
+    lock, an adapter silently refusing sells) produces the same observable,
+    and this criterion reads only the observable.
+
+    Cells are ``(venue, book, mode)``. Paper and live are judged separately on
+    purpose: paper exits kept working throughout that incident, which is
+    precisely why nothing looked wrong in aggregate.
+
+    Entries are BUY rows on ``trades`` (the gateway's mirror carries the
+    exchange and the deciding strategy). Exits are ``pnl_ledger`` rows of kind
+    ``sell`` or ``settlement``, because the ledger attributes a realization to
+    the strategy that OPENED the position while the trades mirror attributes
+    the SELL to the exit path itself. Settlements count: a long-dated book can
+    legitimately hold for weeks with no sell while positions resolve, and
+    excluding them fires constantly on ``long_horizon``.
+
+    Three ways out of a FAIL, each deliberate:
+      * fewer than ``min_entries`` entries — one entry proves nothing;
+      * no exit event ever recorded for the cell — "stopped" presupposes it
+        was running, and a brand-new book's first realization is genuinely
+        weeks away. Reported as not-yet-judgeable rather than silently
+        dropped;
+      * a dormant book (no entries at all) is never a FAIL.
+    """
+    now = datetime.now(timezone.utc)
+    window_days = max((now - since).total_seconds(), 0.0) / 86400.0
+    threshold = (
+        f"every book with ≥{min_entries} entries in {window_days:.0f}d "
+        f"shows ≥1 exit"
+    )
+
+    params: list = [since.astimezone(timezone.utc).isoformat()]
+    clause = ""
+    if exchange:
+        clause = " AND exchange = ?"
+        params.append(exchange)
+    entry_rows = await db.fetchall(
+        f"""SELECT exchange AS venue, strategy_source AS book, is_paper,
+                   COUNT(*) AS n
+              FROM trades
+             WHERE side = 'BUY'
+               AND COALESCE(status, '') NOT IN ('cancelled', 'rejected')
+               AND datetime(timestamp) >= datetime(?){clause}
+             GROUP BY 1, 2, 3""",
+        tuple(params),
+    )
+
+    in_window = await _exit_events_by_cell(
+        db, since=since, exchange=exchange, before=False)
+    earlier = await _exit_events_by_cell(
+        db, since=since, exchange=exchange, before=True)
+
+    stalled: list[str] = []
+    unproven: list[str] = []
+    active: list[str] = []
+    for row in entry_rows:
+        book = (row["book"] or "").strip()
+        if book in _UNJUDGEABLE_BOOKS:
+            continue
+        entries = int(row["n"] or 0)
+        if entries < min_entries:
+            continue
+        venue = row["venue"] or ""
+        is_paper = int(row["is_paper"] or 0)
+        cell = (venue, book, is_paper)
+        label = _exit_cell_label(venue, book, is_paper)
+        exits = in_window.get(cell, 0)
+        if exits > 0:
+            active.append(f"{label}: {entries} entries, {exits} exits")
+        elif earlier.get(cell, 0) == 0:
+            unproven.append(f"{label}: {entries} entries, no exit ever recorded")
+        else:
+            stalled.append(f"{label}: {entries} entries, 0 exits")
+
+    judged = len(active) + len(stalled)
+    if stalled:
+        return CriterionResult(
+            name="exit_liveness",
+            status="FAIL",
+            value=f"{len(stalled)} book(s) entering with no exits",
+            threshold=threshold,
+            detail="; ".join(sorted(stalled)),
+            n_samples=judged,
+        )
+    if judged == 0:
+        detail = (
+            "; ".join(sorted(unproven)) if unproven
+            else f"no book took ≥{min_entries} entries in the window"
+        )
+        return CriterionResult(
+            name="exit_liveness",
+            status="INSUFFICIENT_DATA",
+            value="0 books judgeable",
+            threshold=threshold,
+            detail=detail,
+            n_samples=0,
+        )
+    detail = "; ".join(sorted(active))
+    if unproven:
+        detail += " | not yet judgeable: " + "; ".join(sorted(unproven))
+    return CriterionResult(
+        name="exit_liveness",
+        status="PASS",
+        value=f"{judged} book(s) exiting",
+        threshold=threshold,
+        detail=detail,
+        n_samples=judged,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Top-level evaluator
 # ---------------------------------------------------------------------------
+
+
+def _exit_liveness_settings() -> tuple[int, int]:
+    """Operator overrides for the exit-liveness window and entry floor.
+
+    They live under `monitoring:` — the operator-declared health-check
+    contract — and NOT in any strategy's section. strategy_version hashes
+    exactly {strategy_source, that strategy's own config section, and
+    risk.min_edge_pct / max_spread_pct / confidence_floor}
+    (broker/execution_gateway.py::_capture_decision), and `monitoring` is
+    never resolved as a strategy section, so retuning these cannot reset a
+    14-day graduation clock.
+
+    Never raises: a config fault must degrade to the calibrated defaults
+    rather than take down the whole readiness report.
+    """
+    try:
+        from config.settings import Settings
+
+        monitoring = Settings().monitoring
+        return (
+            max(1, int(monitoring.exit_liveness_window_days)),
+            max(1, int(monitoring.exit_liveness_min_entries)),
+        )
+    except Exception:  # noqa: BLE001 - config must never break the report
+        return _EXIT_LIVENESS_WINDOW_DAYS, _EXIT_LIVENESS_MIN_ENTRIES
 
 
 async def evaluate_readiness(
@@ -767,6 +979,12 @@ async def evaluate_readiness(
     now = datetime.now(timezone.utc)
     since_window = now - timedelta(days=days)
     since_24h = now - timedelta(hours=24)
+    # exit_liveness keeps its own calibrated window rather than following
+    # `days`: the entry floor is only meaningful against the window it was
+    # measured for, and widening the report must not quietly change what the
+    # criterion means. Its threshold string states the window it used.
+    exit_window_days, exit_min_entries = _exit_liveness_settings()
+    since_exits = now - timedelta(days=exit_window_days)
     if log_file is None:
         # Follow the configured logging path (LOGGING__FILE / logging.file) so
         # cycle_health reads the file the bot actually writes — in a container
@@ -789,6 +1007,10 @@ async def evaluate_readiness(
             db, since=since_window, exchange=exchange, fee_rate=fee_rate
         ),
         await check_divergence(db, since=since_window, exchange=exchange),
+        await check_exit_liveness(
+            db, since=since_exits, exchange=exchange,
+            min_entries=exit_min_entries,
+        ),
     ]
     return ReadinessReport(
         timestamp=now,

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1344,6 +1344,12 @@ monitoring:
   pillar_stale_seconds: 900
   candidate_retention_days: 30
   candidate_summary_retention_days: 90
+  # readiness.check_exit_liveness: every book that took >= min_entries entries
+  # in the lookback must show at least one exit (SELL fill or settlement), per
+  # venue and per paper/live mode. Health-check thresholds only — outside every
+  # strategy_version hash, so changing them is graduation-clock safe.
+  exit_liveness_window_days: 7
+  exit_liveness_min_entries: 3
 
 cross_venue_arb:
   # Cross-venue semantic-equivalence arb (Poly x Kalshi): logically equivalent

--- a/config/settings.py
+++ b/config/settings.py
@@ -2110,6 +2110,17 @@ class MonitoringConfig(BaseModel):
     pillar_stale_seconds: int = 900
     candidate_retention_days: int = 30
     candidate_summary_retention_days: int = 90
+    # readiness.check_exit_liveness — "entries continue but exits stopped".
+    # Lookback over which a (venue, book, mode) cell must show at least one
+    # realization (SELL fill or settlement) if it took entries. Calibrated by
+    # replaying the criterion over the full trade history: 7d is the shortest
+    # window whose historical false-alarm count bottoms out, and a window as
+    # long as the outage it is meant to catch never fires at all, because the
+    # pre-outage exits stay inside it. See docs/exit-liveness-criterion.md.
+    # These are health-check thresholds, outside every strategy_version hash,
+    # so tuning them cannot reset a graduation clock.
+    exit_liveness_window_days: int = 7
+    exit_liveness_min_entries: int = 3
 
 
 class BenchmarkConfig(BaseModel):

--- a/docs/exit-liveness-criterion.md
+++ b/docs/exit-liveness-criterion.md
@@ -1,0 +1,109 @@
+# Exit-liveness readiness criterion
+
+`readiness.check_exit_liveness` answers one question per strategy book:
+**it is still taking entries — is anything still leaving?**
+
+## The failure it exists to catch
+
+The live prediction-market exit loop once raised on every tick. The raise was
+caught by a broad `except Exception: log.debug(...)`, so the first position of
+each tick aborted the whole tick, and for an extended period the bot took
+entries and never exited. Readiness reported clean throughout, because
+`check_cycle_health` scores cycles by log level and `debug` is not in
+`_ERROR_LEVELS`.
+
+The fix for that bug (#420) addressed the specific attribute error and raised
+those handlers to `error`. This criterion addresses the **class**. It fires
+regardless of cause — a future exception, a config mistake, a stuck lock, an
+exchange adapter silently refusing sells — because it watches outcomes rather
+than mechanisms. Nothing about it depends on the exit path logging anything at
+all.
+
+## What it measures
+
+A cell is `(venue, book, mode)`. Over a lookback window:
+
+| side | source | why |
+| --- | --- | --- |
+| entries | `trades` rows with `side='BUY'`, excluding `cancelled`/`rejected` | the gateway's mirror is the only row carrying both the venue and the strategy that *decided* to open |
+| exits | `pnl_ledger` rows with `kind IN ('sell','settlement')` | the ledger attributes a realization to the strategy that **opened** the position; the trades mirror attributes the SELL to the exit path itself (`strategy_source='exit'`), which cannot be matched back to a book |
+
+A cell with entries at or above the floor and **zero** exit events FAILs,
+naming the cell and both counts. A cell with entries and some exits PASSes.
+
+### Deliberate exemptions
+
+* **Settlements count as exits.** A position can legitimately leave via
+  resolution rather than a sell. A long-dated book goes weeks with no SELL
+  while positions resolve; counting sells only makes the criterion fire
+  permanently on `long_horizon`.
+* **`commission` rows are not exits.** They are cash adjustments booked
+  against a still-open position. Money moving is not a position leaving, and
+  treating them as exits would let an IBKR book mask a stalled exit path.
+* **Dormant books never FAIL.** A cell with no entries in the window is not
+  evaluated at all. A strategy that stopped trading is not a broken one.
+* **Below the entry floor is INSUFFICIENT_DATA.** One entry proves nothing —
+  a single position can legitimately be held across the window.
+* **A cell that has never produced an exit is not judged.** "Stopped"
+  presupposes it was running; a brand-new book's first realization is
+  genuinely weeks away. Such cells are reported as *not yet judgeable* in the
+  criterion's `detail` rather than silently dropped, so a book that never
+  exits at all is still visible to an operator.
+* **Attribution buckets are not books.** `''`, `exit`, `order_monitor`,
+  `legacy_unattributed`, `adopted_unknown`, `phantom_unattributed` and
+  `venue_unattributed` are entry-attribution fallbacks. `broker/ledger.py`
+  refuses to credit any of them as the entrant, so their exit count is zero
+  *by construction* — judging them is a permanent structural false alarm, not
+  a signal.
+* **Paper and live are judged separately.** Paper exits kept working
+  throughout the incident, which is exactly why nothing looked wrong in
+  aggregate. Collapsing the two modes turns the FAIL back into a PASS.
+
+## Calibration
+
+The thresholds were chosen by replaying the criterion over the whole trade
+history at six-hour steps and counting the distinct episodes in which it would
+have fired, before the outage and during it.
+
+* **Window = 7 days.** Historical false alarms fall as the window widens and
+  bottom out at 7 days; no live cell fires anywhere before the outage at 7
+  days or longer, and widening further buys nothing. Shorter is better for
+  latency, since detection cannot happen before `last_exit + window` — so 7 is
+  the shortest window that reaches the false-alarm floor. Windows as long as
+  the outage itself never fire at all: the pre-outage exits stay inside the
+  window for its entire duration.
+* **Entry floor = 3.** At a 7-day window the false-alarm count is already at
+  its minimum by 3 entries and does not improve at 4 or 5, while raising the
+  floor delays detection by one to two days. Three independent entry decisions
+  in a week with zero realizations of any kind is a real signal.
+
+The criterion keeps this window regardless of `--days`. The entry floor is
+only meaningful against the window it was measured for, and widening the
+report must not quietly change what the criterion means; the `threshold`
+string always states the window actually used.
+
+Both knobs are operator-tunable under `monitoring:` in `config/defaults.yaml`
+(`exit_liveness_window_days`, `exit_liveness_min_entries`). That section is the
+health-check contract, **not** a strategy section: `strategy_version` hashes
+only `{strategy_source, that strategy's own config section, risk.min_edge_pct
+/ max_spread_pct / confidence_floor}` (see
+`broker/execution_gateway.py::_capture_decision`), and `monitoring` is never
+resolved as a strategy section. Retuning these therefore cannot reset a 14-day
+graduation clock.
+
+### Honest limits
+
+No threshold clears the outage while firing *never* before it. Replayed over
+the full history at the chosen settings the criterion produces a small number
+of pre-outage episodes, **all of them paper cells and none live**. They are
+not obviously false either: each is a book that took double-digit entries
+across more than a week with no realization of any kind — the same shape the
+criterion is built to report. The residual risk is a paper cell crying wolf,
+which is why the failure names the cell and the mode rather than reporting a
+single system-wide verdict.
+
+Two live cells that were also entering during the outage are *not* caught,
+because both were new enough to have no prior exit at all. That is the
+"never exited" exemption doing its job: from outcomes alone, a book that has
+never realized is indistinguishable from one whose first realization has not
+come due. They surface as *not yet judgeable* instead.

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -14,6 +14,7 @@ from auramaur.monitoring.readiness import (
     check_cycle_health,
     check_data_sources,
     check_divergence,
+    check_exit_liveness,
     check_pass_rate,
     check_pnl_after_fees,
     check_win_rate,
@@ -496,16 +497,288 @@ async def test_divergence_fail_when_median_high(db: Database):
 
 
 # ---------------------------------------------------------------------------
+# Exit liveness — "entries continue but exits stopped"
+# ---------------------------------------------------------------------------
+
+
+async def _seed_entries(
+    db: Database,
+    *,
+    n: int,
+    venue: str = "polymarket",
+    book: str = "llm",
+    is_paper: int = 0,
+    days_ago: float = 1.0,
+    status: str = "filled",
+) -> None:
+    """BUY rows on the gateway's trades mirror — the entry side of a cell."""
+    for i in range(n):
+        ts = (
+            datetime.now(timezone.utc) - timedelta(days=days_ago, minutes=i)
+        ).isoformat()
+        await db.execute(
+            "INSERT INTO trades (market_id, exchange, timestamp, side, size, "
+            "price, is_paper, status, strategy_source) "
+            "VALUES (?, ?, ?, 'BUY', 10.0, 0.50, ?, ?, ?)",
+            (f"{book}-{is_paper}-{days_ago}-{i}", venue, ts, is_paper, status, book),
+        )
+    await db.commit()
+
+
+async def _seed_exits(
+    db: Database,
+    *,
+    n: int,
+    venue: str = "polymarket",
+    book: str = "llm",
+    is_paper: int = 0,
+    days_ago: float = 1.0,
+    kind: str = "sell",
+) -> None:
+    """Realization rows — the exit side. The ledger attributes a realization
+    to the strategy that OPENED the position, which is why exits are counted
+    from here and not from the trades mirror (whose SELL rows are attributed
+    to the exit path itself)."""
+    for i in range(n):
+        ts = (
+            datetime.now(timezone.utc) - timedelta(days=days_ago, minutes=i)
+        ).isoformat()
+        await db.execute(
+            "INSERT INTO pnl_ledger (market_id, venue, strategy_source, kind, "
+            "token, qty, pnl, fees, is_paper, source_ref, realized_at) "
+            "VALUES (?, ?, ?, ?, 'YES', 10.0, 1.0, 0.0, ?, ?, ?)",
+            (f"{book}-{is_paper}-{i}", venue, book, kind, is_paper,
+             f"exit:{venue}:{book}:{is_paper}:{kind}:{days_ago}:{i}", ts),
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_fail_when_entries_continue_and_exits_are_absent(
+    db: Database,
+):
+    """The core contract: a book with entries above the floor and ZERO exit
+    events fails, and the failure names the cell and both counts."""
+    await _seed_exits(db, n=4, days_ago=20.0)          # established cadence
+    await _seed_entries(db, n=6, days_ago=2.0)         # entries kept coming
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "FAIL"
+    assert "polymarket/llm [live]" in result.detail
+    assert "6 entries" in result.detail
+    assert "0 exits" in result.detail
+    assert result.n_samples == 1
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_pass_when_a_book_enters_and_exits(db: Database):
+    await _seed_exits(db, n=4, days_ago=20.0)
+    await _seed_entries(db, n=6, days_ago=2.0)
+    await _seed_exits(db, n=2, days_ago=1.0)
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "PASS"
+    assert "polymarket/llm [live]" in result.detail
+    assert result.n_samples == 1
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_dormant_book_with_no_entries_never_fails(db: Database):
+    """A strategy that stopped trading is not a broken one. Exits present in
+    history, none in the window, and no entries in the window either."""
+    await _seed_exits(db, n=10, days_ago=20.0)
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status != "FAIL"
+    assert result.status == "INSUFFICIENT_DATA"
+    assert result.n_samples == 0
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_settlements_alone_count_as_exits(db: Database):
+    """A long-dated book can go a long time with no SELL while positions
+    resolve. Settlements are exits; without this the criterion fires forever
+    on long_horizon."""
+    await _seed_exits(db, n=2, book="long_horizon", days_ago=20.0,
+                      kind="settlement")
+    await _seed_entries(db, n=8, book="long_horizon", days_ago=3.0)
+    await _seed_exits(db, n=3, book="long_horizon", days_ago=1.0,
+                      kind="settlement")
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "PASS"
+    assert "3 exits" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_commissions_are_not_exits(db: Database):
+    """A commission is booked against a still-open position. Money moving is
+    not a position leaving, so it must not mask a stalled exit path."""
+    await _seed_exits(db, n=3, days_ago=20.0)
+    await _seed_entries(db, n=5, days_ago=2.0)
+    await _seed_exits(db, n=9, days_ago=1.0, kind="commission")
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "FAIL"
+    assert "0 exits" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_judges_paper_and_live_independently(db: Database):
+    """Paper exits kept working throughout the incident, which is exactly why
+    nothing looked wrong in aggregate. The same book, same venue, healthy in
+    paper and stalled in live: the paper half must not vouch for the live
+    half. Collapse the two modes into one cell and this FAIL becomes a PASS.
+    """
+    await _seed_exits(db, n=3, is_paper=1, days_ago=20.0)
+    await _seed_exits(db, n=3, is_paper=0, days_ago=20.0)
+    await _seed_entries(db, n=6, is_paper=1, days_ago=2.0)
+    await _seed_entries(db, n=6, is_paper=0, days_ago=2.0)
+    await _seed_exits(db, n=4, is_paper=1, days_ago=1.0)   # paper still exiting
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "FAIL"
+    assert result.detail == "polymarket/llm [live]: 6 entries, 0 exits"
+    assert result.n_samples == 2                           # both cells judged
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_entry_floor_keeps_a_single_entry_from_failing(
+    db: Database,
+):
+    """One entry proves nothing — a single position can legitimately be held."""
+    await _seed_exits(db, n=3, days_ago=20.0)
+    await _seed_entries(db, n=2, days_ago=2.0)
+    now = datetime.now(timezone.utc)
+    below = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None, min_entries=3)
+    assert below.status == "INSUFFICIENT_DATA"
+    at_floor = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None, min_entries=2)
+    assert at_floor.status == "FAIL"
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_book_that_never_exited_is_not_judged(db: Database):
+    """"Stopped" presupposes it was running. A brand-new book's first
+    realization is genuinely weeks away, so it is reported as not-yet-
+    judgeable instead of failed."""
+    await _seed_entries(db, n=9, book="term_structure", days_ago=2.0)
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "INSUFFICIENT_DATA"
+    assert "no exit ever recorded" in result.detail
+    assert "polymarket/term_structure [live]" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_ignores_unattributed_entry_buckets(db: Database):
+    """order_monitor / exit / legacy_unattributed are attribution buckets, not
+    books. The ledger refuses to credit them as the entrant, so a realization
+    can never be booked back to them — judging them is a permanent false
+    alarm. Each bucket is given a realistic exit history and then entries with
+    no exits in the window, which is exactly the shape that would fail a real
+    book."""
+    for bucket in ("order_monitor", "exit", "legacy_unattributed"):
+        await _seed_exits(db, n=3, book=bucket, days_ago=20.0)
+        await _seed_entries(db, n=8, book=bucket, days_ago=2.0)
+    await _seed_exits(db, n=2, days_ago=20.0)              # one genuine book
+    await _seed_entries(db, n=5, days_ago=2.0)
+    await _seed_exits(db, n=2, days_ago=1.0)
+    now = datetime.now(timezone.utc)
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "PASS"
+    assert result.detail == "polymarket/llm [live]: 5 entries, 2 exits"
+    assert result.n_samples == 1
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_respects_the_exchange_filter(db: Database):
+    """Scoping to one venue must not let another venue's cells leak into the
+    verdict — in either direction."""
+    await _seed_exits(db, n=3, venue="kalshi", days_ago=20.0)
+    await _seed_entries(db, n=6, venue="kalshi", days_ago=2.0)   # kalshi stalled
+    await _seed_exits(db, n=3, venue="polymarket", days_ago=20.0)
+    await _seed_entries(db, n=6, venue="polymarket", days_ago=2.0)
+    await _seed_exits(db, n=2, venue="polymarket", days_ago=1.0)  # poly healthy
+    now = datetime.now(timezone.utc)
+
+    poly = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange="polymarket")
+    assert poly.status == "PASS"
+    assert "kalshi" not in poly.detail
+
+    kalshi = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange="kalshi")
+    assert kalshi.status == "FAIL"
+    assert kalshi.detail == "kalshi/llm [live]: 6 entries, 0 exits"
+
+    both = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert both.status == "FAIL"
+    assert both.n_samples == 2
+
+
+@pytest.mark.asyncio
+async def test_exit_liveness_detects_the_prediction_market_exit_outage(db: Database):
+    """Reconstruction of the incident this criterion exists to catch.
+
+    The live prediction-market exit loop raised on every tick for an extended
+    period. Entries kept being taken, live SELL fills went to zero, and the
+    only live realizations left were settlements on OTHER books' positions.
+    Paper exits were unaffected. Readiness reported clean the whole time
+    because cycle_health scores log level and the raise was logged at debug.
+    """
+    now = datetime.now(timezone.utc)
+    # Before the outage: the live book was entering AND exiting normally.
+    for day in (14.0, 12.0, 10.0):
+        await _seed_entries(db, n=2, days_ago=day)
+        await _seed_exits(db, n=2, days_ago=day)
+    # The outage: entries accrue every day, not one live realization lands.
+    for day in (6.0, 5.0, 4.0, 3.0, 2.0, 1.0):
+        await _seed_entries(db, n=2, days_ago=day)
+    # Paper kept entering and exiting throughout — the reason it looked fine.
+    await _seed_exits(db, n=2, is_paper=1, days_ago=10.0)
+    for day in (6.0, 4.0, 2.0):
+        await _seed_entries(db, n=2, is_paper=1, days_ago=day)
+        await _seed_exits(db, n=2, is_paper=1, days_ago=day)
+    # A different live book still settled, so venue-level activity was not zero.
+    await _seed_exits(db, n=3, book="market_maker", days_ago=3.0,
+                      kind="settlement")
+
+    result = await check_exit_liveness(
+        db, since=now - timedelta(days=7), exchange=None)
+    assert result.status == "FAIL"
+    assert "polymarket/llm [live]: 12 entries, 0 exits" in result.detail
+    assert "[paper]" not in result.detail
+
+    # And the same window BEFORE the outage began must be clean, so the
+    # failure is attributable to the outage and not to the fixture shape.
+    healthy = await check_exit_liveness(
+        db, since=now - timedelta(days=15), exchange=None,
+        min_entries=100)
+    assert healthy.status == "INSUFFICIENT_DATA"
+
+
+# ---------------------------------------------------------------------------
 # Top-level evaluator
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_evaluate_readiness_aggregates_all_nine_criteria(db: Database, tmp_path):
+async def test_evaluate_readiness_aggregates_all_ten_criteria(db: Database, tmp_path):
     log_file = tmp_path / "auramaur.log"
     log_file.write_text("")
     report = await evaluate_readiness(db, log_file=log_file, exchange="kalshi", days=7)
-    assert len(report.criteria) == 9
+    assert len(report.criteria) == 10
     assert not report.overall_pass
     names = [c.name for c in report.criteria]
     assert names == [
@@ -518,7 +791,26 @@ async def test_evaluate_readiness_aggregates_all_nine_criteria(db: Database, tmp
         "win_rate",
         "pnl_after_fees",
         "divergence",
+        "exit_liveness",
     ]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_readiness_surfaces_a_stalled_exit_path(
+    db: Database, tmp_path,
+):
+    """The criterion must reach the report, not just exist. A live book that
+    keeps entering while its exits are absent has to show up as a FAIL in the
+    aggregate the operator actually reads."""
+    log_file = tmp_path / "auramaur.log"
+    log_file.write_text("")
+    await _seed_exits(db, n=4, venue="kalshi", days_ago=20.0)
+    await _seed_entries(db, n=6, venue="kalshi", days_ago=2.0)
+    report = await evaluate_readiness(db, log_file=log_file, exchange="kalshi", days=7)
+    criterion = next(c for c in report.criteria if c.name == "exit_liveness")
+    assert criterion.status == "FAIL"
+    assert "kalshi/llm [live]" in criterion.detail
+    assert not report.overall_pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

#420 fixed the bug: the live prediction-market exit loop raised on every tick, the raise landed in a broad `except Exception: log.debug(...)`, and the first position of each tick aborted the whole tick. For an extended period the bot took entries and never exited. **Readiness reported clean the entire time**, because `check_cycle_health` scores cycles by log level and `debug` is not in `_ERROR_LEVELS`.

That fix addressed the instance and raised those handlers to `error`. This addresses the **class**. `check_exit_liveness` reads only outcomes, so it fires on a future exception, a config mistake, a stuck lock or an adapter silently refusing sells alike — nothing about it depends on the exit path logging anything at all.

## What it does

Per `(venue, book, mode)` over a 7-day window:

| side | source |
| --- | --- |
| entries | `trades` rows with `side='BUY'`, excluding `cancelled`/`rejected` |
| exits | `pnl_ledger` rows with `kind IN ('sell','settlement')` |

Entries at or above the floor with **zero** exits is a FAIL naming the cell and both counts. Entries plus some exits is a PASS.

### Why the ledger is the exit source

`bot_exits` passes `strategy_source="exit"` to `submit_exit`, so the trades mirror attributes every SELL to the exit path rather than to a book — a cell's exits cannot be recovered from it. The ledger resolves a realization to the strategy that **opened** the position (`broker/ledger.py::_market_context`), which is exactly the cell the entry side is keyed on.

Timestamps are compared with `datetime()`, not lexically: `realized_at` is written both as `YYYY-MM-DD HH:MM:SS` and as offset-aware ISO with a `T`, and those two forms sort against each other wrongly inside a single day.

### Five deliberate exemptions

- **Settlements count as exits.** A position can leave via resolution rather than a sell; counting sells only fires permanently on `long_horizon`.
- **`commission` rows do not.** They are cash adjustments on a still-open position — money moving is not a position leaving.
- **A dormant book is never evaluated.** A strategy that stopped trading is not a broken one.
- **A cell that has never produced an exit is not judged.** "Stopped" presupposes it was running, and a new book's first realization is genuinely weeks away. Reported as *not yet judgeable* in `detail` rather than dropped, so a book that never exits stays visible.
- **Attribution buckets are skipped** (`''`, `exit`, `order_monitor`, `legacy_unattributed`, `adopted_unknown`, `phantom_unattributed`, `venue_unattributed`). The ledger refuses to credit them as the entrant, so their exit count is zero *by construction*.

Paper and live are separate cells. Paper exits kept working throughout the incident, which is precisely why nothing looked wrong in aggregate; collapsing the modes turns the FAIL back into a PASS, and a test pins that.

## Calibration

The criterion was replayed over the full trade history at six-hour steps, counting the distinct episodes it would have fired.

- **Window = 7 days.** Historical false alarms fall as the window widens and bottom out at 7 days, with no live cell firing anywhere before the outage. A window as long as the outage never fires at all — the pre-outage exits stay inside it for its whole duration. Detection cannot precede `last_exit + window`, so 7 is the shortest window that reaches the false-alarm floor.
- **Entry floor = 3.** At 7 days the floor of 3 already sits at that minimum; raising it to 4 or 5 removes no false alarms and only delays detection.

Replaying the **shipped** code over the real history confirms the simulation: it FAILs on the live cell during the outage and clears once exits resume.

### Honest limits

No setting fires during the outage and never before it; `docs/exit-liveness-criterion.md` says so rather than picking one that only looks good. At these thresholds a small number of pre-outage episodes remain — **all paper cells, none live** — each a book that took double-digit entries across more than a week with no realization of any kind, which is the same shape the criterion reports. Two live cells entering during the outage are missed because both were too new to have any prior exit; from outcomes alone that is indistinguishable from a first realization not yet due.

## Config placement

`exit_liveness_window_days` / `exit_liveness_min_entries` go in `MonitoringConfig` — the operator-declared health-check contract. `strategy_version` hashes only `{strategy_source, that strategy's own config section, risk.min_edge_pct / max_spread_pct / confidence_floor}` (`execution_gateway::_capture_decision`), and `monitoring` is never resolved as a strategy section, so retuning them **cannot reset a 14-day graduation clock**. `risk.min_edge_pct`, `max_spread_pct` and `confidence_floor` are untouched.

The criterion keeps its calibrated window regardless of `--days`: the entry floor is only meaningful against the window it was measured for, and its `threshold` string always states the window used.

## Tests

Thirteen behavioural tests on a real schema, including a reconstruction of the incident's shape — entries accruing daily while no live realization lands, paper unaffected, another live book still settling so venue activity is not zero. No `inspect.getsource` assertions.

Eleven mutations were applied one at a time and each confirmed to kill the test that names it: never reporting a stalled cell; dropping settlements; counting commissions; collapsing paper and live; removing the entry floor; judging cells with no entries; failing a never-exited book; judging attribution buckets; dropping the exchange filter; reading exits from the trades mirror; unwiring the criterion from the report. **Three of the eleven survived the first pass**, and the tests they exposed as non-discriminating were rewritten until they died.

## Scope

The criterion, its wiring into the readiness report, its tests, and a docs note. Exit logic, `bot.py` and the other criteria are untouched.

## Verification (CI-identical, in-container)

```
2288 passed, 5 skipped, 1 deselected in 284.64s
Required test coverage of 65.0% reached. Total coverage: 67.32%
ruff check . — All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
