### PR TITLE
Project paper portfolio rows on instant fills, not just deferred ones

### DIFF
--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -69,8 +69,12 @@ class OrderMonitorMixin:
                     # write a portfolio row — the order was resting when
                     # ``submit`` returned — so the deferred fill must leave
                     # one now. Shared with the gateway's instant-fill path
-                    # so the two projections cannot diverge.
-                    await materialize_paper_portfolio_row(db, order)
+                    # so the two projections cannot diverge. The deferred
+                    # queue is the polymarket PaperTrader's, so the order's
+                    # exchange field (defaulting "polymarket") is the venue
+                    # truth available here.
+                    await materialize_paper_portfolio_row(
+                        db, order, venue=order.exchange or "polymarket")
                 if order.decision_id is not None:
                     await DecisionTracker(db).mark_fill(
                         int(order.decision_id),

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -34,7 +34,10 @@ class OrderMonitorMixin:
         Fails soft: a bookkeeping error here must never take down the monitor
         loop that also reaps live orders.
         """
-        from auramaur.broker.execution_gateway import booked_as_position
+        from auramaur.broker.execution_gateway import (
+            booked_as_position,
+            materialize_paper_portfolio_row,
+        )
         from auramaur.exchange.models import Fill
         from auramaur.research.polymarket_strategies import DecisionTracker
 
@@ -62,7 +65,12 @@ class OrderMonitorMixin:
                         token_id=order.token_id, side=order.side,
                         size=result.filled_size, price=result.filled_price,
                         fee=0.0, is_paper=True, order_id=result.order_id))
-                    await self._materialize_paper_portfolio_row(db, order)
+                    # The pillar that placed this order deliberately did not
+                    # write a portfolio row — the order was resting when
+                    # ``submit`` returned — so the deferred fill must leave
+                    # one now. Shared with the gateway's instant-fill path
+                    # so the two projections cannot diverge.
+                    await materialize_paper_portfolio_row(db, order)
                 if order.decision_id is not None:
                     await DecisionTracker(db).mark_fill(
                         int(order.decision_id),
@@ -71,83 +79,6 @@ class OrderMonitorMixin:
             except Exception as exc:  # noqa: BLE001
                 log.warning("order_monitor.deferred_fill_unbooked",
                             order_id=result.order_id, error=str(exc)[:160])
-
-    @staticmethod
-    async def _materialize_paper_portfolio_row(db, order) -> None:
-        """Project the just-updated paper ``cost_basis`` row into ``portfolio``.
-
-        ``PnLTracker.record_fill`` writes ``fills`` and ``cost_basis`` and
-        NOTHING else. The pillar that placed this order deliberately did not
-        write a portfolio row — the order was resting when ``submit`` returned
-        — and nothing else fills the gap: position sync is mode-scoped
-        (``is_paper_flag = 0 if settings.is_live else 1``), so in a live bot it
-        never touches paper rows. That is exactly what every pillar's
-        ``_record_position`` docstring says ("the mode-scoped position sync
-        won't maintain paper rows in a live bot, so the pillar owns this
-        write"). Without this the deferred fill leaves a holding that settles
-        correctly — ``check_resolutions`` scans ``cost_basis`` — but is
-        invisible to ``RiskManager``'s position reads and to every pillar's
-        ``_open_position_count``, both of which read FROM ``portfolio``, so
-        ``max_open`` undercounts. Measured on the live DB 2026-08-06:
-        long_horizon held 13 such paper rows worth $141.03 and llm 18 worth
-        $374.31, all with no portfolio row.
-
-        PROJECTED FROM cost_basis, not from this one fill, so the two cannot
-        diverge. ``cost_basis`` carries the CUMULATIVE size and
-        weighted-average cost for (market, token, mode) across every fill —
-        the second deferred fill in a market would make a fill-shaped upsert
-        undercount, since the portfolio upsert REPLACES size rather than
-        adding to it. It is also the exact row
-        ``resolution_tracker._settle_position`` falls back to when no
-        portfolio row exists.
-
-        Cannot double-book at settlement. ``_settle_position`` reads the
-        portfolio row OR the cost_basis row (portfolio preferred) to obtain
-        (size, entry_price), but derives its idempotency key from neither:
-        ``source_ref = f"settle:{market_id}:{canon_token}:{is_paper_flag}"``
-        comes from the position KEY alone, and ``_prior_settlement`` dedupes
-        on it. Materializing the row therefore changes only WHICH branch
-        supplies the numbers — and because both branches now read the same
-        cost_basis values, they supply identical numbers. ``side`` is
-        hardcoded "BUY" for the same reason ``_settle_position``'s cost_basis
-        branch hardcodes it: Polymarket holdings are always long.
-        """
-        row = await db.fetchone(
-            "SELECT size, avg_cost, token, token_id FROM cost_basis "
-            "WHERE market_id = ? AND is_paper = 1 AND token = ?",
-            (order.market_id, order.token.value),
-        )
-        if row is None:
-            return
-        size = float(row["size"])
-        if size <= 0:
-            # A deferred SELL that closed the holding. Leaving the portfolio
-            # row behind would be the mirror phantom of the one the entry
-            # guards remove, so drop it — the same cleanup _settle_position
-            # performs once cost_basis reaches zero.
-            await db.execute(
-                "DELETE FROM portfolio WHERE market_id = ? AND is_paper = 1 "
-                "AND UPPER(token) = UPPER(?)",
-                (order.market_id, order.token.value),
-            )
-            return
-        price = float(row["avg_cost"])
-        await db.execute(
-            """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
-               current_price, unrealized_pnl, category, token, token_id,
-               is_paper, updated_at)
-               VALUES (?, ?, 'BUY', ?, ?, ?, 0,
-                       COALESCE((SELECT category FROM markets WHERE id = ?), ''),
-                       ?, ?, 1, datetime('now'))
-               ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
-                   size = excluded.size,
-                   avg_price = excluded.avg_price,
-                   current_price = excluded.current_price,
-                   updated_at = excluded.updated_at""",
-            (order.market_id, order.exchange or "polymarket", size, price, price,
-             order.market_id, row["token"] or order.token.value,
-             row["token_id"] or order.token_id),
-        )
 
     async def _task_order_monitor(self) -> None:
         """Monitor pending limit orders for fills and expiry."""

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -157,6 +157,86 @@ def booked_as_position(res: ExecutionResult | OrderResult | None) -> bool:
     return size is not None and size > 0
 
 
+async def materialize_paper_portfolio_row(db, order) -> None:
+    """Project the just-updated paper ``cost_basis`` row into ``portfolio``.
+
+    THE single maintainer of a paper ``portfolio`` row after a booked fill,
+    called from the gateway's ``_record_result`` (instant paper fills — entries
+    AND exits) and from the order monitor's deferred-fill path. One
+    implementation so the two cannot diverge — the same doctrine as
+    :func:`booked_as_position` above.
+
+    Why anything must do this at all: ``PnLTracker.record_fill`` writes
+    ``fills`` and ``cost_basis`` and NOTHING else, and position sync is
+    mode-scoped (``is_paper_flag = 0 if settings.is_live else 1``), so in a
+    live bot nothing else maintains paper rows. On the ENTRY side that left
+    deferred fills invisible to ``RiskManager`` and every pillar's
+    ``_open_position_count`` (measured 2026-08-06: 13 such long_horizon rows
+    and 18 llm rows, all settling correctly yet uncounted). On the EXIT side
+    the mirror image shipped a day later: an exit that filled INSTANTLY
+    through paper interception zeroed ``cost_basis`` and left the portfolio
+    row at FULL SIZE until resolution cleanup (observed live 2026-08-06, the
+    evening after the deferred-fill fix deployed) — inflating exposure and
+    ``max_open`` counts for however long the market kept trading.
+
+    PROJECTED FROM cost_basis, not from the triggering fill, so the two
+    cannot diverge. ``cost_basis`` carries the CUMULATIVE size and
+    weighted-average cost for (market, token, mode) across every fill — a
+    fill-shaped upsert would undercount the second fill in a market (the
+    portfolio upsert REPLACES size) and would leave a stale full-size row
+    after a partial exit. It is also the exact row
+    ``resolution_tracker._settle_position`` falls back to when no portfolio
+    row exists.
+
+    Cannot double-book at settlement. ``_settle_position`` reads the
+    portfolio row OR the cost_basis row (portfolio preferred) to obtain
+    (size, entry_price), but derives its idempotency key from neither:
+    ``source_ref = f"settle:{market_id}:{canon_token}:{is_paper_flag}"``
+    comes from the position KEY alone, and ``_prior_settlement`` dedupes on
+    it. Materializing the row therefore changes only WHICH branch supplies
+    the numbers — and both branches read the same cost_basis values.
+    ``side`` is hardcoded "BUY" for the same reason ``_settle_position``'s
+    cost_basis branch hardcodes it: Polymarket holdings are always long.
+    """
+    row = await db.fetchone(
+        "SELECT size, avg_cost, token, token_id FROM cost_basis "
+        "WHERE market_id = ? AND is_paper = 1 AND token = ?",
+        (order.market_id, order.token.value),
+    )
+    if row is None:
+        return
+    size = float(row["size"])
+    if size <= 0:
+        # The fill closed the holding. Leaving the portfolio row behind is
+        # the stale-exit phantom: it survives until _settle_position's
+        # resolution-time cleanup, inflating exposure the whole way — so
+        # drop it now, the same cleanup settlement performs at cost_basis
+        # zero.
+        await db.execute(
+            "DELETE FROM portfolio WHERE market_id = ? AND is_paper = 1 "
+            "AND UPPER(token) = UPPER(?)",
+            (order.market_id, order.token.value),
+        )
+        return
+    price = float(row["avg_cost"])
+    await db.execute(
+        """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+           current_price, unrealized_pnl, category, token, token_id,
+           is_paper, updated_at)
+           VALUES (?, ?, 'BUY', ?, ?, ?, 0,
+                   COALESCE((SELECT category FROM markets WHERE id = ?), ''),
+                   ?, ?, 1, datetime('now'))
+           ON CONFLICT(market_id, is_paper, token) DO UPDATE SET
+               size = excluded.size,
+               avg_price = excluded.avg_price,
+               current_price = excluded.current_price,
+               updated_at = excluded.updated_at""",
+        (order.market_id, order.exchange or "polymarket", size, price, price,
+         order.market_id, row["token"] or order.token.value,
+         row["token_id"] or order.token_id),
+    )
+
+
 class ExecutionGateway:
     """Routes an approved :class:`TradeIntent` through route → place → record."""
 
@@ -986,6 +1066,23 @@ class ExecutionGateway:
                     # into an apparent placement failure that callers may retry.
                     log.critical(
                         "gateway.fill_record_failed",
+                        order_id=result.order_id,
+                        market_id=order.market_id,
+                        error=str(e),
+                    )
+            if recorded_fill is not None and result.is_paper:
+                # record_fill maintains cost_basis only; nothing else maintains
+                # paper portfolio rows in a live bot (position sync is
+                # mode-scoped). Without this, an instant-fill paper EXIT leaves
+                # its full-size portfolio row standing until resolution.
+                try:
+                    await materialize_paper_portfolio_row(self.db, order)
+                except Exception as e:
+                    # Contained like record_fill above — but at error, never
+                    # debug: a swallow here recreates the stale row this call
+                    # exists to prevent, and readiness must see it.
+                    log.error(
+                        "gateway.paper_portfolio_projection_failed",
                         order_id=result.order_id,
                         market_id=order.market_id,
                         error=str(e),

--- a/auramaur/broker/execution_gateway.py
+++ b/auramaur/broker/execution_gateway.py
@@ -157,7 +157,7 @@ def booked_as_position(res: ExecutionResult | OrderResult | None) -> bool:
     return size is not None and size > 0
 
 
-async def materialize_paper_portfolio_row(db, order) -> None:
+async def materialize_paper_portfolio_row(db, order, venue: str) -> None:
     """Project the just-updated paper ``cost_basis`` row into ``portfolio``.
 
     THE single maintainer of a paper ``portfolio`` row after a booked fill,
