### PR TITLE
Stop the exit-decision log from outgrowing the book it observes

### DIFF
--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -20,7 +20,9 @@ log = structlog.get_logger()
 
 # Mirrors ExecutionConfig.exit_decision_retention_days; used when a caller's
 # settings object cannot supply a usable value (tests, degraded config).
-_DEFAULT_RETENTION_DAYS = 14
+# Keep in lockstep with that field — a degraded config must not silently
+# retain longer than the tracked default (test_exit_policy pins the pair).
+_DEFAULT_RETENTION_DAYS = 3
 
 
 class PortfolioTracker:

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -37,7 +37,13 @@ execution:
   # Set either to 0 to disable the trailing tier entirely.
   trailing_stop_activation_pct: 12.0
   trailing_stop_giveback_fraction: 0.45
-  exit_decision_retention_days: 14
+  # 2026-08-06: 14 -> 3. One row per open position per tick outgrows
+  # candidate_dispositions (the table this was modelled on) ~5.6x and carries
+  # two indexes; 14 days costs roughly the size of the whole trading DB for
+  # rows nothing reads. calibrate_exit_policy.py filters HOLD out and gates on
+  # non-HOLD counts, so this does not affect it. Raise only with a consumer
+  # that actually reads HOLD rows.
+  exit_decision_retention_days: 3
   edge_erosion_min_pct: 2.0
   time_decay_hours: 12.0
   # Free capital from near-certain winners far from resolution (sell early to

--- a/config/settings.py
+++ b/config/settings.py
@@ -192,7 +192,15 @@ class ExecutionConfig(BaseModel):
     trailing_stop_giveback_fraction: float = Field(default=0.45, ge=0, le=1)
     # Exit-decision telemetry is an observation log, not evidence of record;
     # bound it so a holdout cannot grow the trading DB without limit.
-    exit_decision_retention_days: int = Field(default=14, ge=1, le=365)
+    # 2026-08-06: 14 -> 3. A row is written per open position per tick, so at
+    # the 60s portfolio cadence this table outgrows candidate_dispositions —
+    # the table it was modelled on — by ~5.6x, and carries two indexes. At 14
+    # days that is roughly the size of the entire trading DB again, for rows
+    # nothing reads: the sole consumer (scripts/calibrate_exit_policy.py)
+    # selects `policy_action <> 'HOLD'`, and its MIN_TRAIN_EXITS /
+    # MIN_TEST_EXITS gates count non-HOLD rows only, so retention length does
+    # not affect it. Raise this only alongside a consumer that reads HOLDs.
+    exit_decision_retention_days: int = Field(default=3, ge=1, le=365)
     edge_erosion_min_pct: float = 2.0
     time_decay_hours: float = 12.0
     # Free capital from near-certain winners that are still far from resolution:

--- a/tests/test_exit_policy.py
+++ b/tests/test_exit_policy.py
@@ -219,25 +219,35 @@ async def test_unscoped_read_uses_the_positions_own_book_not_paper(tmp_path):
 
 @pytest.mark.asyncio
 async def test_v50_migration_adds_exit_decision_telemetry(tmp_path):
+    """Call the migration DIRECTLY, never through connect().
+
+    ``_init_schema`` runs ``executescript(TABLES)`` before dispatching
+    migrations, so a reconnect-and-migrate test rebuilds the table from
+    TABLES and then runs the migration against a schema that already
+    satisfies it — the migration's own DDL is never observed, and gutting
+    it leaves the test green (verified 2026-08-06).
+    """
     path = tmp_path / "migration.db"
     db = Database(str(path))
     await db.connect()
-    await db.execute("DROP TABLE exit_decisions")
-    await db.execute("UPDATE schema_version SET version = 49")
-    await db.commit()
-    await db.close()
-
-    upgraded = Database(str(path))
-    await upgraded.connect()
     try:
-        version = await upgraded.fetchone("SELECT version FROM schema_version")
-        columns = await upgraded.fetchall("PRAGMA table_info(exit_decisions)")
+        await db.execute("DROP TABLE exit_decisions")
+        await db.execute("UPDATE schema_version SET version = 49")
+
+        await db._migrate_v49_to_v50()
+
+        version = await db.fetchone("SELECT version FROM schema_version")
+        columns = await db.fetchall("PRAGMA table_info(exit_decisions)")
         assert version["version"] == 50
         assert {row["name"] for row in columns} >= {
             "policy_action", "net_pnl_pct", "estimated_fees", "peak_pnl_pct"
         }
