### PR TITLE
Persist exit lifecycle and reconciliation health

### DIFF
--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
@@ -33,6 +33,7 @@ from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
 from auramaur.risk.manager import RiskManager
 from auramaur.risk.portfolio import PortfolioTracker
+from auramaur.risk.exit_lifecycle import ExitState, record_exit_state
 from auramaur.strategy.engine import TradingEngine
 from auramaur.strategy.market_maker import MarketMaker
 from auramaur.strategy.news_reactor import NewsReactor
@@ -508,6 +509,11 @@ class AuramaurBot(
                             retry_at = self._exit_failures.get(exit_key)
                             if retry_at is not None and time.monotonic() < retry_at:
                                 continue
+                            await record_exit_state(
+                                self._components.db, pos, ExitState.REQUESTED,
+                                exchange=name, reason=reason.value,
+                                increment_attempt=True,
+                            )
                             log.info(
                                 "exit.triggered",
                                 exchange=name,
@@ -530,9 +536,26 @@ class AuramaurBot(
                             if ok:
                                 self._exit_pending.add(exit_key)
                                 self._exit_failures.pop(exit_key, None)
+                                await record_exit_state(
+                                    self._components.db, pos, ExitState.ORDER_WORKING,
+                                    exchange=name, reason=reason.value,
+                                )
                             else:
                                 self._exit_failures[exit_key] = (
                                     time.monotonic() + _EXIT_RETRY_BACKOFF_SECONDS)
+                                retry_wall = datetime.now(timezone.utc) + timedelta(
+                                    seconds=_EXIT_RETRY_BACKOFF_SECONDS)
+                                dust = (
+                                    name == "polymarket" and pos.size < 5
+                                ) or (
+                                    name == "kalshi" and pos.size < 1
+                                )
+                                await record_exit_state(
+                                    self._components.db, pos,
+                                    ExitState.UNSALEABLE_DUST if dust else ExitState.RETRYABLE,
+                                    exchange=name, reason=reason.value,
+                                    next_retry_at=None if dust else retry_wall,
+                                )
                                 log.warning(
                                     "exit.suppressed_until_retry", exchange=name,
                                     market_id=pos.market_id, reason=reason.value,

--- a/auramaur/bot.py
+++ b/auramaur/bot.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from pathlib import Path
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from auramaur.killswitch import kill_switch_present
 from typing import TYPE_CHECKING
 
@@ -33,7 +33,12 @@ from auramaur.nlp.cache import NLPCache
 from auramaur.nlp.calibration import CalibrationTracker
 from auramaur.risk.manager import RiskManager
 from auramaur.risk.portfolio import PortfolioTracker
-from auramaur.risk.exit_lifecycle import ExitState, record_exit_state
+from auramaur.risk.exit_lifecycle import (
+    ExitAttempt,
+    ExitState,
+    position_key,
+    record_exit_state,
+)
 from auramaur.strategy.engine import TradingEngine
 from auramaur.strategy.market_maker import MarketMaker
 from auramaur.strategy.news_reactor import NewsReactor
@@ -500,20 +505,16 @@ class AuramaurBot(
                             # per (market, token, mode), and a sub-minimum dust leg
                             # can never sell — a market-wide key let that dust pin
                             # its sibling legs (2026-07-25: a 1.49-share leg pinned
-                            # $322 of exposure in the same market).
-                            exit_key = (f"exit:{name}:{pos.market_id}:"
-                                        f"{getattr(pos.token, 'value', pos.token)}:"
-                                        f"{int(bool(pos.is_paper))}")
+                            # $322 of exposure in the same market). The suppression
+                            # key and the lifecycle row share ONE identity encoding
+                            # so they can never name different positions.
+                            key = position_key(pos, name)
+                            exit_key = "exit:" + ":".join(str(part) for part in key)
                             if exit_key in self._exit_pending:
                                 continue
                             retry_at = self._exit_failures.get(exit_key)
                             if retry_at is not None and time.monotonic() < retry_at:
                                 continue
-                            await record_exit_state(
-                                self._components.db, pos, ExitState.REQUESTED,
-                                exchange=name, reason=reason.value,
-                                increment_attempt=True,
-                            )
                             log.info(
                                 "exit.triggered",
                                 exchange=name,
@@ -521,44 +522,55 @@ class AuramaurBot(
                                 reason=reason.value,
                                 pnl=pos.unrealized_pnl,
                             )
+                            # ONE lifecycle write, AFTER the attempt: nothing
+                            # sits between the exit trigger and the venue call
+                            # that could wait on the DB serializer, and the
+                            # disposition comes from the executor, which is
+                            # the code that actually knows why a sell failed.
+                            err: str | None = None
                             try:
                                 if name == "polymarket":
-                                    ok = await self._execute_poly_exit(pos, reason, discovery, exchange_client, alerts)
+                                    attempt = await self._execute_poly_exit(pos, reason, discovery, exchange_client, alerts)
                                 elif name == "kalshi":
-                                    ok = await self._execute_kalshi_exit(pos, reason, discovery, exchange_client, alerts)
+                                    attempt = await self._execute_kalshi_exit(pos, reason, discovery, exchange_client, alerts)
                                 elif name == "ibkr":
-                                    ok = await self._execute_ibkr_exit(pos, reason, discovery, exchange_client, alerts)
+                                    attempt = await self._execute_ibkr_exit(pos, reason, discovery, exchange_client, alerts)
                                 else:
-                                    ok = False
+                                    attempt = ExitAttempt(False, None, "unknown_exchange")
                             except Exception as e:
                                 log.warning("exit.execute_error", exchange=name, market_id=pos.market_id, error=str(e))
-                                ok = False
-                            if ok:
+                                err = str(e)
+                                attempt = ExitAttempt(False, ExitState.RETRYABLE, "execute_error")
+                            if attempt.ok:
                                 self._exit_pending.add(exit_key)
                                 self._exit_failures.pop(exit_key, None)
                                 await record_exit_state(
-                                    self._components.db, pos, ExitState.ORDER_WORKING,
-                                    exchange=name, reason=reason.value,
+                                    self._components.db, key, ExitState.ORDER_WORKING,
+                                    reason=reason.value, increment_attempt=True,
                                 )
                             else:
                                 self._exit_failures[exit_key] = (
                                     time.monotonic() + _EXIT_RETRY_BACKOFF_SECONDS)
-                                retry_wall = datetime.now(timezone.utc) + timedelta(
-                                    seconds=_EXIT_RETRY_BACKOFF_SECONDS)
-                                dust = (
-                                    name == "polymarket" and pos.size < 5
-                                ) or (
-                                    name == "kalshi" and pos.size < 1
-                                )
+                                disposition = attempt.disposition or ExitState.RETRYABLE
+                                # The wall is recorded for dust too: the
+                                # in-memory gate above retries EVERY failure
+                                # class on the same backoff, and the durable
+                                # record must describe what the bot actually
+                                # does, not an aspiration. CLOSED (position
+                                # pruned mid-attempt) carries no wall.
                                 await record_exit_state(
-                                    self._components.db, pos,
-                                    ExitState.UNSALEABLE_DUST if dust else ExitState.RETRYABLE,
-                                    exchange=name, reason=reason.value,
-                                    next_retry_at=None if dust else retry_wall,
+                                    self._components.db, key, disposition,
+                                    reason=reason.value,
+                                    error=err or attempt.detail or None,
+                                    retry_after_seconds=(
+                                        None if disposition is ExitState.CLOSED
+                                        else _EXIT_RETRY_BACKOFF_SECONDS),
+                                    increment_attempt=True,
                                 )
                                 log.warning(
                                     "exit.suppressed_until_retry", exchange=name,
                                     market_id=pos.market_id, reason=reason.value,
+                                    detail=attempt.detail,
                                     backoff_seconds=_EXIT_RETRY_BACKOFF_SECONDS)
                         except Exception as e:
                             log.error(

--- a/auramaur/bot_exits.py
+++ b/auramaur/bot_exits.py
@@ -16,6 +16,7 @@ import math
 import structlog
 
 from auramaur.exchange.models import Order, OrderSide, OrderType, TokenType
+from auramaur.risk.exit_lifecycle import ExitAttempt, ExitState, advance_terminal
 
 if TYPE_CHECKING:
     from auramaur.exchange.protocols import ExchangeClient, MarketDiscovery
@@ -53,6 +54,22 @@ class ExitExecutionMixin:
             log.info("exit.suppression_cleared", market_id=order.market_id,
                      keys=len(set(cleared)), status=status)
 
+    async def _record_exit_terminal(self, exchange_name: str, order, status: str) -> None:
+        """Durable twin of ``_clear_exit_suppression``: advance the lifecycle
+        rows for a SELL that reached a terminal state, so a filled exit's row
+        ends at CLOSED instead of ORDER_WORKING forever. Same market-level
+        granularity and SELL-only guard as the suppression clear above."""
+        if order is None or getattr(order, "side", None) != OrderSide.SELL:
+            return
+        db = self._components.db
+        if db is None:
+            return
+        await advance_terminal(
+            db, exchange_name, order.market_id,
+            int(bool(getattr(order, "dry_run", False))),
+            filled=(status == "filled"), status=status,
+        )
+
     @property
     def _exit_gateway(self):
         """Lazily build the ExecutionGateway used for exits.
@@ -81,11 +98,13 @@ class ExitExecutionMixin:
         discovery: MarketDiscovery,
         exchange: ExchangeClient,
         alerts: AlertManager,
-    ) -> bool:
+    ) -> ExitAttempt:
         """Execute an exit for a Polymarket position.
 
-        Returns True if the sell was accepted (or a retry is worth attempting
-        next cycle), False if we should stop retrying this position.
+        Returns an :class:`ExitAttempt`. The disposition is decided HERE, at
+        the point of knowledge: dust is judged against the ON-CHAIN-adjusted
+        sell size (not the DB row), and book/venue rebuffs are RETRYABLE —
+        the portfolio monitor's 15-minute backoff does re-attempt them.
         """
         # Resolve the real token_id: reconciler → cost_basis → Gamma
         token_id = ""
@@ -124,7 +143,7 @@ class ExitExecutionMixin:
 
         if not token_id:
             log.warning("exit.no_token", market_id=pos.market_id)
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "no_token")
 
         # Cancel stale sell orders so balance is free
         if hasattr(exchange, "cancel_open_orders_for_token"):
@@ -157,12 +176,18 @@ class ExitExecutionMixin:
 
         if sell_size < 5:
             if self.settings.is_live and sell_size <= 0.01:
+                # The position rows were just deleted; the episode is over,
+                # not blocked — CLOSED keeps the lifecycle row from surviving
+                # as an orphan "blocked exit" for a position that no longer
+                # exists.
                 await self._prune_zero_onchain_poly_position(pos.market_id)
+                log.warning("exit.too_small", market_id=pos.market_id, size=sell_size)
+                return ExitAttempt(False, ExitState.CLOSED, "pruned_zero_onchain")
             log.warning("exit.too_small", market_id=pos.market_id, size=sell_size)
-            return False
+            return ExitAttempt(False, ExitState.UNSALEABLE_DUST, "too_small")
         if pos.current_price < 0.01:
             log.warning("exit.near_zero", market_id=pos.market_id, price=pos.current_price)
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "near_zero")
 
         sell_price = max(0.01, min(0.99, round(pos.current_price, 2)))
         # Marketable exit: a SELL only fills by crossing down to the real bid.
@@ -203,13 +228,13 @@ class ExitExecutionMixin:
                     best_ask=best_ask,
                     best_bid=best_bid,
                 )
-                return False
+                return ExitAttempt(False, ExitState.RETRYABLE, "mark_book_divergence")
             # No buyers at all — nothing to cross into; redeem at resolution.
             if best_bid is None or best_bid <= 0:
                 log.warning(
                     "exit.no_bid", market_id=pos.market_id, snapshot=sell_price,
                 )
-                return False
+                return ExitAttempt(False, ExitState.RETRYABLE, "no_bid")
             # Junk bid below the absolute floor — redeeming beats dumping.
             if best_bid < min_bid:
                 log.warning(
@@ -219,7 +244,7 @@ class ExitExecutionMixin:
                     bid=best_bid,
                     floor=min_bid,
                 )
-                return False
+                return ExitAttempt(False, ExitState.RETRYABLE, "bid_below_floor")
             # Bid too far under the mark to accept the slippage — back off.
             if best_bid < sell_price - max_slip:
                 log.warning(
@@ -229,7 +254,7 @@ class ExitExecutionMixin:
                     bid=best_bid,
                     max_slip=max_slip,
                 )
-                return False
+                return ExitAttempt(False, ExitState.RETRYABLE, "bid_too_thin")
             # Cross to the bid: a marketable SELL that actually fills.
             # FLOOR to the tick, never round: round(0.066)=0.07 and
             # round(0.989)=0.99 lifted the limit ABOVE the bid, so the
@@ -262,14 +287,14 @@ class ExitExecutionMixin:
             sell_order, exchange=exchange, exchange_name="polymarket")
         if res.status == "rejected":
             log.warning("exit.sell_failed", market_id=pos.market_id)
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "sell_rejected")
 
         await alerts.send(
             f"Exit {reason.value} (poly): {pos.market_id[:12]} "
             f"size={pos.size:.2f} pnl={pos.unrealized_pnl:+.2f}",
             level="warning",
         )
-        return True
+        return ExitAttempt(True)
 
     async def _prune_zero_onchain_poly_position(self, market_id: str) -> None:
         """Remove stale live Polymarket rows after an on-chain zero balance check."""
@@ -309,19 +334,21 @@ class ExitExecutionMixin:
         discovery: MarketDiscovery,
         exchange: ExchangeClient,
         alerts: AlertManager,
-    ) -> bool:
+    ) -> ExitAttempt:
         """Execute an exit for a Kalshi position.
 
         Kalshi is ticker-based with direct YES/NO sells, so we just build a
         SELL signal with ``exit_token`` set and let the exchange's
-        ``prepare_order`` do the rest.
+        ``prepare_order`` do the rest. Dust is judged against the venue's
+        REAL minimum (0.01 on fractional-enabled markets), never a caller-side
+        approximation.
         """
         from auramaur.exchange.models import Confidence, Signal
 
         market = await discovery.get_market(pos.market_id)
         if market is None:
             log.debug("exit.no_market", market_id=pos.market_id)
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "no_market")
 
         exit_signal = Signal(
             market_id=pos.market_id,
@@ -339,7 +366,7 @@ class ExitExecutionMixin:
         notional = pos.size * max(pos.current_price, 0.01)
         order = exchange.prepare_order(exit_signal, market, notional, self.settings.is_live)
         if order is None:
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "no_order")
 
         # Never sell more than we hold
         order.size = min(order.size, pos.size)
@@ -349,22 +376,22 @@ class ExitExecutionMixin:
             order.size = float(int(order.size))
         minimum = 0.01 if market.fractional_trading_enabled else 1.0
         if order.size < minimum:
-            return False
+            return ExitAttempt(False, ExitState.UNSALEABLE_DUST, "below_venue_minimum")
 
         order.source = "exit"
         res = await self._exit_gateway.submit_exit(
             order, exchange=exchange, exchange_name="kalshi")
         if res.status == "rejected":
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "sell_rejected")
 
         await alerts.send(
             f"Exit {reason.value} (kalshi): {pos.market_id} "
             f"size={pos.size:.0f} pnl={pos.unrealized_pnl:+.2f}",
             level="warning",
         )
-        return True
+        return ExitAttempt(True)
 
-    async def _execute_ibkr_exit(self, pos, reason, discovery, exchange, alerts) -> bool:
+    async def _execute_ibkr_exit(self, pos, reason, discovery, exchange, alerts) -> ExitAttempt:
         """Close a held IBKR option position by selling the exact contract.
 
         Unlike the prediction-venue exits (which reframe a fresh SELL signal), an
@@ -375,11 +402,14 @@ class ExitExecutionMixin:
         """
         from auramaur.exchange.models import Order, OrderType
 
+        # Not literally dust, but the same operational meaning as
+        # UNSALEABLE_DUST: this path can never sell it (no contract identity /
+        # below one contract), so it needs out-of-band handling, not retries.
         if not pos.token_id or pos.token_id.count(":") < 4:
             log.debug("exit.ibkr.no_contract", market_id=pos.market_id)
-            return False
+            return ExitAttempt(False, ExitState.UNSALEABLE_DUST, "no_contract")
         if pos.size < 1:
-            return False
+            return ExitAttempt(False, ExitState.UNSALEABLE_DUST, "sub_contract_size")
 
         order = Order(
             market_id=pos.market_id,
@@ -407,11 +437,11 @@ class ExitExecutionMixin:
             market_id=pos.market_id,
         )
         if result.status == "rejected":
-            return False
+            return ExitAttempt(False, ExitState.RETRYABLE, "sell_rejected")
         await alerts.send(
             f"Exit {reason.value} (ibkr): {pos.market_id} "
             f"contracts={pos.size:.0f} pnl={pos.unrealized_pnl:+.2f}",
             level="warning",
         )
-        return True
+        return ExitAttempt(True)
 

--- a/auramaur/bot_order_monitor.py
+++ b/auramaur/bot_order_monitor.py
@@ -263,6 +263,7 @@ class OrderMonitorMixin:
 
                                 pending.pop(order_id, None)
                                 self._clear_exit_suppression(exchange_name, order, result.status)
+                                await self._record_exit_terminal(exchange_name, order, result.status)
                                 log.info(
                                     "order_monitor.live_terminal",
                                     exchange=exchange_name,
@@ -295,6 +296,7 @@ class OrderMonitorMixin:
                                         continue
                                     pending.pop(order_id, None)
                                     self._clear_exit_suppression(exchange_name, order, "ttl_cancelled")
+                                    await self._record_exit_terminal(exchange_name, order, "ttl_cancelled")
                                     # Without this status write the trades row
                                     # stays 'pending' forever even though the
                                     # collateral was released (#94).

--- a/auramaur/cli/redeem.py
+++ b/auramaur/cli/redeem.py
@@ -305,9 +305,10 @@ def dust_exit(max_notional: float, exchange: str | None, execute: bool, yes: boo
             for name, discovery, exch, p in sellables:
                 try:
                     if name == "polymarket":
-                        ok = await bot._execute_poly_exit(p, ExitReason.DUST_CLEANUP, discovery, exch, alerts)
+                        attempt = await bot._execute_poly_exit(p, ExitReason.DUST_CLEANUP, discovery, exch, alerts)
                     else:
-                        ok = await bot._execute_kalshi_exit(p, ExitReason.DUST_CLEANUP, discovery, exch, alerts)
+                        attempt = await bot._execute_kalshi_exit(p, ExitReason.DUST_CLEANUP, discovery, exch, alerts)
+                    ok = attempt.ok
                 except Exception as e:
                     console.print(f"[red]ERROR closing {p.market_id[:24]}: {e}[/]")
                     ok = False

--- a/auramaur/db/database.py
+++ b/auramaur/db/database.py
@@ -386,6 +386,27 @@ class Database:
             await self._migrate_v48_to_v49()
         if from_version < 50:
             await self._migrate_v49_to_v50()
+        if from_version < 51:
+            await self._migrate_v50_to_v51()
+
+    async def _migrate_v50_to_v51(self) -> None:
+        """Persist position-scoped exit disposition and retry state."""
+        await self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS exit_lifecycle (
+                exchange TEXT NOT NULL, market_id TEXT NOT NULL,
+                token TEXT NOT NULL DEFAULT 'YES', is_paper INTEGER NOT NULL DEFAULT 1,
+                state TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '',
+                attempt_count INTEGER NOT NULL DEFAULT 0, last_error TEXT,
+                next_retry_at TEXT, requested_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (exchange, market_id, token, is_paper));
+            CREATE INDEX IF NOT EXISTS idx_exit_lifecycle_state_retry
+              ON exit_lifecycle(state, next_retry_at);
+            UPDATE schema_version SET version = 51;
+        """)
+        await self._db.commit()
+        log.info("database.migrated", from_version=50, to_version=51)
+
 
     async def _migrate_v49_to_v50(self) -> None:
         """Add auditable exit-policy observations for holdout calibration."""

--- a/auramaur/db/models.py
+++ b/auramaur/db/models.py
@@ -1,6 +1,6 @@
 """SQLite table schemas as SQL strings."""
 
-SCHEMA_VERSION = 50
+SCHEMA_VERSION = 51
 
 TABLES = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -817,6 +817,19 @@ CREATE INDEX IF NOT EXISTS idx_exit_decisions_position_time
 -- unconstrained, so SQLite has no seekable prefix and full-scans the table.
 CREATE INDEX IF NOT EXISTS idx_exit_decisions_observed_at
     ON exit_decisions(observed_at);
+
+CREATE TABLE IF NOT EXISTS exit_lifecycle (
+    exchange TEXT NOT NULL, market_id TEXT NOT NULL,
+    token TEXT NOT NULL DEFAULT 'YES', is_paper INTEGER NOT NULL DEFAULT 1,
+    state TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '',
+    attempt_count INTEGER NOT NULL DEFAULT 0, last_error TEXT,
+    next_retry_at TEXT, requested_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (exchange, market_id, token, is_paper)
+);
+CREATE INDEX IF NOT EXISTS idx_exit_lifecycle_state_retry
+    ON exit_lifecycle(state, next_retry_at);
+
 
 CREATE TABLE IF NOT EXISTS rebalance_blocks (
     event_key TEXT PRIMARY KEY,

--- a/auramaur/monitoring/diagnostics.py
+++ b/auramaur/monitoring/diagnostics.py
@@ -258,6 +258,36 @@ async def gather_doctor(settings, db, *, max_bytes: int = 8_000_000) -> dict:
     except Exception:  # noqa: BLE001
         checks.append(_chk("positions", "warn", "could not read portfolio"))
 
+    try:
+        lifecycle = await db.fetchall(
+            """SELECT state, COUNT(*) AS c
+                 FROM exit_lifecycle
+                WHERE is_paper = ?
+                GROUP BY state ORDER BY state""",
+            (flag,),
+        )
+        blocked = {r["state"]: int(r["c"]) for r in lifecycle
+                   if r["state"] in ("UNSALEABLE_DUST", "UNMARKABLE", "RETRYABLE")}
+        detail = ", ".join(f"{state.lower()}={count}"
+                           for state, count in blocked.items()) or "no blocked exits"
+        checks.append(_chk("exit lifecycle", "warn" if blocked else "ok", detail))
+    except Exception:  # noqa: BLE001
+        checks.append(_chk("exit lifecycle", "warn", "lifecycle state unavailable"))
+
+    try:
+        missing = await db.fetchone(
+            """SELECT COUNT(*) AS c, COALESCE(SUM(pnl), 0) AS pnl
+                 FROM pnl_ledger
+                WHERE is_paper = ?
+                  AND (strategy_source IS NULL OR TRIM(strategy_source) = '')""",
+            (flag,),
+        )
+        count = int(missing["c"] or 0)
+        detail = f"{count} unattributed rows, {float(missing['pnl'] or 0):+.2f} USD"
+        checks.append(_chk("P&L attribution", "warn" if count else "ok", detail))
+    except Exception:  # noqa: BLE001
+        checks.append(_chk("P&L attribution", "warn", "could not reconcile ledger"))
+
     verdict = max((c["status"] for c in checks), key=lambda s: _STATUS_RANK.get(s, 0))
     return {"checks": checks, "verdict": verdict, "now": now}
 

--- a/auramaur/monitoring/diagnostics.py
+++ b/auramaur/monitoring/diagnostics.py
@@ -258,32 +258,68 @@ async def gather_doctor(settings, db, *, max_bytes: int = 8_000_000) -> dict:
     except Exception:  # noqa: BLE001
         checks.append(_chk("positions", "warn", "could not read portfolio"))
 
+    # Exit lifecycle: warn ONLY on states that are both actionable and
+    # current, or the check trains the operator to ignore it (the condition
+    # that let the 12-day exit outage go unnoticed):
+    #   - the EXISTS keeps rows whose position left the book out-of-band
+    #     (settlement, redemption, manual close) from warning forever;
+    #   - RETRYABLE warns only when its retry wall is PAST DUE beyond a
+    #     2-minute grace — a future wall is routine backoff, not a blockage;
+    #   - UNMARKABLE warns only while FRESH (check_exits re-upserts it every
+    #     tick a market stays dark; a recovered market ages out on its own);
+    #   - UNSALEABLE_DUST on a live position is a known book state with its
+    #     own remedy (close-dust / redemption), so it rides in the detail
+    #     text without degrading the verdict.
     try:
         lifecycle = await db.fetchall(
-            """SELECT state, COUNT(*) AS c
-                 FROM exit_lifecycle
-                WHERE is_paper = ?
-                GROUP BY state ORDER BY state""",
+            """SELECT el.state, COUNT(*) AS c
+                 FROM exit_lifecycle el
+                WHERE el.is_paper = ?
+                  AND EXISTS (SELECT 1 FROM portfolio p
+                               WHERE p.market_id = el.market_id
+                                 AND p.token = el.token
+                                 AND p.is_paper = el.is_paper
+                                 AND p.exchange = el.exchange
+                                 AND p.size > 0)
+                  AND ((el.state = 'RETRYABLE'
+                        AND el.next_retry_at IS NOT NULL
+                        AND el.next_retry_at <= datetime('now', '-120 seconds'))
+                       OR (el.state = 'UNMARKABLE'
+                           AND el.updated_at >= datetime('now', '-600 seconds'))
+                       OR el.state = 'UNSALEABLE_DUST')
+                GROUP BY el.state""",
             (flag,),
         )
-        blocked = {r["state"]: int(r["c"]) for r in lifecycle
-                   if r["state"] in ("UNSALEABLE_DUST", "UNMARKABLE", "RETRYABLE")}
-        detail = ", ".join(f"{state.lower()}={count}"
-                           for state, count in blocked.items()) or "no blocked exits"
-        checks.append(_chk("exit lifecycle", "warn" if blocked else "ok", detail))
+        counts = {r["state"]: int(r["c"]) for r in lifecycle}
+        dust = counts.pop("UNSALEABLE_DUST", 0)
+        parts = [f"{state.lower()}={count}" for state, count in sorted(counts.items())]
+        if dust:
+            parts.append(f"dust={dust} (close-dust / redemption)")
+        detail = ", ".join(parts) or "no blocked exits"
+        checks.append(_chk("exit lifecycle", "warn" if counts else "ok", detail))
     except Exception:  # noqa: BLE001
         checks.append(_chk("exit lifecycle", "warn", "lifecycle state unavailable"))
 
+    # P&L attribution: an empty strategy_source on a NEW row means an entry
+    # row is missing (broker/ledger.py documents that sells keep '' as
+    # exactly that signal). The window keeps known-historical cases from
+    # pinning the check at warn forever; the deliberate sentinel buckets
+    # (phantom_/venue_/legacy_unattributed) are labeled outcomes, not leaks,
+    # and stay out. datetime(realized_at) normalizes the column's two
+    # formats (space-form settlements vs ISO-T sell fills — readiness.py
+    # documents the mix); the scan is bounded and doctor is CLI-on-demand.
     try:
         missing = await db.fetchone(
             """SELECT COUNT(*) AS c, COALESCE(SUM(pnl), 0) AS pnl
                  FROM pnl_ledger
                 WHERE is_paper = ?
-                  AND (strategy_source IS NULL OR TRIM(strategy_source) = '')""",
+                  AND TRIM(strategy_source) = ''
+                  AND datetime(realized_at) >= datetime('now', '-7 days')""",
             (flag,),
         )
         count = int(missing["c"] or 0)
-        detail = f"{count} unattributed rows, {float(missing['pnl'] or 0):+.2f} USD"
+        detail = (f"{count} unattributed rows (7d), "
+                  f"{float(missing['pnl'] or 0):+.2f} USD")
         checks.append(_chk("P&L attribution", "warn" if count else "ok", detail))
     except Exception:  # noqa: BLE001
         checks.append(_chk("P&L attribution", "warn", "could not reconcile ledger"))

--- a/auramaur/risk/exit_lifecycle.py
+++ b/auramaur/risk/exit_lifecycle.py
@@ -1,0 +1,58 @@
+"""Durable, position-scoped exit disposition state."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import StrEnum
+
+import structlog
+
+log = structlog.get_logger()
+
+
+class ExitState(StrEnum):
+    REQUESTED = "REQUESTED"
+    ORDER_WORKING = "ORDER_WORKING"
+    RETRYABLE = "RETRYABLE"
+    UNSALEABLE_DUST = "UNSALEABLE_DUST"
+    UNMARKABLE = "UNMARKABLE"
+    CLOSED = "CLOSED"
+
+
+def position_key(pos, exchange: str | None = None) -> tuple[str, str, str, int]:
+    token = getattr(pos, "token", "YES")
+    return (
+        exchange or getattr(pos, "exchange", "") or "",
+        pos.market_id,
+        getattr(token, "value", token),
+        int(bool(getattr(pos, "is_paper", True))),
+    )
+
+
+async def record_exit_state(
+    db, pos, state: ExitState, *, exchange: str | None = None,
+    reason: str = "", error: str | None = None,
+    next_retry_at: datetime | None = None, increment_attempt: bool = False,
+) -> None:
+    """Upsert the latest lifecycle state for one economic position."""
+    venue, market_id, token, is_paper = position_key(pos, exchange)
+    retry = next_retry_at.astimezone(timezone.utc).isoformat() if next_retry_at else None
+    step = int(increment_attempt)
+    try:
+        await db.execute(
+            """INSERT INTO exit_lifecycle
+                   (exchange, market_id, token, is_paper, state, reason,
+                    attempt_count, last_error, next_retry_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(exchange, market_id, token, is_paper) DO UPDATE SET
+                   state=excluded.state, reason=excluded.reason,
+                   attempt_count=exit_lifecycle.attempt_count + ?,
+                   last_error=excluded.last_error, next_retry_at=excluded.next_retry_at,
+                   updated_at=datetime('now')""",
+            (venue, market_id, token, is_paper, state.value, reason,
+             step, error, retry, step),
+        )
+        await db.commit()
+    except Exception as exc:  # telemetry must never block an exit
+        log.warning("exit.lifecycle_write_failed", exchange=venue,
+                    market_id=market_id, state=state.value, error=str(exc))

--- a/auramaur/risk/exit_lifecycle.py
+++ b/auramaur/risk/exit_lifecycle.py
@@ -1,17 +1,44 @@
-"""Durable, position-scoped exit disposition state."""
+"""Durable, position-scoped exit disposition state.
+
+The bot's in-memory suppression sets (``_exit_pending`` / ``_exit_failures``)
+remain the authoritative retry gate; this table is the durable, operator-facing
+record of where each economic position's exit stands and why. Rows are
+advisory telemetry: a write failure — or a slow write — must never block or
+delay an exit, so every write here is bounded by ``_WRITE_TIMEOUT_SECONDS``
+and exception-contained. Never call these helpers from inside a
+``db.transaction()`` span: ``execute()`` would silently join the span and an
+outer rollback would discard the row while the caller logged success.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import asyncio
 from enum import StrEnum
+from typing import TYPE_CHECKING, NamedTuple
 
 import structlog
 
+if TYPE_CHECKING:
+    from auramaur.db.database import Database
+    from auramaur.exchange.models import Position
+
 log = structlog.get_logger()
+
+# Caps how long the exit loop can stall on the shared serializer for a
+# telemetry write. The exception containment below only covers RAISED errors;
+# a wedged transaction() holder (2026-07-25: 45 minutes) blocks the lock
+# acquisition without raising, and an unbounded await here would freeze every
+# remaining position's exit on every venue.
+_WRITE_TIMEOUT_SECONDS = 5.0
 
 
 class ExitState(StrEnum):
-    REQUESTED = "REQUESTED"
+    # Every member has a writer: ORDER_WORKING / RETRYABLE / UNSALEABLE_DUST /
+    # CLOSED from the portfolio monitor's post-attempt write (dispositions come
+    # from the executors — bot_exits.py), UNMARKABLE from check_exits' frozen-
+    # mark branch, CLOSED also from the order monitor's terminal-fill path.
+    # Add a state only together with its writer: a member nothing writes is a
+    # coverage claim the doctor cannot honor.
     ORDER_WORKING = "ORDER_WORKING"
     RETRYABLE = "RETRYABLE"
     UNSALEABLE_DUST = "UNSALEABLE_DUST"
@@ -19,40 +46,130 @@ class ExitState(StrEnum):
     CLOSED = "CLOSED"
 
 
-def position_key(pos, exchange: str | None = None) -> tuple[str, str, str, int]:
-    token = getattr(pos, "token", "YES")
+class ExitAttempt(NamedTuple):
+    """An executor's verdict: did the sell go in, and if not, what class of no.
+
+    ``disposition`` is set by the code that actually knows why the attempt
+    failed (venue minimums, on-chain balances, book state live in the
+    executors); the portfolio monitor must not re-derive it from ``pos.size``.
+    ``detail`` is the machine-readable cause ("too_small", "no_bid", ...).
+    """
+
+    ok: bool
+    disposition: ExitState | None = None
+    detail: str = ""
+
+
+def position_key(pos: Position, exchange: str) -> tuple[str, str, str, int]:
+    """Canonical (exchange, market_id, token, is_paper) identity of a position.
+
+    Attribute access is deliberately raw: a position object missing ``token``
+    or ``is_paper`` must raise here, not be silently misfiled — the 12-day
+    exit outage (#420) was a position model missing ``is_paper``, and a
+    getattr default would have filed live rows under the paper key, exactly
+    where live-mode diagnostics never look.
+    """
+    token = pos.token
     return (
-        exchange or getattr(pos, "exchange", "") or "",
+        exchange or pos.exchange,
         pos.market_id,
-        getattr(token, "value", token),
-        int(bool(getattr(pos, "is_paper", True))),
+        getattr(token, "value", str(token)),  # TokenType member or DB string
+        int(bool(pos.is_paper)),
     )
 
 
 async def record_exit_state(
-    db, pos, state: ExitState, *, exchange: str | None = None,
-    reason: str = "", error: str | None = None,
-    next_retry_at: datetime | None = None, increment_attempt: bool = False,
+    db: Database,
+    key: tuple[str, str, str, int],
+    state: ExitState,
+    *,
+    reason: str = "",
+    error: str | None = None,
+    retry_after_seconds: float | None = None,
+    increment_attempt: bool = False,
 ) -> None:
-    """Upsert the latest lifecycle state for one economic position."""
-    venue, market_id, token, is_paper = position_key(pos, exchange)
-    retry = next_retry_at.astimezone(timezone.utc).isoformat() if next_retry_at else None
+    """Upsert the latest lifecycle state for one economic position.
+
+    ``next_retry_at`` is computed SQL-side via ``datetime('now', ?)`` so the
+    column stays lexically comparable with its siblings and with consumer-side
+    ``datetime('now')`` (readiness.py documents what a T-format/space-format
+    mix inside one table costs); ``datetime('now', NULL)`` is NULL, so passing
+    ``retry_after_seconds=None`` clears the wall.
+
+    A row found in CLOSED is a dead episode: the upsert restarts
+    ``attempt_count`` and ``requested_at`` so a re-entered position doesn't
+    inherit a prior position's counters.
+
+    The single INSERT is atomic on its own under the autocommit connection
+    (txn-migration classification B) — no commit call belongs here.
+    """
+    venue, market_id, token, is_paper = key
     step = int(increment_attempt)
+    retry_mod = (
+        f"+{int(retry_after_seconds)} seconds"
+        if retry_after_seconds is not None else None
+    )
     try:
-        await db.execute(
-            """INSERT INTO exit_lifecycle
-                   (exchange, market_id, token, is_paper, state, reason,
-                    attempt_count, last_error, next_retry_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 ON CONFLICT(exchange, market_id, token, is_paper) DO UPDATE SET
-                   state=excluded.state, reason=excluded.reason,
-                   attempt_count=exit_lifecycle.attempt_count + ?,
-                   last_error=excluded.last_error, next_retry_at=excluded.next_retry_at,
-                   updated_at=datetime('now')""",
-            (venue, market_id, token, is_paper, state.value, reason,
-             step, error, retry, step),
+        await asyncio.wait_for(
+            db.execute(
+                """INSERT INTO exit_lifecycle
+                       (exchange, market_id, token, is_paper, state, reason,
+                        attempt_count, last_error, next_retry_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', ?))
+                     ON CONFLICT(exchange, market_id, token, is_paper) DO UPDATE SET
+                       state=excluded.state, reason=excluded.reason,
+                       attempt_count=CASE WHEN exit_lifecycle.state = 'CLOSED'
+                                          THEN excluded.attempt_count
+                                          ELSE exit_lifecycle.attempt_count + ?
+                                     END,
+                       requested_at=CASE WHEN exit_lifecycle.state = 'CLOSED'
+                                         THEN datetime('now')
+                                         ELSE exit_lifecycle.requested_at
+                                    END,
+                       last_error=excluded.last_error,
+                       next_retry_at=excluded.next_retry_at,
+                       updated_at=datetime('now')""",
+                (venue, market_id, token, is_paper, state.value, reason,
+                 step, error, retry_mod, step),
+            ),
+            timeout=_WRITE_TIMEOUT_SECONDS,
         )
-        await db.commit()
-    except Exception as exc:  # telemetry must never block an exit
+    except Exception as exc:  # telemetry must never block or fail an exit
         log.warning("exit.lifecycle_write_failed", exchange=venue,
                     market_id=market_id, state=state.value, error=str(exc))
+
+
+async def advance_terminal(
+    db: Database,
+    exchange: str,
+    market_id: str,
+    is_paper: int,
+    *,
+    filled: bool,
+    status: str,
+) -> None:
+    """Advance a market's lifecycle rows when a resting SELL turns terminal.
+
+    The order monitor only knows the market (its exit orders don't carry the
+    position's token), so this mirrors ``_clear_exit_suppression`` and touches
+    every token's row under the (exchange, market, mode). A fill CLOSES the
+    episode; a cancel/expiry re-opens it as RETRYABLE with no wall — the
+    suppression keys were just cleared, so the portfolio monitor re-attempts
+    on its next tick and overwrites this with the real outcome.
+    """
+    new_state = ExitState.CLOSED if filled else ExitState.RETRYABLE
+    try:
+        await asyncio.wait_for(
+            db.execute(
+                """UPDATE exit_lifecycle
+                      SET state=?, reason=?, next_retry_at=NULL,
+                          updated_at=datetime('now')
+                    WHERE exchange=? AND market_id=? AND is_paper=?
+                      AND state != 'CLOSED'""",
+                (new_state.value, status, exchange, market_id, is_paper),
+            ),
+            timeout=_WRITE_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        log.warning("exit.lifecycle_terminal_failed", exchange=exchange,
+                    market_id=market_id, status=status, error=str(exc))

--- a/auramaur/risk/portfolio.py
+++ b/auramaur/risk/portfolio.py
@@ -9,6 +9,7 @@ import structlog
 
 from auramaur.db.database import Database
 from auramaur.exchange.models import ExitReason, OrderSide, Position, TokenType
+from auramaur.risk.exit_lifecycle import ExitState, position_key, record_exit_state
 from auramaur.risk.exit_policy import (
     binary_exit_economics,
     lifecycle_profit_target,
@@ -462,8 +463,17 @@ class PortfolioTracker:
                     # The position freezes here: no re-mark, no exit
                     # evaluation, and nothing ever closes it (149 paper
                     # positions rotted this way for 3 days carrying -$553
-                    # of stale marks, 2026-07-22). Surface it below.
+                    # of stale marks, 2026-07-22). Surface it below, and leave
+                    # a durable trace the doctor can count: the row is
+                    # re-upserted every tick while the market stays dark, so
+                    # the doctor keys on updated_at FRESHNESS — a recovered
+                    # market stops the writes and the row ages out of the
+                    # check on its own, with no clearing write needed.
                     unmarkable.append(pos.market_id)
+                    await record_exit_state(
+                        self.db, position_key(pos, exchange or pos.exchange),
+                        ExitState.UNMARKABLE, reason="no_market_data",
+                    )
                     continue
                 # IBKR holds options priced in premium dollars, not 0-1 resolution
                 # probabilities, and its discovery returns the *reframed* binary
@@ -734,6 +744,11 @@ class PortfolioTracker:
     _EXIT_DECISION_PRUNE = (
         "DELETE FROM exit_decisions WHERE observed_at < datetime('now', ?)")
 
+    # CLOSED-only: finished episodes age out; blocked states never do.
+    _EXIT_LIFECYCLE_PRUNE = (
+        "DELETE FROM exit_lifecycle WHERE state = 'CLOSED' "
+        "AND updated_at < datetime('now', ?)")
+
     def _exit_decision_row(
         self, pos, mode_flag: int | None, reason: str, gross_pct: float,
         net_pct: float, peak_pct: float, target_pct: float | None,
@@ -781,6 +796,13 @@ class PortfolioTracker:
                 # every cycle, while holding the write lock on the exit path.
                 await self.db.execute(
                     self._EXIT_DECISION_PRUNE, (f"-{retention_days} days",))
+                # exit_lifecycle retention rides the same batch: CLOSED rows
+                # are finished episodes kept briefly for operator inspection;
+                # without a prune the table (and any state it froze in) grows
+                # for the life of the bot. Non-CLOSED rows are never pruned —
+                # a blocked exit must stay visible until something closes it.
+                await self.db.execute(self._EXIT_LIFECYCLE_PRUNE,
+                                      (f"-{retention_days} days",))
         except Exception as exc:  # noqa: BLE001 — never compromise exits
             log.debug("exit.decision_record_failed", count=len(rows), error=str(exc))
 

--- a/tests/test_bot_exit_loop.py
+++ b/tests/test_bot_exit_loop.py
@@ -29,6 +29,7 @@ from structlog.testing import capture_logs
 from auramaur.bot import AuramaurBot
 from auramaur.components import Components
 from auramaur.exchange.models import ExitReason, OrderSide, Position, TokenType
+from auramaur.risk.exit_lifecycle import ExitAttempt
 
 
 def _position(market_id: str = "M1", *, is_paper: bool,
@@ -66,7 +67,7 @@ def _bot(exit_list: list, *, is_live: bool = True):
 
     async def _execute_poly_exit(pos, reason, _discovery, _exchange, _alerts):
         attempted.append((pos, reason))
-        return True
+        return ExitAttempt(True)
 
     bot._execute_poly_exit = _execute_poly_exit
     bot._components = Components({

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -158,6 +158,115 @@ def test_doctor_fails_when_zero_expected_pillars_are_alive(tmp_path):
     asyncio.run(run())
 
 
+def test_doctor_exit_lifecycle_warns_only_on_actionable_rows():
+    """The blocked-exit check must be falsifiable: routine backoff and rows
+    whose position already left the book are NOT blockages, or the check
+    degrades to a permanently-warning counter the operator learns to ignore
+    (the alarm-fatigue mode the 12-day exit outage postmortem warned about).
+    """
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = SimpleNamespace(
+            is_live=False, kill_switch_active=False,
+            logging=SimpleNamespace(file="/nonexistent/auramaur.log"),
+        )
+
+        async def seed_row(market, state, retry_mod):
+            await db.execute(
+                """INSERT INTO exit_lifecycle
+                       (exchange, market_id, token, is_paper, state,
+                        next_retry_at)
+                     VALUES ('polymarket', ?, 'YES', 1, ?,
+                             datetime('now', ?))""",
+                (market, state, retry_mod))
+
+        async def seed_position(market):
+            await db.execute(
+                """INSERT INTO portfolio
+                       (market_id, exchange, side, size, avg_price,
+                        current_price, category, token, token_id, is_paper)
+                     VALUES (?, 'polymarket', 'BUY', 10, 0.5, 0.5,
+                             'politics', 'YES', 't', 1)""",
+                (market,))
+
+        # Routine backoff: future wall, live position -> not blocked.
+        await seed_position("M-backoff")
+        await seed_row("M-backoff", "RETRYABLE", "+10 minutes")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "exit lifecycle")
+        assert check["status"] == "ok"
+
+        # Past-due wall with NO surviving position (settled out-of-band):
+        # invisible, never an eternal warning.
+        await seed_row("M-ghost", "RETRYABLE", "-30 minutes")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "exit lifecycle")
+        assert check["status"] == "ok"
+
+        # Past-due wall WITH a live position: genuinely stuck -> warn.
+        await seed_position("M-stuck")
+        await seed_row("M-stuck", "RETRYABLE", "-30 minutes")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "exit lifecycle")
+        assert check["status"] == "warn"
+        assert "retryable=1" in check["detail"]
+
+        # Held dust is a known book state with its own remedy: named in the
+        # detail, but it alone must not degrade the verdict.
+        await db.execute("DELETE FROM exit_lifecycle")
+        await db.execute("DELETE FROM portfolio")
+        await seed_position("M-dust")
+        await seed_row("M-dust", "UNSALEABLE_DUST", "+15 minutes")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "exit lifecycle")
+        assert check["status"] == "ok"
+        assert "dust=1" in check["detail"]
+        await db.close()
+
+    asyncio.run(run())
+
+
+def test_doctor_attribution_is_windowed_and_skips_sentinels():
+    """One pre-attribution '' row from history must not pin the check at warn
+    forever, and deliberately-bucketed rows (venue_/phantom_/legacy_
+    unattributed) are labeled outcomes, not leaks."""
+    async def run():
+        db = Database(":memory:")
+        await db.connect()
+        settings = SimpleNamespace(
+            is_live=False, kill_switch_active=False,
+            logging=SimpleNamespace(file="/nonexistent/auramaur.log"),
+        )
+
+        async def seed_ledger(ref, source, age_mod):
+            await db.execute(
+                """INSERT INTO pnl_ledger
+                       (market_id, strategy_source, kind, pnl, is_paper,
+                        source_ref, realized_at)
+                     VALUES ('M1', ?, 'sell', 1.0, 1, ?,
+                             datetime('now', ?))""",
+                (source, ref, age_mod))
+
+        # Ancient empty-source row: historical, outside the window -> ok.
+        await seed_ledger("old-empty", "", "-30 days")
+        # Recent sentinel-bucket row: a labeled outcome, not a leak -> ok.
+        await seed_ledger("recent-bucket", "venue_unattributed", "-1 hours")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "P&L attribution")
+        assert check["status"] == "ok"
+
+        # Recent empty-source row: a live leak -> warn.
+        await seed_ledger("recent-empty", "", "-1 hours")
+        s = await gather_doctor(settings, db)
+        check = next(c for c in s["checks"] if c["name"] == "P&L attribution")
+        assert check["status"] == "warn"
+        assert "1 unattributed" in check["detail"]
+        await db.close()
+
+    asyncio.run(run())
+
+
 if __name__ == "__main__":
     test_summarize_counts_and_excludes_info()
     test_summarize_empty()

--- a/tests/test_exit_lifecycle.py
+++ b/tests/test_exit_lifecycle.py
@@ -1,11 +1,19 @@
-from datetime import datetime, timedelta, timezone
+"""Exit-lifecycle persistence: durability, episode reset, terminal advance,
+migration, and the never-block-an-exit containment contract."""
+
 from types import SimpleNamespace
 
 import pytest
 
 from auramaur.db.database import Database
+from auramaur.db.models import SCHEMA_VERSION
 from auramaur.exchange.models import TokenType
-from auramaur.risk.exit_lifecycle import ExitState, position_key, record_exit_state
+from auramaur.risk.exit_lifecycle import (
+    ExitState,
+    advance_terminal,
+    position_key,
+    record_exit_state,
+)
 
 
 def _position():
@@ -15,7 +23,18 @@ def _position():
 
 
 def test_position_key_is_the_canonical_economic_position():
-    assert position_key(_position()) == ("polymarket", "m-1", "NO", 0)
+    assert position_key(_position(), "polymarket") == ("polymarket", "m-1", "NO", 0)
+
+
+def test_position_key_fails_loud_on_a_partial_position():
+    """A position object missing is_paper must RAISE, never default: the
+    12-day exit outage was a position model missing this exact field, and a
+    silent paper-default would file live rows where live-mode diagnostics
+    never look."""
+    partial = SimpleNamespace(exchange="polymarket", market_id="m-1",
+                              token=TokenType.NO)
+    with pytest.raises(AttributeError):
+        position_key(partial, "polymarket")
 
 
 @pytest.mark.asyncio
@@ -23,26 +42,102 @@ async def test_exit_state_is_durable_and_attempts_increment(tmp_path):
     db = Database(str(tmp_path / "exit.db"))
     await db.connect()
     try:
-        pos = _position()
+        key = position_key(_position(), "polymarket")
         await record_exit_state(
-            db, pos, ExitState.REQUESTED, reason="STOP_LOSS",
+            db, key, ExitState.RETRYABLE, reason="STOP_LOSS",
+            error="book unavailable", retry_after_seconds=900,
             increment_attempt=True,
         )
-        retry = datetime.now(timezone.utc) + timedelta(minutes=15)
         await record_exit_state(
-            db, pos, ExitState.RETRYABLE, reason="STOP_LOSS",
-            error="book unavailable", next_retry_at=retry,
+            db, key, ExitState.RETRYABLE, reason="STOP_LOSS",
+            error="book unavailable", retry_after_seconds=900,
+            increment_attempt=True,
         )
         row = await db.fetchone(
             """SELECT * FROM exit_lifecycle
                 WHERE exchange=? AND market_id=? AND token=? AND is_paper=?""",
-            position_key(pos),
+            key,
         )
         assert row["state"] == "RETRYABLE"
         assert row["reason"] == "STOP_LOSS"
-        assert row["attempt_count"] == 1
+        assert row["attempt_count"] == 2
         assert row["last_error"] == "book unavailable"
         assert row["next_retry_at"] is not None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_next_retry_at_compares_lexically_with_sqlite_now(tmp_path):
+    """The wall is written SQL-side in datetime('now') space format, so the
+    natural consumer predicate (col <= datetime('now')) orders correctly —
+    a Python isoformat 'T' would sort after every same-day sqlite string."""
+    db = Database(str(tmp_path / "fmt.db"))
+    await db.connect()
+    try:
+        key = position_key(_position(), "polymarket")
+        await record_exit_state(
+            db, key, ExitState.RETRYABLE, retry_after_seconds=900)
+        row = await db.fetchone(
+            """SELECT next_retry_at,
+                      next_retry_at > datetime('now') AS still_future,
+                      next_retry_at <= datetime('now', '+16 minutes') AS due_soon
+                 FROM exit_lifecycle WHERE market_id=?""", ("m-1",))
+        assert "T" not in row["next_retry_at"]
+        assert row["still_future"] == 1
+        assert row["due_soon"] == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_closed_resets_the_episode_for_a_reentered_position(tmp_path):
+    """A row parked at CLOSED belongs to a dead episode: the next write must
+    restart attempt_count (and requested_at) instead of inheriting months of
+    a prior position's counters."""
+    db = Database(str(tmp_path / "episode.db"))
+    await db.connect()
+    try:
+        key = position_key(_position(), "polymarket")
+        for _ in range(3):
+            await record_exit_state(db, key, ExitState.RETRYABLE,
+                                    increment_attempt=True)
+        await advance_terminal(db, "polymarket", "m-1", 0,
+                               filled=True, status="filled")
+        row = await db.fetchone(
+            "SELECT state FROM exit_lifecycle WHERE market_id=?", ("m-1",))
+        assert row["state"] == "CLOSED"
+
+        await record_exit_state(db, key, ExitState.RETRYABLE,
+                                increment_attempt=True)
+        row = await db.fetchone(
+            "SELECT state, attempt_count FROM exit_lifecycle WHERE market_id=?",
+            ("m-1",))
+        assert row["state"] == "RETRYABLE"
+        assert row["attempt_count"] == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_cancel_reopens_as_retryable(tmp_path):
+    """A TTL-cancelled/expired exit order is not a closed position: the
+    suppression keys were just cleared, so the row re-opens RETRYABLE and the
+    next tick's attempt overwrites it with the real outcome."""
+    db = Database(str(tmp_path / "cancel.db"))
+    await db.connect()
+    try:
+        key = position_key(_position(), "polymarket")
+        await record_exit_state(db, key, ExitState.ORDER_WORKING,
+                                increment_attempt=True)
+        await advance_terminal(db, "polymarket", "m-1", 0,
+                               filled=False, status="ttl_cancelled")
+        row = await db.fetchone(
+            "SELECT state, reason, next_retry_at FROM exit_lifecycle "
+            "WHERE market_id=?", ("m-1",))
+        assert row["state"] == "RETRYABLE"
+        assert row["reason"] == "ttl_cancelled"
+        assert row["next_retry_at"] is None
     finally:
         await db.close()
 
@@ -58,22 +153,50 @@ async def test_fresh_schema_contains_exit_lifecycle(tmp_path):
             """SELECT name FROM sqlite_master
                 WHERE type='table' AND name='exit_lifecycle'"""
         )
-        assert version["version"] == 51
+        assert version["version"] == SCHEMA_VERSION
         assert table["name"] == "exit_lifecycle"
     finally:
         await db.close()
 
 
 @pytest.mark.asyncio
+async def test_v51_migration_creates_exit_lifecycle(tmp_path):
+    """Call the migration DIRECTLY, never through connect(): _init_schema
+    runs executescript(TABLES) before dispatching migrations, so a
+    reconnect-and-migrate test rebuilds the table from TABLES and a gutted
+    migration stays green (the pattern test_exit_policy.py documents)."""
+    db = Database(str(tmp_path / "migration.db"))
+    await db.connect()
+    try:
+        await db.execute("DROP TABLE exit_lifecycle")
+        await db.execute("UPDATE schema_version SET version = 50")
+
+        await db._migrate_v50_to_v51()
+
+        version = await db.fetchone("SELECT version FROM schema_version")
+        columns = await db.fetchall("PRAGMA table_info(exit_lifecycle)")
+        assert version["version"] == 51
+        assert {row["name"] for row in columns} >= {
+            "exchange", "market_id", "token", "is_paper", "state",
+            "attempt_count", "last_error", "next_retry_at",
+        }
+        # Idempotent: a second dispatch must not raise.
+        await db._migrate_v50_to_v51()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_telemetry_failure_never_blocks_exit():
+    """A raising database is logged and contained; the caller never sees it.
+    (The wall-clock side of the contract — a WAIT, not an exception — is
+    bounded by the module's asyncio.wait_for timeout.)"""
+
     class BrokenDatabase:
         async def execute(self, *args, **kwargs):
             raise RuntimeError("locked")
 
-        async def commit(self):
-            raise AssertionError("commit must not follow a failed write")
-
     await record_exit_state(
-        BrokenDatabase(), _position(), ExitState.REQUESTED,
+        BrokenDatabase(), ("polymarket", "m-1", "NO", 0), ExitState.RETRYABLE,
         reason="STOP_LOSS", increment_attempt=True,
     )

--- a/tests/test_exit_lifecycle.py
+++ b/tests/test_exit_lifecycle.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from auramaur.db.database import Database
+from auramaur.exchange.models import TokenType
+from auramaur.risk.exit_lifecycle import ExitState, position_key, record_exit_state
+
+
+def _position():
+    return SimpleNamespace(
+        exchange="polymarket", market_id="m-1", token=TokenType.NO, is_paper=False,
+    )
+
+
+def test_position_key_is_the_canonical_economic_position():
+    assert position_key(_position()) == ("polymarket", "m-1", "NO", 0)
+
+
+@pytest.mark.asyncio
+async def test_exit_state_is_durable_and_attempts_increment(tmp_path):
+    db = Database(str(tmp_path / "exit.db"))
+    await db.connect()
+    try:
+        pos = _position()
+        await record_exit_state(
+            db, pos, ExitState.REQUESTED, reason="STOP_LOSS",
+            increment_attempt=True,
+        )
+        retry = datetime.now(timezone.utc) + timedelta(minutes=15)
+        await record_exit_state(
+            db, pos, ExitState.RETRYABLE, reason="STOP_LOSS",
+            error="book unavailable", next_retry_at=retry,
+        )
+        row = await db.fetchone(
+            """SELECT * FROM exit_lifecycle
+                WHERE exchange=? AND market_id=? AND token=? AND is_paper=?""",
+            position_key(pos),
+        )
+        assert row["state"] == "RETRYABLE"
+        assert row["reason"] == "STOP_LOSS"
+        assert row["attempt_count"] == 1
+        assert row["last_error"] == "book unavailable"
+        assert row["next_retry_at"] is not None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_schema_contains_exit_lifecycle(tmp_path):
+    db = Database(str(tmp_path / "schema.db"))
+    await db.connect()
+    try:
+        version = await db.fetchone("SELECT version FROM schema_version")
+
+        table = await db.fetchone(
+            """SELECT name FROM sqlite_master
+                WHERE type='table' AND name='exit_lifecycle'"""
+        )
+        assert version["version"] == 51
+        assert table["name"] == "exit_lifecycle"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_failure_never_blocks_exit():
+    class BrokenDatabase:
+        async def execute(self, *args, **kwargs):
+            raise RuntimeError("locked")
+
+        async def commit(self):
+            raise AssertionError("commit must not follow a failed write")
+
+    await record_exit_state(
+        BrokenDatabase(), _position(), ExitState.REQUESTED,
+        reason="STOP_LOSS", increment_attempt=True,
+    )

--- a/tests/test_exit_pricing.py
+++ b/tests/test_exit_pricing.py
@@ -76,9 +76,9 @@ async def test_exit_takes_bid_within_band():
     """Bid 2c below the snapshot, well within the band — cross to the bid."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.88, 0.91), current_price=0.90)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is True
+    assert attempt.ok is True
     order = exchange.place_order.await_args.args[0]
     assert order.price == 0.88  # the real bid, marketable
 
@@ -89,9 +89,9 @@ async def test_exit_crosses_to_bid_not_a_resting_floor():
     — never at a 'budget floor' (0.87) that would only rest above the bid."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.85, 0.95), current_price=0.90)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is True
+    assert attempt.ok is True
     order = exchange.place_order.await_args.args[0]
     assert order.price == 0.85  # crosses to the bid, not 0.87
 
@@ -102,9 +102,9 @@ async def test_exit_skips_when_bid_below_band():
     would dump well under the mark, so skip and back off (the wide-spread case)."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.70, 0.95), current_price=0.90)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is False
+    assert attempt.ok is False
     exchange.place_order.assert_not_awaited()
 
 
@@ -114,9 +114,9 @@ async def test_exit_skips_junk_bid_below_floor():
     rather than dump into a 2c buyer."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.02, 0.20), current_price=0.12)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is False
+    assert attempt.ok is False
     exchange.place_order.assert_not_awaited()
 
 
@@ -126,9 +126,9 @@ async def test_exit_skips_when_book_has_no_bid():
     at the snapshot that can only TTL-cancel."""
     bot, pos, reason, exchange, alerts = _setup(_book(None, None), current_price=0.90)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is False
+    assert attempt.ok is False
     exchange.place_order.assert_not_awaited()
 
 
@@ -139,9 +139,9 @@ async def test_exit_best_effort_when_book_fetch_errors():
     bot, pos, reason, exchange, alerts = _setup(_book(0.88, 0.91), current_price=0.90)
     exchange.get_order_book = AsyncMock(side_effect=RuntimeError("clob timeout"))
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is True
+    assert attempt.ok is True
     order = exchange.place_order.await_args.args[0]
     assert order.price == 0.90
 
@@ -152,7 +152,7 @@ async def test_exit_skips_when_mark_contradicts_book():
     (wrong-side label, stale price). Skip the order entirely."""
     bot, pos, reason, exchange, alerts = _setup(_book(0.07, 0.13), current_price=0.90)
 
-    ok = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
+    attempt = await bot._execute_poly_exit(pos, reason, AsyncMock(), exchange, alerts)
 
-    assert ok is False
+    assert attempt.ok is False
     exchange.place_order.assert_not_awaited()

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -204,8 +204,8 @@ class TestIBKRExit:
             token_id="123:buy_call:C:200:20260418",
             token=TokenType.YES, size=2.0, current_price=4.0, unrealized_pnl=10.0)
 
-        ok = await bot._execute_ibkr_exit(pos, ExitReason.STOP_LOSS, None, exch, alerts)
-        assert ok is True
+        attempt = await bot._execute_ibkr_exit(pos, ExitReason.STOP_LOSS, None, exch, alerts)
+        assert attempt.ok is True
         order = exch.place_order.await_args.args[0]
         assert order.side == OrderSide.SELL
         assert order.exchange == "ibkr"
@@ -220,9 +220,9 @@ class TestIBKRExit:
         exch = SimpleNamespace(place_order=AsyncMock())
         pos = SimpleNamespace(market_id="x", token_id="", token=TokenType.YES,
                               size=2.0, current_price=4.0, unrealized_pnl=0.0)
-        ok = await bot._execute_ibkr_exit(
+        attempt = await bot._execute_ibkr_exit(
             pos, ExitReason.STOP_LOSS, None, exch, SimpleNamespace(send=AsyncMock()))
-        assert ok is False
+        assert attempt.ok is False
         exch.place_order.assert_not_called()
 
 


### PR DESCRIPTION
Summary:
- add schema v51 with durable position-scoped exit lifecycle state (`exit_lifecycle`, PK = exchange/market/token/mode)
- executors return their own disposition (`ExitAttempt`): Polymarket dust is judged on the ON-CHAIN-adjusted sell size, Kalshi against the real venue minimum (0.01 on fractional-enabled markets), and IBKR's permanently-unexitable paths (no contract id, sub-1 size) stop cycling as retryable — the caller no longer re-derives venue minimums from DB `pos.size`
- ONE lifecycle write per attempt, AFTER the venue call, bounded by a 5s `asyncio.wait_for`: no DB await sits between an exit trigger and order placement, and a wedged serializer can delay telemetry but never an exit
- terminal transitions wired: an order-monitor fill advances rows to CLOSED (cancel/TTL re-opens RETRYABLE for the next tick), the stale-zero prune closes its episode, CLOSED resets attempt_count/requested_at for re-entered positions, and CLOSED rows age out alongside the exit-decision prune
- `check_exits` records UNMARKABLE while a market stays dark; the doctor keys on row freshness, so a recovered market self-clears without a clearing write
- doctor checks are falsifiable: the blocked-exit check warns only on past-due RETRYABLE or fresh UNMARKABLE rows whose position still exists (held dust rides in the detail text, not the verdict); the P&L-attribution check is windowed to 7 days, drops the dead `IS NULL` arm, and normalizes the ledger's two timestamp formats
- `next_retry_at` is computed SQL-side in sqlite space format so it compares correctly with `datetime('now')`; it is recorded for every failure class because the in-memory gate retries them all — the durable record describes actual behavior
- `position_key` fails loud on partial position objects (the #420 defect class) and the in-memory suppression key derives from it, so the two encodings of "one economic position" can never diverge

Verification:
- full suite green in-container at the fix commit, run in an isolated worktree
- ruff (0.15.22) clean
- new tests: direct v50→v51 migration call (DROP + call, per the repo's migration-test pattern), episode reset via CLOSED, terminal advance (fill vs cancel), retry-wall format comparability with `datetime('now')`, fail-loud `position_key`, and both doctor checks exercised against seeded rows in both directions

Rollout:
- migration is additive and advances schema 50 to 51
- lifecycle telemetry is fail-open AND bounded for exits: write failures are logged, and a slow serializer is cut off at 5s — neither can stop an exit order
- deploy-order note: `ensure_schema=False` still migrates a BEHIND schema by design, so the first CLI invocation from an updated checkout would run the v51 migration against the live DB if the bot container hasn't migrated it yet. Restart the container (which migrates on boot) before running host-side CLI against the live file.

Review provenance: multi-agent review (10 finder angles, adversarially verified — 15 confirmed findings), all findings addressed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