@@ -197,7 +197,25 @@ async def materialize_paper_portfolio_row(db, order) -> None:
     the numbers — and both branches read the same cost_basis values.
     ``side`` is hardcoded "BUY" for the same reason ``_settle_position``'s
     cost_basis branch hardcodes it: Polymarket holdings are always long.
+
+    SCOPED to the prediction-market venues whose paper holdings ``portfolio``
+    actually represents. The IBKR arms route their simulated fills through
+    the gateway for the rails (``fills``/``cost_basis``/``pnl_ledger`` —
+    without those the book cannot graduate) but keep positions in their own
+    ``ibkr_*`` tables; a portfolio row for one would leak into the
+    paper-breadth cap, the drawdown fallback and the exit monitor, none of
+    which manage that book. Kraken rows are pillar-owned and never pass
+    through here.
+
+    ``venue`` must be the CALLER's venue truth — the gateway passes its
+    venue-scoped ``exchange_name``. ``Order.exchange`` is deliberately not
+    consulted: its ``"polymarket"`` DEFAULT is truthy, so an
+    ``order.exchange or exchange_name`` fallback silently mislabels every
+    order whose builder left the field alone (the kalshi long_horizon
+    instance does exactly that, and its portfolio rows must say kalshi).
     """
+    if venue not in ("polymarket", "kalshi"):
+        return
     row = await db.fetchone(
         "SELECT size, avg_cost, token, token_id FROM cost_basis "
         "WHERE market_id = ? AND is_paper = 1 AND token = ?",
@@ -231,7 +249,7 @@ async def materialize_paper_portfolio_row(db, order) -> None:
                avg_price = excluded.avg_price,
                current_price = excluded.current_price,
                updated_at = excluded.updated_at""",