+        # Idempotent: a second dispatch must not raise or lose rows.
+        await db._migrate_v49_to_v50()
+        assert (await db.fetchone(
+            "SELECT version FROM schema_version"))["version"] == 50
     finally:
-        await upgraded.close()
+        await db.close()
 
 
 async def _prune_plan(db) -> list[str]:
@@ -348,3 +358,46 @@ def test_every_schema_step_dispatches_to_a_distinct_migration():
     for name in dispatched:
         start, end = (int(g) for g in _MIGRATION_STEP.match(name).groups())
         assert end == start + 1, f"{name} is not a single-version step"
+
+
+def test_degraded_default_matches_the_tracked_setting():
+    """The module fallback and the tracked default must not drift apart —
+    a degraded config must never retain LONGER than a healthy one."""
+    from config.settings import Settings
+
+    from auramaur.risk import portfolio as portfolio_mod
+
+    assert (portfolio_mod._DEFAULT_RETENTION_DAYS
+            == Settings().execution.exit_decision_retention_days)
+
+
+async def test_exit_decision_write_is_one_atomic_span(tmp_path):
+    """Insert batch and retention prune land together or not at all.
+
+    Nothing pinned the span before 2026-08-06: replacing the
+    ``db.transaction`` context manager with ``if True:`` left the suite
+    green, so a partial write (rows inserted, prune skipped) was
+    undetectable.
+    """
+    db = Database(str(tmp_path / "span.db"))
+    await db.connect()
+    try:
+        tracker = PortfolioTracker(db)
+        owners: list[str] = []
+        original = db.transaction
+
+        def _spy(owner=None):
+            owners.append(owner or "")
+            return original(owner=owner)
+
+        db.transaction = _spy
+        rows = [(
+            "2026-08-06 00:00:00", "m1", "polymarket", "YES", 1, "HOLD",
+            10.0, 9.0, 12.0, 50.0, 0.1, 0.6, 0.5, 10.0,
+        )]
+        await tracker._record_exit_decisions(rows, 3)
+        assert owners == ["portfolio.exit_decisions"], (
+            "the batch must take exactly one named span")
+    finally:
+        db.transaction = original
+        await db.close()


### PR DESCRIPTION
Follow-up to #419, applying its review''s one recommended change plus the two test gaps it found.

## Retention default 14 -> 3

`exit_decisions` writes one row per open position per tick. At the 60s portfolio cadence that outgrows `candidate_dispositions` — the table it was modelled on, and already the DB''s second largest — by roughly **5.6x**, and it carries two indexes rather than one. A 14-day window therefore costs about as much disk as the entire trading database, on the same serialized SQLite connection every pillar shares.

None of it is read. The sole consumer, `scripts/calibrate_exit_policy.py`, opens with `WHERE d.policy_action <> ''HOLD''`, and its `MIN_TRAIN_EXITS` / `MIN_TEST_EXITS` gates count non-HOLD rows only — so retention length cannot affect what it can learn. Three days lands at parity with the precedent and costs the shipped tooling nothing. Raise it only alongside a consumer that actually reads HOLD rows.

The module fallback (`_DEFAULT_RETENTION_DAYS`) moves with it: a degraded config must never retain LONGER than a healthy one. A new test pins the pair so they cannot drift apart.

Worth recording for whoever raises it later: the HOLD set is also a weaker counterfactual than it looks. Rows are written for positions that subsequently exit via edge erosion, time decay or dust, and stop-loss writes no row at all — so it is not a clean "what if I had held" sample.

## Two tests that could not fail

**The v50 migration test was vacuous.** It reconnected and let `connect()` migrate, but `_init_schema` runs `executescript(TABLES)` **before** dispatching migrations — so the table was rebuilt from TABLES and the migration then ran against a schema that already satisfied it. Its own DDL was never observed, and gutting the migration left the test green. It now calls `_migrate_v49_to_v50()` directly against a dropped table, and additionally checks idempotence.

This shape is worth watching for elsewhere: any migration test that reconnects rather than calling the step directly proves nothing about the migration.

**Nothing pinned the telemetry span.** Replacing the `db.transaction` context manager with `if True:` left the whole suite green, so a partial write — rows inserted, retention prune skipped — was undetectable. A spy now asserts the batch takes exactly one named span.

Both mutations were verified to fail before this change and pass after.

## Verification

Full suite in the CI-identical container: **2307 passed, 5 skipped**, coverage **67.44%** (floor 65.0), ruff clean.

Assisted-by: Claude (Anthropic)