-        (order.market_id, order.exchange or "polymarket", size, price, price,
+        (order.market_id, venue, size, price, price,
          order.market_id, row["token"] or order.token.value,
          row["token_id"] or order.token_id),
     )
@@ -1076,7 +1094,8 @@ class ExecutionGateway:
                 # mode-scoped). Without this, an instant-fill paper EXIT leaves
                 # its full-size portfolio row standing until resolution.
                 try:
-                    await materialize_paper_portfolio_row(self.db, order)
+                    await materialize_paper_portfolio_row(
+                        self.db, order, venue=exchange_name)
                 except Exception as e:
                     # Contained like record_fill above — but at error, never
                     # debug: a swallow here recreates the stale row this call

--- a/tests/test_fill_booking_guards.py
+++ b/tests/test_fill_booking_guards.py
@@ -735,6 +735,35 @@ async def test_partial_paper_exit_projects_the_remaining_size():
 
 
 @pytest.mark.asyncio
+async def test_projection_labels_the_row_with_the_gateways_venue():
+    """``Order.exchange`` DEFAULTS to "polymarket" — truthy — so any
+    ``order.exchange or ...`` fallback mislabels every order whose builder
+    left the field alone, and the kalshi long_horizon instance does exactly
+    that. The projection must take the gateway's own venue-scoped name."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        s = Settings()
+        gw = _exit_gateway(db, s, _instant_fill_exchange())
+        order = Order(market_id="kx1", token_id="tok", side=OrderSide.BUY,
+                      token=TokenType.YES, size=10.0, price=0.30,
+                      order_type=OrderType.LIMIT, dry_run=True)
+        result = OrderResult(order_id="PAPER-K-1", market_id="kx1",
+                             status="paper", filled_size=10.0,
+                             filled_price=0.30, is_paper=True)
+
+        await gw.record_external_fill(
+            order, result, strategy_source="long_horizon_kalshi",
+            exchange_name="kalshi")
+
+        rows = await _portfolio_rows(db, "kx1")
+        assert len(rows) == 1
+        assert rows[0]["exchange"] == "kalshi"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_live_fill_does_not_touch_paper_portfolio_rows():
     """The projection is paper-mode maintenance only. Live portfolio rows
     belong to position sync against the venue; a live fill on a market that

--- a/tests/test_fill_booking_guards.py
+++ b/tests/test_fill_booking_guards.py
@@ -624,3 +624,135 @@ def test_every_position_booking_site_uses_the_shared_predicate():
     assert offenders == [], (
         "hand-rolled fill predicate(s) — use "
         f"broker.execution_gateway.booked_as_position: {offenders}")
+
+
+# ======================================================================
+# 4. The gateway's instant-fill mirror: a paper fill that closes the
+#    holding must take the portfolio row with it.
+#
+#    The deferred-fill path got this projection first; the INSTANT path
+#    did not, so a paper exit that filled immediately through paper
+#    interception zeroed cost_basis and left the portfolio row at full
+#    size until resolution cleanup — inflating RiskManager exposure and
+#    every max_open count the whole time (observed on the live book the
+#    evening the deferred-fill fix deployed). These drive the real
+#    consumer path: submit_exit → _place_and_record → _record_result.
+# ======================================================================
+
+def _instant_fill_exchange():
+    """An exchange whose place_order executes immediately, paper-style."""
+    ex = MagicMock()
+    ex.place_order = AsyncMock(side_effect=lambda o: OrderResult(
+        order_id=f"PAPER-X-{o.market_id}", market_id=o.market_id,
+        status="paper" if o.dry_run else "filled",
+        filled_size=o.size, filled_price=o.price, is_paper=o.dry_run))
+    return ex
+
+
+def _exit_gateway(db, settings, exchange):
+    from auramaur.broker.execution_gateway import ExecutionGateway
+
+    return ExecutionGateway(
+        router=None, exchange=exchange, exchange_name="polymarket",
+        settings=settings, db=db, pnl_tracker=PnLTracker(db, settings))
+
+
+async def _seed_paper_holding(db, settings, market_id, token, size, price):
+    """A pillar-shaped holding: cost_basis via record_fill + the pillar's own
+    portfolio write (exactly the state an instant-fill exit finds)."""
+    from auramaur.exchange.models import Fill
+
+    await PnLTracker(db, settings).record_fill(Fill(
+        order_id=f"seed-{market_id}", market_id=market_id, token_id="tok",
+        side=OrderSide.BUY, token=token, size=size, price=price,
+        is_paper=True))
+    await db.execute(
+        """INSERT INTO portfolio (market_id, exchange, side, size, avg_price,
+           token, token_id, is_paper, updated_at)
+           VALUES (?, 'polymarket', 'BUY', ?, ?, ?, 'tok', 1, datetime('now'))""",
+        (market_id, size, price, token.value))
+
+
+def _exit_order(market_id, token, size, price, dry_run=True) -> Order:
+    return Order(market_id=market_id, exchange="polymarket", token_id="tok",
+                 side=OrderSide.SELL, token=token, size=size, price=price,
+                 order_type=OrderType.LIMIT, dry_run=dry_run, source="exit")
+
+
+@pytest.mark.asyncio
+async def test_instant_paper_exit_deletes_the_portfolio_row():
+    """The full-close regression: cost_basis reaches zero, and the portfolio
+    row — which used to stand at full size until the market resolved — goes
+    with it."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        s = Settings()
+        gw = _exit_gateway(db, s, _instant_fill_exchange())
+        await _seed_paper_holding(db, s, "xm1", TokenType.NO, 10.99, 0.91)
+
+        res = await gw.submit_exit(
+            _exit_order("xm1", TokenType.NO, 10.99, 0.96),
+            exchange=gw.exchange, exchange_name="polymarket")
+
+        assert res.status == "paper"
+        cb = await db.fetchone(
+            "SELECT size, realized_pnl FROM cost_basis WHERE market_id='xm1'")
+        assert cb is not None and abs(cb["size"]) < 1e-9
+        assert cb["realized_pnl"] > 0, "the sell itself must still book P&L"
+        assert await _portfolio_rows(db, "xm1") == [], (
+            "a closed paper holding must not keep a portfolio row")
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_partial_paper_exit_projects_the_remaining_size():
+    """A partial close must shrink the row to cost_basis's remainder — the
+    same projected-from-cost_basis rule the deferred path follows, for the
+    same reason: the upsert REPLACES size, so any fill-shaped write here
+    would leave the FULL entry size standing."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        s = Settings()
+        gw = _exit_gateway(db, s, _instant_fill_exchange())
+        await _seed_paper_holding(db, s, "xm2", TokenType.YES, 20.0, 0.50)
+
+        await gw.submit_exit(
+            _exit_order("xm2", TokenType.YES, 8.0, 0.60),
+            exchange=gw.exchange, exchange_name="polymarket")
+
+        cb = await db.fetchone(
+            "SELECT size, avg_cost FROM cost_basis WHERE market_id='xm2'")
+        rows = await _portfolio_rows(db, "xm2")
+        assert abs(cb["size"] - 12.0) < 1e-9
+        assert len(rows) == 1
+        assert abs(rows[0]["size"] - cb["size"]) < 1e-9
+        assert abs(rows[0]["avg_price"] - cb["avg_cost"]) < 1e-9
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_live_fill_does_not_touch_paper_portfolio_rows():
+    """The projection is paper-mode maintenance only. Live portfolio rows
+    belong to position sync against the venue; a live fill on a market that
+    also carries a paper holding must leave the paper row alone."""
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        s = Settings()
+        gw = _exit_gateway(db, s, _instant_fill_exchange())
+        await _seed_paper_holding(db, s, "xm3", TokenType.YES, 15.0, 0.40)
+
+        await gw.submit_exit(
+            _exit_order("xm3", TokenType.YES, 15.0, 0.55, dry_run=False),
+            exchange=gw.exchange, exchange_name="polymarket")
+
+        rows = await _portfolio_rows(db, "xm3")
+        assert len(rows) == 1 and rows[0]["is_paper"] == 1
+        assert abs(rows[0]["size"] - 15.0) < 1e-9, (
+            "a live fill must not resize or delete the paper row")
+    finally:
+        await db.close()


### PR DESCRIPTION
## Problem

#412's amendment made DEFERRED paper fills project their portfolio row from cost_basis. The INSTANT path never got the same treatment: an exit that fills immediately through paper interception records the fill and zeroes cost_basis, but nothing on that path maintains the paper portfolio row — position sync is mode-scoped and never touches paper rows in a live bot, and resolution-time settlement is the only cleanup. The exited position therefore stands at full size in `portfolio` until its market resolves, inflating RiskManager exposure and every max_open count the whole way.

Observed on the live paper book the evening #412 deployed: a paper exit booked its P&L correctly (fills, cost_basis, ledger all consistent) and left the portfolio row untouched at its original batch stamp. The accumulated residue was repaired operator-side with in-DB backups; this PR closes the producer.

## Fix

- Move the projection out of the order monitor into the gateway: `materialize_paper_portfolio_row`, next to `booked_as_position` — the same one-implementation doctrine. `_record_result` calls it after every booked paper fill, so instant entries, instant exits, partial exits and deferred fills all agree by construction.
- SCOPED to the venues `portfolio` actually represents (polymarket, kalshi). The IBKR arms route their simulated fills through the gateway for the rails but keep positions in their own `ibkr_*` tables; a portfolio row for one would leak into the paper-breadth cap, the drawdown fallback and the exit monitor.
- The projection takes the gateway's venue-scoped `exchange_name`, not `Order.exchange`, whose truthy `"polymarket"` default mislabels every venue-scoped order whose builder keeps the default (the kalshi long_horizon instance does exactly that).
- A projection failure logs at `error`, never `debug` — a swallow here recreates the stale row this call exists to prevent, and readiness must see it.

## Tests

Behavioral, driving the real consumer path (`submit_exit` → `_place_and_record` → `_record_result`) against a real in-memory DB:

- a full close deletes the portfolio row; a partial close projects the remainder from cost_basis
- a live fill leaves paper rows alone
- the projected row carries the gateway's venue, not the Order model default
- mutation-tested: removing the projection call fails both exit tests

Full suite in the locked-deps container: 2311 passed, coverage 67.44% (ratchet 65%), ruff clean. The one local failure (`test_live_gate::test_committed_defaults_yaml_is_not_live`) is a container artifact — it shells out to `git`, which the runtime image lacks — and fails identically on unmodified main in the same container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)